### PR TITLE
Initial Unarmed Pass

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -391,6 +391,10 @@
 	effectedstats = list(STATKEY_PER = -3, STATKEY_LCK = -1)
 	duration = 8 SECONDS
 
+/datum/status_effect/debuff/dazed/unarmed
+	effectedstats = list(STATKEY_INT = -2, STATKEY_LCK = -1)
+	duration = 10 SECONDS
+
 /atom/movable/screen/alert/status_effect/debuff/dazed
 	name = "Dazed"
 	desc = "You've been smacked on the head very hard. Which way is left, again?"

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -1,29 +1,4 @@
 /// INTENT DATUMS	v
-/datum/intent/katar/cut
-	name = "cut"
-	icon_state = "incut"
-	attack_verb = list("cuts", "slashes")
-	animname = "cut"
-	blade_class = BCLASS_CUT
-	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
-	penfactor = 0
-	chargetime = 0
-	swingdelay = 0
-	damfactor = 1.3
-	clickcd = CLICK_CD_INTENTCAP
-	item_d_type = "slash"
-
-/datum/intent/katar/thrust
-	name = "thrust"
-	icon_state = "instab"
-	attack_verb = list("thrusts")
-	animname = "stab"
-	blade_class = BCLASS_STAB
-	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 40
-	chargetime = 0
-	clickcd = CLICK_CD_INTENTCAP
-	item_d_type = "stab"
 
 /datum/intent/lordbash
 	name = "bash"
@@ -47,31 +22,6 @@
 	tranged = TRUE
 	noaa = TRUE
 
-/datum/intent/knuckles/strike
-	name = "punch"
-	blade_class = BCLASS_BLUNT
-	attack_verb = list("punches", "clocks")
-	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
-	chargetime = 0
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	clickcd = 8
-	damfactor = 1.1
-	swingdelay = 0
-	icon_state = "inpunch"
-	item_d_type = "blunt"
-
-/datum/intent/knuckles/smash
-	name = "smash"
-	blade_class = BCLASS_SMASH
-	attack_verb = list("smashes")
-	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
-	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 1.1
-	clickcd = CLICK_CD_MELEE
-	swingdelay = 8
-	intent_intdamage_factor = 1.35
-	icon_state = "insmash"
-	item_d_type = "blunt"
 /// INTENT DATUMS	^
 
 /obj/item/rogueweapon/lordscepter
@@ -110,7 +60,7 @@
 	. = ..()
 	if(get_dist(user, target) > 7)
 		return
-	
+
 	user.changeNext_move(CLICK_CD_MELEE)
 
 	if(ishuman(user))
@@ -134,7 +84,7 @@
 			if(H.anti_magic_check())
 				to_chat(user, span_danger("Something is disrupting the rod's power!"))
 				return
-		
+
 			if(!(H in SStreasury.bank_accounts))
 				to_chat(user, span_danger("The target must have a Meister account!"))
 				return
@@ -259,163 +209,6 @@
 		update_icon()
 		playsound(src, pick('sound/items/stunmace_toggle (1).ogg','sound/items/stunmace_toggle (2).ogg','sound/items/stunmace_toggle (3).ogg'), 100, TRUE)
 
