### PR TITLE
Quarterstaffs & Silly Fix

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -160,12 +160,11 @@
 	hitsound = list('sound/combat/hits/blunt/bluntsmall (1).ogg', 'sound/combat/hits/blunt/bluntsmall (2).ogg')
 	penfactor = BLUNT_DEFAULT_PENFACTOR
 	damfactor = 1.3 // Adds up to be slightly stronger than an unenhanced ebeak strike.
-	chargetime = 6 // Meant to be stronger than a bash, but with a delay.
 
 /datum/intent/spear/thrust/lance
 	damfactor = 1.5 // Turns its base damage into 30 on the 2hand thrust. It keeps the spear thrust one handed.
 
-/datum/intent/lance/
+/datum/intent/lance
 	name = "lance"
 	icon_state = "inlance"
 	attack_verb = list("lances", "runs through", "skewers")
@@ -1019,7 +1018,8 @@
 	force_wielded = 20
 	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff)
 	icon_state = "quarterstaff"
-	max_integrity = 150
+	max_integrity = 150//-100.
+	intdamage_factor = 1.25//It's a ranged blunt no-pen thrust option as a spear sidegrade. How often do you see this?
 
 /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 	name = "iron quarterstaff"
@@ -1028,7 +1028,7 @@
 	force_wielded = 22
 	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff)
 	icon_state = "quarterstaff_iron"
-	max_integrity = 200
+	max_integrity = 200//-50.
 
 /obj/item/rogueweapon/woodstaff/quarterstaff/steel
 	name = "steel quarterstaff"
@@ -1037,7 +1037,7 @@
 	force_wielded = 25
 	gripped_intents = list(/datum/intent/spear/bash/ranged/quarterstaff, /datum/intent/spear/thrust/quarterstaff)
 	icon_state = "quarterstaff_steel"
-	max_integrity = 200
+	max_integrity = 225//-25.
 
 //The partizan is a peeling weapon, intended for rending.
 //It's horrible for one-handed use, has heavy balance and a higher strength requirement.

--- a/code/modules/cargo/packsrogue/merchant/adventure_supplies.dm
+++ b/code/modules/cargo/packsrogue/merchant/adventure_supplies.dm
@@ -76,6 +76,11 @@
 	cost = 6
 	contains = list(/obj/item/rogueweapon/woodstaff)
 
+/datum/supply_pack/rogue/adventure_supplies/quarterstaff
+	name = "Eight Foot Pole"
+	cost = 12
+	contains = list(/obj/item/rogueweapon/woodstaff/quarterstaff)
+
 /datum/supply_pack/rogue/adventure_supplies/lamptern
 	name = "Lamptern"
 	cost = 15

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_iron.dm
@@ -53,6 +53,13 @@
 					/obj/item/rogueweapon/stoneaxe/woodcut,
 				)
 
+/datum/supply_pack/rogue/iron_weapons/quarterstaff
+	name = "Reinforced Quarterstaff - Iron"
+	cost = 25 // 1 Iron Ingot
+	contains = list(
+					/obj/item/rogueweapon/woodstaff/quarterstaff/iron,
+				)
+
 /datum/supply_pack/rogue/iron_weapons/spear
 	name = "Spear"
 	cost = 25 // 1 Iron Ingot

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_melee_steel.dm
@@ -33,7 +33,7 @@
 	contains = list(
 					/obj/item/rogueweapon/sword/rapier,
 				)
-				
+
 /datum/supply_pack/rogue/steel_weapons/cutlass
 	name = "Cutlass"
 	cost = 40 // 1 Steel Ingot
@@ -83,6 +83,13 @@
 	cost = 40 // 1 Steel Ingot
 	contains = list(
 					/obj/item/rogueweapon/mace/warhammer/steel,
+				)
+
+/datum/supply_pack/rogue/steel_weapons/quarterstaff
+	name = "Reinforced Quarterstaff - Steel"
+	cost = 40 // 1 Steel Ingot
+	contains = list(
+					/obj/item/rogueweapon/woodstaff/quarterstaff/steel,
 				)
 
 /datum/supply_pack/rogue/steel_weapons/longsword
@@ -199,7 +206,7 @@
 
 /datum/supply_pack/rogue/steel_weapons/fishingspear
 	name = "Fishing Spear"
-	cost = 75 // 2 Steel Ingot, 1 Small Log. 
+	cost = 75 // 2 Steel Ingot, 1 Small Log.
 	contains = list(
 					/obj/item/rogueweapon/fishspear,
 				)

