### PR TITLE
Ports SR Thug subclasses

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -39,7 +39,7 @@
 			H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 			H.adjust_skillrank(/datum/skill/misc/stealing, 3, TRUE)
 			H.change_stat("strength", 2)
-			H.change_stat("endurance", 1)
+			H.change_stat("willpower", 1)
 			H.change_stat("constitution", 3)
 			H.change_stat("speed", -1)
 			H.change_stat("intelligence", -1)


### PR DESCRIPTION
## About The Pull Request

Mostly copies the thug rework done here https://github.com/Scarlet-Reach/Scarlet-Reach/pull/829
Slightly changes the description to include petty crimes, and replaces the Axe option with with a big club. More flavourful and less of an escalation-into-murder.
Also removes the option to spawn with a random weapon because it was completely bugged.

## Testing Evidence

<img width="1262" height="764" alt="image" src="https://github.com/user-attachments/assets/e2f49000-5361-40ff-9b63-f88912f3d16b" />


## Why It's Good For The Game

The subclasses are fun and flavourful, and it's good to encourage some low level thuggery that all deadly foreign wandering badasses in fullplate.