### PR TITLE
WW Imperial Ban

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -108,6 +108,7 @@
 	mind.transfer_to(W)
 	skills?.known_skills = list()
 	skills?.skill_experience = list()
+	W.remove_all_languages()
 	W.grant_language(/datum/language/beast)
 
 	W.base_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB)
@@ -189,6 +190,7 @@
 	mind.transfer_to(W)
 
 	var/mob/living/carbon/human/species/werewolf/WA = src
+	W.remove_all_languages()
 	W.copy_known_languages_from(WA.stored_language)
 	skills?.known_skills = WA.stored_skills.Copy()
 	skills?.skill_experience = WA.stored_experience.Copy()


### PR DESCRIPTION
## About The Pull Request
No, thanks.
Removes WWs speaking Imperial.
It works perfectly.
I don't know who returned them speaking common. They're mad beasts, not cuddly creatures. Treat them as such.

## Testing Evidence
It just works. I'd tested it. There you go. Good enough.

## Why It's Good For The Game
Every second WW rolls over for the town roundstart. Not great. Ruins a limited antag slot for that particular round.