### PR TITLE
Rework of scrying orb

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -81,6 +81,7 @@
 #define TRAIT_WING_BOUND "Wing Bound"//Welcome back, OldAcrobat. Offbalance (12s) and stun(2s) from falling 1Z, but no damage.
 #define TRAIT_DWARF_REPAIR "Dwarvish Knowledge"//Squire Repair, but very slightly worse. Only for needle / hammer.
 #define TRAIT_DRUNK_HEALING "Drunk Healing"//Having anything with booze power of 25 or more in your system slowly heals you.
+#define TRAIT_SIMPLESPEECH "Simple Speech" // Can only say the 1000 most common English-language words; other words get modified
 
 //Hearthstone port (Tracking)
 #define TRAIT_PERFECT_TRACKER "Perfect Tracker" //Will always find any tracks and analyzes them perfectly.
@@ -400,7 +401,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_WING_BOUND = span_info("The wings upon my back allow me to glide. Poorly. Falls will be less painful, but still not ideal."),
 	TRAIT_DWARF_REPAIR = span_info("Never again will there be a people like ours. Repairs come easy to me."),
 	TRAIT_DRUNK_HEALING = span_info("A little drinking never hurt!"),
-	TRAIT_RESONANCE = span_suppradio("My miracles will <b><u>fortify</u></b> others nearby.")
+	TRAIT_RESONANCE = span_suppradio("My miracles will <b><u>fortify</u></b> others nearby."),
+	TRAIT_SIMPLESPEECH = span_info("I can not say hard words.")
 ))
 
 // trait accessor defines

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -99,10 +99,11 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	var/heretic_nickname 	// Nickname used for heretic commune
 
 	var/picking = FALSE		// Variable that lets the event picker see if someones getting chosen or not
-	
+
 	var/job_bitflag = NONE	// the bitflag our job applied
 
 	var/list/personal_objectives = list() // List of personal objectives not tied to the antag roles
+	var/list/special_people = list() // For characters whose text will display in a different colour when seen by this Mind
 
 /datum/mind/New(key)
 	src.key = key
@@ -202,7 +203,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 					var/heretic_text = C.get_heretic_symbol(H)
 					if (heretic_text)
 						M.known_people[H.real_name]["FHERESY"] = heretic_text
-				
+
 
 /datum/mind/proc/do_i_know(datum/mind/person, name)
 	if(!person && !name)
@@ -851,6 +852,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	..()
 	if(!mind.assigned_role)
 		mind.assigned_role = "Unassigned" //default
+
 
 //AI
 /mob/living/silicon/ai/mind_initialize()

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -548,3 +548,305 @@
 	name = "Action Delayed"
 	desc = "I cannot take another action."
 	icon_state = "clickcd"
