### PR TITLE
Min player for dreamwalker

### DIFF
--- a/code/modules/events/antagonist/solo/dreamwalker.dm
+++ b/code/modules/events/antagonist/solo/dreamwalker.dm
@@ -14,6 +14,7 @@
 
 	base_antags = 1
 	maximum_antags = 2
+	min_players = 40
 
 	weight = 18
 	max_occurrences = 2


### PR DESCRIPTION
## About The Pull Request
Puts a minimum number of players required for the dreamwalker to spawn, kind of like the werewolf
Puts the min_player to: 40
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Same code as the werewolf, and players are needed
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Dropping in super lowpop rounds and curbstomping folks = bad

Min_players for dreamwalkers = good
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
