### PR TITLE
Re-adds Fennec Ears

### DIFF
--- a/code/modules/client/customizer/customizers/organ/ears.dm
+++ b/code/modules/client/customizer/customizers/organ/ears.dm
@@ -17,6 +17,7 @@
 	sprite_accessories = list(
 		/datum/sprite_accessory/ears/fox,
 		/datum/sprite_accessory/ears/vulp,
+		/datum/sprite_accessory/ears/fennec,
 		/datum/sprite_accessory/ears/big/sandfox_large,
 		/datum/sprite_accessory/ears/bigwolf,
 		/datum/sprite_accessory/ears/bigwolf_inner,
@@ -98,7 +99,7 @@
 		/datum/sprite_accessory/ears/goblin_small,
 		/datum/sprite_accessory/ears/halforc)
 
-/datum/customizer/organ/ears/goblin 
+/datum/customizer/organ/ears/goblin
 	customizer_choices = list(/datum/customizer_choice/organ/ears/goblin)
 	allows_disabling = FALSE
 
@@ -148,6 +149,7 @@
 		/datum/sprite_accessory/ears/fish,
 		/datum/sprite_accessory/ears/fox,
 		/datum/sprite_accessory/ears/vulp,
+		/datum/sprite_accessory/ears/fennec,
 		/datum/sprite_accessory/ears/husky,
 		/datum/sprite_accessory/ears/jellyfish,
 		/datum/sprite_accessory/ears/kangaroo,
@@ -208,6 +210,7 @@
 		/datum/sprite_accessory/ears/fish,
 		/datum/sprite_accessory/ears/fox,
 		/datum/sprite_accessory/ears/vulp,
+		/datum/sprite_accessory/ears/fennec,
 		/datum/sprite_accessory/ears/husky,
 		/datum/sprite_accessory/ears/jellyfish,
 		/datum/sprite_accessory/ears/kangaroo,
@@ -303,6 +306,7 @@
 		/datum/sprite_accessory/ears/fish,
 		/datum/sprite_accessory/ears/fox,
 		/datum/sprite_accessory/ears/vulp,
+		/datum/sprite_accessory/ears/fennec,
 		/datum/sprite_accessory/ears/husky,
 		/datum/sprite_accessory/ears/jellyfish,
 		/datum/sprite_accessory/ears/kangaroo,


### PR DESCRIPTION
## About The Pull Request

Adds fennec ears as an option for vernardine as well as half-kin/wildkin/verminfolk/dullahan

## Testing Evidence

<img width="792" height="584" alt="image" src="https://github.com/user-attachments/assets/8e9c0e89-7a52-40fb-8d02-1a23c678014a" />
<img width="974" height="643" alt="image" src="https://github.com/user-attachments/assets/1eb39256-05c8-4f3f-aea7-b0f246b654ba" />


## Why It's Good For The Game

Some ratwood 1 character had these and it'd be nice to port
