### PR TITLE
Ports Azure fix for Teleporting NPC mobs

### DIFF
--- a/code/game/objects/items/rogueweapons/intents/mmb/jump.dm
+++ b/code/game/objects/items/rogueweapons/intents/mmb/jump.dm
@@ -13,37 +13,37 @@
 /mob/living/proc/jump_action(atom/A)
 	if(istype(get_turf(src), /turf/open/water))
 		to_chat(src, span_warning("I can't jump while floating."))
-		return
+		return FALSE
 
 	if(!A || QDELETED(A) || !A.loc)
-		return
+		return FALSE
 
 	if(A == src || A == loc)
-		return
+		return FALSE
 
 	if(src.get_num_legs() < 2)
-		return
+		return FALSE
 
 	if(pulledby && pulledby != src)
 		to_chat(src, span_warning("I'm unable to jump while grabbed."))
-		return
+		return FALSE
 
 	if(IsOffBalanced())
 		to_chat(src, span_warning("I haven't regained my balance yet."))
-		return
+		return FALSE
 
 	if(!(mobility_flags & MOBILITY_STAND))
 		if(!HAS_TRAIT(src, TRAIT_LEAPER))// The Jester cares not for such social convention.
 			to_chat(src, span_warning("I should stand up first."))
-			return
+			return FALSE
 
 	if(!isatom(A))
-		return
+		return FALSE
 
 	if(A.z != z)
 		if(!HAS_TRAIT(src, TRAIT_ZJUMP))
 			to_chat(src, span_warning("That's too high for me..."))
-			return
+			return FALSE
 
 	changeNext_move(mmb_intent.clickcd)
 
@@ -75,6 +75,7 @@
 			jrange = 1
 
 	jump_action_resolve(A, jadded, jrange, jextra)
+	return TRUE
 
 #define FLIP_DIRECTION_CLOCKWISE 1
 #define FLIP_DIRECTION_ANTICLOCKWISE 0

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -271,12 +271,13 @@
 		QDEL_NULL(mmb_intent) // unset our intent after
 		m_intent = old_m_intent
 		if(.)
+			clear_path()
 			start_pathing_to(target) // regenerate path now that we've jumped
 		return
 	m_intent = old_m_intent
 	return FALSE
 
-/// Force the NPC to jump to a specific destination. Handles 
+/// Force the NPC to jump to a specific destination. Handles
 /mob/living/carbon/human/proc/npc_try_jump_to(atom/jump_destination)
 	if(!jump_destination)
 		return FALSE
@@ -431,8 +432,8 @@
 			pathing_frustration = 0
 			myPath -= myPath[1]
 			NPC_THINK("MOVEMENT TURN [movement_turn]: Movement on cooldown for [movespeed/10] seconds!")
-			sleep(movespeed) // wait until next move	
-		
+			sleep(movespeed) // wait until next move
+
 // blocks, but only while path is being calculated
 /mob/living/carbon/human/proc/start_pathing_to(new_target)
 	if(!new_target)
@@ -628,7 +629,7 @@
 			// Flee before trying to pick up a weapon.
 			if(flee_in_pain && target && (target.stat == CONSCIOUS))
 				var/paine = get_complex_pain()
-				if(paine >= ((STAWIL * 10)*0.9)) 
+				if(paine >= ((STAWIL * 10)*0.9))
 					NPC_THINK("Ouch! Entering flee mode!")
 					mode = NPC_AI_FLEE
 					m_intent = MOVE_INTENT_RUN
@@ -816,7 +817,7 @@
 			return TRUE // and end turn
 	else if(!OffWeapon && prob(make_grab_chance)) // grab with our empty offhand instead of attack
 		if(npc_try_make_grab(victim)) // returns TRUE if we've finished our turn, not if we succeeded at the grab
-			return TRUE 
+			return TRUE
 
 	// attack with weapon if we have one
 	if(Weapon)


### PR DESCRIPTION

## About The Pull Request
Mobs will no longer teleport backwards after leaping.
Port of https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/4251

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
A bit self explanatory I'd say, but having mobs not teleport after jumping is ideal.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
