### PR TITLE
Map generation changes for maneater

### DIFF
--- a/code/modules/roguetown/mapgen/bog.dm
+++ b/code/modules/roguetown/mapgen/bog.dm
@@ -32,7 +32,7 @@
 							/obj/structure/closet/dirthole/closed/loot = 3,
 							/obj/structure/flora/roguegrass/swampweed = 10,
 							/obj/structure/flora/roguegrass/bush/westleach = 10,
-							/obj/structure/flora/roguegrass/maneater/real = 3,
+							/obj/structure/flora/roguegrass/maneater/real/juvenile = 3,
 							/obj/structure/zizo_bane = 2)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=2,
 						/turf/open/water/swamp=1)
@@ -61,7 +61,7 @@
 							/obj/structure/flora/roguegrass/bush = 10,
 							/obj/structure/flora/roguegrass = 44,
 							/obj/structure/flora/roguegrass/maneater = 15,
-							/obj/structure/flora/roguegrass/maneater/real = 10,
+							/obj/structure/flora/roguegrass/maneater/real/juvenile = 10,
 							/obj/item/natural/stone = 6,
 							/obj/item/natural/rock = 1,
 							/obj/item/grown/log/tree/stick = 3,

--- a/code/modules/roguetown/mapgen/bograt.dm
+++ b/code/modules/roguetown/mapgen/bograt.dm
@@ -41,7 +41,7 @@
 							/obj/effect/decal/remains/bear = 1,
 							/obj/effect/decal/remains/human = 1,
 							/obj/structure/zizo_bane = 3,
-							/obj/structure/flora/roguegrass/maneater/real = 2)
+							/obj/structure/flora/roguegrass/maneater/real/juvenile = 2)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=5,
 						/turf/open/water/swamp=5,
 						/turf/open/floor/rogue/grass = 20)
@@ -63,7 +63,7 @@
 							/obj/structure/flora/roguegrass/bush = 20,
 							/obj/structure/flora/roguegrass = 180,
 							/obj/structure/flora/roguegrass/maneater = 15,
-							/obj/structure/flora/roguegrass/maneater/real = 5,
+							/obj/structure/flora/roguegrass/maneater/real/juvenile = 5,
 							/obj/item/natural/stone = 12,
 							/obj/item/natural/rock = 5,
 							/obj/item/grown/log/tree/stick = 6,

--- a/code/modules/roguetown/mapgen/decap.dm
+++ b/code/modules/roguetown/mapgen/decap.dm
@@ -20,7 +20,7 @@
 	/obj/structure/flora/grass/green = 20,
 	/obj/item/grown/log/tree/stick = 16,
 	/obj/structure/flora/roguegrass/pyroclasticflowers = 3,
-	/obj/structure/flora/roguegrass/maneater/real=3,
+	/obj/structure/flora/roguegrass/maneater/real/juvenile=3,
 	/obj/structure/flora/roguegrass/herb/random = 5)
 	spawnableTurfs = list(/turf/open/floor/rogue/snowpatchy=15)
 	allowed_areas = list(/area/rogue/outdoors/mountains/decap)

--- a/code/modules/roguetown/mapgen/forest.dm
+++ b/code/modules/roguetown/mapgen/forest.dm
@@ -28,7 +28,7 @@
 							/obj/structure/flora/roguetree/stump/log = 3,
 							/obj/structure/flora/roguetree/stump = 4,
 							/obj/structure/closet/dirthole/closed/loot=3,
-							/obj/structure/flora/roguegrass/maneater/real=3)
+							/obj/structure/flora/roguegrass/maneater/real/juvenile=3)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=2,
 						/turf/open/water/swamp=1)
 	allowed_areas = list(/area/rogue/outdoors/woods)
@@ -57,7 +57,7 @@
 							/obj/structure/flora/roguegrass/herb/random = 7,
 							/obj/structure/flora/roguegrass/bush/westleach = 7,
 							/obj/structure/flora/roguegrass/maneater = 13,
-							/obj/structure/flora/roguegrass/maneater/real=2,
+							/obj/structure/flora/roguegrass/maneater/real/juvenile=2,
 							/obj/item/natural/stone = 6,
 							/obj/item/natural/rock = 1,
 							/obj/item/grown/log/tree/stick = 3,

--- a/code/modules/roguetown/mapgen/forestrat.dm
+++ b/code/modules/roguetown/mapgen/forestrat.dm
@@ -28,7 +28,7 @@
 							/obj/structure/flora/roguetree/stump/log = 3,
 							/obj/structure/flora/roguetree/stump = 4,
 							/obj/structure/closet/dirthole/closed/loot=3,
-							/obj/structure/flora/roguegrass/maneater/real=3)
+							/obj/structure/flora/roguegrass/maneater/real/juvenile=3)
 	spawnableTurfs = list(/turf/open/floor/rogue/dirt/road=2,
 						/turf/open/water/swamp=1)
 	allowed_areas = list(/area/rogue/outdoors/woodsrat)
@@ -50,7 +50,7 @@
 							/obj/structure/flora/roguegrass/herb/random = 7,
 							/obj/structure/flora/roguegrass/bush/westleach = 7,
 							/obj/structure/flora/roguegrass/maneater = 13,
-							/obj/structure/flora/roguegrass/maneater/real=2,
+							/obj/structure/flora/roguegrass/maneater/real/juvenile=2,
 							/obj/item/natural/stone = 6,
 							/obj/item/natural/rock = 1,
 							/obj/item/grown/log/tree/stick = 3,


### PR DESCRIPTION
## About The Pull Request
It makes all random generation maneaters take some time to fully grow.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I checked the plant and saw that it spawned
<img width="991" height="798" alt="image" src="https://github.com/user-attachments/assets/03bcfac5-6331-4bf5-a207-a08e77e9bc13" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It removes all-around start killing of players from random generation from maneaters, people at least want to be given a chance to go around a little bit, before they are killed.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
