### PR TITLE
Buffs Orison water healing a bit.

### DIFF
--- a/modular_azurepeak/code/modules/spells/orison.dm
+++ b/modular_azurepeak/code/modules/spells/orison.dm
@@ -208,21 +208,21 @@
 
 /datum/reagent/water/blessed
 	name = "blessed water"
-	description = "A gift of Devotion. Very slightly heals wounds."
+	description = "A gift of Devotion. Heals the body from within, but not physical wounds."
 
 /datum/reagent/water/blessed/on_mob_life(mob/living/carbon/M)
 	. = ..()
 	if (M.mob_biotypes & MOB_UNDEAD)
 		M.adjustFireLoss(1.5*REM)
 	else
-		M.adjustBruteLoss(-0.5*REM)
-		M.adjustFireLoss(-0.5*REM)
-		M.adjustOxyLoss(-0.5, 0)
-		var/list/our_wounds = M.get_wounds()
-		if (LAZYLEN(our_wounds))
-			var/upd = M.heal_wounds(1.5)
-			if (upd)
-				M.update_damage_overlays()
+		// Heals internal damage very well like potions
+		if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+			M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_NORMAL)
+		M.adjustToxLoss(-3*REM, 0)
+		M.adjustOxyLoss(-3*REM, 0)
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3*REM)
+		M.adjustCloneLoss(-3*REM, 0)
+		// Does NOT heal brute or fire damage
 
 /datum/reagent/water/blessed/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if (!istype(M))
@@ -238,7 +238,7 @@
 
 /datum/reagent/water/cursed
 	name = "cursed water"
-	description = "A gift of Devotion. Very slightly heals wounds of the dead and the enlightened."
+	description = "A gift of Devotion. Heals the body from within, but not physical wounds."
 
 /datum/reagent/water/cursed/on_mob_life(mob/living/carbon/M)
 	. = ..()
@@ -246,23 +246,23 @@
 	if(istype(M,/mob/living/carbon/human/))
 		M_hum = M
 	if((M.mob_biotypes & MOB_UNDEAD) || (M_hum.patron.undead_hater == FALSE))
-		M.adjustBruteLoss(-0.5*REM)
-		M.adjustFireLoss(-0.5*REM)
-		M.adjustOxyLoss(-0.5, 0)
-		var/list/our_wounds = M.get_wounds()
-		if (LAZYLEN(our_wounds))
-			var/upd = M.heal_wounds(1.5)
-			if (upd)
-				M.update_damage_overlays()
+		// Heals internal damage very well like potions for undead/dark patrons
+		if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+			M.blood_volume = min(M.blood_volume+10, BLOOD_VOLUME_NORMAL)
+		M.adjustToxLoss(-3*REM, 0)
+		M.adjustOxyLoss(-3*REM, 0)
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3*REM)
+		M.adjustCloneLoss(-3*REM, 0)
+		// Does NOT heal brute or fire damage
 	else
-		M.adjustBruteLoss(-0.2*REM) // Heal less for divine worshippers.
-		M.adjustFireLoss(-0.2*REM)
-		M.adjustOxyLoss(-0.2, 0)
-		var/list/our_wounds = M.get_wounds()
-		if (LAZYLEN(our_wounds))
-			var/upd = M.heal_wounds(1)
-			if (upd)
-				M.update_damage_overlays()
+		// Heals less for divine worshippers, but still internal damage only
+		if(M.blood_volume < BLOOD_VOLUME_NORMAL)
+			M.blood_volume = min(M.blood_volume+5, BLOOD_VOLUME_NORMAL)
+		M.adjustToxLoss(-1.5*REM, 0)
+		M.adjustOxyLoss(-1.5*REM, 0)
+		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.5*REM)
+		M.adjustCloneLoss(-1.5*REM, 0)
+		// Does NOT heal brute or fire damage
 		M.stamina_add(1*REM)
 
 /obj/item/melee/touch_attack/orison/proc/create_water(atom/thing, mob/living/carbon/human/user)


### PR DESCRIPTION
## About The Pull Request
Buffs holy and unholy water to heals a bit more than 0.1 per tick. Not better than normal health potions at all but it SHOULD heal now roughly 2~ per two ticks.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I tested but eh... too lazy. Its just line edit.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes holy water less useful.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
