### PR TITLE
Adds Cross Training of Skills

### DIFF
--- a/code/datums/sleep_adv/sleep_adv.dm
+++ b/code/datums/sleep_adv/sleep_adv.dm
@@ -180,12 +180,12 @@ var/global/list/CROSS_TRAINING_MAP = list(
 	//"slings" = (),
 
 	//"farming" = (),
-	"mining" = list("axes" = 0.1, "maces" = 0.1),
+	"mining" = list("axes" = 0.1, "maces" = 0.1, "athletics" = 0.1),
 	//"fishing" = (),
-	"butchering" = list("tanning" = 0.25, "medicine" = 0.25),
-	"lumberjacking" = list("axes" = 0.25, "unarmed" = 0.05),
+	"butchering" = list("tanning" = 0.25, "medicine" = 0.25, "knives" = 0.25),
+	"lumberjacking" = list("axes" = 0.25, "unarmed" = 0.05, "athletics" = 0.1),
 
-	"athletics" = list("swimming" = 0.5, "climbing" = 0.5),
+	"athletics" = list("swimming" = 1, "climbing" = 1),
 	"climbing" = list("athletics" = 0.25, "swimming" = 0.25),
 	//"reading" = (),
 	"swimming" = list("athletics" = 0.1, "climbing" = 0.1),


### PR DESCRIPTION
## About The Pull Request
This PR adds the ability to train secondary skills from primary skills, for example, if you train how to use an axe, your lumberjacking gets better. If you swim, you become more generally athletic (at a low rate), if you train in armorsmithing, your general blacksmithing gets better, etc etc.

The skills are laid out and their secondary skills are assigned along with a multiplier rate.

## Testing Evidence
There is no testing done or necessarily required. It can not be perfect and I fully assume the crosstraining table MUST be tweaked and altered to be higher in the future. An example being, training from 0 to level 3 with swords wouldn't even get you a knives level 1

## Why It's Good For The Game
If you learn how to cut a tree, you at least know how to use an axe in a basic manner. If you learn how to smith armor, you can at least understand how a sword COULD be made. I feel this is immersive.