### PR TITLE
Better descriptors

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -238,10 +238,10 @@ Turf and target are separate in case you want to teleport some distance from a t
 			continue
 		if(M.client && M.client.holder && M.client.holder.fakekey) //stealthmins
 			continue
-		var/name = avoid_assoc_duplicate_keys(M.name, namecounts)
+		var/name = avoid_assoc_duplicate_keys(M.real_name, namecounts)
 
 		if(M.real_name && M.real_name != M.name)
-			name += " \[[M.real_name]\]"
+			name += " \[[M.name]\]"
 		if(M.stat == DEAD)
 			continue
 		pois[name] = M
@@ -251,7 +251,7 @@ Turf and target are separate in case you want to teleport some distance from a t
 			if(!A || !A.loc)
 				continue
 			pois[avoid_assoc_duplicate_keys(A.name, namecounts)] = A
-
+	pois = sort_list(pois)
 	return pois
 //Orders mobs by type then by name
 /proc/sortmobs()

--- a/code/_onclick/hud/mouseover.dm
+++ b/code/_onclick/hud/mouseover.dm
@@ -152,7 +152,7 @@
 		if(ishuman(src))
 			var/mob/living/carbon/human/H = src
 			if(H.voice_color)
-				if(H.name != "Unknown")
+				if(H.name == H.real_name)
 					mousecolor = "#[H.voice_color]"
 		p.client.mouseovertext.maptext = {"<span style='font-size:8pt;font-family:"Pterra";color:[mousecolor];text-shadow:0 0 10px #fff, 0 0 20px #fff, 0 0 30px #e60073, 0 0 40px #e60073, 0 0 50px #e60073, 0 0 60px #e60073, 0 0 70px #e60073;' class='center maptext '>[name]"}
 		p.client.mouseovertext.movethis(PM)

--- a/code/datums/mob_descriptors/descriptors/height.dm
+++ b/code/datums/mob_descriptors/descriptors/height.dm
@@ -26,3 +26,7 @@
 /datum/mob_descriptor/height/tiny
 	name = "Tiny"
 	prefix = "a"
+	
+/datum/mob_descriptor/height/giant
+	name = "Giant"
+	prefix = "a"

--- a/code/datums/mob_descriptors/descriptors/prominent.dm
+++ b/code/datums/mob_descriptors/descriptors/prominent.dm
@@ -366,3 +366,7 @@
 /datum/mob_descriptor/prominent/vulpine_features
 	name = "Vulpine Features"
 	verbage = "%HAVE%"
+
+/datum/mob_descriptor/prominent/prominent_ears
+	name = "Prominent Ears"
+	verbage = "%HAVE%"

--- a/code/datums/mob_descriptors/descriptors/stature.dm
+++ b/code/datums/mob_descriptors/descriptors/stature.dm
@@ -156,3 +156,33 @@
 
 /datum/mob_descriptor/stature/dignitary
 	name = "Dignitary"
+
+/datum/mob_descriptor/stature/degenerate
+	name = "Degenerate"
+
+/datum/mob_descriptor/stature/zealot
+	name = "Zealot"
+
+/datum/mob_descriptor/stature/churl
+	name = "Churl"
+
+/datum/mob_descriptor/stature/archon
+	name = "Archon"
+
+/datum/mob_descriptor/stature/vizier
+	name = "Vizier"
+
+/datum/mob_descriptor/stature/blaggard
+	name = "Blaggard"
+
+/datum/mob_descriptor/stature/creep
+	name = "Creep"
+
+/datum/mob_descriptor/stature/freek
+	name = "Freek"
+
+/datum/mob_descriptor/stature/weerdoe
+	name = "Weerdoe"
+
+/datum/mob_descriptor/stature/plump
+	name = "Plump figure"

--- a/code/modules/client/descriptors/descriptor_choice.dm
+++ b/code/modules/client/descriptors/descriptor_choice.dm
@@ -123,6 +123,8 @@
 		/datum/mob_descriptor/stature/patriarch,
 		/datum/mob_descriptor/stature/villain,
 		/datum/mob_descriptor/stature/thug,
+		/datum/mob_descriptor/stature/knave,
+		/datum/mob_descriptor/stature/wench,
 		/datum/mob_descriptor/stature/snob,
 		/datum/mob_descriptor/stature/slob,
 		/datum/mob_descriptor/stature/brute,
@@ -135,6 +137,7 @@
 		/datum/mob_descriptor/stature/fiend,
 		/datum/mob_descriptor/stature/adventurer,
 		/datum/mob_descriptor/stature/valiant,
