### PR TITLE
Peeling Inaccuracy

### DIFF
--- a/code/modules/mob/living/combat/accuracy_checks.dm
+++ b/code/modules/mob/living/combat/accuracy_checks.dm
@@ -1,5 +1,5 @@
-#define ULTRA_PRECISE_ZONE 1 
-#define PRECISE_ZONE 2 
+#define ULTRA_PRECISE_ZONE 1
+#define PRECISE_ZONE 2
 #define NO_PENALTY_ZONE 3
 #define RANGED_MAX_ULTRA_PRECISE_HIT_CHANCE 50 // No matter what max 50% chance to hit
 #define RANGED_ULTRA_PRECISE_HIT_PENALTY -25 // -25 for you - THEN we clamp.
@@ -35,11 +35,11 @@
 	if(used_intent)
 		if(used_intent.blade_class == BCLASS_STAB)
 			chance2hit += 10
-		if(used_intent.blade_class == BCLASS_PEEL)
-			chance2hit += 25
 		if(used_intent.blade_class == BCLASS_CUT)
 			chance2hit += 6
 		if((used_intent.blade_class == BCLASS_BLUNT || used_intent.blade_class == BCLASS_SMASH) && check_zone(zone) != zone)	//A mace can't hit the eyes very well
+			chance2hit -= 10
+		if(used_intent.blade_class == BCLASS_PEEL)
 			chance2hit -= 10
 
 	if(I)
@@ -56,7 +56,7 @@
 		chance2hit += 20
 	if(istype(user.rmb_intent, /datum/rmb_intent/swift))
 		chance2hit -= 20
-	
+
 	if(HAS_TRAIT(user, TRAIT_CURSE_RAVOX))
 		chance2hit -= 40
 


### PR DESCRIPTION
## About The Pull Request
Peeling has a +25 to hit, right now.
This swaps that to a -10. Simple as.

We were discussing behind the scenes a way to make weapons more viable, for those that don't have access to peeling. Given right now, a sabre outperforms most weapons because of peeling being a wild thing when combined with certain intents. I will not sling shade at my beloved partizan. Leave it alone.

This may well be a way to correct the issue. Is it good? I 'unno. Peeling is weird and awful though, but we're stuck with it. May as well make the best of a bad thing.

Doubly so without gutting existing weaponry. Ironic as it is to say, given recent PRs.

## Testing Evidence
Simple number tweak. Another coal Carl PR. Slop. Not tested. Objectively awful. Whatever.

## Why It's Good For The Game
Find man who doesn't have peel weapon, while wearing full armour. Watch as you peel and delimb him / poke out his eyes in seconds, while he struggles to do much of anything. Assuming he's not smart enough to grapple.
Does this fix that? No. It helps with it being so obscene, though. I'd hope.