+
+// Magical mishaps
+// Victim loses common, their default language, or a random language (in order of preference) for the duration
+/atom/movable/screen/alert/status_effect/mishap_langloss
+	name = "Forgotten Tongue"
+	desc = "I can't remember how to speak in-- what was the language even called, again..?"
+	icon_state = "mind_control"
+	var/removed_language = null
+
+/datum/status_effect/debuff/mishap_langloss
+	id = "language_loss"
+	duration = 5 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_langloss
+	var/datum/language/removed_language
+
+/datum/status_effect/debuff/mishap_langloss/on_apply()
+	. = ..()
+	var/datum/language_holder/holder = owner.mind?.language_holder
+	if (holder)
+		if (owner.has_language(/datum/language/common))
+			// Always remove common, if the character has it
+			removed_language = /datum/language/common
+		else if (holder.selected_default_language != /datum/language/common)
+			// Otherwise, remove their default language, if one is defined
+			removed_language = holder.selected_default_language
+		else
+			// And if there's no default language, remove a random language
+			removed_language = holder.get_random_understood_language()
+
+		if (removed_language == /datum/language/aphasia)
+			return
+
+		// If we haven't selected a language by this point there's probably no language to select
+		if (removed_language)
+			owner.remove_language(removed_language)
+
+
+/datum/status_effect/debuff/mishap_langloss/on_remove()
+	..()
+	if (removed_language)
+		owner.grant_language(removed_language)
+
+
+// Reduces intelligence by 20 (!!) and removes all languages except Aphasia for the duration.
+/atom/movable/screen/alert/status_effect/mishap_feeblemind
+	name = "Feebleminded"
+	desc = "Wuh-- uh..."
+	icon_state = "mind_control"
+
+/datum/status_effect/debuff/mishap_feeblemind
+	id = "feeblemind"
+	duration = 7 MINUTES // This effect is really nasty but is deliberately one of the worst mishap effects, so it has a fairly long duration.
+	status_type = STATUS_EFFECT_REFRESH
+	// Won't necessarily force intelligence to 1, if we're really smart and have buffs
+	effectedstats = list("intelligence" = -20, "speed" = -5)
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_feeblemind
+	var/datum/language_holder/owner_language_holder
+	var/datum/language_holder/old_languages
+
+/datum/status_effect/debuff/mishap_feeblemind/on_apply()
+	. = ..()
+	owner_language_holder = owner.get_language_holder()
+	old_languages = owner_language_holder.copy()
+	owner_language_holder.remove_all_languages()
+	owner.language_holder.grant_language(/datum/language/aphasia)
+	ADD_TRAIT(owner, TRAIT_SPELLCOCKBLOCK, id)
+
+/datum/status_effect/debuff/mishap_feeblemind/tick()
+	..()
+	if (prob(5))
+		owner.emote(pick("drools", "stares blankly"))
+
+/datum/status_effect/debuff/mishap_feeblemind/on_remove()
+	..()
+	owner_language_holder.remove_language(/datum/language/aphasia)
+	owner_language_holder.copy_known_languages_from(old_languages)
+	REMOVE_TRAIT(owner, TRAIT_SPELLCOCKBLOCK, id)
+
+// Functions as Nimrod, but a bit worse, for the duration, and enforces simple speech.
+/atom/movable/screen/alert/status_effect/mishap_dimwitted
+	name = "Dim-witted"
+	desc = "My thoughts are so slow..."
+	icon_state = "mind_control"
+
+/datum/status_effect/debuff/mishap_dimwitted
+	id = "dimwitted"
+	duration = 10 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
+	effectedstats = list("intelligence" = -6, "speed" = -3) // 50% worse than the Nimrod special at the time of implementation (for 10 minutes)
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_dimwitted
+
+/datum/status_effect/debuff/mishap_dimwitted/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_SIMPLESPEECH, id)
+
+/datum/status_effect/debuff/mishap_dimwitted/on_remove()
+	..()
+	REMOVE_TRAIT(owner, TRAIT_SIMPLESPEECH, id)
+
+// Reduces some stats, applies a high overlay, increases slurring by 10 and keeps slurring at a minimum of 10.
+/atom/movable/screen/alert/status_effect/mishap_arcane_high
+	name = "Arcyne High"
+	desc = ""
+	icon_state = "high"
+
+/datum/status_effect/debuff/mishap_arcane_high
+	id = "arcane_high"
+	duration = 5 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
+	effectedstats = list("intelligence" = -4, "perception" = -4)
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_arcane_high
+
+/datum/status_effect/debuff/mishap_arcane_high/on_apply()
+	. = ..()
+	owner.slurring += 10
+	ADD_TRAIT(owner, TRAIT_DRUQK, id)
+	owner.overlay_fullscreen("arcane_high", /atom/movable/screen/fullscreen/druqks)
+	if (owner.client)
+		SSdroning.area_entered(get_area(owner), owner.client)
+
+/datum/status_effect/debuff/mishap_arcane_high/tick()
+	..()
+	owner.slurring = max(owner.slurring, 10)
+	if (prob(5))
+		owner.emote(pick("giggle", "drools", "grins", "fidgets", "twitch_s"))
+
+/datum/status_effect/debuff/mishap_arcane_high/on_remove()
+	..()
+	owner.slurring = max(owner.slurring - 10, 0)
+	REMOVE_TRAIT(owner, TRAIT_DRUQK, id)
+	owner.clear_fullscreen("arcane_high")
+	if (owner.client)
+		SSdroning.play_area_sound(get_area(owner), owner.client)
+
+// Increases drunkenness by 50. Prevents drunkenness from falling below 50.
+/atom/movable/screen/alert/status_effect/mishap_arcane_drunkenness
+	name = "Arcyne Drunkenness"
+	desc = "I feel so drunk... But I haven't been drinking! Hah..."
+	icon_state = "drunk"
+
+/datum/status_effect/debuff/mishap_arcane_drunkenness
+	id = "arcane_drunk"
+	duration = 10 MINUTES // Drunkenness we add is forcibly removed on expiry
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_arcane_drunkenness
+	var/mob/living/carbon/human/human_owner
+	var/const/drunk_amount = 50
+
+/datum/status_effect/debuff/mishap_arcane_drunkenness/on_apply()
+	. = ..()
+	if (ishuman(owner))
+		human_owner = owner
+		human_owner.drunkenness += drunk_amount
+
+/datum/status_effect/debuff/mishap_arcane_drunkenness/tick()
+	..()
+	if (human_owner)
+		human_owner.drunkenness = max(human_owner.drunkenness, drunk_amount)
+
+/datum/status_effect/debuff/mishap_arcane_drunkenness/on_remove()
+	..()
+	if (human_owner)
+		human_owner.drunkenness = max(human_owner.drunkenness - drunk_amount, 0)
+		if (human_owner.drunkenness <= 0)
+			human_owner.remove_status_effect(/datum/status_effect/buff/drunk)
+
+// On application, each limb has a 50% chance of being paralyzed.
+// At least one limb is guaranteed to be paralyzed.
+/atom/movable/screen/alert/status_effect/mishap_arcane_paralysis
+	name = "Arcyne Paralysis"
+	desc = "I can't move parts of my body..."
+	icon_state = "paralyze"
+
+/datum/status_effect/debuff/mishap_arcane_paralysis
+	id = "arcane_paralysis"
+	duration = 2 MINUTES // Nasty effect, let's not have it last as long as the others.
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_arcane_paralysis
+	var/list/traits_added = list()
+	var/list/bodyparts_disabled = list()
+
+#define PARALYZE_L_ARM 0x1
+#define PARALYZE_R_ARM 0x2
+#define PARALYZE_L_LEG 0x4
+#define PARALYZE_R_LEG 0x8
+#define PARALYZE_SUM (PARALYZE_L_ARM | PARALYZE_R_ARM | PARALYZE_L_LEG | PARALYZE_R_LEG)
+/datum/status_effect/debuff/mishap_arcane_paralysis/on_apply()
+	. = ..()
+	var/limbs = rand(1, PARALYZE_SUM) // To be used as bits, NOT a meaningful integer value
+	// This method ensures our limbs are chosen randomly,
+	// that all limbs have a 50% chance of being paralyzed,
+	// and at least one limb is guaranteed to be paralyzed
+	if (limbs & PARALYZE_L_ARM)
+		ADD_TRAIT(owner, TRAIT_PARALYSIS_L_ARM, id)
+		traits_added.Add(TRAIT_PARALYSIS_L_ARM)
+		bodyparts_disabled.Add(BODY_ZONE_L_ARM)
+	if (limbs & PARALYZE_R_ARM)
+		ADD_TRAIT(owner, TRAIT_PARALYSIS_R_ARM, id)
+		traits_added.Add(TRAIT_PARALYSIS_R_ARM)
+		bodyparts_disabled.Add(BODY_ZONE_R_ARM)
+	if (limbs & PARALYZE_L_LEG)
+		ADD_TRAIT(owner, TRAIT_PARALYSIS_L_LEG, id)
+		traits_added.Add(TRAIT_PARALYSIS_L_LEG)
+		bodyparts_disabled.Add(BODY_ZONE_L_LEG)
+	if (limbs & PARALYZE_R_LEG)
+		ADD_TRAIT(owner, TRAIT_PARALYSIS_R_LEG, id)
+		traits_added.Add(TRAIT_PARALYSIS_R_LEG)
+		bodyparts_disabled.Add(BODY_ZONE_R_LEG)
+
+	for (var/bp in bodyparts_disabled)
+		var/obj/item/bodypart/bodypart = owner.get_bodypart(bp)
+		if (bodypart && bodypart.can_disable())
+			bodypart.update_disabled()
+
+/datum/status_effect/debuff/mishap_arcane_paralysis/on_remove()
+	..()
+	for (var/trait in traits_added)
+		REMOVE_TRAIT(owner, trait, id)
+
+	for (var/part in bodyparts_disabled)
+		var/obj/item/bodypart/bodypart = owner.get_bodypart(part)
+		if (bodypart && bodypart.can_disable() && bodypart.disabled == BODYPART_DISABLED_PARALYSIS)
+			bodypart.update_disabled()
+
+// Makes the victim blind... Obviously
+/atom/movable/screen/alert/status_effect/mishap_blindness
+	name = "Arcyne Blindness"
+	desc = "Arcyne darkness clouds my eyes!"
+	icon_state = "blind"
+
+/datum/status_effect/debuff/mishap_blindness
+	id = "arcane_blindness"
+	duration = 2 MINUTES // Another nasty effect - victim will need to be led around until it expires.
+	status_type = STATUS_EFFECT_REFRESH
+	effectedstats = list("perception" = -100) // Blind, can't see
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_blindness
+	var/const/blindness_amount = 20 // 20 should be plenty to keep the victim blind between tick()s
+
+/datum/status_effect/debuff/mishap_blindness/on_apply()
+	. = ..()
+	owner.adjust_blindness(blindness_amount)
+
+/datum/status_effect/debuff/mishap_blindness/tick()
+	..()
+	owner.set_blindness(max(owner.eye_blind, blindness_amount))
+
+/datum/status_effect/debuff/mishap_blindness/on_remove()
+	..()
+	owner.adjust_blindness(-blindness_amount)
+
+// Keep putting the user to sleep for the duration.
+/atom/movable/screen/alert/status_effect/mishap_sleepy
+	name = "Arcyne Sleep"
+	desc = "I can't keep myself awake..."
+	icon_state = "hypnosis"
+
+/datum/status_effect/debuff/mishap_sleepy
+	id = "arcane_sleep"
+	duration = 15 SECONDS // Sleep amount is 60 seconds, so effectively ~75 seconds. User is completely incapacitated so this shouldn't be too long.
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_sleepy
+	var/const/sleeping_amount = 60 SECONDS
+
+/datum/status_effect/debuff/mishap_sleepy/on_apply()
+	. = ..()
+	owner.eyesclosed = TRUE
+	for(var/atom/movable/screen/eye_intent/eyet in owner.hud_used.static_inventory)
+		eyet.update_icon(owner)
+	owner.become_blind("eyelids")
+	owner.Sleeping(sleeping_amount)
+
+/datum/status_effect/debuff/mishap_sleepy/tick()
+	..()
+	owner.Sleeping(sleeping_amount)
+
+// Makes the victim confused for 5 minutes
+/atom/movable/screen/alert/status_effect/mishap_confused
+	name = "Arcyne Confusion"
+	desc = "Where-- where am I..?"
+	icon_state = "mind_control"
+
+/datum/status_effect/debuff/mishap_confused
+	id = "arcane_confusion"
+	duration = 5 MINUTES
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/mishap_confused
+	var/const/confusion_amount = 15
+
+/datum/status_effect/debuff/mishap_confused/on_apply()
+	. = ..()
+	owner.confused += confusion_amount
+
+/datum/status_effect/debuff/mishap_confused/tick()
+	owner.confused = max(owner.confused, confusion_amount)
+	if (prob(5))
+		owner.emote(pick("babbles", "murmurs", "stares", "frowns"))
+	..()
+
+/datum/status_effect/debuff/mishap_confused/on_remove()
+	owner.confused = max(owner.confused - confusion_amount, 0)
+	..()

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -261,3 +261,19 @@
 	timer = 5 MINUTES
 	stressadd = -3
 	desc = "<span class='green'>I got some love, and it was wonderful!</span>"
