### PR TITLE
Trades a Warden's Expert axes for Journeyman in a wider variety of weapons (except not really now)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -85,7 +85,6 @@
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 4, TRUE)
@@ -151,11 +150,9 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/signal_horn = 1
 		)
-	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/slings, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)


### PR DESCRIPTION
## About The Pull Request

-Trades away the Warden Forester's Expert axe skill for Journeyman in axes, swords and maces, making them journeyman in all of them instead of expert in one, journeyman in another, and having no skill at all in the rest
-Warden Ranger gets Apprentice in a variety of melee weapons to meet their apprentice skill in axes.
-Adjusts descriptions to match
-Changes the text on the helmet-choice to more accurately inform you what you're doing (choosing a helmet)

## Testing Evidence

<img width="1145" height="480" alt="image" src="https://github.com/user-attachments/assets/18008828-8ad5-47c5-a33e-10dc24a7ff38" />


## Why It's Good For The Game

Means you can have a modestly wider variety of playstyles as a Warden Forester and can use more of the weapons you might scavenge while out doing warden stuff. Also means you don't feel so bad about using the other weapons because you're not significantly worse with them than with your axe.
And I don't think wardens needed expert weapon skill - proficient works serviceably enough, especially as wardens have so much else going for them beyond being an expert axe-duellist.

It makes them wind up mechanically a little closer to the old bog/vanguard; I don't know whether we'll be eventually rebranding them more towards one of those but in the meantime I think this would be a good change.