### PR TITLE
Non-Tossblades in Boots

### DIFF
--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -58,19 +58,23 @@
 
 /obj/item/clothing/shoes/roguetown/boots/attack_right(mob/user)
 	if(holdingknife != null)
-		if(!user.get_active_held_item())
-			user.put_in_active_hand(holdingknife, user.active_hand_index)
-			holdingknife = null
-			playsound(loc, 'sound/foley/equip/swordsmall1.ogg')
-			return TRUE
+		user.visible_message(span_warning("[user] is drawing something from [src]!"), span_warning("I begin drawing a knife from [src]!"))
+		if(do_after(user, 2 SECONDS))
+			if(!user.get_active_held_item())
+				user.put_in_active_hand(holdingknife, user.active_hand_index)
+				holdingknife = null
+				playsound(loc, 'sound/foley/equip/swordsmall1.ogg')
+				return TRUE
 
 /obj/item/clothing/shoes/roguetown/boots/MiddleClick(mob/user)
 	if(holdinglockpick != null)
-		if(!user.get_active_held_item())
-			user.put_in_active_hand(holdinglockpick, user.active_hand_index)
-			holdinglockpick = null
-			playsound(loc, 'sound/foley/equip/rummaging-01.ogg')
-			return TRUE
+		user.visible_message(span_warning("[user] is drawing something from [src]!"), span_warning("I begin drawing a lockpick from [src]!"))
+		if(do_after(user, 2 SECONDS))
+			if(!user.get_active_held_item())
+				user.put_in_active_hand(holdinglockpick, user.active_hand_index)
+				holdinglockpick = null
+				playsound(loc, 'sound/foley/equip/rummaging-01.ogg')
+				return TRUE
 
 /obj/item/clothing/shoes/roguetown/boots/aalloy
 	name = "decrepit boots"


### PR DESCRIPTION
## About The Pull Request
Allows players to shove both knives and lockpicks into their boot. You can have one of each.
You could do this with tossblades, but given how fragile they were, it wasn't ideal.
Nor do most folks know about that, seemingly. This should open it up to more use.

You may MMB to remove the lockpicks. RMB is still used for knives.
You cannot store lockpick rings, to be clear. Just a singular lockpick.

Drawing either knife or lockpick takes two seconds, while also presenting a message to yourself and anyone nearby.
## Testing Evidence
<img width="506" height="131" alt="image" src="https://github.com/user-attachments/assets/991e1805-970a-4279-985e-94409333a330" />

## Why It's Good For The Game
It probably isn't.
Tossblades were the item you'd stuff into a boot.
This makes sheathes pointless in almost every case, for knives.

However, it's _cool_, and gives another use for boots. I've had times elsewhere, where I've gutted a captor because they forgot to check my boots. Not that you can't do that already with tossblades. Perhaps now players will have another method of escape / fighting. If we humor this.