### PR TITLE
Unarmed Diminishing Returns Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -130,27 +130,18 @@
 	if(domhand)
 		used_str = get_str_arms(used_hand)
 
-	if(used_str >= 11)
-		var/bonus = 0
-
-		if(used_str <= 14)
-			// Normal scaling: +20% per point over 10
-			bonus = (used_str - 10) * 0.2
-		else
-			// Diminishing returns after 14
-			// Start with the full +0.8 from 14 STR
-			bonus = 0.8
-			var/extra = used_str - 14
-			// Each point beyond 14 gives a smaller bonus than the last:
-			// e.g., +0.1, +0.075, +0.05625, etc.
-			var/next_bonus = 0.1
-			for(var/i = 1, i <= extra, i++)
-				bonus += next_bonus
-				next_bonus *= 0.75 // reduces 25% each time
-		damage = max(damage + (damage * bonus), 1)
-
 	if(used_str <= 9)
 		damage = max(damage - (damage * ((10 - used_str) * 0.1)), 1)
+	else if(used_str >= 11)
+		if(used_str >= 15) //15 and up
+			var/dim_returns = 0.3
+			var/extra = used_str - 14
+			dim_returns = dim_returns - (extra * 0.025)
+			if (dim_returns < 0.125)
+				dim_returns = 0.125
+			damage = max(damage + (damage * ((used_str - 10) * dim_returns)), 1)
+		else // 11 to 14
+			damage = max(damage + (damage * ((used_str - 10) * 0.3)), 1)
 
 	if(istype(G, /obj/item/clothing/gloves/roguetown))
 		var/obj/item/clothing/gloves/roguetown/GL = G


### PR DESCRIPTION
## About The Pull Request
-Fixes the near global unarmed nerf so that it only effects higher STR
-Fixes the diminishing returns so that they are actually diminishing returns instead of a small flat increase

See the below graph where old damage was exponential and new damage is weird and lumpy ending in a 1.5 flat damage increase per STR, the proposed is a diminishing damage curve ending at the damage of an iron sword at 20 STR.

All numbers in the graph are plate gloves against armor so 20% higher than no gloves at all.
## Testing Evidence
Number tweak
<img width="663" height="410" alt="image" src="https://github.com/user-attachments/assets/61581069-94e4-450d-9446-b047ef19be51" />

## Why It's Good For The Game
-People with 11 STR didn't need a nerf.
-Makes the numerous unarmed subclasses playable again