### PR TITLE
Garrote Buff - Absolver Rites - Slurbow Rarity

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -290,7 +290,6 @@
 	desc = "I can barely feel my limbs!"
 	icon_state = "chilled"
 
-
 /datum/status_effect/debuff/ritesexpended
 	id = "ritesexpended"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/ritesexpended
@@ -309,6 +308,16 @@
 /atom/movable/screen/alert/status_effect/debuff/ritesexpended_heavy
 	name = "Rites Complete"
 	desc = "It will take a lot of time before I can perform a next rite. I am drained."
+	icon_state = "ritesexpended"
+
+/datum/status_effect/debuff/ritesexpended_lesser
+	id = "ritesexpended_lesser"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/ritesexpended_lesser
+	duration = 5 MINUTES
+
+/atom/movable/screen/alert/status_effect/debuff/ritesexpended_lesser
+	name = "Rites Complete"
+	desc = "It will be a short period before I can perform another rite."
 	icon_state = "ritesexpended"
 
 /datum/status_effect/debuff/call_to_arms

--- a/code/modules/cargo/packsrogue/Knave.dm
+++ b/code/modules/cargo/packsrogue/Knave.dm
@@ -157,11 +157,6 @@
 	cost = 20
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow)
 
-/datum/supply_pack/rogue/Knave/slurbow
-	name = "Slurbow"
-	cost = 20
-	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow)
-
 /datum/supply_pack/rogue/Knave/recurvebow
 	name = "Recurve Bow"
 	cost = 20
@@ -171,6 +166,11 @@
 	name = "Longbow"
 	cost = 40
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow)
+
+/datum/supply_pack/rogue/Knave/slurbow
+	name = "Slurbow"
+	cost = 40
+	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow)
 
 /datum/supply_pack/rogue/Knave/steeltossblades
 	name = "Steel Tossblade Belt"

--- a/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
+++ b/code/modules/cargo/packsrogue/merchant/weapons/merch_weapons_ranged.dm
@@ -25,7 +25,7 @@
 
 /datum/supply_pack/rogue/ranged_weapons/hurlbat
 	name = "Hurlbat"
-	cost = 50 // 1 Steel Ingot, but a pretty strong weapon. 
+	cost = 50 // 1 Steel Ingot, but a pretty strong weapon.
 	contains = list(/obj/item/rogueweapon/stoneaxe/hurlbat)
 
 /datum/supply_pack/rogue/ranged_weapons/crossbow
@@ -33,13 +33,6 @@
 	cost = 30
 	contains = list(
 					/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-				)
-
-/datum/supply_pack/rogue/ranged_weapons/crossbow/slurbow
-	name = "Slurbow"
-	cost = 30
-	contains = list(
-					/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow,
 				)
 
 /datum/supply_pack/rogue/ranged_weapons/recurvebow
@@ -86,7 +79,7 @@
 
 /datum/supply_pack/rogue/ranged_weapons/quivers/poisonarrows
 	name = "Quiver of Poison Arrows"
-	cost = 100 
+	cost = 100
 	contains = list(
 					/obj/item/quiver/poisonarrows,
 				)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -26,7 +26,8 @@
 		TRAIT_SILVER_BLESSED,
 		TRAIT_STEELHEARTED,
 		TRAIT_INQUISITION,
-		TRAIT_OUTLANDER
+		TRAIT_OUTLANDER,
+		TRAIT_RITUALIST//Handles conversions, too, now.
 	)
 
 	job_stats = list(
@@ -86,6 +87,7 @@
 		/obj/item/needle = 1,
 		/obj/item/natural/worms/leech/cheele = 1,
 		/obj/item/roguekey/inquisition = 1,
+		/obj/item/ritechalk = 1,
 		)
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_ABSOLVER, start_maxed = TRUE) // PSYDONIAN MIRACLE-WORKER. LUX-MERGING FREEK.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1251,7 +1251,6 @@
 			if(!gcord)
 				gcord = L.get_inactive_held_item()
 			to_chat(pulledby, span_warning("[src] struggles against the [gcord]!"))
-			gcord.take_damage(25)
 		if(!HAS_TRAIT(src, TRAIT_GARROTED))
 			visible_message(span_warning("[src] struggles to break free from [L]'s grip!"), \
 						span_warning("I struggle against [L]'s grip![rchance]"), null, null, L)
