### PR TITLE
Highwaymen equipment pass

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/bog_deserters.dm
@@ -20,7 +20,7 @@
 		if(2)
 			r_hand = /obj/item/rogueweapon/spear
 		if(3)
-			r_hand = /obj/item/rogueweapon/stoneaxe/battle
+			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 			l_hand = /obj/item/rogueweapon/shield/heater
 
 /datum/outfit/job/roguetown/human/northern/bog_deserters/proc/add_random_deserter_weapon_hard(mob/living/carbon/human/H)
@@ -33,7 +33,7 @@
 			r_hand = /obj/item/rogueweapon/mace/warhammer
 			l_hand = /obj/item/rogueweapon/shield/heater
 		if(3)
-			r_hand = /obj/item/rogueweapon/stoneaxe/battle
+			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
 			l_hand = /obj/item/rogueweapon/shield/heater
 		if(4)
 			r_hand = /obj/item/rogueweapon/flail

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -128,6 +128,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	if(prob(10))
 		l_hand = /obj/item/rogueweapon/huntingknife/idagger
 		l_hand = /obj/item/rogueweapon/huntingknife/idagger
+	H.eye_color = "27becc"
 	H.hair_color = "61310f"
 	H.facial_hair_color = H.hair_color
 	if(H.gender == FEMALE)

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -117,8 +117,12 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 		r_hand = /obj/item/rogueweapon/sword/short/iron
 	else
 		r_hand = /obj/item/rogueweapon/mace/cudgel
-	if(prob(20))
+	if(prob(10))
 		r_hand = /obj/item/rogueweapon/sword/falchion/militia
+	if(prob(10))
+		/obj/item/rogueweapon/sword/short/messer/iron
+	if(prob(10))
+		/obj/item/rogueweapon/stoneaxe/handaxe
 	if(prob(20))
 		r_hand = /obj/item/rogueweapon/pick/militia
 	if(prob(25))	

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -84,25 +84,29 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	if(prob(50))
 		mask = /obj/item/clothing/mask/rogue/ragmask/red
 	if(prob(50))
-		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+		wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	armor = /obj/item/clothing/suit/roguetown/armor/leather
 	if(prob(50))
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/hide
+		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/black
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/vagrant
 	if(prob(50))
-		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/light
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	if(prob(50))
-		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-	if(prob(50))
+		pants = /obj/item/clothing/under/roguetown/tights/random
+	if(prob(30))
 		head = /obj/item/clothing/head/roguetown/helmet/leather
 	if(prob(30))
 		head = /obj/item/clothing/head/roguetown/helmet/leather/volfhelm
-	if(prob(50))
+	if(prob(70))
 		neck = /obj/item/clothing/neck/roguetown/coif
-	gloves = /obj/item/clothing/gloves/roguetown/leather
+	if(prob(70))
+		gloves = /obj/item/clothing/gloves/roguetown/leather
 	if(prob(50))
-		gloves = /obj/item/clothing/gloves/roguetown/angle
+		gloves = /obj/item/clothing/gloves/roguetown/fingerless
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	if(prob(25))
+		cloak = /obj/item/clothing/cloak/raincloak/brown
 	H.STASTR = rand(12,14) //GENDER EQUALITY!!
 	H.STASPD = 11
 	H.STACON = rand(10,12) //so their limbs no longer pop off like a skeleton
@@ -121,10 +125,9 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 		l_hand = /obj/item/rogueweapon/shield/wood
 	if(prob(10))
 		l_hand = /obj/item/rogueweapon/shield/buckler/palloy
-	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
-	if(prob(30))
-		neck = /obj/item/clothing/neck/roguetown/leather
-	H.eye_color = "27becc"
+	if(prob(10))
+		l_hand = /obj/item/rogueweapon/huntingknife/idagger
+		l_hand = /obj/item/rogueweapon/huntingknife/idagger
 	H.hair_color = "61310f"
 	H.facial_hair_color = H.hair_color
 	if(H.gender == FEMALE)
@@ -136,6 +139,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE) // Trash mobs, untrained.
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)

--- a/code/modules/mob/living/carbon/human/npc/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/highwayman.dm
@@ -120,9 +120,9 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	if(prob(10))
 		r_hand = /obj/item/rogueweapon/sword/falchion/militia
 	if(prob(10))
-		/obj/item/rogueweapon/sword/short/messer/iron
+		r_hand = /obj/item/rogueweapon/sword/short/messer/iron
 	if(prob(10))
-		/obj/item/rogueweapon/stoneaxe/handaxe
+		r_hand = /obj/item/rogueweapon/stoneaxe/handaxe
 	if(prob(20))
 		r_hand = /obj/item/rogueweapon/pick/militia
 	if(prob(25))	


### PR DESCRIPTION
## About The Pull Request
Was going to do this earlier but forgot. I saw Azurepeak do the same thing which reminded me.

1) Highwaymen no longer spawn with best-in-slot hardened light armour. 
2) Have a modestly wider variety of potential starting weapons and armour, including a small chance to spawn with dual daggers!
3) bog deserters spawn with iron axes instead of steel battleaxes

I had wanted to *also* change the eye colour of the NPC highwaymen to glowing evil red and imply in lore that they are possessed by evil spirits and thus don't have souls (They are NPCs after all!) but no matter what I can do I can't make their eyes not just be white all the time... ah well. Maybe some day we figure that out.

## Testing Evidence

<img width="2022" height="1082" alt="image" src="https://github.com/user-attachments/assets/fdc74f37-b4d8-42e8-9cae-b80bb4f9de7a" />

## Why It's Good For The Game

Feels very disheartening for any leatherworker or light-armour-salesmen when Hardened Leather bracers and gorgets are just lying around on the floor as trash being spawned by infinitely spawning random easy NPCs.
