### PR TITLE
Ports the vomit emote code (and the followup adjustments)

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -601,11 +601,14 @@
 	add_nausea(-1)
 
 
-/mob/living/carbon/proc/vomit(lost_nutrition = 50, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, toxic = FALSE, harm = FALSE, force = FALSE)
+// made default lost nutrition 100 (equivalent to one jacksberries) per vomit
+// made gag requirement = to starving
+/mob/living/carbon/proc/vomit(lost_nutrition = 100, blood = FALSE, stun = TRUE, distance = 1, message = TRUE, toxic = FALSE, harm = FALSE, force = FALSE)
 	if(HAS_TRAIT(src, TRAIT_TOXINLOVER) && !force)
 		return TRUE
 
 	mob_timers["puke"] = world.time
+
 
 	var/obj/item/bodypart/head/dullahan/vomitrelay
 	if(isdullahan(src))
@@ -616,7 +619,7 @@
 
 	var/atom/movable/vomit_source = vomitrelay ? vomitrelay : src
 
-	if(nutrition <= 50 && !blood)
+	if(nutrition <= NUTRITION_LEVEL_STARVING && !blood)
 		if(message)
 			emote("gag")
 		if(stun)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -648,7 +648,7 @@
 		override = dna.species.override_float
 	..()
 
-/mob/living/carbon/human/vomit(lost_nutrition = 10, blood = 0, stun = 1, distance = 0, message = 1, toxic = 0)
+/mob/living/carbon/human/vomit(lost_nutrition = 100, blood = 0, stun = 1, distance = 0, message = 1, toxic = 0)
 	if(blood && (NOBLOOD in dna.species.species_traits) && !HAS_TRAIT(src, TRAIT_TOXINLOVER))
 		if(message)
 			visible_message(span_warning("[src] dry heaves!"), \

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1852,3 +1852,23 @@
         to_chat(L, span_warning("Nothing happens."))
 
     return TRUE   
+
+
+/* Vomit emote */
+/mob/living/carbon/human/verb/emote_vomit()
+	set name = "Vomit"
+	set category = "Emotes"
+
+	emote("vomit", intentional = TRUE)
+
+/datum/emote/living/vomit
+	key = "vomit"
+	nomsg = TRUE
+
+/datum/emote/living/vomit/run_emote(mob/user, params, type_override, intentional, targetted)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.vomit()
+		var/msg = "[key_name(H)] puked!"
+		message_admins(msg)
+		log_admin(msg)


### PR DESCRIPTION
## About The Pull Request

Lets you puke manually with an emote! There is a stun and a cooldown and an admin message logged when used to prevent abuse. It also increases the amount of hunger and thirst caused by puking to make it more of a real issue.
Porting from 
-https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2873/files
-https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2900

## Testing Evidence

<img width="536" height="79" alt="image" src="https://github.com/user-attachments/assets/e2c252d4-c127-4384-b548-2ca1f74a64a6" />
<img width="922" height="934" alt="image" src="https://github.com/user-attachments/assets/36272ca3-efa1-432b-aab7-3eb080e3ab8a" />


## Why It's Good For The Game

A fantastic feature from ratwood 1! It was funny and flavourful.