### PR TITLE
Ports outdoorsman-branch-sleeping-fix

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -573,7 +573,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	//Healing while sleeping in a bed
 	if(IsSleeping())
 		var/sleepy_mod = 0.5
-		var/yess = HAS_TRAIT(src, TRAIT_NOHUNGER)
+		var/doesnt_hunger = HAS_TRAIT(src, TRAIT_NOHUNGER)
 		if(HAS_TRAIT(src, TRAIT_BETTER_SLEEP))
 			energy_add(sleepy_mod * 4)
 		if(buckled?.sleepy)
@@ -582,9 +582,14 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			var/obj/structure/bed/rogue/bed = locate() in loc
 			if(bed)
 				sleepy_mod = bed.sleepy
-		if(nutrition > 0 || yess)
+			else
+				if(HAS_TRAIT(src, TRAIT_OUTDOORSMAN))
+					var/obj/structure/flora/newbranch/branch = locate() in loc
+					if(branch)
+						sleepy_mod = 1.6 // little worse than a bedroll
+		if(nutrition > 0 || doesnt_hunger)
 			energy_add(sleepy_mod * 15)
-		if(hydration > 0 || yess)
+		if(hydration > 0 || doesnt_hunger)
 			if(!bleed_rate)
 				blood_volume = min(blood_volume + (4 * sleepy_mod), BLOOD_VOLUME_NORMAL)
 			for (var/obj/item/bodypart/affecting in bodyparts)
@@ -620,7 +625,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 				if(HAS_TRAIT(src, TRAIT_OUTDOORSMAN))
 					var/obj/structure/flora/newbranch/branch = locate() in loc
 					if(branch)
-						sleepy_mod = 1.5 //Worse than a bedroll, better than nothing.
+						sleepy_mod = 0.8 // better than leaning against a wall, since you get this while NOT asleep
 		if(sleepy_mod > 0)
 			if(eyesclosed)
 				var/armor_blocked = FALSE


### PR DESCRIPTION
## About The Pull Request

I noticed that as Warden whenever I tried to sleep in a tree I didn't get hardly any blue bar back. Turns out they coded in the Outdoorsman effect for laying down on branches but not for sleeping. Someone fixed it! I made it so that sleeping on a branch is a little less good than sleeping on a bedroll, but better than nothing.
Ports https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1237

## Testing Evidence

<img width="1372" height="1197" alt="image" src="https://github.com/user-attachments/assets/417ae39b-133c-4a47-b0ea-b424b4dd413d" />

Set my energy to 1, slept on some branches, slept on some beds. Branches better than floor, bed better than branch.

## Why It's Good For The Game

Fixes a bug
