### PR TITLE
Matthios' Theft of the Flame [Draft]

### DIFF
--- a/code/game/objects/lighting/_base_roguelight.dm
+++ b/code/game/objects/lighting/_base_roguelight.dm
@@ -12,6 +12,7 @@
 	var/cookonme = FALSE
 	var/crossfire = TRUE
 	var/can_damage = FALSE
+	var/divine = FALSE
 
 /obj/machinery/light/rogue/Initialize()
 	if(soundloop)
@@ -47,7 +48,6 @@
 		else
 			if(initial(fueluse) > 0)
 				. += span_warning("The fire is burned out and hungry...")
-
 
 /obj/machinery/light/rogue/extinguish()
 	if(on)

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -80,6 +80,27 @@
 	status = LIGHT_BURNED
 	desc = "The fire is gone!"
 
+/obj/machinery/light/rogue/firebowl/church/astrata
+
+	name = "astrata's flame"
+	desc = "A metal bowl containing a divine flame."
+	icon_state = "churchfire1"
+	base_state = "churchfire"
+	bulb_colour = "#aaffff"
+
+/obj/machinery/light/rogue/firebowl/church/astrata/off
+	icon_state = "churchfire0"
+	base_state = "churchfire"
+	soundloop = null
+	status = LIGHT_BURNED
+	desc = "The divine fire has been stolen!"
+
+/obj/machinery/light/rogue/firebowl/church/astrata/off/fire_act(added, maxstacks)
+	to_chat(src.loc, "<span class='notice'>The [src] refuses to be lit!</span>")
+
+/obj/machinery/light/rogue/firebowl/church/astrata/extinguish()
+	to_chat(src.loc, "<span class='notice'>Astrata's fire persists!</span>")
+
 /obj/machinery/light/rogue/firebowl/standing
 	name = "standing fire"
 	desc = "Wrought metal spun into a surprisingly stable stand for a large candle to sit upon."

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -181,6 +181,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		playsound(src, 'sound/misc/enflame.ogg', 100, TRUE)
 		return 1
 
+/obj/proc/force_fire_act(added, maxstacks)
+	fire_act(added, maxstacks)
+	
 ///called when the obj is destroyed by fire
 /obj/proc/burn()
 	if(resistance_flags & ON_FIRE)
@@ -195,6 +198,9 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		SSfire_burning.processing -= src
 		if(fire_burn_start)
 			fire_burn_start = null
+
+/obj/proc/force_extinguish()
+	extinguish()
 
 ///Called when the obj is hit by a tesla bolt.
 /obj/proc/tesla_act(power, tesla_flags, shocked_targets)


### PR DESCRIPTION
## About The Pull Request

Adds Astrata's Flame, an objective for bandits.

-1 lit brazier (astrata's flame) is placed on the top floor of the church
-1 unlit brazier is placed at the bandit camp
-a player may steal the lit flame with a torch/lamptern, snuffing the brazier's flame in the process, the special brazier can not be put out by any other means
-when lit by this holy source the torch/lamptern becomes "astrata's flame" and notifies all astratans what has happened
-astrata's flame can never be extinguished only placed onto a torch or one of the two braziers
-when lit at the church, church areas have a passive devotion increase and a flat astrata influence increase
-when lit at the bandit camp it provides bandits a passive point increase and a flat matthios influence increase, further it informs all church staff of the bandit camp location
-when in torch/lamptern form, astrata's flame provides +4 perception when held in your hand

## Testing Evidence

none yet

## Why It's Good For The Game

A fun capture the flag mini objective
