### PR TITLE
Armored Templar Buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -220,8 +220,6 @@
 		STATKEY_WIL = 3,
 		STATKEY_STR = 2,
 		STATKEY_CON = 2,
-		STATKEY_INT = 2,
-		STATKEY_PER = 2,
 	)
 
 /datum/outfit/job/roguetown/templar/crusader/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -12,8 +12,8 @@
 	min_pq = 3 //Deus vult, but only according to the proper escalation rules
 	max_pq = null
 	round_contrib_points = 2
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	advclass_cat_rolls = list(CTAG_TEMPLAR = 20)
 	display_order = JDO_TEMPLAR
 
@@ -220,6 +220,8 @@
 		STATKEY_WIL = 3,
 		STATKEY_STR = 2,
 		STATKEY_CON = 2,
+		STATKEY_INT = 2,
+		STATKEY_PER = 2,
 	)
 
 /datum/outfit/job/roguetown/templar/crusader/pre_equip(mob/living/carbon/human/H)
@@ -311,10 +313,10 @@
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/wrestling, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/magic/holy, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)


### PR DESCRIPTION
## About The Pull Request

As title, buffs the heavy armor Templar stats+skills. The changes are as follows:

Added: +2 int, +2 per (EDIT: Removed this.)
Adjusted: +1 wrestling, +1 athletics, up to Expert from Journeyman for both
Removed: 1 job slot, 4 -> 3, to account for its increased strength there shouldn't be as many of these guys running around-- and this is how it was on old-RW.

## Testing Evidence

Builds and runs. Just a numbers change.

## Why It's Good For The Game

Templars used to be a very strong force for the church back on old Ratwood. Azure Peak nerfed them quite severely, presumably to make room for roles like the Martyr as well as the 'Monk' Templar subclass, which is so much stronger than heavy armor Templar it's not even funny.

That subclass and the possible adjusting/removal thereof is a whole different subject entirely, so I've limited the scope of this PR to purely change the heavy armor Templar-- to put their wrestling and athleticism on-par with other martial fighters (such as men at arms, the other templar subclass, knights, etc.) and granting them some of their mental faculties that holy warriors ought to be revered for.

The role should be strong. You shouldn't have to run an unarmed build to make it good.