### PR TITLE
Estoc Tweaks

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -90,7 +90,7 @@
 
 /datum/intent/sword/lunge/estoc
 	damfactor = 1.2
-	penfactor = 20
+	penfactor = 37//25 base, +5, at 67. More for applying bleed through armour, since it's a needle.
 	swingdelay = 0
 	clickcd = CLICK_CD_CHARGED
 


### PR DESCRIPTION
## About The Pull Request
The estoc is currently a very peculiar weapon.

It has a chop, despite being needle thin. It has an odd setup where next to someone, it's on par with a spear just about. 
The entire point of something like an estoc is that it's long and designed to deal with armour, not lop off limbs.

Gave it a unique lunge with AP to allow it to bleed through armour. Not as great as the actual adjacent stab. In fact, it's only useful for bleeding when it comes to armoured targets, doing 1 brute through armour yet causing bleeds at 16STR. Which is what I'd tested it at.

Additionally, I'd removed both one handed and two-handed chopping.
Gave it the standard sword thrust when one-handed, and for two-handed I'd given it greatsword peeling. Which, if you're not familiar, is ranged, with a divisor of 5 as opposed to a sword's standard 4. We could probably just drop the peeling here altogether, if it's not something we want. Assuming the PR is humored. I just thought it thematic, since it's pushing between plates and the like anyways.

Further, I'd removed the swing delay on both the lunge and thrust, putting it on par with the spear for attack speed and click cooldown. Is this a good idea? I've no clue. I'd just like to see anti-armour variety, personally. Doubly so as something like the greatsword doesn't have this swing delay for anything but the lunge it shared with the estoc, previously.

I was just super disappointed that the estoc is effectively a greatsword, with less damage, and a weird adjacent pen. But worse otherwise aside from that. Mind, it doesn't need to return to what it used to be. It's just kinda vestigial when compared to a lot of other choices.

I miss the old estoc...

## Testing Evidence
Very simple number tweaks.
Tested in game. Forgot to take screenshots.
16STR doing one damage through armour via the lunge, on a typical knight setup.

## Why It's Good For The Game
It'd be funny, while also returning an old gem back into active play.