--- a/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
+++ b/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
@@ -1,4 +1,4 @@
-/* * 
+/* *
  * Deranged Knight
  * A miniboss for quest system, designed to be a high-level challenge for multiple players.
  * Uses fuckoff gear that should not be looted - hence snowflake dismemberment code.
@@ -102,13 +102,13 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	var/obj/item/organ/eyes/organ_eyes = getorgan(/obj/item/organ/eyes)
 	var/obj/item/organ/ears/organ_ears = getorgan(/obj/item/organ/ears)
 	var/obj/item/bodypart/head/head = get_bodypart(BODY_ZONE_HEAD)
-	var/hairf = pick(list(/datum/sprite_accessory/hair/head/himecut, 
-						/datum/sprite_accessory/hair/head/countryponytailalt, 
-						/datum/sprite_accessory/hair/head/stacy, 
+	var/hairf = pick(list(/datum/sprite_accessory/hair/head/himecut,
+						/datum/sprite_accessory/hair/head/countryponytailalt,
+						/datum/sprite_accessory/hair/head/stacy,
 						/datum/sprite_accessory/hair/head/kusanagi_alt))
-	var/hairm = pick(list(/datum/sprite_accessory/hair/head/ponytailwitcher, 
-						/datum/sprite_accessory/hair/head/dave, 
-						/datum/sprite_accessory/hair/head/emo, 
+	var/hairm = pick(list(/datum/sprite_accessory/hair/head/ponytailwitcher,
+						/datum/sprite_accessory/hair/head/dave,
+						/datum/sprite_accessory/hair/head/emo,
 						/datum/sprite_accessory/hair/head/sabitsuki,
 						/datum/sprite_accessory/hair/head/sabitsuki_ponytail))
 
@@ -131,10 +131,10 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	if(organ_eyes)
 		organ_eyes.eye_color = "#FFBF00"
 		organ_eyes.accessory_colors = "#FFBF00#FFBF00"
-	
+
 	if(organ_ears)
 		organ_ears.accessory_colors = "#5f5f70"
-	
+
 	skin_tone = "5f5f70"
 
 	if(prob(1))
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	H.STACON = 16
 	H.STAWIL = 20
 	H.STAPER = 12
-	H.STAINT = 12  
+	H.STAINT = 12
 	H.STALUC = 12
 
 	H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
@@ -236,6 +236,7 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel
 	r_hand = /obj/item/rogueweapon/flail/peasantwarflail/matthios
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
+	H.set_patron(/datum/patron/inhumen/matthios)
 
 /datum/outfit/job/roguetown/quest_miniboss/zizo/pre_equip(mob/living/carbon/human/H)
 	. = ..()
@@ -249,6 +250,7 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel
 	r_hand = /obj/item/rogueweapon/sword/long/zizo
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
+	H.set_patron(/datum/patron/inhumen/zizo)
 
 /datum/outfit/job/roguetown/quest_miniboss/graggar/pre_equip(mob/living/carbon/human/H)
 	. = ..()
@@ -264,6 +266,7 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	mask = /obj/item/clothing/mask/rogue/facemask/steel
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	cloak = /obj/item/clothing/cloak/graggar
+	H.set_patron(/datum/patron/inhumen/graggar)
 
 /datum/outfit/job/roguetown/quest_miniboss/blacksteel/pre_equip(mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Buffs Quarterstaff users. Fixes bosses being unable to use their weapons.

Staves:
 - All three types, added to vendors. You can find them in expected locations, for the iron and steel variant in the blacksmith vendor, with the normal in the adventurer tab of the merchant vendor as an 'eight foot pole', as opposed to the wooden staff, which is still a 'six foot pole'.
 - Integrity increased for the steel quarterstaff by +25.
 - Charge time removed from ranged blunt stab.
 - Staves given an inherent +25% damage increase to integrity.

Other:
 - Quest bosses now have their respective patron, and can use the equipment they spawn with as a result. Woe.

## Testing Evidence
wow look at him go
<img width="64" height="69" alt="image" src="https://github.com/user-attachments/assets/a982c330-577a-438b-8cf2-240eda4a0260" />
## Why It's Good For The Game
Quarterstaff users need a treat, for suffering as they do. (It had the charge mechanic still for some reason, too.)

Otherwise, quest bosses really didn't have any reason to be as goofy as they were, dropping their weapon on spawn and wrastling anyone who came across them. Genuine bug that needed fixing.