@@ -1280,7 +1279,7 @@
 		var/obj/item/inqarticles/garrote/gcord = L.get_active_held_item()
 		if(!gcord)
 			gcord = L.get_inactive_held_item()
-		gcord.take_damage(gcord.max_integrity)
+		gcord.take_damage(100)//Two escapes to snap it.
 		gcord.wipeslate(src)
 	log_combat(L, src, "broke grab")
 	L.changeNext_move(agg_grab ? CLICK_CD_GRABBING : CLICK_CD_GRABBING + 1 SECONDS)

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -1044,7 +1044,6 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 			spawn(120)
 				icon_state = "zizo_chalky"
 
-
 /obj/structure/ritualcircle/zizo/proc/zizoarmaments(mob/living/carbon/human/target)
 	if(!HAS_TRAIT(target, TRAIT_CABAL))
 		loc.visible_message(span_cult("THE RITE REJECTS ONE NOT OF THE CABAL"))
@@ -1218,9 +1217,6 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 		target.apply_damage(100, BURN, BODY_ZONE_HEAD)
 		target.emote("Agony")
 		loc.visible_message(span_cult("[target] is violently thrashing atop the rune, writhing, as they dare to defy ZIZO."))
-
-
-
 
 /obj/structure/ritualcircle/matthios
 	name = "Rune of Transaction"
@@ -1469,8 +1465,6 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 		target.apply_damage(100, BURN, BODY_ZONE_HEAD)
 		loc.visible_message(span_cult("[target] is violently thrashing atop the rune, writhing, as they dare to defy MATTHIOS."))
 
-
-
 /obj/structure/ritualcircle/graggar
 	name = "Rune of Violence"
 	desc = "A Holy Rune of Graggar. Fate broken once, His gift is true freedom for all."
@@ -1699,19 +1693,11 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 		target.apply_damage(100, BURN, BODY_ZONE_HEAD)
 		loc.visible_message(span_cult("[target] is violently thrashing atop the rune, writhing, as they dare to defy GRAGGAR."))
 
-
-
-
 /obj/structure/ritualcircle/baotha
 	name = "Rune of Hedonism"
 	desc = "A Holy Rune of Baotha. Relief for the broken hearted."
 	icon_state = "baotha_chalky"
 	var/baotharites = list("Conversion")
-
-/obj/structure/ritualcircle/psydon // done as a joke, but it is good for Psydonites to decorate with.
-	name = "Rune of Enduring"
-	desc = "A Holy Rune of Psydon. It depicts His holy symbol, yet nothing stirs within you."
-	icon_state = "psydon_chalky"
 
 /obj/structure/ritualcircle/baotha/attack_hand(mob/living/user)
 	if((user.patron?.type) != /datum/patron/inhumen/baotha)
@@ -1747,10 +1733,10 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 					if(do_after(user, 50))
 						user.say("#The world's momentary pleasures have left us wanting...") // can someone else write this instead of me
 						if(do_after(user, 50))
-							icon_state = "eora_active" // hello mister placeholder
+							icon_state = "baotha_active"
 							baothaconversion(target) // removed CD bc it's gonna be coal to sit there and wait for it to go off rite cooldown, this one is purely social in its nature
 							spawn(120)
-								icon_state = "eora_chalky" // hello mister placeholder
+								icon_state = "baotha_chalky"
 
 /obj/structure/ritualcircle/baotha/proc/baothaconversion(mob/living/carbon/human/target)
 	if(!target || QDELETED(target) || target.loc != loc)
@@ -1806,3 +1792,273 @@ var/forgerites = list("Ritual of Blessed Reforgance")
 		target.emote("Agony")
 		target.apply_damage(100, BURN, BODY_ZONE_HEAD)
 		loc.visible_message(span_cult("[target] is violently thrashing atop the rune, writhing, as they dare to defy Baotha."))
