### PR TITLE
Wretch PQ + Respawns

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -12,7 +12,7 @@
 	outfit_female = null
 	display_order = JDO_WRETCH
 	show_in_credits = FALSE
-	min_pq = 20
+	min_pq = 60//Three slots. Intended for round progression. Lunatic at 100, Martyr at 10.
 	max_pq = null
 
 	obsfuscated_job = TRUE
@@ -25,7 +25,7 @@
 	wanderer_examine = TRUE
 	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
-	job_reopens_slots_on_death = TRUE
+	job_reopens_slots_on_death = FALSE//Haha! No. Stop. No endless waves of better adventurers, thanks.
 	same_job_respawn_delay = 1 MINUTES
 	virtue_restrictions = list(/datum/virtue/heretic/zchurch_keyholder) //all wretch classes automatically get this
 	carebox_table = /datum/carebox_table/wretch


### PR DESCRIPTION
## About The Pull Request
Simply removes slots opening on Wretch death, and jumps the PQ requirement to a staggering 60. Up from 20. Nearest highest is Lunatic at 100, and Martyr at 10 below both, IIRC.

We don't want new folks playing this. At all. Spawning armour roundstart and rushing into town is cringe and you should stop. Play other roles, such as bandit, to get a feel for antag. You're intended to progress the round and contribute in a meaningful way. You get the tools to do serious damage when you're trusted and gain enough PQ.

It's not as if PQ is hard to get either. This is just a gate so we don't have new friends stumbling into it and being dumb.
## Testing Evidence
It just works.
## Why It's Good For The Game
Read above.
New players should not have access to tools such as heretical major regen casters who get rites and such. They complain too much about dying immediately in the armour after being valid, or don't actually understand the role.
Wretch drives the tempo and happenings of events within round, and is something we want experienced players to be doing.