### PR TITLE
Return of Species Stress Events | Starsugar Nerf

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -778,6 +778,19 @@
 				if (stuck_thing.w_class >= WEIGHT_CLASS_SMALL)
 					. += span_bloody("<b>[m3] \a [stuck_thing] stuck in [m2] [part.name]!</b>")
 
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/stress = H.get_stress_amount()//stress check for racism
+		if(H.has_flaw(/datum/charflaw/paranoid) || stress >= 4)//Paranoid or stressed, for basic examine.
+			if(H.dna.species.name != dna.species.name)
+				if(dna.species.stress_examine)//some species don't have a stress desc
+					. += dna.species.stress_desc
+				if(!HAS_TRAIT(user, TRAIT_TOLERANT))//They're given the stress event if they qualify for racism and aren't tolerant.
+					var/stress_type = /datum/stressevent/shunned_race
+					if(HAS_TRAIT(user, TRAIT_XENOPHOBIC))//Xenophobic are hit worse. By a bit.
+						stress_type = /datum/stressevent/shunned_race_xenophobic
+					user.add_stress(stress_type)
+
 	if((user != src) && isliving(user))
 		var/mob/living/L = user
 		var/final_str = STASTR

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -367,7 +367,7 @@
 
 /datum/reagent/starsugar/on_mob_metabolize(mob/living/L)
 	..()
-	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.5, blacklisted_movetypes=(FLYING|FLOATING))
 	L.playsound_local(L, 'sound/ravein/small/hello_my_friend.ogg', 100, FALSE)
 	L.flash_fullscreen("whiteflash")
 	animate(L.client, pixel_y = 1, time = 1, loop = -1, flags = ANIMATION_RELATIVE)

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -370,3 +370,11 @@
 	name = "Mountable"
 	desc = "You have trained or been trained into a suitable mount. People may ride you as they would a saiga."
 	added_traits = list(TRAIT_PONYGIRL_RIDEABLE)
+
+/datum/virtue/utility/tolerant
+	name = "Tolerant"
+	desc = "Whether fostered through travel or care, you just don't see an issue with certain folks."
+	custom_text = "Prevents you from experiencing negative stress events when looking at select species."
+	added_traits = list(TRAIT_TOLERANT)
+
+


### PR DESCRIPTION
## About The Pull Request
Two very simple changes.
- - - 
Firstly, pulls a change from SR([#672](https://github.com/Scarlet-Reach/Scarlet-Reach/pull/672)) and chops it apart.

Makes use of the vestigial Tolerant trait, by making folks who have it immune to negative species stress events on examine. Additionally introduces it as a virtue, if you want that, for some reason.

Xenophobic classes (just slavers for now) are hit by the old Xenophobic stress, unlike those without tolerant, who'll just get the old standard stress event.

- - -
Now, for the other, which should be atomised, but I'm lazy and angry. A flat nerf to Starsugar. All this does is tank the multiplicative slowdown. From a MASSIVE -2, to -0.5, which means you're still objectively faster than others. Just not teleporting wall-to-wall without sprint. A very simple but effective nerf. You still get DE/DS from it, too, alongside the other benefits. So it's not a big deal.

## Testing Evidence
<img width="231" height="25" alt="image" src="https://github.com/user-attachments/assets/b029dc0b-82bc-4224-a9c2-b88c81c0a8b9" />
<img width="529" height="147" alt="image" src="https://github.com/user-attachments/assets/f93aa3f3-6e38-442e-a93a-549c63fa3d22" />

## Why It's Good For The Game
Species interactions are fairly fun for both RP and otherwise. To have it locked as SR did behind a stress threshold, or paranoia? Well, it's certainly better than it used to be. We'll have to see if this is something we want.

Otherwise, starsugar BLOWS to fight. Everyone knows this. If you defend it, you're probably a starsugar user. I say this as someone who carries, at minimum, three at a time depending on role if I can get access to it. No more teleporting wall-to-wall, at least unless you're sprinting, which, y'know, I suppose live your life king.