### PR TITLE
Dualwielding Zeybek

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -116,6 +116,11 @@
 	wrists = /obj/item/clothing/wrists/roguetown/splintarms
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex/raneshen
+	shoes = /obj/item/clothing/shoes/roguetown/shalal
+	belt = /obj/item/storage/belt/rogue/leather/shalal
+	beltl = /obj/item/rogueweapon/scabbard/sword
+	beltr = /obj/item/rogueweapon/scabbard/sword
+	l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
 	backr = /obj/item/storage/backpack/rogue/satchel/black
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary,
@@ -144,12 +149,6 @@
 			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 			r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			backl = /obj/item/quiver/arrows
-	shoes = /obj/item/clothing/shoes/roguetown/shalal
-	belt = /obj/item/storage/belt/rogue/leather/shalal
-	beltl = /obj/item/rogueweapon/scabbard/sword
-	beltr = /obj/item/rogueweapon/scabbard/sword
-	l_hand = /obj/item/rogueweapon/sword/sabre/shamshir
-
 	H.merctype = 4
 
 /datum/advclass/mercenary/desert_rider/almah


### PR DESCRIPTION
## About The Pull Request
Adds the dualwielding trait to Zeybeck mercenaries
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's fitting given they're given two identical swords, only no way to use both at once.
If any other roles should have the dual wielding trait, feel free to let me know.

It's entirely possible I just like the role and want it buffed, so I'd prefer others vibe check me on this. It seemed fitting though.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
