### PR TITLE
Catches and fixes all the remaining uses of Meister

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -222,7 +222,7 @@
 GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_STEELHEARTED = span_info("I have hardened nerves, and do not waiver from the sight of violence in battle."),
 	TRAIT_OUTLANDER = span_info("Those of the vale see me as not of their land."),
-	TRAIT_OUTLAW = span_info("This land's meisters and castificos reject my touch."),
+	TRAIT_OUTLAW = span_info("This land's nervelocks and castificos reject my touch."),
 	TRAIT_LEPROSY = span_necrosis("I'm a disgusting leper..."),
 	TRAIT_UNDIVIDED = span_info("I have seen past petty squabbles, and am a true follower of the Ten Undivided. I feel most comfortable around churchmen."),
 	TRAIT_TAVERN_FIGHTER = span_info("I am vigilant in my duties. The Tavern is my home, none shall dare oppose me or skip out on payment."),
@@ -345,7 +345,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_NOHUNGER = span_info("I do not hunger, or thirst."),
 	TRAIT_DARKVISION = span_info("I can see better in the dark."),
 	TRAIT_NOCSHADES = span_info("The lens I look through allows me to see in the dark clear as dae, at the cost of greater vision."),
-	TRAIT_RESIDENT = span_info("I've been granted a Meister account, and the ownership of a house in the vale."),
+	TRAIT_RESIDENT = span_info("I've been granted a Nervelock account, and the ownership of a house in the vale."),
 	TRAIT_LIGHT_STEP = span_info("My steps are light and swift. I make less noise while sneaking, and can sneak much quicker."),
 	TRAIT_NOMOOD = span_info("I feel no sorrow, no joy, and no stress."),
 	TRAIT_AZURENATIVE = span_info("I've grown up and lived all my lyfe in these lands. I can only trigger ambushes if I sprint through them."),

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -122,7 +122,7 @@ SUBSYSTEM_DEF(treasury)
 			else
 				// Check if the amount to be fined exceeds the player's account balance
 				if(abs(amt) > bank_accounts[X])
-					send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the account to complete the fine.", name = target_name)
+					send_ooc_note("<b>NERVELOCK:</b> Error: Insufficient funds in the account to complete the fine.", name = target_name)
 					return FALSE  // Return early if the player has insufficient funds
 				bank_accounts[X] -= abs(amt)  // Deduct the fine amount from the player's account
 			found_account = TRUE
@@ -133,18 +133,18 @@ SUBSYSTEM_DEF(treasury)
 	if (amt > 0)
 		// Player received money
 		if(source)
-			send_ooc_note("<b>MEISTER:</b> You received [amt]m. ([source])", name = target_name)
+			send_ooc_note("<b>NERVELOCK:</b> You received [amt]m. ([source])", name = target_name)
 			log_to_steward("+[amt] from treasury to [target_name] ([source])")
 		else
-			send_ooc_note("<b>MEISTER:</b> You received [amt]m.", name = target_name)
+			send_ooc_note("<b>NERVELOCK:</b> You received [amt]m.", name = target_name)
 			log_to_steward("+[amt] from treasury to [target_name]")
 	else
 		// Player was fined
 		if(source)
-			send_ooc_note("<b>MEISTER:</b> You were fined [amt]m. ([source])", name = target_name)
+			send_ooc_note("<b>NERVELOCK:</b> You were fined [amt]m. ([source])", name = target_name)
 			log_to_steward("[target_name] was fined [amt] ([source])")
 		else
-			send_ooc_note("<b>MEISTER:</b> You were fined [amt]m.", name = target_name)
+			send_ooc_note("<b>NERVELOCK:</b> You were fined [amt]m.", name = target_name)
 			log_to_steward("[target_name] was fined [amt]")
 
 	return TRUE
@@ -187,10 +187,10 @@ SUBSYSTEM_DEF(treasury)
 	for(var/X in bank_accounts)
 		if(X == target)
 			if(bank_accounts[X] < amt)  // Check if the withdrawal amount exceeds the player's account balance
-				send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the account to complete the withdrawal.", name = target_name)
+				send_ooc_note("<b>NERVELOCK:</b> Error: Insufficient funds in the account to complete the withdrawal.", name = target_name)
 				return  // Return without processing the transaction
 			if(treasury_value < amt)  // Check if the amount exceeds the treasury balance
