### PR TITLE
Brawler's Apprentice gives Knuckles instead of a Katar

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -115,7 +115,7 @@
 	name = "Brawler's Apprentice"
 	desc = "I have trained under a skilled brawler, and have some experience fighting with my fists."
 	custom_text = "+1 to Unarmed and Wrestling, Up to Journeyman, Minimum Apprentice."
-	added_stashed_items = list("Katar" = /obj/item/rogueweapon/katar)
+	added_stashed_items = list("Knuckles" = /obj/item/rogueweapon/knuckles, "More Knuckles" = /obj/item/rogueweapon/knuckles)
 	
 /datum/virtue/combat/brawler/apply_to_human(mob/living/carbon/human/recipient)
 	if(recipient.get_skill_level(/datum/skill/combat/unarmed) < SKILL_LEVEL_APPRENTICE)


### PR DESCRIPTION
## About The Pull Request

As the title says. Gives you two knuckles, one for each hand. Handy!

## Testing Evidence

<img width="389" height="137" alt="image" src="https://github.com/user-attachments/assets/60925837-88fd-4c9c-97d7-0cfd9300385f" />
<img width="540" height="340" alt="image" src="https://github.com/user-attachments/assets/7deac34b-b707-4d79-9fd2-23e7c5857eeb" />
<img width="694" height="808" alt="image" src="https://github.com/user-attachments/assets/031d5d77-febd-4dca-af6b-31e4a53ada32" />


## Why It's Good For The Game

The Katar strikes me as a very niche specialist tool that doesn't really fit the concept of a 'brawler' - you don't really brawl with a katar, a katar is a murder dagger! Think knuckles fit better as a tool of brawling. Nice to have some blunt weapons that aren't as much of an escalation into murder too.