+		/datum/mob_descriptor/stature/plump,
 		/datum/mob_descriptor/stature/daredevil,
 		/datum/mob_descriptor/stature/stoic,
 		/datum/mob_descriptor/stature/stooge,
@@ -142,6 +145,15 @@
 		/datum/mob_descriptor/stature/bookworm,
 		/datum/mob_descriptor/stature/lowlife,
 		/datum/mob_descriptor/stature/dignitary,
+		/datum/mob_descriptor/stature/degenerate,
+		/datum/mob_descriptor/stature/zealot,
+		/datum/mob_descriptor/stature/churl,
+		/datum/mob_descriptor/stature/archon,
+		/datum/mob_descriptor/stature/vizier,
+		/datum/mob_descriptor/stature/blaggard,
+		/datum/mob_descriptor/stature/creep,
+		/datum/mob_descriptor/stature/freek,
+		/datum/mob_descriptor/stature/weerdoe,
 	)
 
 /datum/descriptor_choice/voice
@@ -255,6 +267,7 @@
 		/datum/mob_descriptor/height/short,
 		/datum/mob_descriptor/height/towering,
 		/datum/mob_descriptor/height/tiny,
+		/datum/mob_descriptor/height/giant,
 	)
 
 /datum/descriptor_choice/skin_all

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -52,14 +52,16 @@
 		"Unknown Man",
 		"Unknown Woman",
 	)
-	if(get_visible_name() in unknown_names)
+	if(get_face_name() != real_name)
 		obscure_name = TRUE
 
 	if(observer_privilege)
 		obscure_name = FALSE
 
-	if(obscure_name)
-		. = list(span_info("ø ------------ ø\nThis is <EM>Unknown</EM>."))
+	if(name in unknown_names)
+		. = list(span_info("ø ------------ ø\nThis is <EM>[name]</EM>."))
+	else if(obscure_name)
+		. = list(span_info("ø ------------ ø\nThis is an unknown <EM>[name]</EM>."))
 	else
 		on_examine_face(user)
 		var/used_name = name
@@ -862,7 +864,7 @@
 
 
 	var/list/lines
-	if(get_visible_name() in unknown_names)
+	if((get_face_name() != real_name) && !observer_privilege)
 		lines = build_cool_description_unknown(get_mob_descriptors_unknown(obscure_name, user), src)
 	else
 		lines = build_cool_description(get_mob_descriptors(obscure_name, user), src)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -44,6 +44,12 @@
 		return face_name
 	if(id_name)
 		return id_name
+	var/list/d_list = get_mob_descriptors()
+	var/height_desc = "[capitalize(build_coalesce_description_nofluff(d_list, src, list(MOB_DESCRIPTOR_SLOT_HEIGHT), "%DESC1%"))]"
+	var/stature_desc = "[capitalize(build_coalesce_description_nofluff(d_list, src, list(MOB_DESCRIPTOR_SLOT_STATURE), "%DESC1%"))]"
+	var/descriptor_name = "[height_desc] [stature_desc]"
+	if(descriptor_name != " ")
+		return descriptor_name
 	return "Unknown"
 
 //Returns "Unknown" if facially disfigured and real_name if not. Useful for setting name when Fluacided or when updating a human's name variable


### PR DESCRIPTION
## About The Pull Request
Better description for players with mask/hood
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Maintainer edit: Port of https://github.com/Scarlet-Reach/Scarlet-Reach/pull/851
## Testing Evidence
Few examples:
<img width="156" height="113" alt="image" src="https://github.com/user-attachments/assets/e2ae75a4-f401-4bd7-8762-159491e94645" />
<img width="250" height="30" alt="image" src="https://github.com/user-attachments/assets/4deb9a06-df3c-4c04-8d47-997f22688ee9" />

<img width="137" height="115" alt="image" src="https://github.com/user-attachments/assets/cf54ea09-addc-4685-b70a-44a579b91684" />
<img width="87" height="108" alt="image" src="https://github.com/user-attachments/assets/20dab0f8-ee1a-43e4-b029-e4c1859417cb" />
<img width="388" height="44" alt="image" src="https://github.com/user-attachments/assets/8395ab59-68c6-4a45-ac14-1e04af62838b" />


Examining from observer bypass it:
<img width="385" height="44" alt="image" src="https://github.com/user-attachments/assets/ca9eddbc-1420-4a09-9283-b68349bdce5e" />



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Easy to tell someone's height and how they look within a single mouse swing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