+
+
+/datum/stressevent/dimwitted
+	timer = 10 MINUTES
+	stressadd = -4
+	desc = span_green("Everything is nice and simple...")
+
+/datum/stressevent/feebleminded
+	timer = 10 MINUTES
+	stressadd = -10
+	desc = span_green("Heeh...")
+
+/datum/stressevent/arcane_high
+	timer = 10 MINUTES
+	stressadd = -2
+	desc = span_green("Since my magical accident, everything just seems so funny!")

--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -2,7 +2,7 @@
 
 /obj/item/scrying
 	name = "scrying orb"
-	desc = "Within its glass depths, you can scry on many beings..."
+	desc = "On it's glass depths, you can scry on many beings..."
 	icon = 'icons/roguetown/items/misc.dmi'
 	icon_state ="scrying"
 	throw_speed = 3
@@ -13,91 +13,332 @@
 	hitsound = 'sound/blank.ogg'
 	sellprice = 30
 	dropshrink = 0.6
-	resistance_flags = FIRE_PROOF
-
-	grid_height = 32
-	grid_width = 32
 
 	var/mob/current_owner
 	var/last_scry
+	w_class = WEIGHT_CLASS_SMALL
+	var/cooldown = 30 SECONDS
+	var/extended_cooldown = 10 MINUTES
+	var/on_extended_cooldown = FALSE
 
