### PR TITLE
Funny Prayer Logging & Peel Wording

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -134,7 +134,7 @@
 /datum/intent/partizan/peel
 	name = "armor peel"
 	icon_state = "inpeel"
-	attack_verb = list("snags")
+	attack_verb = list("<font color ='#e7e7e7'>strongly peels</font>")
 	animname = "cut"
 	blade_class = BCLASS_PEEL
 	hitsound = list('sound/combat/hits/blunt/metalblunt (1).ogg', 'sound/combat/hits/blunt/metalblunt (2).ogg', 'sound/combat/hits/blunt/metalblunt (3).ogg')

--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -148,6 +148,7 @@
 
 //Old partizan peel, for the naginata.
 /datum/intent/partizan/peel/nag
+	attack_verb = list("<font color ='#e7e7e7'>peels</font>")
 	swingdelay = 5
 	peel_divisor = 4
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -88,6 +88,7 @@
 
 /datum/intent/sword/peel/big
 	name = "big sword armor peel"
+	attack_verb = list("<font color ='#e7e7e7'>weakly peels</font>")
 	reach = 2
 	peel_divisor = 5
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -31,7 +31,7 @@
 	var/prayer = input("Whisper your prayer:", "Prayer") as text|null
 	if(!prayer)
 		return
-	
+
 	//If God can hear your prayer (long enough, no bad words, etc.)
 	if(patron.hear_prayer(follower, prayer))
 		if(follower.has_flaw(/datum/charflaw/addiction/godfearing))
@@ -1811,13 +1811,13 @@
 	set category = "Noises"
 
 	emote("yip", intentional = TRUE)
-	
+
 /datum/emote/living/praysuicide
     key = "praysuicide"
     key_third_person = "utters their last words"
-    message = ""                   
+    message = ""
     emote_type = EMOTE_AUDIBLE
-    stat_allowed = UNCONSCIOUS      
+    stat_allowed = UNCONSCIOUS
     show_runechat = FALSE
 
 /mob/living/carbon/human/verb/emote_praysuicide()
@@ -1826,32 +1826,33 @@
     emote("praysuicide", intentional = TRUE)
 
 /datum/emote/living/praysuicide/run_emote(mob/user, params, type_override, intentional)
-    if(!user)
-        return FALSE
+	if(!user)
+		return FALSE
 
-    var/mob/living/L = user
+	var/mob/living/L = user
 
+	to_chat(L, span_danger("I pray to my patron for my death... and I am heard."))
 
-    to_chat(L, span_danger("I pray to my patron for my death... and I am heard."))
+	var/lastmsg = params
+	if(!lastmsg)
+		lastmsg = input("Whisper your final words:", "Last Words") as text|null
+	if(!lastmsg)
+		return FALSE
 
+	L.whisper(lastmsg)
+	var/msg = "[key_name(L)] has prayed for suicide! Their last words: [lastmsg]"
+	message_admins(msg)
+	log_admin(msg)
 
-    var/lastmsg = params
-    if(!lastmsg)
-        lastmsg = input("Whisper your final words:", "Last Words") as text|null
-    if(!lastmsg)
-        return FALSE
+	if(iscarbon(L))
+		var/mob/living/carbon/C = L
+		C.adjustOxyLoss(200)
+	else if(isliving(L))
+		L.death()
+	else
+		to_chat(L, span_warning("Nothing happens."))
 
-    L.whisper(lastmsg)
-
-    if(iscarbon(L))
-        var/mob/living/carbon/C = L
-        C.adjustOxyLoss(200)
-    else if(isliving(L))
-        L.death()
-    else
-        to_chat(L, span_warning("Nothing happens."))
-
-    return TRUE   
+	return TRUE
 
 
 /* Vomit emote */


### PR DESCRIPTION
## About The Pull Request
Adds logging for suicide prayers and cleans up the file.
Additionally, adds special wording to peeling for different peel types.

## Testing Evidence
<img width="523" height="54" alt="image" src="https://github.com/user-attachments/assets/81a45319-6660-45f4-8a12-6d4d68a15739" />
<img width="509" height="54" alt="image" src="https://github.com/user-attachments/assets/bc539991-6e77-4501-b3d4-b7415a36da35" />
<img width="281" height="23" alt="image" src="https://github.com/user-attachments/assets/194f3613-fe6e-4e11-be2e-cc3955f19e7d" />

## Why It's Good For The Game
Players should know the strength of the peel hitting them. If they're knowledgeable, they'll understand the exact amount of strikes they can afford as a result. Otherwise, it's just fluff.
Other stuff is admin facing and doesn't matter.