### PR TITLE
Adds TRAIT_PONYGIRL_RIDEABLE as a virtue

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -74,7 +74,7 @@
 #define TRAIT_HERESIARCH "Forbidden Knowledge" //allows entry to ascendant church
 #define TRAIT_DREAMWALKER "Dreamwalker"
 #define TRAIT_JACKOFALLTRADES "Jack of All Trades"	//Reduces skill up cost
-#define TRAIT_PONYGIRL_RIDEABLE "Slave" //riding
+#define TRAIT_PONYGIRL_RIDEABLE "Mount" //riding
 #define TRAIT_BLACKLEG	"Blackleg" //Rig coin flips and dice. Fluvian exclusive.
 
 //Hearthstone port (Tracking)
@@ -382,7 +382,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_RACISMISBAD = span_warning("The Black Oaks can spot ANY Foreigners and Outsiders, no matter how long they've lived in the vale. This is an easy skill to master, as it is simply identifying who isn't an elf."),
 	TRAIT_HERESIARCH = span_warning("I know of sacred sites of worship where followers of the Ascendants convene, and the path to the nearest conclave is etched into my memory."),
 	TRAIT_GOODWRITER = span_notice("I'm proficient at writing. Any skillbooks made by me will allow the reader to learn the subject more quickly."),
-	TRAIT_PONYGIRL_RIDEABLE = span_notice("They stripped me of pride and gave me reins; I exist now only to carry anothers weight."),
+	TRAIT_PONYGIRL_RIDEABLE = span_notice("Willing or not, I've been trained to carry other peoples' burdens."),
 	TRAIT_VENOMOUS = span_necrosis("I am venomous. When chewing someone I've bitten, I will inject venom."),
 	TRAIT_COMBAT_AWARE = span_notice("My honed senses and intuition allow me to spot notable things in the midst of battle with ease."),
 	TRAIT_DREAMWALKER = span_warning("I walk the dream and reality at the same time. My mind frays, but my vision shall be reality."),

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -382,7 +382,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_RACISMISBAD = span_warning("The Black Oaks can spot ANY Foreigners and Outsiders, no matter how long they've lived in the vale. This is an easy skill to master, as it is simply identifying who isn't an elf."),
 	TRAIT_HERESIARCH = span_warning("I know of sacred sites of worship where followers of the Ascendants convene, and the path to the nearest conclave is etched into my memory."),
 	TRAIT_GOODWRITER = span_notice("I'm proficient at writing. Any skillbooks made by me will allow the reader to learn the subject more quickly."),
-	TRAIT_PONYGIRL_RIDEABLE = span_notice("Willing or not, I've been trained to carry other peoples' burdens."),
+	TRAIT_PONYGIRL_RIDEABLE = span_notice("Willing or not, I've been trained to carry other people's burdens."),
 	TRAIT_VENOMOUS = span_necrosis("I am venomous. When chewing someone I've bitten, I will inject venom."),
 	TRAIT_COMBAT_AWARE = span_notice("My honed senses and intuition allow me to spot notable things in the midst of battle with ease."),
 	TRAIT_DREAMWALKER = span_warning("I walk the dream and reality at the same time. My mind frays, but my vision shall be reality."),

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -365,3 +365,8 @@
 	name = "Heresiarch"
 	desc = "The 'Holy' See has their blood-stained grounds, and so do we. Underneath their noses, we pray to the true gods - I know the location of the local heretic conclave. Secrecy is paramount. If found out, I will surely be killed."
 	added_traits = list(TRAIT_HERESIARCH)
+
+/datum/virtue/utility/mountable
+	name = "Mountable"
+	desc = "You have trained or been trained into a suitable mount. People may ride you as they would a saiga."
+	added_traits = list(TRAIT_PONYGIRL_RIDEABLE)


### PR DESCRIPTION
## About The Pull Request

I've been wanting to play a proper centaur knight who can be ridden into battle. It's not really possible with current systems; this fixes that without forcing all taurs to be mountable. I also changed the former name/description to be more open ended.

## Testing Evidence

**Mounted**
<img width="382" height="273" alt="image" src="https://github.com/user-attachments/assets/9cfe8089-95bd-48a5-aaba-a916e55c927a" />

**List**
<img width="306" height="196" alt="image" src="https://github.com/user-attachments/assets/0c0cef2f-fbe9-4719-aa6e-db1535ef592c" />

**Description Change**
<img width="505" height="114" alt="image" src="https://github.com/user-attachments/assets/12dd3b5d-ebe2-4ab9-af38-c73265dc9d9b" />


## Why It's Good For The Game

People have been wanting rideable centaurs for awhile. This is a simple solution - sacrifices a virtue slot for the player but it's worth it to those who want to play the archetype. It'll add more gameplay and roleplay options to taur characters, I imagine centaurs specifically. Technically anyone can take this ... but if a bipedal wants to, that's their prerogative.