+	var/debugseverity = FALSE
+	var/debugprob = 0
+
+/obj/item/scrying/eye
+	name = "accursed eye"
+	desc = "It is pulsating."
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state ="scryeye"
+	cooldown = 5 MINUTES
+
+/obj/item/scrying/examine(mob/user)
+	. = ..()
+	if(on_cooldown())
+		. += "The orb requires rest..."
+	else
+		. += "The orb seems eager to be used!"
+
+/obj/item/scrying/proc/on_cooldown()
+	if (world.time < last_scry + (on_extended_cooldown ? extended_cooldown : cooldown))
+		return TRUE
+	// No longer on cooldown, so reset the extended cooldown flag if it was set
+	on_extended_cooldown = FALSE
+	return FALSE
 
 /obj/item/scrying/attack_self(mob/living/user)
 	. = ..()
 	if(!user.mind)
 		return
-	if(world.time < last_scry + 30 SECONDS)
-		to_chat(user, span_warning("I look into the ball but only see inky smoke. Maybe I should wait."))
-		return
-	var/input = input(user, "Who are you looking for?", "Scrying Orb")
+	var/input = html_decode(input(user, "Who are you looking for?", "Scrying Orb"))
 	if(!input)
 		return
 	if(!user.key)
-		return
-	if(world.time < last_scry + 30 SECONDS)
-		to_chat(user, span_warning("I look into the ball but only see inky smoke. Maybe I should wait."))
 		return
 	if(!user.mind || !user.mind.do_i_know(name=input))
 		to_chat(user, span_warning("I don't know anyone by that name."))
 		return
 	var/arcane_skill = user.get_skill_level(/datum/skill/magic/arcane)
-	var/success_chance = 0
-	switch(arcane_skill)
-		if(SKILL_LEVEL_NONE)
-			success_chance = 50
-		if(SKILL_LEVEL_NOVICE)
-			success_chance = 65
-		if(SKILL_LEVEL_APPRENTICE) //Apprentices have this
-			success_chance = 80
-		if(SKILL_LEVEL_JOURNEYMAN) // Adventurer mages have this
-			success_chance = 90
-		if(SKILL_LEVEL_EXPERT)
-			success_chance = 94
-		if(SKILL_LEVEL_MASTER) // Magus has this
-			success_chance = 97
-		if(SKILL_LEVEL_LEGENDARY)
-			success_chance = 100
-	if(!prob(success_chance))
-		to_chat(user, span_boldwarning("You focus your thoughts on the orb, but feel a sharp pain!"))
-		visible_message("\The [src] shatters!")
-		user.flash_fullscreen("redflash1")
-		new /obj/item/natural/glass_shard(get_turf(src))
-		playsound(src, "shatter", 70, TRUE)
-		qdel(src)
+	if(on_cooldown())
+		if (on_extended_cooldown)
+			to_chat(user, span_warning("I've pushed the orb far enough already - this is risky..."))
+		else
+			to_chat(user, span_warning("The orb doesn't seem ready. Maybe I should wait..."))
+
+	var/time_to_use
+	if (arcane_skill >= 1)
+		time_to_use = 60 / arcane_skill
+	else
+		time_to_use = 100
+
+	if(!do_after(user, time_to_use, target = user))
+		to_chat(user, span_warning("I need to focus..."))
 		return
