### PR TITLE
Doll Feature Expansion

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/constructm.dm
@@ -64,15 +64,12 @@
 		/datum/customizer/organ/penis/anthro,
 		/datum/customizer/organ/breasts/human,
 		/datum/customizer/organ/vagina/human_anthro,
+		/datum/customizer/organ/testicles/anthro,
 		/datum/customizer/organ/ears/demihuman,
 		/datum/customizer/organ/horns/demihuman,
 		/datum/customizer/organ/tail/demihuman,
 		/datum/customizer/organ/snout/anthro,
 		/datum/customizer/organ/wings/anthro,
-		/datum/customizer/organ/penis/anthro,
-		/datum/customizer/organ/breasts/human,
-		/datum/customizer/organ/vagina/human_anthro,
-		/datum/customizer/organ/testicles/anthro,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,
@@ -118,7 +115,8 @@
 		"Rust" = CONSTRUCT_RUST,
 		"Obsidian" = CONSTRUCT_OBSIDIAN,
 		"Lapis" = CONSTRUCT_LAPIS,
-		"Basalt" = CONSTRUCT_BASALT
+		"Basalt" = CONSTRUCT_BASALT,
+		"Marble" = CONSTRUCT_MARBLE
 	)
 
 /datum/species/construct/metal/get_hairc_list()

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/doll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/doll.dm
@@ -62,13 +62,20 @@
 	customizers = list(
 		/datum/customizer/organ/eyes/humanoid,
 		/datum/customizer/bodypart_feature/hair/head/humanoid,
+		/datum/customizer/bodypart_feature/hair/facial/humanoid,
 		/datum/customizer/bodypart_feature/accessory,
 		/datum/customizer/bodypart_feature/face_detail,
 		/datum/customizer/bodypart_feature/underwear,
+		/datum/customizer/bodypart_feature/legwear,
 		/datum/customizer/organ/penis/anthro,
 		/datum/customizer/organ/breasts/human,
 		/datum/customizer/organ/vagina/human_anthro,
 		/datum/customizer/organ/testicles/anthro,
+		/datum/customizer/organ/ears/demihuman,
+		/datum/customizer/organ/horns/demihuman,
+		/datum/customizer/organ/tail/demihuman,
+		/datum/customizer/organ/snout/anthro,
+		/datum/customizer/organ/wings/anthro,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,


### PR DESCRIPTION
## About The Pull Request
Provides dolls an almost identical feature set to constructs, allowing for more customization.

Removes double feature sets on constructs.
Allows constructs to access the unused marble coloring.

## Testing Evidence
<img width="104" height="134" alt="image" src="https://github.com/user-attachments/assets/36fbde3c-99b5-4505-9c24-6b07e1ddd70e" />

## Why It's Good For The Game
It was weird that dolls, specifically, were locked out of construct customization.
Why? I've no idea. Maybe it was the 'lore', but they're also heretical murder goonbait, so I've no idea why that would even hold up.