### PR TITLE
Wretch slot increase per player, RCP changes

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -215,6 +215,7 @@ SUBSYSTEM_DEF(migrants)
 
 	SSticker.minds += character.mind
 	GLOB.joined_player_list += character.ckey
+	update_wretch_slots() // Wretch slot code
 
 	if(humanc)
 		var/fakekey = character.ckey

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -463,6 +463,7 @@ SUBSYSTEM_DEF(ticker)
 			continue
 		if(player.ready == PLAYER_READY_TO_PLAY)
 			GLOB.joined_player_list += player.ckey
+			update_wretch_slots() // Wretch slot code
 			player.create_character(FALSE)
 		else
 			player.new_player_panel()

--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -248,7 +248,7 @@
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(json))
 
-	if(curcomm < 100 || get_playerquality(key) < 10)
+	if(curcomm < 100 || get_playerquality(key) < 50)
 		adjust_playerquality(round(amt/10,0.1), ckey(key))
 
 /proc/get_roundpoints(key)

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -4,7 +4,7 @@
 	flag = WRETCH
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 3//From 8.
+	total_positions = 3
 	spawn_positions = 3
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Somewhere in your lyfe, you fell to the wrong side of civilization. Hounded by the consequences of your actions, you now threaten the peace of those who still heed the authority that condemned you."
@@ -12,7 +12,7 @@
 	outfit_female = null
 	display_order = JDO_WRETCH
 	show_in_credits = FALSE
-	min_pq = 60//Three slots. Intended for round progression. Lunatic at 100, Martyr at 10.
+	min_pq = 50//Three slots. Intended for round progression. Lunatic at 100, Martyr at 10.
 	max_pq = null
 
 	obsfuscated_job = TRUE
@@ -25,7 +25,7 @@
 	wanderer_examine = TRUE
 	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
-	job_reopens_slots_on_death = FALSE//Haha! No. Stop. No endless waves of better adventurers, thanks.
+	job_reopens_slots_on_death = FALSE //If true, it will stop the dynamic wretch code to work
 	same_job_respawn_delay = 1 MINUTES
 	virtue_restrictions = list(/datum/virtue/heretic/zchurch_keyholder) //all wretch classes automatically get this
 	carebox_table = /datum/carebox_table/wretch
@@ -117,4 +117,21 @@
 			my_crime = "crimes against the Crown"
 		add_bounty_noface(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, bounty_total, FALSE, my_crime, bounty_poster)
 
-	to_chat(H, span_danger("You are an Antagonistic role. You are expected, by choosing to be a wretch, to sow chaos and division amongst the town while driving a story. Failure to use proper gravitas for this may get you punished for Low Role Play standards."))
+	to_chat(H, span_danger("You are a minor antagonist role. By playing Wretch, you have decided to drive an interesting story. The gods frown upon those who abuse the gifts they're given for this purpose."))
+
+/proc/update_wretch_slots()
+    var/datum/job/wretch_job = SSjob.GetJob("Wretch")
+    if(!wretch_job)
+        return
+
+    var/player_count = length(GLOB.joined_player_list)
+
+    var/slots = 3
+    if(player_count > 36)
+        var/extra = floor((player_count - 36) / 12)
+        slots += extra
+
+    slots = min(slots, 8)
+
+    wretch_job.total_positions = slots
+    wretch_job.spawn_positions = slots

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -555,6 +555,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			give_madness(humanc, GLOB.curse_of_madness_triggered)
 */
 	GLOB.joined_player_list += character.ckey
+	update_wretch_slots() // Wretch slot code
 /*
 	if(CONFIG_GET(flag/allow_latejoin_antagonists) && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
 		if(SSshuttle.emergency)


### PR DESCRIPTION
## About The Pull Request
The PQ that you can earn from RCP has been changed to 50 (so you can earn all the roles)
The Player per wretch is changed to 12
PQ for wretch changed to 50
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Worked before
Still need to test the RCP thing, but it should work
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
3 wretches were not supposed to be the finale number of wretches
RCP giving PQ to 50 makes you able to earn wretch (slowly) by playing
It will still take 100 rounds at a minimum if you never get any PQ, but every little help
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