-	for(var/mob/living/carbon/human/HL in GLOB.human_list)
-		if(HL.real_name == input)
-			var/turf/T = get_turf(HL)
-			if(!T)
-				continue
-			if(HAS_TRAIT(HL, TRAIT_ANTISCRYING))
-				to_chat(user, span_warning("I peer into the ball, but an impenetrable fog shrouds [input]."))
-				to_chat(HL, span_warning("My magical shrouding reacted to something."))
-				return
-			message_admins("SCRYING: [user.real_name] ([user.ckey]) has used the scrying orb to leer at [HL.real_name] ([HL.ckey])")
-			log_game("SCRYING: [user.real_name] ([user.ckey]) has used the scrying orb to leer at [HL.real_name] ([HL.ckey])")
-			ADD_TRAIT(user, TRAIT_NOSSDINDICATOR, "scryingorb")
-			var/mob/dead/observer/screye/S = user.scry_ghost()
-			if(!S)
-				return
-			S.ManualFollow(HL)
-			last_scry = world.time
-			user.visible_message(span_danger("[user] stares into [src], [user.p_their()] eyes rolling back into [user.p_their()] head."))
-			addtimer(CALLBACK(S, TYPE_PROC_REF(/mob/dead/observer, reenter_corpse)), 8 SECONDS)
-			if(!HL.stat)
-				if(HL.STAPER >= 15)
-					if(HL.mind)
-						if(HL.mind.do_i_know(name=user.real_name))
-							to_chat(HL, span_warning("I can clearly see the face of [user.real_name] staring at me!."))
-							return
-					to_chat(HL, span_warning("I can clearly see the face of an unknown [user.gender == FEMALE ? "woman" : "man"] staring at me!"))
-					return
-				if(HL.STAPER >= 11)
-					to_chat(HL, span_warning("I feel a pair of unknown eyes on me."))
-			REMOVE_TRAIT(user, TRAIT_NOSSDINDICATOR, "scryingorb")
-			return
+
+	var/success_chance = 0
+	var/break_on_fail = FALSE
+	var/failure_severity = 6 - arcane_skill
+
+	// Max severity: 6 (no arcane) + 6 (1 intelligence) + 4 (on cooldown) = 16
+	// For an Apprentice using the orb, 3-7 would be the realistic results, depending on whether the orb is on cooldown.
+	// Max severity with a unique effect: 10
+
+	// Users too unintelligent to read a mage's tome get worse failures,
+	// but not worse success chance
+	if (user.STAINT < 12)
+		failure_severity += max((6 - (user.STAINT/2)), 1)
+
+	var/on_cooldown = world.time < last_scry + cooldown
+
+	if(on_cooldown)
+		// Failure severity is increased, and chance of success is reduced by one proficiency level
+		// if the orb is on cooldown
+		failure_severity += rand(1, 4)
+		switch(arcane_skill)
+			if(SKILL_LEVEL_NONE)
+				break_on_fail = TRUE
+				success_chance = 20
+			if(SKILL_LEVEL_NOVICE)
+				break_on_fail = TRUE
+				success_chance = 50
+			if(SKILL_LEVEL_APPRENTICE) //Apprentices have this
+				success_chance = 65
+			if(SKILL_LEVEL_JOURNEYMAN) // refugee mages have this
+				success_chance = 80
+			if(SKILL_LEVEL_EXPERT)
+				success_chance = 90
+			if(SKILL_LEVEL_MASTER) // Magus has this
+				success_chance = 94
+			if(SKILL_LEVEL_LEGENDARY)
+				success_chance = 100
+
+		// Only a true master of the arcane can reliably use the orb when it's REALLY been pushed
+		if (on_extended_cooldown && arcane_skill < SKILL_LEVEL_LEGENDARY)
+			success_chance /= 2
+	else
+		switch(arcane_skill)
+			if(SKILL_LEVEL_NONE)
+				break_on_fail = TRUE
+				success_chance = 50
+			if(SKILL_LEVEL_NOVICE)
+				break_on_fail = TRUE
+				success_chance = 65
+			if(SKILL_LEVEL_APPRENTICE) //Apprentices have this
+				success_chance = 80
+			if(SKILL_LEVEL_JOURNEYMAN) // refugee mages have this
+				success_chance = 90
+			if(SKILL_LEVEL_EXPERT)
+				success_chance = 94
+			if(SKILL_LEVEL_MASTER to SKILL_LEVEL_LEGENDARY) // Magus has this
+				success_chance = 100
+
+	if (debugseverity)
+		success_chance = 0
+
+	var/lucky_prob = user.get_scaled_sq_luck(1, 50)
+	if (prob(lucky_prob))
+		break_on_fail = FALSE
+		failure_severity -= rand(1, 3)
+
+	var/mob/living/carbon/human/target = get_named_mob(input)
+	if (target == null)
+		return
+
+	if(!prob(success_chance))
+		on_failure(user, target, failure_severity)
+		if (break_on_fail)
+			failure_break(user)
+		return
+
+	playsound(src, 'sound/magic/whiteflame.ogg', 100, TRUE)
+	scry(user, target)
+
 	to_chat(user, span_warning("I peer into the ball, but can't find [input]."))
 	return
