### PR TITLE
Sets the black market navigator's tax to 50% instead of 70%

### DIFF
--- a/code/modules/roguetown/roguemachine/merchant/navigator.dm
+++ b/code/modules/roguetown/roguemachine/merchant/navigator.dm
@@ -41,7 +41,7 @@
 	else
 		contents += "<center>FEED ME<BR>"
 		contents += "--------------<BR>"
-		contents += "Guild's Tax: 70%<BR>"
+		contents += "Guild's Tax: 50%<BR>"
 		contents += "Next Balloon: [time2text((next_airlift - world.time), "mm:ss")]</center><BR>"
 
 	if(!user.can_read(src, TRUE))
@@ -94,7 +94,7 @@
 			for(var/obj/I in T)
 				if(I.anchored || !isturf(I.loc) || istype(I, /obj/item/roguecoin)|| istype(I, /obj/structure/handcart))
 					continue
-				var/prize = I.get_real_price() - (I.get_real_price() * (blackmarket ? 0.7 : SStreasury.queens_tax))
+				var/prize = I.get_real_price() - (I.get_real_price() * (blackmarket ? 0.5 : SStreasury.queens_tax))
 				if(prize >= 1)
 					play_sound=TRUE
 					budgie += prize


### PR DESCRIPTION
## About The Pull Request

As per title

## Testing Evidence

<img width="575" height="340" alt="image" src="https://github.com/user-attachments/assets/f1ebbca1-6ca8-488e-a805-1ad287a9002a" />
Text displays.
<img width="1384" height="436" alt="image" src="https://github.com/user-attachments/assets/90847a9e-c902-497d-88ff-ae6bc27a4d5a" />
place an item worth 42
<img width="340" height="294" alt="image" src="https://github.com/user-attachments/assets/4b905218-124b-4acd-9ddf-5050f89ce015" />
Turns to... 21 coins!
Tried again, worked.

## Why It's Good For The Game

The cut is more than enough to encourage merchant use as it is I think. We had it somewhere around this in RW1 and I think that was fine. At 70% it feels overly punishing for something you have to really go out of your way to find.