### PR TITLE
Reimplements the Ancestry System

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -181,7 +181,7 @@
 					if(racist.skin_tone == user_skin_tones[tone])
 						user_skin_tone_seen = lowertext(tone)
 						break
-			. += span_info("[capitalize(m2)] [skin_tone_wording] is [skin_tone_seen][slop_lore_string]")	*/
+			. += span_info("[capitalize(m2)] [skin_tone_wording] is [skin_tone_seen][slop_lore_string]")
 
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user


### PR DESCRIPTION
## About The Pull Request

Direct revert of https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/211

## Testing Evidence

Started the game, spawned in, looked at myself and saw my ancestry.

## Why It's Good For The Game

There was no reason to remove the examine component aside from the wish to not tie regions to skin color, that's fine, but there's better ways to do that such as using non-existent colors and giving them species_traits = list(MUTCOLORS ....) etc or by other means i'm not currently aware of. 