+
+/obj/item/scrying/proc/get_named_mob(mob_real_name)
+	for(var/mob/living/carbon/human/HL in GLOB.human_list)
+		if (HL.real_name == mob_real_name)
+			return HL
+	return null
+
+/obj/item/scrying/proc/scry_wrong_person(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	// We take the mobname so we know NOT to scry them
+	var/len = length(GLOB.human_list)
+	var/index = rand(1, len)
+	var/mob/living/carbon/human/HL = GLOB.human_list[index]
+
+	// If we get the desired target, add a random value to the index
+	// Taking an upper limit of (len-1) should mean that we never roll the desired mob again
+	if (HL.real_name == target.real_name)
+		index = (index + rand(1, len-1)) % len
+		HL = GLOB.human_list[index]
+
+	scry(user, HL)
+
+/obj/item/scrying/proc/scry(mob/living/carbon/human/user, mob/living/carbon/human/target)
+	var/turf/T = get_turf(target)
+	if(!T)
+		return
+	message_admins("SCRYING: [user.real_name] ([user.ckey]) has used the scrying orb to leer at [target.real_name] ([target.ckey])")
+	log_game("SCRYING: [user.real_name] ([user.ckey]) has used the scrying orb to leer at [target.real_name] ([target.ckey])")
+	var/mob/dead/observer/screye/S = user.scry_ghost()
+	if(!S)
+		return
+	S.ManualFollow(target)
+	last_scry = world.time
+	user.visible_message(span_danger("[user] stares into [src], [user.p_their()] eyes rolling back into [user.p_their()] head."))
+	addtimer(CALLBACK(S, TYPE_PROC_REF(/mob/dead/observer, reenter_corpse)), 8 SECONDS)
+	if(!target.stat)
+		if(target.STAPER >= 15)
+			if(target.mind)
+				if(target.mind.do_i_know(name=user.real_name))
+					to_chat(target, span_warning("I can clearly see the face of [user.real_name] staring at me!."))
+					return
+			to_chat(target, span_warning("I can clearly see the face of an unknown [user.gender == FEMALE ? "woman" : "man"] staring at me!"))
+			return
+		if(target.STAPER >= 11)
+			to_chat(target, span_warning("I feel a pair of unknown eyes on me."))
+	return
+
+/obj/item/scrying/proc/failure_break(mob/living/user)
+	visible_message("\The [src] shatters!")
+	user.flash_fullscreen("redflash1")
+	new /obj/item/natural/glass_shard(get_turf(src))
+	playsound(src, "shatter", 70, TRUE)
+	qdel(src)
+
+/obj/item/scrying/proc/on_failure(mob/living/user, mob/living/carbon/human/target, severity)
+	var/chance = rand(0, 99) // (chance < n) has n% probability, but we only need to calculate once here
+
+	if (debugseverity)
+		severity = debugseverity
+		chance = debugprob
+
+	if (on_cooldown())
+		extended_cooldown = TRUE
+		last_scry = world.time
+
+	switch (severity)
+		if (0)
+			to_chat(user, span_boldwarning("You focus your thoughts on the orb, but it doesn't respond."))
+		if (1)
+			if (chance < 40)
+				failure_random_person(user, target)
+			else if (chance < 70)
+				failure_burn(user)
+			else
+				failure_confused(user)
+		if (2)
+			if (chance < 20)
+				failure_confused(user)
+			else if (chance < 80)
+				failure_sleep(user)
+			else
+				failure_drunk(user)
+		if (3)
+			if (chance < 20)
+				failure_sleep(user)
+			else if (chance < 80)
+				failure_drunk(user)
+			else
+				failure_high(user)
+		if (4)
+			if (chance < 20)
+				failure_drunk(user)
+			else if (chance < 80)
+				failure_high(user)
+			else
+				failure_dimwitted(user)
+		if (5)
+			if (chance < 10)
+				failure_drunk(user)
+			else if (chance < 20)
+				failure_high(user)
+			else
+				failure_dimwitted(user)
+
+		// Past this point, the effects of failure can be especially nasty.
+		if (6)
+			if (chance < 10)
+				failure_paralysis(user)
+			else
+				failure_blind(user)
+		if (7)
+			if (chance < 10)
+				failure_obsession(user)
+			else if (chance < 30)
+				failure_languageloss(user, target)
+			else
+				failure_paralysis(user)
+		if (8)
+			if (chance < 15)
+				failure_paralysis(user)
+			if (chance < 35)
+				failure_obsession(user, target)
+			else
+				failure_languageloss(user)
+		if (9)
+			failure_obsession(user, target)
+		if (10 to INFINITY)
+			failure_feeblemind(user)
+
+/obj/item/scrying/proc/failure_languageloss(mob/living/user)
+	to_chat(user, span_boldwarning("You focus your thoughts on the orb - but as you do, you feel your grasp of language slipping away..."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_langloss)
+
+/obj/item/scrying/proc/failure_obsession(mob/living/user, mob/living/target)
+	user.visible_message(span_danger("[user] stares into [src], [user.p_their()] eyes rolling back into [user.p_their()] head. [user.p_they(TRUE)] smiles beatifically at something..."), span_boldwarning("You focus your thoughts on the orb - you can see the target in front of you. So beautiful, charming... You find yourself falling in love, into obsession. Why are you wasting time? You need them so badly..."))
+	if(user.mind)
+		user.mind.store_memory("You are obsessed with [target].")
+	user.faction |= "[REF(target)]"
+	user.apply_status_effect(STATUS_EFFECT_INLOVE, target)
+	scry(user, target) // Got to see them to fall in love with them...
+
+/obj/item/scrying/proc/failure_feeblemind(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src] - [user.p_their()] eyes lose their wit, and [user.p_their()] mouth hangs open..."), span_boldwarning("You focus your thoughts on the orb - and feel them slipping away, away, slowly... draining... into..."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_feeblemind)
+
+/obj/item/scrying/proc/failure_paralysis(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src]. Parts of [user.p_their()] body seem to go limp..."), span_boldwarning("You focus your thoughts on the orb - you feel a pain shooting through your head, and begin to feel a strange numbness..."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_arcane_paralysis)
+
+/obj/item/scrying/proc/failure_blind(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src]. Arcyne darkness seem to cloud [user.p_their()] eyes!"), span_boldwarning("You focus your thoughts on the orb - your vision darkens... And doesn't return."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_blindness)
+
+/obj/item/scrying/proc/failure_dimwitted(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src]... And [user.p_their()] eyes gain a witless look."), span_boldwarning("You focus your thoughts on the orb - and though you see nothing, suddenly the world becomes so much simpler."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_dimwitted)
+
+/obj/item/scrying/proc/failure_high(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src]. Suddenly, [user.p_they()] seems unable to stay still!"), span_boldwarning("You focus your thoughts on the orb - and you begin to feel so happy and giddy!"))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_arcane_high)
+
+/obj/item/scrying/proc/failure_random_person(mob/living/user, mob/living/target)
+	user.visible_message(span_danger("[user] stares into [src], [user.p_their()] eyes rolling back into [user.p_their()] head."), span_boldwarning("You focus your thoughts on the orb - and... Wait, this isn't right..."))
+	scry_wrong_person(user, target)
+
+/obj/item/scrying/proc/failure_sleep(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src] - and then, without warning, falls asleep!"), span_boldwarning("You focus your thoughts on the orb - and begin feeling tired, so tired; maybe you should... Should..."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_sleepy)
+
+/obj/item/scrying/proc/failure_confused(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src]... And then looks around in confusion."), span_boldwarning("You focus your thoughts on the orb - and suddenly, you feel disoriented, as if the world no longer makes sense."))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_confused)
+
+/obj/item/scrying/proc/failure_drunk(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src] - and then hiccups."), span_boldwarning("You focus your thoughts on the orb - the world spins and, oh TEN, have you been DRINKING? Ha ha!"))
+	user.apply_status_effect(/datum/status_effect/debuff/mishap_arcane_drunkenness)
+
+/obj/item/scrying/proc/failure_burn(mob/living/user)
+	user.visible_message(span_danger("[user] stares into [src]... But the orb glows red, and you hear a sizzling sound!"), span_boldwarning("You focus your thoughts on the orb - it heats up, until it's painfully hot!"))
+	var/obj/item = user.get_item_for_held_index(1)
+	if (item == src)
+		user.apply_damage(25, BURN, user.get_bodypart(BODY_ZONE_L_ARM))
+	else
+		user.apply_damage(25, BURN, user.get_bodypart(BODY_ZONE_R_ARM))
+	user.flash_fullscreen("redflash1")
+	user.emote("scream")
 
 /////////////////////////////////////////Crystal ball ghsot vision///////////////////
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -235,7 +235,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		else
 			if(L.spans?.len)
 				chosen_spans = L.spans
-		
+
 		if(chosen_spans?.len && islist(chosen_spans))
 			spans |= chosen_spans
 
@@ -324,8 +324,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			AM.Hear(rendered, src, message_language, highlighted_message, , spans, message_mode, original_message)
 		else
 			AM.Hear(rendered, src, message_language, message, , spans, message_mode, original_message)
-		
-		
+
+
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_LIVING_SAY_SPECIAL, src, message)
 
 	//time for emoting!!
@@ -477,7 +477,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			listener_has_ceiling = TRUE
 			if(istransparentturf(listener_ceiling))
 				listener_has_ceiling = FALSE
-		if(!hearall)		
+		if(!hearall)
 			if((!Zs_too && !isobserver(AM)) || message_mode == MODE_WHISPER)
 				if(AM.z != src.z)
 					continue
@@ -500,7 +500,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 					for(var/mob/living/MH in viewers(world.view, speaker_ceiling))
 						if(M == MH && MH.z == speaker_ceiling?.z)
 							speaker_obstructed = FALSE
-					
+
 				if(!listener_has_ceiling)
 					for(var/mob/living/ML in viewers(world.view, listener_ceiling))
 						if(ML == src && ML.z == listener_ceiling?.z)
@@ -575,7 +575,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 /mob/living/proc/can_speak_vocal(message) //Check AFTER handling of xeno and ling channels
 	if(HAS_TRAIT(src, TRAIT_MUTE)|| HAS_TRAIT(src, TRAIT_PERMAMUTE) || HAS_TRAIT(src, TRAIT_BAGGED))
-		return FALSE	
+		return FALSE
 
 	if(is_muzzled())
 		return FALSE
@@ -619,6 +619,9 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(cultslurring)
 		message = cultslur(message)
+
+	if (HAS_TRAIT(src, TRAIT_SIMPLESPEECH))
+		message = simplespeech(message)
 
 	message = capitalize(message)
 

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -267,6 +267,20 @@
 				BUFLUC++
 			STALUC = newamt
 
+/mob/living/proc/get_scaled_sq_luck(min, max)
+	if (min < 0)
+		min = 0
+	if (max > 100)
+		max = 100
+	if (min > max)
+		var/temp = min
+		min = max
+		max = temp
+	var/adjusted_luck = (src.STALUC * src.STALUC) / 400
+
+	return LERP(min, max, adjusted_luck)
+
+
 /proc/generic_stat_comparison(userstat as num, targetstat as num)
 	var/difference = userstat - targetstat
 	if(difference > 1 || difference < -1)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -551,8 +551,8 @@
 			mmb_intent.glow_color = ranged_ability.glow_color
 			mmb_intent.mob_charge_effect = ranged_ability.mob_charge_effect
 			mmb_intent.update_chargeloop()
-	
-	if(hud_used)		
+
+	if(hud_used)
 		hud_used.quad_intents?.switch_intent(input)
 		hud_used.give_intent?.switch_intent(input)
 	givingto = null
@@ -1009,3 +1009,57 @@
 	if(!HAS_TRAIT_FROM(user.client, TRAIT_AI_ACCESS, ADMIN_TRAIT)) // Do they have it enabled?
 		return FALSE
 	return TRUE
+
+/// Forces the user to speak with only the 1000 most common (English-language) words.
+/// Other words will be replaced with filler or scrambled.
+/proc/simplespeech(message)
+	var/static/list/common_words = world.file2list("strings/1000_most_common.txt")
+
+	if(message)
+		var/list/message_split = splittext(message, " ")
+		var/list/new_message = list()
+
+		for(var/word in message_split)
+			word = html_decode(word)
+
+			// Find all leading and trailing special characters - we'll re-add them to the word later.
+			// This should cover quotes, formatting, and just about any other characters.
+			var/first_letter = findtext(word, regex("\[a-zA-Z\]+"))
+			var/last_letter = findtext(word, regex("\[^a-zA-Z\]+"), first_letter) - 1
+
+			var/suffix = copytext(word, last_letter + 1)
+			var/prefix = copytext(word, 1, first_letter)
+
+			word = copytext(word, first_letter, last_letter + 1)
+
+			// Common words or words of three or fewer characters don't need replacing.
+			if((lowertext(word) in common_words) || length(word) <= 3)
+				new_message += prefix + word + suffix
+			else
+				var/chance = rand(0, 99)
+				// 25% chance to add a filler word as the character stumbles over the word
+				if(chance < 30 && message_split.len > 2)
+					new_message += pick("uh...", "um...")
+					// 1/6 chance of giving up on the sentence entirely
+					if (chance < 5)
+						break
+					else if (chance < 10) // 1/6 chance of skipping the word after stumbling
+						continue
+					// 2/3 chance of proceeding to the word (still scrambling it)
+
+				var/list/charlist = splittext(word, "")
+				// Functions like shuffle_inplace but does not touch the first or last characters.
+				// Should allow most words to still be understood (with context) while communicating the idea of struggling with them.
+				// In time, we might refine this somewhat to make words generally more pronounceable...
+				for (var/i = 2; i<charlist.len-1; ++i)
+					charlist.Swap(i,rand(i,charlist.len-1))
+
+				// If we reach this point, 50% chance of stammering a little
+				if (chance < 55)
+					new_message += prefix + charlist[1] + "-" + html_encode(jointext(charlist,"")) + suffix
+				else
+					new_message += prefix + html_encode(jointext(charlist,"")) + suffix
+
+		message = jointext(new_message, " ")
+
+	return trim(message)


### PR DESCRIPTION
## About The Pull Request
ports the Scrying orb Rework from Rw1. https://github.com/Rotwood-Vale/Ratwood-Keep/pull/3012
 No more will your orb break upon failure! To quote the other PR:
`This PR adds a variety of failure effects that can occur when using the scrying orb, based on the user's arcane skill and intelligence, and whether or not the orb is on cooldown. These failure effects are intended to be somewhat-punishing, but - mostly - more flavourful than mechanically frustrating, with those with the harshest mechanical penalties being the shortest-lived. I've also taken the opportunity to refactor the orb code a little and fix some bugs (eg. the examine text not working, and division by zero when a person with no arcane skill attempts to use it). `
 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Breaking a scrying orb based on RNG was really lame. This is a much more satisfactory method of handling scrying at low/midline arcana.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
