### PR TITLE
Dreamwalker Disabling

### DIFF
--- a/code/modules/events/antagonist/solo/dreamwalker.dm
+++ b/code/modules/events/antagonist/solo/dreamwalker.dm
@@ -16,7 +16,7 @@
 	maximum_antags = 2
 
 	weight = 18
-	max_occurrences = 2
+	max_occurrences = 0//From 2. Why was this TWO? Zero for now. Staff can inject it otherwise.
 
 	earliest_start = 0 SECONDS
 


### PR DESCRIPTION
## About The Pull Request
This was dropping in super lowpop rounds and curbstomping folks. It really has no reason to exist with our current lore, either, and could do with a rework. I guess. Staff can still inject it, but the lowpop tide of these was not great.

## Testing Evidence
Carl slop. No testing.

## Why It's Good For The Game
I really don't think I need to explain this. We started refunding / canceling it in round with how common it was.