### PR TITLE
Unarmed Destruction

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -131,7 +131,24 @@
 		used_str = get_str_arms(used_hand)
 
 	if(used_str >= 11)
-		damage = max(damage + (damage * ((used_str - 10) * 0.2)), 1)
+		var/bonus = 0
+
+		if(used_str <= 14)
+			// Normal scaling: +20% per point over 10
+			bonus = (used_str - 10) * 0.2
+		else
+			// Diminishing returns after 14
+			// Start with the full +0.8 from 14 STR
+			bonus = 0.8
+			var/extra = used_str - 14
+			// Each point beyond 14 gives a smaller bonus than the last:
+			// e.g., +0.1, +0.075, +0.05625, etc.
+			var/next_bonus = 0.1
+			for(var/i = 1, i <= extra, i++)
+				bonus += next_bonus
+				next_bonus *= 0.75 // reduces 25% each time
+		damage = max(damage + (damage * bonus), 1)
+
 	if(used_str <= 9)
 		damage = max(damage - (damage * ((10 - used_str) * 0.1)), 1)
 


### PR DESCRIPTION
## About The Pull Request
~~One line adjustment.~~
Now applies diminishing returns after 14STR.
```
Normal scaling: +20% per point over 10

Diminishing returns after 14
Start with the full +0.8 from 14 STR

Each point beyond 14 gives a smaller bonus than the last:
e.g., +0.1, +0.075, +0.05625, etc.
```
As opposed to 80 per hit at 20STR without gauntlets...

20STR = 42.1 UNARMED | 50.5 PLATE GAUNTLETS
14STR(BEFORE LOSS OF RETURNS) = 22.4 UNARMED | 26.9 PLATE GAUNTLETS
9STR(BEFORE BONUS) = 7.2 UNARMED | 8.6 PLATE GAUNTLETS

~~20STR = 72 BRUTE with PLATE GAUNTLETS~~
~~14STR = 22.4 BRUTE | 25.8 with CHAIN GAUNTLETS | 30.2 with PLATE GAUNTLETS~~

~~20STR = 25.4 BRUTE~~
~~14STR = 15.3 BRUTE~~
~~1STR = 1 BRUTE~~

Is this good? I 'unno. CivBarb will still help for actual crits. But this'll stop a very particular playstyle that is very gross and wildly blowing everything else out of the water. Thanks, unarmed. Continuing to be the pain that you are.

## Testing Evidence
Very simple change. Tested numbers are above.

## Why It's Good For The Game
I didn't think I'd need to argue this. But I do.
Extreme edge cases had brawlers outcompeting anything else by far. It felt like the katar all over again.

Unarmed cannot be disarmed. You cannot take it. You cannot prevent it from being used, unless you outright break someone's arms. It was the equivalent of bringing a hand grenade to a knife fight in a lot of cases. Classes like berserker were better off discarding knuckles / katars as a result.

Further adjustments to this have retained it as a viable strategy, to be clear, if you've the strength. It's a simple 0.3 to 0.2.