### PR TITLE
Jump Resist Begone

### DIFF
--- a/code/game/objects/items/rogueweapons/intents/mmb/jump.dm
+++ b/code/game/objects/items/rogueweapons/intents/mmb/jump.dm
@@ -25,9 +25,7 @@
 		return
 
 	if(pulledby && pulledby != src)
-		to_chat(src, span_warning("I'm being grabbed."))
-		changeNext_move(mmb_intent.clickcd)
-		resist_grab()
+		to_chat(src, span_warning("I'm unable to jump while grabbed."))
 		return
 
 	if(IsOffBalanced())


### PR DESCRIPTION
## About The Pull Request
Removes being able to use jump to resist out of grabs. It's that simple. Makes captures obscenely painful if someone knows about this. Removed elsewhere, and while it looks like someone tried to 'fix this' via a cooldown? It's not great. At all. Period. Effectively an exploit. IS an exploit in some use cases. I'm near certain the intent isn't to allow someone to drop from chain grabs, given captures are effectively impossible at that rate without delimbing. Outta here.
## Testing Evidence
Slop PR. No testing. Effectively a two line change that _just works_.
## Why It's Good For The Game
I really don't think I need to explain this one, if you've either used it or abused it.