-/obj/item/rogueweapon/katar
-	slot_flags = ITEM_SLOT_HIP
-	force = 24
-	possible_item_intents = list(/datum/intent/katar/cut, /datum/intent/katar/thrust)
-	name = "katar"
-	desc = "A blade that sits above the users fist. Commonly used by those proficient at unarmed fighting"
-	icon_state = "katar"
-	icon = 'icons/roguetown/weapons/32.dmi'
-	gripsprite = FALSE
-	wlength = WLENGTH_SHORT
-	w_class = WEIGHT_CLASS_SMALL
-	parrysound = list('sound/combat/parry/bladed/bladedsmall (1).ogg','sound/combat/parry/bladed/bladedsmall (2).ogg','sound/combat/parry/bladed/bladedsmall (3).ogg')
-	max_blade_int = 200
-	max_integrity = 80
-	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
-	associated_skill = /datum/skill/combat/unarmed
-	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
-	throwforce = 12
-	wdefense = 0	//Meant to be used with bracers
-	wbalance = WBALANCE_SWIFT
-	thrown_bclass = BCLASS_CUT
-	anvilrepair = /datum/skill/craft/weaponsmithing
-	smeltresult = /obj/item/ingot/steel
-	grid_height = 64
-	grid_width = 32
-	sharpness_mod = 2	//Can't parry, so it decays quicker on-hit.
-
-/obj/item/rogueweapon/katar/getonmobprop(tag)
-	. = ..()
-	if(tag)
-		switch(tag)
-			if("gen")
-				return list("shrink" = 0.4,"sx" = -7,"sy" = -4,"nx" = 7,"ny" = -4,"wx" = -3,"wy" = -4,"ex" = 1,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 110,"sturn" = -110,"wturn" = -110,"eturn" = 110,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
-			if("onbelt")
-				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
-
-
-/obj/item/rogueweapon/katar/abyssor
-	name = "barotrauma"
-	desc = "A gift from a creature of the sea. The claw is sharpened to a wicked edge."
-	icon_state = "abyssorclaw"
-	force = 27	//Its thrust will be able to pen 80 stab armor if the wielder has 17 STR. (With softcap)
-	max_integrity = 80
-
-/obj/item/rogueweapon/katar/punchdagger
-	name = "punch dagger"
-	desc = "A weapon that combines the ergonomics of the Ranesheni katar with the capabilities of the Western Psydonian \"knight-killers\". It can be tied around the wrist."
-	slot_flags = ITEM_SLOT_WRISTS
-	max_integrity = 120		//Steel dagger -30
-	force = 15		//Steel dagger -5
-	throwforce = 8
-	wdefense = 0	//Hell no!
-	thrown_bclass = BCLASS_STAB
-	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/thrust/pick)
-	icon_state = "plug"
-
-/obj/item/rogueweapon/katar/punchdagger/frei
-	name = "vývrtka"
-	desc = "A type of punch dagger of Aavnic make initially designed to level the playing field with an orc in fisticuffs, its serrated edges and longer, thinner point are designed to maximize pain for the recipient. It's aptly given the name of \"corkscrew\", and this specific one has the colours of Szöréndnížina. Can be worn on your ring slot."
-	icon_state = "freiplug"
-	slot_flags = ITEM_SLOT_RING
-/obj/item/rogueweapon/katar/psydon
-	name = "psydonian katar"
-	desc = "An exotic weapon taken from the hands of wandering monks, an esoteric design to the Otavan Orthodoxy. Special care was taken into account towards the user's knuckles: silver-tipped steel from tip to edges, and His holy cross reinforcing the heart of the weapon, with curved shoulders to allow its user to deflect incoming blows - provided they lead it in with the blade."
-	icon_state = "psykatar"
-
-/obj/item/rogueweapon/katar/psydon/ComponentInitialize()
-	. = ..()							//+3 force, +50 int, +1 def, make silver
-	add_psyblessed_component(is_preblessed = FALSE, bonus_force = 3, bonus_sharpness = 0, bonus_integrity = 50, bonus_wdef = 1, make_silver = TRUE)
-
-/obj/item/rogueweapon/knuckles/psydon
-	name = "psydonian knuckles"
-	desc = "A simple piece of harm molded in a holy mixture of steel and silver, finished with three stumps - Psydon's crown - to crush the heretics' garments and armor into smithereens."
-	icon_state = "psyknuckle"
-
-/obj/item/rogueweapon/knuckles/psydon/ComponentInitialize()
-	. = ..()							//+3 force, +50 int, +1 def, make silver
-	add_psyblessed_component(is_preblessed = FALSE, bonus_force = 3, bonus_sharpness = 0, bonus_integrity = 50, bonus_wdef = 1, make_silver = TRUE)
-
-/obj/item/rogueweapon/knuckles
-	name = "steel knuckles"
-	desc = "A mean looking pair of steel knuckles."
-	force = 22
-	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
-	icon = 'icons/roguetown/weapons/32.dmi'
-	icon_state = "steelknuckle"
-	gripsprite = FALSE
-	wlength = WLENGTH_SHORT
-	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_HIP
-	parrysound = list('sound/combat/parry/pugilism/unarmparry (1).ogg','sound/combat/parry/pugilism/unarmparry (2).ogg','sound/combat/parry/pugilism/unarmparry (3).ogg')
-	sharpness = IS_BLUNT
-	max_integrity = 150
-	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
-	associated_skill = /datum/skill/combat/unarmed
-	throwforce = 12
-	wdefense = 4
-	wbalance = WBALANCE_NORMAL
-	anvilrepair = /datum/skill/craft/weaponsmithing
-	smeltresult = /obj/item/ingot/steel
-	grid_width = 64
-	grid_height = 32
-
-/obj/item/rogueweapon/knuckles/getonmobprop(tag)
-	. = ..()
-	if(tag)
-		switch(tag)
-			if("gen")
-				return list("shrink" = 0.2,"sx" = -7,"sy" = -4,"nx" = 7,"ny" = -4,"wx" = -3,"wy" = -4,"ex" = 1,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 110,"sturn" = -110,"wturn" = -110,"eturn" = 110,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
-			if("onbelt")
-				return list("shrink" = 0.1,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
-
-/obj/item/rogueweapon/knuckles/bronzeknuckles
-	name = "bronze knuckles"
-	desc = "A mean looking pair of bronze knuckles. Mildly heavier than it's steel counterpart, making it a solid defensive option, if less wieldy."
-	force = 18
-	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
-	icon = 'icons/roguetown/weapons/32.dmi'
-	icon_state = "bronzeknuckle"
-	gripsprite = FALSE
-	wlength = WLENGTH_SHORT
-	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_HIP
-	parrysound = list('sound/combat/parry/pugilism/unarmparry (1).ogg','sound/combat/parry/pugilism/unarmparry (2).ogg','sound/combat/parry/pugilism/unarmparry (3).ogg')
-	sharpness = IS_BLUNT
-	max_integrity = 200
-	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
-	associated_skill = /datum/skill/combat/unarmed
-	throwforce = 12
-	wdefense = 6
-	wbalance = WBALANCE_HEAVY
-	anvilrepair = /datum/skill/craft/weaponsmithing
-	smeltresult = /obj/item/ingot/bronze
-
-/obj/item/rogueweapon/knuckles/aknuckles
-	name = "decrepit knuckles"
-	desc = "a set of knuckles made of ancient metals, Aeon's grasp wither their form."
-	icon_state = "aknuckle"
-	force = 12
-	max_integrity = 100
-	wdefense = 4
-	smeltresult = /obj/item/ingot/aalloy
-	blade_dulling = DULLING_SHAFT_CONJURED
-
-/obj/item/rogueweapon/knuckles/paknuckles
-	name = "ancient knuckles"
-	desc = "a set of knuckles made of ancient metals, Aeon's grasp has been lifted from their form."
-	icon_state = "aknuckle"
-	smeltresult = /obj/item/ingot/aaslag
-
-
-/obj/item/rogueweapon/knuckles/eora
-	name = "close caress"
-	desc = "Some times call for a more intimate approach."
-	force = 25
-	icon_state = "eoraknuckle"
-
 ///Peasantry / Militia Weapon Pack///
 
 /obj/item/rogueweapon/woodstaff/militia
@@ -477,7 +270,7 @@
 	light_outer_range = 5
 	light_on = FALSE
 	light_color = "#db892b"
-	var/is_loaded = FALSE 
+	var/is_loaded = FALSE
 	var/list/hay_types = list(/obj/structure/fluff/nest, /obj/structure/composter, /obj/structure/flora/roguegrass, /obj/item/reagent_containers/food/snacks/grown/wheat)
 
 /obj/item/rogueweapon/spear/militia/ComponentInitialize()
@@ -592,7 +385,7 @@
 					user.regenerate_icons()
 
 
-	
+
 /datum/component/ignitable/proc/on_examine(datum/source, mob/user, list/examine_list)
 	return
 

--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -51,6 +51,14 @@
 	icon_state = "insmash"
 	item_d_type = "blunt"
 
+//Knuckle utility. Use it to line up strikes. -2PER, -1LCK.
+//Open up a feint window with it. 10 seconds duration.
+/datum/intent/effect/daze/unarmed
+	attack_verb = list("strikes")
+	damfactor = 0.8
+	swingdelay = 8//Same as smash.
+	intent_effect = /datum/status_effect/debuff/dazed/unarmed
+
 /// INTENT DATUMS	^
 
 /obj/item/rogueweapon/katar
@@ -112,7 +120,6 @@
 	max_integrity = 120		//Steel dagger -30
 	force = 15		//Steel dagger -5
 	throwforce = 8
-	wdefense = 0	//Hell no!
 	thrown_bclass = BCLASS_STAB
 	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/thrust/pick)
 	icon_state = "plug"
@@ -128,7 +135,7 @@
 	name = "steel knuckles"
 	desc = "A mean looking pair of steel knuckles."
 	force = 21
-	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
+	possible_item_intents = list(/datum/intent/knuckles/strike, /datum/intent/knuckles/smash, /datum/intent/effect/daze/unarmed)
 	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "steelknuckle"
 	gripsprite = FALSE
@@ -160,23 +167,10 @@
 /obj/item/rogueweapon/knuckles/bronzeknuckles
 	name = "bronze knuckles"
 	desc = "A mean looking pair of bronze knuckles. Mildly heavier than it's steel counterpart."
-	force = 18
-	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
-	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "bronzeknuckle"
-	gripsprite = FALSE
-	wlength = WLENGTH_SHORT
-	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_HIP
-	parrysound = list('sound/combat/parry/pugilism/unarmparry (1).ogg','sound/combat/parry/pugilism/unarmparry (2).ogg','sound/combat/parry/pugilism/unarmparry (3).ogg')
-	sharpness = IS_BLUNT
+	force = 18
 	max_integrity = 200
-	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
-	associated_skill = /datum/skill/combat/unarmed
-	throwforce = 12
-	wdefense = 0	//Meant to be used with bracers
 	wbalance = WBALANCE_HEAVY
-	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/bronze
 
 /obj/item/rogueweapon/knuckles/aknuckles
@@ -185,7 +179,6 @@
 	icon_state = "aknuckle"
 	force = 12
 	max_integrity = 100
-	wdefense = 4
 	smeltresult = /obj/item/ingot/aalloy
 	blade_dulling = DULLING_SHAFT_CONJURED
 

--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -134,7 +134,7 @@
 /obj/item/rogueweapon/knuckles
 	name = "steel knuckles"
 	desc = "A mean looking pair of steel knuckles."
-	force = 21
+	force = 22
 	possible_item_intents = list(/datum/intent/knuckles/strike, /datum/intent/knuckles/smash, /datum/intent/effect/daze/unarmed)
 	icon = 'icons/roguetown/weapons/32.dmi'
 	icon_state = "steelknuckle"
@@ -148,7 +148,7 @@
 	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
 	associated_skill = /datum/skill/combat/unarmed
 	throwforce = 12
-	wdefense = 0	//Meant to be used with bracers
+	wdefense = 4	//Meant to be used with bracers. Temp for now.
 	wbalance = WBALANCE_NORMAL
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel
@@ -170,6 +170,7 @@
 	icon_state = "bronzeknuckle"
 	force = 18
 	max_integrity = 200
+	wdefense = 6	//Meant to be used with bracers. Temp for now.
 	wbalance = WBALANCE_HEAVY
 	smeltresult = /obj/item/ingot/bronze
 
@@ -191,7 +192,7 @@
 /obj/item/rogueweapon/knuckles/eora
 	name = "close caress"
 	desc = "Some times call for a more intimate approach."
-	force = 24
+	force = 25
 	icon_state = "eoraknuckle"
 
 /obj/item/rogueweapon/knuckles/psydon
@@ -203,12 +204,13 @@
 	. = ..()							//+3 force, +50 int, +1 def, make silver
 	add_psyblessed_component(is_preblessed = FALSE, bonus_force = 3, bonus_sharpness = 0, bonus_integrity = 50, bonus_wdef = 1, make_silver = TRUE)
 
-//This had 11 WD. No, thanks.
+//This has 11 WD. Eeeeugh....
 /obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct
 	name = "construct knuckles"
 	desc = "A vicous pair of bronze knuckles designed specifically for constructs. There is a terrifying, hollow spike in the center of the grip. There doesn't seem to be a way to wield it without impaling yourself."
 	color = "#5f1414"
 	max_integrity = 500
+	wdefense = 11	//Meant to be used with bracers. Temp for now.
 	anvilrepair = /datum/skill/craft/engineering
 
 /obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct/pickup(mob/living/user)

--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -202,3 +202,19 @@
 /obj/item/rogueweapon/knuckles/psydon/ComponentInitialize()
 	. = ..()							//+3 force, +50 int, +1 def, make silver
 	add_psyblessed_component(is_preblessed = FALSE, bonus_force = 3, bonus_sharpness = 0, bonus_integrity = 50, bonus_wdef = 1, make_silver = TRUE)
+
+//This had 11 WD. No, thanks.
+/obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct
+	name = "construct knuckles"
+	desc = "A vicous pair of bronze knuckles designed specifically for constructs. There is a terrifying, hollow spike in the center of the grip. There doesn't seem to be a way to wield it without impaling yourself."
+	color = "#5f1414"
+	max_integrity = 500
+	anvilrepair = /datum/skill/craft/engineering
+
+/obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct/pickup(mob/living/user)
+	if(!HAS_TRAIT(user, TRAIT_BLOODLOSS_IMMUNE))
+		to_chat(user, "<font color='purple'> You attempt to wield the knuckles. The spike sinks deeply into your hand, piercing it and drinking deep of your vital energies!</font>")
+		user.adjustBruteLoss(15)
+		user.Stun(40)
+		playsound(get_turf(user), 'sound/misc/drink_blood.ogg', 100)
+	..()

--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -1,0 +1,211 @@
+/// INTENT DATUMS	v
+
+/datum/intent/katar/cut
+	name = "cut"
+	icon_state = "incut"
+	attack_verb = list("cuts", "slashes")
+	animname = "cut"
+	blade_class = BCLASS_CUT
+	hitsound = list('sound/combat/hits/bladed/smallslash (1).ogg', 'sound/combat/hits/bladed/smallslash (2).ogg', 'sound/combat/hits/bladed/smallslash (3).ogg')
+	penfactor = 0
+	chargetime = 0
+	swingdelay = 0
+	clickcd = CLICK_CD_FAST
+	item_d_type = "slash"
+
+/datum/intent/katar/thrust
+	name = "thrust"
+	icon_state = "instab"
+	attack_verb = list("thrusts")
+	animname = "stab"
+	blade_class = BCLASS_STAB
+	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
+	penfactor = 40
+	chargetime = 0
+	clickcd = CLICK_CD_FAST
+	item_d_type = "stab"
+
+/datum/intent/knuckles/strike
+	name = "punch"
+	blade_class = BCLASS_BLUNT
+	attack_verb = list("punches", "clocks")
+	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
+	chargetime = 0
+	penfactor = BLUNT_DEFAULT_PENFACTOR
+	clickcd = CLICK_CD_FAST
+	damfactor = 1.1
+	swingdelay = 0
+	icon_state = "inpunch"
+	item_d_type = "blunt"
+
+/datum/intent/knuckles/smash
+	name = "smash"
+	blade_class = BCLASS_SMASH
+	attack_verb = list("smashes")
+	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
+	penfactor = BLUNT_DEFAULT_PENFACTOR
+	damfactor = 1.1
+	clickcd = CLICK_CD_MELEE
+	swingdelay = 8
+	intent_intdamage_factor = 1.35
+	icon_state = "insmash"
+	item_d_type = "blunt"
+
+/// INTENT DATUMS	^
+
+/obj/item/rogueweapon/katar
+	slot_flags = ITEM_SLOT_HIP
+	force = 18//Two more than a punch dagger.
+	possible_item_intents = list(/datum/intent/katar/cut, /datum/intent/katar/thrust)
+	name = "katar"
+	desc = "A blade that sits above the users fist. Commonly used by those proficient at unarmed fighting"
+	icon_state = "katar"
+	icon = 'icons/roguetown/weapons/32.dmi'
+	gripsprite = FALSE
+	wlength = WLENGTH_SHORT
+	w_class = WEIGHT_CLASS_SMALL
+	parrysound = list('sound/combat/parry/bladed/bladedsmall (1).ogg','sound/combat/parry/bladed/bladedsmall (2).ogg','sound/combat/parry/bladed/bladedsmall (3).ogg')
+	max_blade_int = 200
+	max_integrity = 120
+	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
+	associated_skill = /datum/skill/combat/unarmed
+	pickup_sound = 'sound/foley/equip/swordsmall2.ogg'
+	throwforce = 12
+	wdefense = 0	//Meant to be used with bracers
+	wbalance = WBALANCE_SWIFT
+	thrown_bclass = BCLASS_CUT
+	anvilrepair = /datum/skill/craft/weaponsmithing
+	smeltresult = /obj/item/ingot/steel
+	grid_height = 64
+	grid_width = 32
+	sharpness_mod = 2	//Can't parry, so it decays quicker on-hit.
+
+/obj/item/rogueweapon/katar/getonmobprop(tag)
+	. = ..()
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.4,"sx" = -7,"sy" = -4,"nx" = 7,"ny" = -4,"wx" = -3,"wy" = -4,"ex" = 1,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 110,"sturn" = -110,"wturn" = -110,"eturn" = 110,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+			if("onbelt")
+				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
+/obj/item/rogueweapon/katar/abyssor
+	name = "barotrauma"
+	desc = "A gift from a creature of the sea. The claw is sharpened to a wicked edge."
+	icon_state = "abyssorclaw"
+	force = 21	//Its thrust will be able to pen 80 stab armor if the wielder has 17 STR. (With softcap)
+	max_integrity = 120
+
+/obj/item/rogueweapon/katar/psydon
+	name = "psydonian katar"
+	desc = "An exotic weapon taken from the hands of wandering monks, an esoteric design to the Otavan Orthodoxy. Special care was taken into account towards the user's knuckles: silver-tipped steel from tip to edges, and His holy cross reinforcing the heart of the weapon, with curved shoulders to allow its user to deflect incoming blows - provided they lead it in with the blade."
+	icon_state = "psykatar"
+
+/obj/item/rogueweapon/katar/psydon/ComponentInitialize()
+	. = ..()							//+3 force, +50 int, +1 def, make silver
+	add_psyblessed_component(is_preblessed = FALSE, bonus_force = 3, bonus_sharpness = 0, bonus_integrity = 50, bonus_wdef = 1, make_silver = TRUE)
+
+/obj/item/rogueweapon/katar/punchdagger
+	name = "punch dagger"
+	desc = "A weapon that combines the ergonomics of the Ranesheni katar with the capabilities of the Western Psydonian \"knight-killers\". It can be tied around the wrist."
+	slot_flags = ITEM_SLOT_WRISTS
+	max_integrity = 120		//Steel dagger -30
+	force = 15		//Steel dagger -5
+	throwforce = 8
+	wdefense = 0	//Hell no!
+	thrown_bclass = BCLASS_STAB
+	possible_item_intents = list(/datum/intent/dagger/thrust, /datum/intent/dagger/thrust/pick)
+	icon_state = "plug"
+
+/obj/item/rogueweapon/katar/punchdagger/frei
+	name = "vývrtka"
+	desc = "A type of punch dagger of Aavnic make initially designed to level the playing field with an orc in fisticuffs, its serrated edges and longer, thinner point are designed to maximize pain for the recipient. It's aptly given the name of \"corkscrew\", and this specific one has the colours of Szöréndnížina. Can be worn on your ring slot."
+	icon_state = "freiplug"
+	slot_flags = ITEM_SLOT_RING
+
+//TODO: Add caestus, for an unarmed option with defence.
+/obj/item/rogueweapon/knuckles
+	name = "steel knuckles"
+	desc = "A mean looking pair of steel knuckles."
+	force = 21
+	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
+	icon = 'icons/roguetown/weapons/32.dmi'
+	icon_state = "steelknuckle"
+	gripsprite = FALSE
+	wlength = WLENGTH_SHORT
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = ITEM_SLOT_HIP
+	parrysound = list('sound/combat/parry/pugilism/unarmparry (1).ogg','sound/combat/parry/pugilism/unarmparry (2).ogg','sound/combat/parry/pugilism/unarmparry (3).ogg')
+	sharpness = IS_BLUNT
+	max_integrity = 150
+	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
+	associated_skill = /datum/skill/combat/unarmed
+	throwforce = 12
+	wdefense = 0	//Meant to be used with bracers
+	wbalance = WBALANCE_NORMAL
+	anvilrepair = /datum/skill/craft/weaponsmithing
+	smeltresult = /obj/item/ingot/steel
+	grid_width = 64
+	grid_height = 32
+
+/obj/item/rogueweapon/knuckles/getonmobprop(tag)
+	. = ..()
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.2,"sx" = -7,"sy" = -4,"nx" = 7,"ny" = -4,"wx" = -3,"wy" = -4,"ex" = 1,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 110,"sturn" = -110,"wturn" = -110,"eturn" = 110,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+			if("onbelt")
+				return list("shrink" = 0.1,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+
+/obj/item/rogueweapon/knuckles/bronzeknuckles
+	name = "bronze knuckles"
+	desc = "A mean looking pair of bronze knuckles. Mildly heavier than it's steel counterpart."
+	force = 18
+	possible_item_intents = list(/datum/intent/knuckles/strike,/datum/intent/knuckles/smash)
+	icon = 'icons/roguetown/weapons/32.dmi'
+	icon_state = "bronzeknuckle"
+	gripsprite = FALSE
+	wlength = WLENGTH_SHORT
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = ITEM_SLOT_HIP
+	parrysound = list('sound/combat/parry/pugilism/unarmparry (1).ogg','sound/combat/parry/pugilism/unarmparry (2).ogg','sound/combat/parry/pugilism/unarmparry (3).ogg')
+	sharpness = IS_BLUNT
+	max_integrity = 200
+	swingsound = list('sound/combat/wooshes/punch/punchwoosh (1).ogg','sound/combat/wooshes/punch/punchwoosh (2).ogg','sound/combat/wooshes/punch/punchwoosh (3).ogg')
+	associated_skill = /datum/skill/combat/unarmed
+	throwforce = 12
+	wdefense = 0	//Meant to be used with bracers
+	wbalance = WBALANCE_HEAVY
+	anvilrepair = /datum/skill/craft/weaponsmithing
+	smeltresult = /obj/item/ingot/bronze
+
+/obj/item/rogueweapon/knuckles/aknuckles
+	name = "decrepit knuckles"
+	desc = "a set of knuckles made of ancient metals, Aeon's grasp wither their form."
+	icon_state = "aknuckle"
+	force = 12
+	max_integrity = 100
+	wdefense = 4
+	smeltresult = /obj/item/ingot/aalloy
+	blade_dulling = DULLING_SHAFT_CONJURED
+
+/obj/item/rogueweapon/knuckles/paknuckles
+	name = "ancient knuckles"
+	desc = "a set of knuckles made of ancient metals, Aeon's grasp has been lifted from their form."
+	icon_state = "aknuckle"
+	smeltresult = /obj/item/ingot/aaslag
+
+/obj/item/rogueweapon/knuckles/eora
+	name = "close caress"
+	desc = "Some times call for a more intimate approach."
+	force = 24
+	icon_state = "eoraknuckle"
+
+/obj/item/rogueweapon/knuckles/psydon
+	name = "psydonian knuckles"
+	desc = "A simple piece of harm molded in a holy mixture of steel and silver, finished with three stumps - Psydon's crown - to crush the heretics' garments and armor into smithereens."
+	icon_state = "psyknuckle"
+
+/obj/item/rogueweapon/knuckles/psydon/ComponentInitialize()
+	. = ..()							//+3 force, +50 int, +1 def, make silver
+	add_psyblessed_component(is_preblessed = FALSE, bonus_force = 3, bonus_sharpness = 0, bonus_integrity = 50, bonus_wdef = 1, make_silver = TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -64,7 +64,7 @@
 			beltr = /obj/item/rogueweapon/knuckles
 		if ("Punch Dagger")
 			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
-			beltr = /obj/item/rogueweapon/katar/punchdagger
+			r_hand = /obj/item/rogueweapon/katar/punchdagger
 		if ("MY BARE HANDS!!!")
 			H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
 			ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)

--- a/code/modules/mob/living/carbon/human/npc/zizoconstruct.dm
+++ b/code/modules/mob/living/carbon/human/npc/zizoconstruct.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(zizoconstruct_aggro, world.file2list("strings/rt/zconstructaggr
 	gender = pick(MALE, FEMALE)
 	regenerate_icons()
 	skin_tone = "e2a670"
-	
+
 	if(gender == FEMALE)
 		real_name = pick("Bronze Construct")
 	else
@@ -79,22 +79,6 @@ GLOBAL_LIST_INIT(zizoconstruct_aggro, world.file2list("strings/rt/zconstructaggr
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
-
-/obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct //I have no unarmed and I must parry. More interesting than defprob and gives construct PC a fun item to loot and use
-	name = "construct knuckles"
-	desc = "A vicous pair of bronze knuckles designed specifically for constructs. There is a terrifying, hollow spike in the center of the grip. There doesn't seem to be a way to wield it without impaling yourself."
-	wdefense = 11
-	color = "#5f1414"
-	max_integrity = 500
-	anvilrepair = /datum/skill/craft/engineering
-
-/obj/item/rogueweapon/knuckles/bronzeknuckles/zizoconstruct/pickup(mob/living/user)
-	if(!HAS_TRAIT(user, TRAIT_BLOODLOSS_IMMUNE))
-		to_chat(user, "<font color='purple'> You attempt to wield the knuckles. The spike sinks deeply into your hand, piercing it and drinking deep of your vital energies!</font>")
-		user.adjustBruteLoss(15)
-		user.Stun(40)
-		playsound(get_turf(user), 'sound/misc/drink_blood.ogg', 100) 
-	..()
 
 /obj/item/clothing/suit/roguetown/armor/skin_armor/zizoconstructarmor //ww armor but for construct
 	slot_flags = SHIRT_LAYER

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1023,6 +1023,7 @@
 #include "code\game\objects\items\rogueweapons\melee\polearms.dm"
 #include "code\game\objects\items\rogueweapons\melee\special.dm"
 #include "code\game\objects\items\rogueweapons\melee\swords.dm"
+#include "code\game\objects\items\rogueweapons\melee\unarmed.dm"
 #include "code\game\objects\items\rogueweapons\melee\whip.dm"
 #include "code\game\objects\items\rogueweapons\ranged\ammo.dm"
 #include "code\game\objects\items\rogueweapons\ranged\bows.dm"


### PR DESCRIPTION
## About The Pull Request
Modifies some of the most polarizing weapons, by far.

~~All unarmed given 0 WDefense. Bracers serve this purpose.
My concern with that change was brass knuckles, but they've higher integrity and heavy weight, so they should be fine. I guess? It's not like anyone used them as is. We really need to add caestus, for a proper unarmed defensive option that doesn't use bracers.~~

In general, the changes below should make unarmed specific weapons not as absurd while still being viable. We can number tweak them further, especially if the damage is too low, but they were fine in testing. The DPS decrease, alongside the base damage, serves to make them reasonable, and not just swift intent nose spam knockout clubs. In regards to the katar, that is. Knuckles having defence values was odd, given bracers serve for that with unarmed.

Finally, this wraps them all into their own weapon file, so it's not as difficult to navigate, and fixes berserker punch dagger spawns.

Anyhow, here's the raw stuff below.
For katars:
 - Katar cut lost damage increase.
 - Katar thrust and cut now has a cooldown of 8, as opposed to 6. Same as a dagger.
 - Katar's damage dropped from 24 to 18. Punch dagger's was 15 by comparison.
 - Katar integrity raised to 120, from 80. Identical to punch dagger.
 - Barotrauma from 27 to 21.

For knuckles:
 - ~~Knuckles dropped 1 point of damage.~~
 - ~~Close Caress dropped 1 point of damage.~~
 - ~~Given a unique daze intent as tradeoff for the loss of defence.~~ Same functionality as maces. -2INT, -1FOR. 10 seconds. 20% less damage, same strike time as smash. Used for opening a parry window. Should give them more use.

## Testing Evidence
Lotta number changes. Spawned in and it worked for the Berserker fix. Weapons tested fine locally. Not really sure how you'd want me to document that.

## Why It's Good For The Game
Katars are, by far, the best weapon in the game. Hands down. No competition. You can take on an entire crowd and win without contest just by aiming nose. You don't even need swift intent. Templar Monks are an incredible example of a meta class that makes use of this. Berserker Wretches are even worse, spawning with a katar as is. There's no variety for unarmed. Knuckles are pointless by comparison.
Not to mention that katars had their own unique cooldown of SIX(6!!!!), compared to contemporaries (daggers) having EIGHT(8!!!!). So with them unified in cooldown for thrust, it shouldn't be as nutty.

~~The only weapons unarmed wise to retain their defence are Psydonite unarmed weapons, and that's a basic +1. Nothing great, but it still makes them stand out by being the only weapons in the lineup with defensive value. For however little.~~