### PR TITLE
Adds back run mode

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -135,6 +135,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/masked_examine = FALSE
 	var/mute_animal_emotes = FALSE
 	var/autoconsume = FALSE
+	var/runmode = FALSE
 
 	var/lastclass
 

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -581,6 +581,17 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 			S.cmode_music_override_name = combat_music.name
 	return
 
+/client/verb/runm()
+	set name = "Run Mode"
+	set desc = "Changes if you run continually or if you stop running when you turn"
+	set category = "Options"
+	prefs.runmode = !prefs.runmode
+	if(prefs.runmode)
+		to_chat(usr, "Running changed (no turning)")
+	else
+		to_chat(usr, "Running changed (turning)")
+	prefs.save_preferences()
+
 /client/verb/policy()
 	set name = "Show Policy"
 	set desc = ""

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -165,12 +165,16 @@
 			if(L.m_intent == MOVE_INTENT_RUN)
 				L.toggle_rogmove_intent(MOVE_INTENT_WALK)
 	else
-		if(L.dir != target_dir)
-			if(abs(dir2angle(L.dir) - dir2angle(target_dir)) == 180)	//If we do a 180 turn, we cancel our run
-				if(L.m_intent == MOVE_INTENT_RUN)
+		if(prefs.runmode)
+			if(L.dir != target_dir)
+				if(L.m_intent == MOVE_INTENT_RUN && L.sprinted_tiles > 0) //If any turn is done, we cancel our run
 					L.toggle_rogmove_intent(MOVE_INTENT_WALK)
-			// Reset our sprint counter if we change direction
-			L.sprinted_tiles = 0
+					// Classic run-cancelling when turning
+		else if(abs(dir2angle(L.dir) - dir2angle(target_dir)) == 180)	//If we do a 180 turn, we cancel our run
+			if(L.m_intent == MOVE_INTENT_RUN)
+				L.toggle_rogmove_intent(MOVE_INTENT_WALK)
+				// Reset our sprint counter if we change direction
+				L.sprinted_tiles = 0
 
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. --> Ports Rotwood-Vale/Ratwood-Keep/pull/1835 back from OG Ratwood. Adds an option in the options menu to switch to a more precise mode of running where you stop when you turn.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="242" height="59" alt="image" src="https://github.com/user-attachments/assets/8407a42e-6d62-4acb-8ef8-29e994d351b5" />

https://github.com/user-attachments/assets/a08972e1-a86a-4890-8d40-f18f695700e6



## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. --> Good for accessibility and/or gameplay. Also I have been asked to make this by multiple people

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
