### PR TITLE
Buffs/rebalances Masked Lunatics

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/vigilante.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/vigilante.dm
@@ -6,7 +6,7 @@
 	outfit = /datum/outfit/job/roguetown/wretch/vigilante
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_DECEIVING_MEEKNESS, TRAIT_PERFECT_TRACKER)
-	maximum_possible_slots = 2
+	maximum_possible_slots = 1
 	extra_context = "This class is best experienced without preparation."
 
 /datum/outfit/job/roguetown/wretch/vigilante/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
## About The Pull Request
-replaces watchman's 3 willpower with 1 willpower, 1 PER and 1 SPD

-gives gadgeteer +1 unarmed, polearms, and engineering now (expert in everything)
-replaces gadgeteer's 3 int with 2 int and 2 CON

-raises masked lunatic slots to two
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Austere, thirsty humen

<img width="1933" height="1193" alt="image" src="https://github.com/user-attachments/assets/5e82010b-71c9-4854-9450-de71da5a4c06" />
<img width="1869" height="1239" alt="image" src="https://github.com/user-attachments/assets/2fec6210-8cb8-4716-92af-65eb5c6db98f" />



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
That's right, the vigilante guy is buffing vigilante.
Not that I need it, but it does bother me _how_ weak they are. Wretches are generally a bit better than adventurers in exchange for their downsides, but Watchman is weaker than even regular barbarian in some ways. But at least it has HALF of a defensive trait; gadgeteer doesn't even get that OR any expert weapon skills.

I first noticed how ass these classes are when I realized that Watchman is essentially just a severely worse berserker with a hurlbat (I'm not counting their steel tossblade belt, wretches can get a free iron tossblade belt from their care packages, so this doesn't mean too much.) and minor skill differences. But most wretches are weaker than berserker- this just makes watchman feel like an alternative instead of a downgrade.

Watchman has no crit resist or civilized barbarian (this is the more painful thing, really, pugilist is a massive unarmed buff), and in exchange gets 8 statpoints, and avoids the normal barbarian/berserker penalties to per and int. the problem is those stats don't mean much for a grappler, and the stat that REALLY doesn't matter to someone with pain immunity, is willpower. But Lunatic gets 3 willpower! Lot of wasted potential, makes the 8 statpoints feel like five. So I moved two of the WIL points to SPD and PER. Maybe int would be good too, didn't want to give them too much. Should make them feel different from berserker though.

Gadgeteer has a different problem, it's just extremely weak and fragile. Every round I've played gadgeteer, things go okay until you get grappled in melee and have slightly bad luck escaping, or you just get mobbed by more than one person. The sling is fun to hit people with, but it and your quarterstaff don't do enough to justify how vulnerable you are with only proficient weapon skills and no armor or dodge expert. It makes you feel _really_ encouraged to run sentinel of wits, which is boring. Soo I reduced their int a bit to discourage that, and gave them some CON so they don't fall over as easily from a few hits. 10 statpoints is quite a bit, but none of them are in STR or SPD, so I think it should be okay. compare with Freifechter's 9 statpoints and master swords, if you like.

More importantly, the expert polearms skill I added should give them a comfy parry chance, without making them feel too strong because they still have 10 base str.

The other problems with gadgeteer... two are that it's hard to actually get more gadgets 'cause your engineering skill is too low and you don't have any of the tools to use it. I gave them 1 extra engineering to help with the first issue, second issue should keep them in check.

The third is just that gadgeteer is just a painful amount of inventory management because when you DO have gadgets, you only have a satchel to store them in because the quarterstaff takes up your other back slot. Maybe a special hip quarterstaff for them would be nice, but I just gave them expert unarmed too in case they want to ditch the quarterstaff to punch people with their 10 strength.

Also, I raised the slots to two, why not? It's essentially three different classes under one label, though they should probably be limited in _some_ capacity because the themes are similar. I haven't had it happen to me, but it'd suck to spawn as wretch and suddenly discover the subclass you want to play is taken by someone doing something completely different.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
