### PR TITLE
Adds other grass types to the terraingen for the Coast area

### DIFF
--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -438,6 +438,8 @@
 	canSmoothWith = list(/turf/open/floor/rogue/grassred,
 						/turf/open/floor/rogue/grassyel,
 						/turf/open/floor/rogue/grasscold,
+						/turf/open/floor/rogue/grassgrey,
+						/turf/open/floor/rogue/grasspurple,
 						/turf/open/floor/rogue/snowpatchy,
 						/turf/open/floor/rogue/snow,
 						/turf/open/floor/rogue/snowrough,)
@@ -470,6 +472,8 @@
 						/turf/open/floor/rogue/grassred,
 						/turf/open/floor/rogue/grassyel,
 						/turf/open/floor/rogue/grasscold,
+						/turf/open/floor/rogue/grassgrey,
+						/turf/open/floor/rogue/grasspurple,
 						/turf/open/floor/rogue/snowpatchy,
 						/turf/open/floor/rogue/snow,
 						/turf/open/floor/rogue/snowrough,)
@@ -495,6 +499,8 @@
 						/turf/open/floor/rogue/grassred,
 						/turf/open/floor/rogue/grassyel,
 						/turf/open/floor/rogue/grasscold,
+						/turf/open/floor/rogue/grassgrey,
+						/turf/open/floor/rogue/grasspurple,
 						/turf/open/floor/rogue/snowpatchy,
 						/turf/open/floor/rogue/snow,
 						/turf/open/floor/rogue/snowrough,

--- a/code/modules/roguetown/mapgen/beach.dm
+++ b/code/modules/roguetown/mapgen/beach.dm
@@ -27,7 +27,7 @@
 
 /datum/mapGeneratorModule/beachgrass
 	clusterCheckFlags = CLUSTER_CHECK_DIFFERENT_ATOMS
-	allowed_turfs = list(/turf/open/floor/rogue/grass)
+	allowed_turfs = list(/turf/open/floor/rogue/grass, /turf/open/floor/rogue/grasscold, /turf/open/floor/rogue/grassyel, /turf/open/floor/rogue/grassred)
 	spawnableAtoms = list(/obj/structure/flora/roguegrass/bush = 5,
 							/obj/structure/flora/roguegrass = 35,
 							/obj/structure/flora/roguegrass/maneater = 4,


### PR DESCRIPTION
## About The Pull Request

Adds blue/yellow/red grass to the terraingenerator for the coast area. Previously it was only set up to spawn grass on green grass tiles, and so when blue grass was added it became rather barren.

Also a few tiny changes to make new grasstypes blend with dirt properly

## Testing Evidence

Trust me....

## Why It's Good For The Game

The coast area got rather barren. Hard to find fibre for a sack