### PR TITLE
Smithing items quality affects max integrity

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/smith_components.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smith_components.dm
@@ -255,6 +255,9 @@
 					I.polished = 4
 					I.AddComponent(/datum/component/metal_glint)
 
+		if(modifier < 1)
+			I.max_integrity *= modifier
+
 		I.sellprice *= modifier
 		if(istype(I, /obj/item/lockpick))
 			var/obj/item/lockpick/L = I


### PR DESCRIPTION
## About The Pull Request
Same as for sellprice, quality of item made by smith affects its max integrity too (only for items that are worse then "standart")

Kinda experimental, lets see how it will go
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
varedit
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Item quality has more impact
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
