### PR TITLE
Makes Keys and Locks Easier to Craft

### DIFF
--- a/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
+++ b/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
@@ -115,7 +115,7 @@
 /datum/artificer_recipe/iron/lockpicks
 	name = "Lockpick (x3)"
 	required_item = /obj/item/ingot/iron
-	created_item = list(/obj/item/lockpickring,/obj/item/lockpickring,/obj/item/lockpickring)
+	created_item = list(/obj/item/lockpick,/obj/item/lockpick,/obj/item/lockpick)
 	hammers_per_item = 5
 	skill_level = 2
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

Makes keys and locks use iron instead of bronze to craft at the artificer table.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

Very simple change. Should just work.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Allows for base-building to be easier. Bronze is hard to get, especially if you are solo.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
