### PR TITLE
Fixes/Rebalances knuckles

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -34,6 +34,7 @@
 	penfactor = BLUNT_DEFAULT_PENFACTOR
 	clickcd = CLICK_CD_FAST
 	damfactor = 1.1
+	intent_intdamage_factor = 1.15
 	swingdelay = 0
 	icon_state = "inpunch"
 	item_d_type = "blunt"
@@ -44,10 +45,9 @@
 	attack_verb = list("smashes")
 	hitsound = list('sound/combat/hits/punch/punch_hard (1).ogg', 'sound/combat/hits/punch/punch_hard (2).ogg', 'sound/combat/hits/punch/punch_hard (3).ogg')
 	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 1.1
+	damfactor = 1.5
 	clickcd = CLICK_CD_MELEE
 	swingdelay = 8
-	intent_intdamage_factor = 1.35
 	icon_state = "insmash"
 	item_d_type = "blunt"
 
@@ -155,6 +155,7 @@
 	associated_skill = /datum/skill/combat/unarmed
 	throwforce = 12
 	wdefense = 4	//Meant to be used with bracers. Temp for now.
+	intdamage_factor = 1.15
 	wbalance = WBALANCE_NORMAL
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/steel


### PR DESCRIPTION
## About The Pull Request
Dusters now do inherently 15% extra damage to armor, and another 15% on basic punches. the smash attack, rather than being an extra 35% damage to armor, is instead an extra 50% damage overall.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="805" height="600" alt="image" src="https://github.com/user-attachments/assets/2151ebc4-935d-4fbf-9ba3-d5eb3b83176a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I realized in the process of making this PR that radiant was doing something similar for other blunt weapons, (https://github.com/Rotwood-Vale/Ratwood-2.0/pull/172) and I have partially factored that in as it seems to be being approved, but I made this because the knuckles smash intent has been broken for a while but feels double broken now; doing slightly more damage to armor in exchange for a big delay before hitting- was not worth it at all, and when it's the main selling point of knuckles it felt stupid that it was just totally broken. Not to mention that, even with these changes, someone with civilized barbarian can pen armor with their punches better than someone with dusters can. 

I don't want to make knuckles better than maces, so I tried to keep them weaker than other options, but this should give them some use. I was going to give them a significantly weaker smash attack (and it will be slightly weaker, if Radiant's blunt buff is merged) but I realized that the base 22 damage of knuckles really hampers them. For comparison, a cudgel or an iron mace needs 11 strength to penetrate plate armor and do minor damage, while **steel** knuckles, with this buff, will still need 13 strength to do the same. On the other hand, their ability to smash with one hand is powerful (though there are many one-handed picking weapons, including the punch dagger, normal dagger, and Warhammer, which can be stronger) and its smash is slightly faster than the usual. I think I leaned towards making it too weak rather than too strong.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
