### PR TITLE
Wrastle Return

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -507,11 +507,17 @@
 		O.update_hands(src)
 		update_grab_intents()
 
+//Free resists ahead.
+//This is STUPID strong.
+//We're stuck with it for economy reasons.
+//As of now, you get a free resist if either is met:
+// - Grabbed character skill at master or higher(5).
+// - Grabbing character skill at journeymen or lower(3).
 	if(isliving(AM))
 		var/mob/living/M = AM
 		if(M.mind)
 			if(M.cmode && M.stat == CONSCIOUS && !M.restrained(ignore_grab = TRUE))
-				if(M.get_skill_level(/datum/skill/combat/wrestling) > 4 || src.get_skill_level(/datum/skill/combat/wrestling) < 5) //Grabber skill less than Master OR grabbed skill at Master or above.
+				if(M.get_skill_level(/datum/skill/combat/wrestling) >= 5 || src.get_skill_level(/datum/skill/combat/wrestling) <= 3)
 					M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
 
 /mob/living/proc/is_limb_covered(obj/item/bodypart/limb)
@@ -1054,13 +1060,14 @@
 	if(!can_resist() || surrendering)
 		return
 
+	changeNext_move(CLICK_CD_RESIST)
+
 	if(atkswinging)
 		stop_attack(FALSE)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_RESIST, src)
 	//resisting grabs (as if it helps anyone...)
 	if(pulledby)
-		changeNext_move(8)
 		var/mob/living/P
 		if(isliving(pulledby))
 			P = pulledby
@@ -1075,13 +1082,11 @@
 
 	//unbuckling yourself
 	if(buckled && last_special <= world.time)
-		changeNext_move(CLICK_CD_RESIST)
 		resist_buckle()
 		return
 
 	//Breaking out of a container (Locker, sleeper, cryo...)
 	if(isobj(loc))
-		changeNext_move(CLICK_CD_RESIST)
 		var/obj/C = loc
 		C.container_resist(src)
 		return
@@ -1089,23 +1094,19 @@
 	if(mobility_flags & MOBILITY_MOVE)
 		if(on_fire)
 			resist_fire() //stop, drop, and roll
-			changeNext_move(CLICK_CD_RESIST)
 			return
 		if(has_status_effect(/datum/status_effect/leash_pet))
 			if(istype(src, /mob/living/carbon))
 				src:resist_leash()
-				changeNext_move(CLICK_CD_RESIST)
 				return
 		if(last_special <= world.time)
 			resist_restraints() //trying to remove cuffs.
 			if(restrained() && !prob(5))
-				changeNext_move(CLICK_CD_RESIST)
 				return
 			var/datum/component/riding/human/riding_datum = GetComponent(/datum/component/riding/human)
 			if(HAS_TRAIT(src, TRAIT_PONYGIRL_RIDEABLE) && riding_datum)
 				for(var/mob/M in buckled_mobs)
 					riding_datum.force_dismount(M)
-			changeNext_move(CLICK_CD_RESIST)
 			return
 
 /mob/living/proc/submit(var/instant = FALSE)


### PR DESCRIPTION
## About The Pull Request
TL;DR, this is making it so MAAs/Sergeant/Knights/Wretches/Warden Foresters/Etc can grapple again.

Wrastling had been horribly gutted.
This returns the previous resist time cooldown of two seconds, retains the free resists for anyone not above journeyman and somewhat cleans up the code. That's about it. Nothing else exists here that shouldn't. Hand over heart. Probably.

An edit of work from: SR's [#587](https://github.com/Scarlet-Reach/Scarlet-Reach/pull/587)
## Testing Evidence
It probably works. Another Carl slop PR where he doesn't test stuff? Shocking, I know.
Simple changes that compile.
## Why It's Good For The Game
This checks first to second, mind. Whatever value is first. So master or higher wrestling always gets a free resist. Which is fine, as you'll see soon. A very small group of classes.

Previous values:
```
Grabbed skill at master or higher(5).
Grabber skill at expert or lower(4).
```
What that meant, is that MAAs for example couldn't actually grab antags and the like. Meaning, even as described by a comment on the PR that introduced this on SR, they would have to opt for skullcracks. Subjectively better than old grapples, but I'd argue it's much worse, given you have to near RR someone to restrain them. I've suffered it. I've had to do it. I've seen others RR'd for it when that shouldn't have even been remotely close to an option otherwise.

In fact, to make matters worse, only Iconoclasts, Lunacy Embracers, Dungeoneers, WWs, Maniacs, VLs/Vampires, Ascendants, Ponygirls and Ult'd Martyrs could actually grapple people without them getting a free resist using these values. Which, as you can imagine, made grapple combat _dead_. Which would be fine, if that didn't bleed into everything else.

I didn't like those values. Because I'm a fool and want people to not be bled to death for capturing. Or decapitated / limb chopped.

So, now, in order to be eligible for an auto resist, with free resisting and no stamina cost? One of two conditions needs to be met in the new values, first to second as before as it's a simple number change:
```
Grabbed skill at master or higher(5).
Grabber skill at journeyman or lower(3).
```
This means only the aforementioned classes can actually get a free resist, but on top of that, now ~50 (mostly subclasses, kind of?) can engage with grapple combat as the grabber. It also places a lack of grapple emphasis on others by retaining that lower wrestling skill check for the grabber.

I include the grabbed skill for the displays, despite not being touched, because I hate how this was written and it'd been a `> 4` and `< 5`, as opposed to simply `>= 5` and `<= 4` respectively. This is cleaner and it made me want to weep.