+
+
+//TIME FOR THE ONE. Exclusive to ABSOLVERS. Allowing conversion, deconversion and removal of rite armour.
+//'Lesser' expenditure allows us to have a stopgap to this, while not entirely making poultice farming useless.
+
+
+/obj/structure/ritualcircle/psydon//No longer just a decoration.
+	name = "Rune of Enduring"
+	desc = "A Holy Rune of Psydon. It depicts His holy symbol, yet nothing stirs within you."
+	icon_state = "psydon_chalky"
+	var/psydonrites = list("Conversion", "Admonishment", "Freedom")
+
+/obj/structure/ritualcircle/psydon/attack_hand(mob/living/user)
+	if((user.patron?.type) != /datum/patron/old_god)
+		to_chat(user,span_smallred("I don't know the proper rites for this..."))
+		return
+	if(!HAS_TRAIT(user, TRAIT_RITUALIST))
+		to_chat(user,span_smallred("I don't know the proper rites for this..."))
+		return
+	if(!HAS_TRAIT(user, TRAIT_INQUISITION))//Just in case someone OUTSIDE of the Inquisition has this combination. A converted ritualist, for example.
+		to_chat(user,span_smallred("This isn't something I'm capable of. The conduction and manipulation of lux is beyond me."))
+		return
+	if(user.has_status_effect(/datum/status_effect/debuff/ritesexpended_lesser))//We only use lesser cooldown for this, given it's just the Absolver.
+		to_chat(user,span_smallred("I have done enough for the moment. I should take a brief rest."))
+		return
+	var/riteselection = input(user, "Rites of the Lost", src) as null|anything in psydonrites
+	switch(riteselection)
+		if("Conversion")//Convert non-Psydonites to Psydon.
+			if(!Adjacent(user))
+				to_chat(user, "You must stand close to the rune to understand the One's will.")
+				return
+			var/list/valids_on_rune = list()
+			for(var/mob/living/carbon/human/peep in range(0, loc))
+				if(HAS_TRAIT(peep, TRAIT_PSYDONIAN_GRIT))
+					continue
+				valids_on_rune += peep
+			if(!valids_on_rune.len)
+				to_chat(user, "No valid targets on the rune!")
+				return
+			var/mob/living/carbon/human/target = input(user, "Choose a host") as null|anything in valids_on_rune
+			if(!target || QDELETED(target) || target.loc != loc)
+				return
+			if(do_after(user, 5 SECONDS))
+				user.say("Your silence, a test.")
+				if(do_after(user, 5 SECONDS))
+					user.say("Your will, a gift.")
+					if(do_after(user, 5 SECONDS))
+						user.say("I beg of you, accept this wayward soul.")//WEEP FOR THEM, LASZLO.
+						user.emote("cry")
+						loc.visible_message(span_cult("[user] weeps."))
+						if(do_after(user, 5 SECONDS))
+							psydonconversion(target)
+		if("Admonishment")//Deconvert WWs/Vampires.
+			if(!Adjacent(user))
+				return
+			var/list/valids_on_rune = list()
+			for(var/mob/living/carbon/human/peep in range(0, loc))
+				if(HAS_TRAIT(peep, TRAIT_SILVER_BLESSED))
+					continue
+				valids_on_rune += peep
+			if(!valids_on_rune.len)
+				to_chat(user, "No valid targets on the rune!")
+				return
+			var/mob/living/carbon/human/target = input(user, "Choose a host") as null|anything in valids_on_rune
+			if(!target || QDELETED(target) || target.loc != loc)
+				return
+			if(do_after(user, 5 SECONDS))
+				to_chat(user, span_warning("You reach out, a hold upon [user.p_their()] lux..."))
+				if(do_after(user, 5 SECONDS))
+					to_chat(user, span_warning("You begin rooting around, searching for traces of the taint..."))
+					if(do_after(user, 5 SECONDS))
+						to_chat(user, span_warning("A blind leap, as you call upon the One to rebuke the Inhumen..."))
+						user.emote("cry")
+						loc.visible_message(span_cult("[user] weeps."))
+						if(do_after(user, 5 SECONDS))
+							psydonadmonishment(target)
+							user.apply_status_effect(/datum/status_effect/debuff/ritesexpended_lesser)
+		if("Freedom")//Strip folks in rite armour.
+			if(!Adjacent(user))
+				return
+			var/list/valids_on_rune = list()
+			for(var/mob/living/carbon/human/peep in range(0, loc))
+				if(!HAS_TRAIT(peep, TRAIT_OVERTHERETIC))
+					continue
+				valids_on_rune += peep
+			if(!valids_on_rune.len)
+				to_chat(user, "No valid targets on the rune!")
+				return
+			var/mob/living/carbon/human/target = input(user, "Choose a host") as null|anything in valids_on_rune
+			if(!target || QDELETED(target) || target.loc != loc)
+				return
+			if(do_after(user, 5 SECONDS))
+				to_chat(user, span_warning("You reach out, a hold upon [user.p_their()] lux..."))
+				if(do_after(user, 5 SECONDS))
+					to_chat(user, span_warning("You tug at the vice..."))
+					if(do_after(user, 5 SECONDS))
+						to_chat(user, span_warning("A measured strike, as you attempt to sever the cords..."))
+						user.emote("cry")
+						loc.visible_message(span_cult("[user] weeps."))
+						if(do_after(user, 5 SECONDS))
+							psydonstrip(target)
+							user.apply_status_effect(/datum/status_effect/debuff/ritesexpended_lesser)
+
+/obj/structure/ritualcircle/psydon/proc/psydonconversion(mob/living/carbon/human/target)
+	if(!target || QDELETED(target) || target.loc != loc)
+		to_chat(usr, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive the One's will.")
+		return
+	if(HAS_TRAIT(target, TRAIT_PSYDONIAN_GRIT))
+		loc.visible_message(span_cult("Anguish already plagues this one's heart."))
+		return
+	var/prompt = alert(target, "DO YOU ACCEPT THE ONE'S WILL?",, "VERILY", "NAE")
+	if(prompt == "VERILY")
+		to_chat(target, span_warning("A blunt pang of guilt surges through your thoughts. The One's gaze is upon you. He weeps."))
+		target.emote("cry")
+		loc.visible_message(span_cult("[target] weeps."))
+		target.Stun(80)//Keep them in place, for a bit. Until we're done.
+		spawn(20)
+			playsound(target, 'sound/magic/PSYDONE.ogg', 60)
+			to_chat(target, span_mind_control("..."))
+			spawn(20)
+				to_chat(target, span_warning("Has it always been this quiet? It's all so dim..."))
+				to_chat(target, span_mind_control("..."))
+				spawn(40)
+					to_chat(target, span_mind_control("..."))
+					if(target.devotion == null)
+						target.set_patron(new /datum/patron/old_god)
+						return
+					else
+						var/previous_level = target.devotion.level //now you might ask why we get previous_level variable before switching le patron. reason is when swapping patrons it completely fucks up devotion data for people
+						target.set_patron(new /datum/patron/old_god)
+						var/datum/devotion/C = new /datum/devotion(target, target.patron)
+						if(previous_level == 4)
+							target.mind?.RemoveAllMiracles()
+							C.grant_miracles(target, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE) // gotta change?
+						if(previous_level == 3)
+							target.mind?.RemoveAllMiracles()
+							C.grant_miracles(target, cleric_tier = CLERIC_T3, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_3) // gotta change?
+						if(previous_level == 2)
+							target.mind?.RemoveAllMiracles()
+							C.grant_miracles(target, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_2)
+						if(previous_level == 1)
+							target.mind?.RemoveAllMiracles()
+							C.grant_miracles(target, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_DEVOTEE, devotion_limit = CLERIC_REQ_1)
+
+	if(prompt == "NAE")
+		to_chat(target, span_warning("You brace. Why do you brace? Nothing comes."))
+		loc.visible_message(span_cult("[target] stands untouched. They reject His will."))
+
+/obj/structure/ritualcircle/psydon/proc/psydonadmonishment(mob/living/carbon/human/target)
+	if(!target || QDELETED(target) || target.loc != loc)
+		to_chat(usr, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive the One's admonishment.")
+		return
+
+	if(!target.mind) //Stopping null lookup runtimes
+		loc.visible_message(span_warning("[target] does not have the mind to benefit from the One's guidance."))
+		return
+
+	if(HAS_TRAIT(target, TRAIT_SILVER_BLESSED))
+		loc.visible_message(span_warning("[target] has already been saved by the One's admonishment."))
+		return
+
+	if(target.stat == DEAD)
+		loc.visible_message(span_warning("With their heart stilled, the ritual will have no purchase upon [target]. It would be a waste."))
+		return
+
+	var/datum/antagonist/werewolf/Were = target.mind.has_antag_datum(/datum/antagonist/werewolf)
+	var/datum/antagonist/werewolf/lesser/Wereless = target.mind.has_antag_datum(/datum/antagonist/werewolf/lesser)
+	var/datum/antagonist/vampirelord/Vamp = target.mind.has_antag_datum(/datum/antagonist/vampirelord)
+	var/datum/antagonist/vampirelord/lesser/Vampless = target.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser)
+
+	//Werewolf deconversion
+	if(Were && !Wereless) //The roundstart elder/alpha werewolf, it cannot be saved
+		to_chat(target, span_userdanger("This wretched rite weighs heavy on my soul. Dendor's blessing shall not be quit of me so easily."))
+		target.visible_message(span_danger("[target] viscerally rejects the One's admonishment. They cannot be saved."))
+		target.Stun(30)
+		target.Knockdown(30)
+		return
+
+	else if(Wereless) //A lesser werewolf can be deconverted
+		if(Were.transformed == TRUE)
+			var/mob/living/carbon/human/I = target.stored_mob
+			to_chat(target, span_userdanger("THIS FOUL RITE! MY BODY RENDS ITSELF ASUNDER!"))
+			target.werewolf_untransform()
+			Were.on_removal()
+			ADD_TRAIT(I, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)
+			I.emote("agony", forced = TRUE)
+			I.Stun(30)
+			I.Knockdown(30)
+			I.Jitter(30)
+			return
+		else
+			target.flash_fullscreen("redflash3")
+			target.emote("agony", forced = TRUE)
+			to_chat(target, span_userdanger("THIS FOUL RITE! IT BURNS ME TO MY CORE!"))
+			Were.on_removal()
+			ADD_TRAIT(target, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)
+			target.Stun(30)
+			target.Knockdown(30)
+			target.Jitter(30)
+			return
+
+	else if(Vamp && !Vampless) //We're the vampire lord, we can't be saved.
+		to_chat(target, span_userdanger("This wretched rite weighs heavy on my soul. An insult I shall never forget, for as long as I die."))
+		target.visible_message(span_danger("[target] viscerally rejects the One's admonishment. They cannot be saved."))
+		target.Stun(30)
+		target.Knockdown(30)
+		return
+
+	else if(Vampless) //Lesser vampires being saved
+		target.mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
+		var/obj/item/organ/eyes/eyes = target.getorganslot(ORGAN_SLOT_EYES)
+		if(eyes)
+			eyes.Remove(target,1)
+			QDEL_NULL(eyes)
+			eyes = new /obj/item/organ/eyes
+			eyes.Insert(target)
+		target.skin_tone = Vampless.cache_skin
+		target.hair_color = Vampless.cache_hair
+		target.facial_hair_color = Vampless.cache_hair
+		target.eye_color = Vampless.cache_eyes
+		target.update_body()
+		target.update_hair()
+		target.update_body_parts(redraw = TRUE)
+		Vampless.on_removal()
+		target.mind.special_role = null
+		target.emote("agony", forced = TRUE)
+		to_chat(target, span_userdanger("THIS FOUL RITE! IT QUICKENS MY HEART!"))
+		REMOVE_TRAIT(target, TRAIT_INFINITE_STAMINA, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_NOSLEEP, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_NOBREATH, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_NOPAIN, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_NOHUNGER, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_TOXIMMUNE, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_VAMP_DREAMS, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_HEAVYARMOR, "/datum/antagonist/vampirelord/lesser")
+		REMOVE_TRAIT(target, TRAIT_STEELHEARTED, "/datum/antagonist/vampirelord/lesser")
+		target.verbs -= /mob/living/carbon/human/proc/disguise_button
+		target.verbs -= /mob/living/carbon/human/proc/vampire_telepathy
+		target.verbs -= /mob/living/carbon/human/proc/vamp_regenerate
+		target.RemoveSpell(/obj/effect/proc_holder/spell/targeted/transfix)
+		ADD_TRAIT(target, TRAIT_SILVER_BLESSED, TRAIT_GENERIC)
+		target.Stun(30)
+		target.Knockdown(30)
+		target.Jitter(30)
+		return
+
+/obj/structure/ritualcircle/psydon/proc/psydonstrip(mob/living/carbon/human/target)
+	if(!HAS_TRAIT(target, TRAIT_OVERTHERETIC))//A fallback. You should never see this.
+		loc.visible_message(span_cult("This one is not bound by chains upon their lux. I can do nothing more with this rite."))
+		return
+	target.Stun(20)
+	target.Knockdown(20)
+	to_chat(target, span_userdanger("IT'S INSIDE MY HEAD!"))
+	target.emote("Agony")
+	playsound(loc, 'sound/misc/pressurepad_up.ogg', 50)
+	loc.visible_message(span_cult("[target]'s flesh briefly warps, as some unseen force tears the equipment from their frame!"))
+	spawn(20)
+		playsound(loc, 'sound/misc/pressurepad_down.ogg', 50)
+		target.equipOutfit(/datum/outfit/job/roguetown/rite_strip)
+		if(HAS_TRAIT(target, TRAIT_OVERTHERETIC))
+			REMOVE_TRAIT(target, TRAIT_OVERTHERETIC, TRAIT_MIRACLE)
+
+//Dropping rite armour. Or, well, basically everything.
+/datum/outfit/job/roguetown/rite_strip/pre_equip(mob/living/carbon/human/H)
+	..()
+	var/list/items = list()
+	items |= H.get_equipped_items(TRUE)
+	for(var/I in items)
+		H.dropItemToGround(I, TRUE)
+	H.drop_all_held_items()


### PR DESCRIPTION
## About The Pull Request
Does as it says on the title. A number of changes facing Inquisition content.

Firstly, garrote.
These required EIGHT resists to snap. You would never actually knock someone out with this, as it has 200 integrity, and takes 25 damage per resist. On escape, it immediately broke the wire. I've replaced this with removal of the integrity damage on resist, with escapes dealing a flat 100 integrity damage. Two escapes will snap it. I hope that it adds some actual use to an otherwise typically ignored item, given it's only used currently for stopping chases and muting mages, as opposed to the actual functionality intended for it. Especially since wrestling 'balance' as is make these even more painful to use.

Skipping ahead, slurbows.
I've removed them from the merchant vendor, fullstop. They had an identical price range to crossbows. For some reason. Wow. Wonder why. Additionally, knaves get it at an identical price setup to the longbow, making it a direct upgrade of the crossbow. Because it is.

Now, to actual content. Absolver rites.
This takes the rite circle stuff, the existing non-functional rite circle for Psydonites and actually turns it into something with content. Three rites exist. 'Conversion', 'Admonishment' and 'Freedom'. 'Admonishment' and 'Freedom' provide a five minute cooldown. 'Conversion' can be used at any time, so long as that cooldown isn't in effect. Only Absolver (Ritualists with the Inquisition trait) can actually use these rites.
 - 'Conversion': Allows any non-Psydonites to be converted to Psydon worship. It functions identically to 'Inhumen' conversion, with the exception being that it doesn't actually do anything beyond conversion. You get no skills or boons. It's just a matter of faith swapping, with your devotion taken into account as with others.
 - 'Admonishment': Quicksilver poultice via ritual. That's it. It's that simple. There's nothing more to this. Once every five minutes, to allow for mass-deconversion.
 - 'Freedom': Fullstrips anyone that this is used on. Can only be used on overt heretics, which are those in rite armour. It also removes the trait, which once more allows them to enter hallowed ground without issue. Pair with conversion for best results. As with 'Admonishment', this is on a five minute timer.

## Testing Evidence
<img width="504" height="206" alt="image" src="https://github.com/user-attachments/assets/c45329c9-93c8-411d-be3b-55d3fd44e7ad" />
<img width="507" height="75" alt="image" src="https://github.com/user-attachments/assets/5c7513b0-fb17-44c1-9c50-882e8bdbce10" />
<img width="456" height="159" alt="image" src="https://github.com/user-attachments/assets/57a544c4-04af-4725-8efb-692312b6f5fd" />
<img width="520" height="53" alt="image" src="https://github.com/user-attachments/assets/a769f7c1-28ec-4c90-a3ef-ed42fc2bc275" />
<img width="509" height="153" alt="image" src="https://github.com/user-attachments/assets/9d989bfb-4ae0-49fa-ae32-b089d3bab511" />
<img width="495" height="35" alt="image" src="https://github.com/user-attachments/assets/e3a508a0-f67c-43c6-9512-c4955cf20fe6" />

## Why It's Good For The Game
Garrotes are boring. They don't work for their intended function. Is it a good change? I 'unno. Is it balanced? Probably not. But they're so rarely used as is, that I don't think I've seen anyone else use them, and the one time I had it on me, I'd immediately snapped it and sprinted away without issue.

Slurbows are a meta weapon. They just are. They shouldn't be so stupidly easy to get.

Absolver can do with more content, and ways to handle antags they otherwise can't deal with. This PR will allow them to ACTUALLY CONVERT PEOPLE and deconvert antags when poultice counterplay abuse has taken place. Also just otherwise removing rite armour from folks for whatever reason they'd need.