### PR TITLE
DRider Jannisary changes: one fix, one change, one flavor choice change!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -1,6 +1,6 @@
 /datum/advclass/mercenary/desert_rider
 	name = "Desert Rider Janissary"
-	tutorial = "The Janissaries are the Empire's elite infantry units, wielding mace and shield. We do not break."
+	tutorial = "The Janissaries are the Empire's elite infantry units, wielding a variety of weapons and carrying shields. We do not break."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/mercenary/desert_rider
@@ -10,15 +10,15 @@
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_WIL = 2,
-		STATKEY_SPD = 2,
-		STATKEY_PER = -1
+		STATKEY_CON = 2,
+		STATKEY_PER = 1
 	)
 
 
 /datum/outfit/job/roguetown/mercenary/desert_rider/pre_equip(mob/living/carbon/human/H)
 	..()
-	to_chat(H, span_warning("The Janissaries are the Empire's elite infantry units, wielding mace and shield. We do not break."))
-	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+	to_chat(H, span_warning("The Janissaries are the Empire's elite infantry units, wielding a variety of weapons and carrying shields. We do not break."))
+	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
@@ -31,7 +31,6 @@
 	H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/sneaking, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
-	head = /obj/item/clothing/head/roguetown/helmet/sallet/raneshen
 	neck = /obj/item/clothing/neck/roguetown/bevor
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/scale
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/raneshen
@@ -48,26 +47,34 @@
 		/obj/item/storage/belt/rogue/pouch/coins/poor
 		)
 	H.grant_language(/datum/language/celestial)
-	var/weapons = list("Heavy Mace","Shamshir and Shield","Spear and Shield")
+	var/weapons = list("Axe and Shield","Shamshir and Shield","Spear and Shield")
 	var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
-		if("Heavy Mace")
-			H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-			backl = /obj/item/rogueweapon/mace/goden
+		if("Axe and Shield")
+			H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
+			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
+			backl = /obj/item/rogueweapon/shield/tower/raneshen
 		if("Shamshir and Shield")
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 			r_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 			backl = /obj/item/rogueweapon/shield/tower/raneshen
+			beltr = /obj/item/rogueweapon/scabbard/sword
 		if("Spear and Shield")
 			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 			r_hand = /obj/item/rogueweapon/spear
 			backl = /obj/item/rogueweapon/shield/tower/raneshen
-
+	var/armors = list("Khulad Helmet","Padded Hijab and Mask")
+	var/armor_choice = input("Cover thine head.", "HIDE THE HAIR") as anything in armors
+	switch(armor_choice)
+		if("Khulad Helmet")
+			head = /obj/item/clothing/head/roguetown/helmet/sallet/raneshen
+		if("Padded Hijab and Mask")
+			head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/raneshen
+			mask = /obj/item/clothing/mask/rogue/facemask/steel/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/shalal
 	belt = /obj/item/storage/belt/rogue/leather/shalal
 	beltl = /obj/item/rogueweapon/scabbard/sword
-	beltr = /obj/item/rogueweapon/scabbard/sword
 	l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 	
 	H.merctype = 4


### PR DESCRIPTION
## About The Pull Request
Gives Desert Rider's Jannisary subclass a _(small)_ coat of paint!
- They **no longer get 2 SPD and receive a -1 PER malus**, but change to **2 CON and +1 PER**. This makes them sturdier, but slower than their Zeybek and Almah counterparts. More reason to make honor to your *Rider* portion of the name!
- They **no longer get a goedendang start** or mace skills, but rather **axe** skills and a basic iron axe + shield start. Can always upgrade! *Probably should*!
- They can choose between their iconic helmet, or a padded hijab + mask start, as the Zeybek (the hijab is too drippy to pass on).
- They started with 2 sword scabbards always. For some reason. Removed one. You can get the 2nd one by starting with the extra shamshir start!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="348" height="193" alt="image" src="https://github.com/user-attachments/assets/d64ddc9b-8723-4ef2-83d2-d91581785761" />
<img width="194" height="149" alt="image" src="https://github.com/user-attachments/assets/1d4b9c74-8108-4f5a-a244-427cea481be3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Whenever I see Jannisaries (and the few I spoke with), they don't really **pick** the goedendang. It's almost always the extra shamshir, or **rarely** the spear and shield one because its fun to use polearms on saigas. A friend/acquaintance said that maybe going axes instead of maces for greataxe use could be funny.

While I do agree it WOULD be funny, I am not gonna give'em a greataxe roundstart. Chop a tree and get a smith or something.

As for the stats, them getting +2 SPD yet no CON left them in a predicament if *(or rather WHEN)* their armor gave out. Even more so when omniwounds turbofuck combatants. If this sucks for the janny users, I'll revert it (or maybe even out at 1 con 1 spd no per buff?

Last but not least: The extra scabbard was ????. And drip is good. Not having a helmet sucks but dying with style is fun.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
