### PR TITLE
Carpentry for Woodcutters

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/carpenter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/carpenter.dm
@@ -1,7 +1,7 @@
 /datum/advclass/carpenter
-	name = "Carpenter"
-	tutorial = "A skilled carpenter, able to manipulate wood to suit their needs \
-	building forts and stores, carpenting floors, putting up crosses. You can do it all with enough logs"
+	name = "Builder"
+	tutorial = "A skilled carpenter and mason, able to manipulate wood and stone to suit their needs \
+	building forts and stores, carpenting floors, putting up crosses. You can do it all with enough logs or rocks"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/carpenter
@@ -28,7 +28,7 @@
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE) // They work at great heights.
 	H.adjust_skillrank(/datum/skill/craft/crafting, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/carpentry, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/craft/masonry, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/masonry, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/engineering, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/traps, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodcutter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/woodcutter.dm
@@ -26,7 +26,7 @@
 	H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/crafting, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/craft/carpentry, 1, TRUE)
+	H.adjust_skillrank(/datum/skill/craft/carpentry, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/masonry, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/craft/engineering, 1, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sewing, 1, TRUE)


### PR DESCRIPTION
## About The Pull Request

1) Gives better carpentry to woodcutters so that they have something to do with all those logs they cut other than dump them at the stockpile for mammons.
2) Gives Carpenters extra Masonry, a smidge of mining, a chisel, and renames them Builders


## Testing Evidence

Simple number edits

## Why It's Good For The Game

Woodcutters are left without much to do with their logs other than crash the economy with the stockpile. It was a good change in ratwood 1 and worth keeping.

Instead of *removing* carpenter as a role completely I thought it might fill a niche to make it more firmly in that role.

It's nice to have more people around for the keep to call in to fix their broken doors.
