### PR TITLE
Buffs for Witch towner subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -5,7 +5,7 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/witch
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)
-	traits_applied = list(TRAIT_DEATHSIGHT, TRAIT_WITCH, TRAIT_ARCYNE_T2)
+	traits_applied = list(TRAIT_DEATHSIGHT, TRAIT_WITCH, TRAIT_ARCYNE_T1)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_SPD = 2,
@@ -38,7 +38,8 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/arcynebolt)
-		H.mind.adjust_spellpoints(14)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
+		H.mind.adjust_spellpoints(9)
 	if(H.gender == FEMALE)
 		armor = /obj/item/clothing/suit/roguetown/armor/corset
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut
@@ -49,7 +50,7 @@
 	H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/magic/arcane, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 2, TRUE)
 	if(H.age == AGE_OLD)


### PR DESCRIPTION
## About The Pull Request

After Witch - understandably - had their zad form removed pending a rework, currently, in my opinion, witch is in a terrible and deplorable state, outclassed by other mages and pretty much has nothing going for it except for magic missile and a few things. This aims to change it.

Gives witch Message spell.

Gives witch 9 spells points ( was 6 )


## Testing Evidence

It's just number changes.

## Why It's Good For The Game

Witch, understandably, was hard nerfed due to Zad form being arguably incredibly overpowered and unfun to play against. Now, though, it's got very little going on for it. I wouldn't go as far as to say it's potter level of useless, but it definitely feels gutted. This should bring some love back to it.

