### PR TITLE
Mercenary respawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -18,6 +18,8 @@
 	advclass_cat_rolls = list(CTAG_MERCENARY = 20)
 	job_traits = list(TRAIT_OUTLANDER, TRAIT_STEELHEARTED)
 	always_show_on_latechoices = TRUE
+	job_reopens_slots_on_death = TRUE
+	same_job_respawn_delay = 1 MINUTES
 	job_subclasses = list(
 		/datum/advclass/mercenary/atgervi,
 		/datum/advclass/mercenary/atgervi/shaman,


### PR DESCRIPTION
## About The Pull Request
Allows people to spawn in as a mercenary if they end up dying.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
N/A
Same code as the adventure.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It sucks that there are always 4 mercenaries busy in a private room, while 4 are dead in a corner of the map. Allowing the ability for people to respawn when it's high-pop would make a lot of people able to play their character.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
