### PR TITLE
Gives the Inn Cook a cleaver on spawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/cook.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/cook.dm
@@ -66,6 +66,7 @@
 		H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE)
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/roguekey/tavern
+	beltr = /obj/item/rogueweapon/huntingknife/cleaver
 	backr = /obj/item/storage/backpack/rogue/satchel
 	cloak = /obj/item/clothing/cloak/apron/cook
 	head = /obj/item/clothing/head/roguetown/cookhat


### PR DESCRIPTION
## About The Pull Request
Gives the innkeep cook a cleaver on spawn, just like every other role. Just in case you latespawn and someone stole it.

## Testing Evidence

<img width="393" height="582" alt="image" src="https://github.com/user-attachments/assets/29b94a72-6c6e-423e-94c9-adfb94f55ac3" />


## Why It's Good For The Game

Fixes a possible annoyance of having to "acquire" a cleaver as a latejoiner. Every other role has this on spawn.