-				send_ooc_note("<b>MEISTER:</b> Error: Insufficient funds in the treasury to complete the transaction.", name = target_name)
+				send_ooc_note("<b>NERVELOCK:</b> Error: Insufficient funds in the treasury to complete the transaction.", name = target_name)
 				return  // Return early if the treasury balance is insufficient
 			bank_accounts[X] -= amt //The account accounts accountingly. Shame on you if you copy this, apple.
 			treasury_value -= amt

--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -91,7 +91,7 @@
 				return
 
 			if(!(H in SStreasury.bank_accounts))
-				to_chat(user, span_danger("The target must have a Meister account!"))
+				to_chat(user, span_danger("The target must have a Nervelock account!"))
 				return
 
 			if(istype(user.used_intent, /datum/intent/lord_electrocute))

--- a/code/modules/roguetown/roguemachine/noticeboard.dm
+++ b/code/modules/roguetown/roguemachine/noticeboard.dm
@@ -354,7 +354,7 @@
 	var/deposit = difficulty_data[actual_difficulty]["deposit"]
 
 	if(SStreasury.bank_accounts[user] < deposit)
-		say("Insufficient balance funds. You need [deposit] mammons in your meister.")
+		say("Insufficient balance funds. You need [deposit] mammons in your nervelock.")
 		return
 
 	var/list/type_choices = list(

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile.dm
@@ -123,7 +123,7 @@
 					var/amt = R.payout_price * B.amount
 					SStreasury.economic_output += R.export_price * B.amount
 					if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
-						say("No account found. Submit your fingers to a Meister for inspection.")
+						say("No account found. Submit your fingers to a Nervelock for inspection.")
 			continue
 		// Bloc to replace old vault mechanics
 		else if(istype(I,R.item_type))
@@ -153,7 +153,7 @@
 			else if(amt)
 				SStreasury.economic_output += true_value
 				if(!SStreasury.give_money_account(amt, H, "+[amt] from [R.name] bounty") && message == TRUE)
-					say("No account found. Submit your fingers to a Meister for inspection.")
+					say("No account found. Submit your fingers to a Nervelock for inspection.")
 			return
 
 /obj/structure/roguemachine/stockpile/attackby(obj/item/P, mob/user, params)

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -4,7 +4,7 @@
 
 /obj/effect/proc_holder/spell/invoked/appraise
 	name = "Appraise"
-	desc = "Tells you how many mammons someone has on them and in the meister."
+	desc = "Tells you how many mammons someone has on them and in the nervelock."
 	overlay_state = "appraise"
 	releasedrain = 10
 	chargedrain = 0
@@ -34,7 +34,7 @@
 		var/mammonsonperson = get_mammons_in_atom(target)
 		var/mammonsinbank = SStreasury.bank_accounts[target]
 		var/totalvalue = mammonsinbank + mammonsonperson
-		to_chat(user, ("<font color='yellow'>[target] has [mammonsonperson] mammons on them, [mammonsinbank] in their meister, for a total of [totalvalue] mammons.</font>"))
+		to_chat(user, ("<font color='yellow'>[target] has [mammonsonperson] mammons on them, [mammonsinbank] in their nervelock, for a total of [totalvalue] mammons.</font>"))
 
 // T1 - Take value of item in hand, apply that as healing. Destroys item.
 

--- a/modular_azurepeak/virtues/items.dm
+++ b/modular_azurepeak/virtues/items.dm
@@ -3,7 +3,7 @@
 	desc = "Through a stroke of luck or shrewd planning, I've come into a considerable amount of mammon. I can tell the value of those I speak to, and what they offer."
 	added_traits = list(TRAIT_SEEPRICES)
 	added_skills = list(list(/datum/skill/misc/reading, 1, 6))	//So the spell would work
-	custom_text = "Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Meister."
+	custom_text = "Grants Secular Appraise -- a spell that allows you to tell how much wealth someone has on them, and in their Nervelock."
 	
 /datum/virtue/items/rich/apply_to_human(mob/living/carbon/human/recipient)
 	var/obj/item/pouch = new /obj/item/storage/belt/rogue/pouch/coins/virtuepouch(get_turf(recipient))


### PR DESCRIPTION
## About The Pull Request

There were still a few places where nervelocks were being called Meisters that I hadn't caught such as in the Appraise ability

## Testing Evidence

Simple word replace

## Why It's Good For The Game

Consistency fix

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
