### PR TITLE
Adds a Mage Duke subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -219,10 +219,10 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/reading, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
-	H.mind?.adjust_spellpoints(27) //More than an Associate actually gets- but much like how the Warrior Duke gets a set of full blacksteel plate, I think we can give the mage duke a little something extra.
+	
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-
+		H.mind?.adjust_spellpoints(27) //More than an Associate actually gets- but much like how the Warrior Duke gets a set of full blacksteel plate, I think we can give the mage duke a little something extra.
 
 
 /**


### PR DESCRIPTION
## About The Pull Request

As title. New subclass for the Duke which is a wizard. Made to be about the same level of strength as a mage's associate, with slightly more spellpoints. Can be toned down if needed.

## Testing Evidence

<img width="1586" height="1000" alt="dreamseeker_2025-10-08_19-32-52" src="https://github.com/user-attachments/assets/29dea0e1-ed8a-4efd-93bd-e5d98cbe37b1" />
<img width="987" height="529" alt="dreamseeker_2025-10-08_19-38-37" src="https://github.com/user-attachments/assets/1ba2893c-67fd-40e2-a43c-40b593d72302" />


## Why It's Good For The Game

Many people (including myself) are fans of this idea. The bookworm heir is a popular subclass, magic is very powerful in-setting, powerful magicians are great courtiers (see: Court Magos), it's completely justifiable and setting-appropriate that a noble wizard could rise/be born to power and become Duke.

As far as balance is concerned- I generally think this will be fine. As my comments in the code itself suggest, the actual wizarding-power of the mage duke is only slightly higher than a roundstart Associate-- and of course, the Associate will have the time to progress through the mageloop, do alchemy, etc., while the wizard Duke would be expected to... well, be a Duke. Much like how you don't see the Valiant Warrior Duke run off to patrol the town as if they were a Knight/MAA, I don't think it'll be much of a problem of magic dukes running off to the mana fountain to collect crystals and whatnot. 