### PR TITLE
Ratwood skill names

### DIFF
--- a/code/controllers/subsystem/skills.dm
+++ b/code/controllers/subsystem/skills.dm
@@ -10,18 +10,18 @@ SUBSYSTEM_DEF(skills)
 	var/list/all_skills = list()
 	///Static assoc list of levels (ints) - strings
 	var/static/list/level_names = list(
-		SKILL_LEVEL_NOVICE = span_info("<span class='small'>Novice</span>"),
-		SKILL_LEVEL_APPRENTICE = span_info("Apprentice"),
-		SKILL_LEVEL_JOURNEYMAN = span_biginfo("Journeyman"),
+		SKILL_LEVEL_NOVICE = span_info("<span class='small'>Beginner</span>"),
+		SKILL_LEVEL_APPRENTICE = span_info("Competent"),
+		SKILL_LEVEL_JOURNEYMAN = span_biginfo("Proficient"),
 		SKILL_LEVEL_EXPERT = span_biginfo("Expert"),
 		SKILL_LEVEL_MASTER = "<b>Master</b>",
 		SKILL_LEVEL_LEGENDARY = span_greentext("<b>Legendary</b>"),
 	)//This list is already in the right order, due to indexing
 	///Plain level names without the span
 	var/static/list/level_names_plain = list(
-		SKILL_LEVEL_NOVICE = "Novice",
-		SKILL_LEVEL_APPRENTICE = "Apprentice",
-		SKILL_LEVEL_JOURNEYMAN = "Journeyman",
+		SKILL_LEVEL_NOVICE = "Beginner",
+		SKILL_LEVEL_APPRENTICE = "Competent",
+		SKILL_LEVEL_JOURNEYMAN = "Proficient",
 		SKILL_LEVEL_EXPERT = "Expert",
 		SKILL_LEVEL_MASTER = "Master",
 		SKILL_LEVEL_LEGENDARY = "Legendary",


### PR DESCRIPTION
## About The Pull Request

Replaces the skill names 'Novice', 'Apprentice' and 'Journeyman' with Beginner, Competent and Proficient from Ratwood.

## Testing Evidence

<img width="1232" height="480" alt="image" src="https://github.com/user-attachments/assets/5ecf62bd-7fd3-458b-97fd-91ad3949e08b" />


## Why It's Good For The Game

I like the wording of beginner/competent/proficient, it much more accurately describes how good you are with a thing, rather than describing your relationship with the medieval guild system. Y'know, you're probably not an Apprentice swimmer. Where are you doing your swimming Apprenticeship? Who are you Apprenticing under for your wrestling?

Keeping as a draft before going through the ramifications more thoroughly and combing through all the descriptions later