### PR TITLE
Adds Honey to Stockpile

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile_food.dm
+++ b/code/modules/roguetown/roguestock/stockpile_food.dm
@@ -170,6 +170,20 @@
 	passive_generation = 1
 	category = "Foodstuffs"
 
+/datum/roguestock/stockpile/honey
+	name = "Honey"
+	desc = "Sweet sweet honey that decays into sugar. Has antibacterial and natural healing properties."
+	item_type = /obj/item/reagent_containers/food/snacks/rogue/honey
+	held_items = list(0, 0)
+	payout_price = 6
+	withdraw_price = 6
+	transport_fee = 3
+	export_price = 9
+	importexport_amt = 5
+	stockpile_limit = 25
+	passive_generation = 1
+	category = "Foodstuffs"
+
 /datum/roguestock/stockpile/cheese
 	name = "Cheese"
 	desc = "The product of milk and salt."


### PR DESCRIPTION
## About The Pull Request

An odd oversight; cannot sell honey in the stockpile (or import it from nervemaster)! Beekeepers weep. This fixes it. I don't know a lot about pricing, so I asked someone who does apiaries - they suggested 6 mammons, so I went with 6 mammons. I extrapolated the other numbers based on other foodstuff entries. If it proves too powerful (somehow), we can always adjust.

## Testing Evidence

**Stockpile**
<img width="342" height="54" alt="image" src="https://github.com/user-attachments/assets/c588a424-1d3c-4551-9122-e3ab33fb391e" />

**Nervemaster**
<img width="512" height="25" alt="image" src="https://github.com/user-attachments/assets/79972621-6c33-437b-903d-a5c301880d3b" />

**Proof of Capitalism**
<img width="1200" height="603" alt="image" src="https://github.com/user-attachments/assets/c8b8c08e-6ca1-46d9-ac93-fc6ffaa1c662" />


## Why It's Good For The Game

Our Soilsons and brides are hard workers. They deserve to earn money from any agricultural source they dare endeavor to; honey included! This also helps druids or beespider tamers, as spider honey is now able to be stockpiled (though cannot be withdrawn as spider honey). 