### PR TITLE
Adds a really bad alternative lux purification method (also makes lux slightly more valuable)

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -471,3 +471,14 @@
 		)
 	skillcraft = /datum/skill/misc/medicine
 	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/survival/purify_lux_compress
+	name = "purifiy lux (compression)"
+	result = list(
+		/obj/item/reagent_containers/lux,
+		)
+	reqs = list(
+		/obj/item/reagent_containers/lux_impure = 2,
+		)
+	skillcraft = /datum/skill/misc/medicine
+	craftdiff = 4

--- a/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
+++ b/modular_hearthstone/code/modules/reagents/reagent_containers/lux.dm
@@ -8,7 +8,7 @@
 	volume = 15
 	list_reagents = list(/datum/reagent/vitae = 5)
 	grind_results = list(/datum/reagent/vitae = 5)
-	sellprice = 90
+	sellprice = 100
 
 /datum/reagent/vitae
 	name = "Vitae"


### PR DESCRIPTION
## About The Pull Request
-expert medicine skill recipe, lets you craft 1 pure lux from 2 impure lux.
-Lux is now sells for 100 instead of 90. yeah that's it
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="579" height="653" alt="image" src="https://github.com/user-attachments/assets/7ba7cf4d-cd44-43ec-aa21-8c91fa258c6d" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Frankly I don't think the heartbeast should exist, but not everyone does, and removing lux purification would make the beast much less important. I do this because the heartbeast is excessively harsh on towner physicians and in emergencies, and heartblood is a bit finnicky to get since you're pretty much entirely dependent on the keepers or breaking in (and the beast is hidden in a basement, so it's harder to get keeper attention)

The beast passively generates heartblood quite quickly and easily, and church has other revival methods. The apothecary also has the chair (though that also wants heartblood...) so, for these groups, needing heartblood to purify lux is an insignificant requirement.

For a towner surgeon or if no one else is available to revive, it's cruel and painful for no real reason. You HAVE to go to the keepers and ask for/buy heartblood (they have a peddler, but there's no way for them to be sure you'll return the can, and they don't start with a lot of cans... they also don't really need money. so, you can't rely on them to sell heartblood that way.) You can go to the Heartbeast through the mine tunnels, but you'll still have to break in, which feels bad. 

Needing a resource only found at one location to do lux revival also really ruins half the point of lux. some say lux is too common since you can just rip it out of an NPC. but in an emergency, you might just have to pull it out of a donor or someone less willing instead. if you have time to get heartblood, it's probably not an emergency... if you're in an emergency, you better have the lux beforehand! So in a way, heartblood encourages people to rip lux out of NPCs in advance instead of players in an emergency.

2 impure for 1 pure lux is a really bad trade, but it can be done.

I know you can revive people with leechbait, and there was clearly effort put into that, but there's a few reasons I don't think that should be the only method.

1. it also isn't any good in a rush; the body is going to rot by the time you can make the bait, set it outside, get a leech and feed it. So any drama of 'I need your lux if you want your friend to live!' is gone and replaced with stealing a bandit NPC's lux well in advance of a catastrophe.
2. it's really unfriendly to new and returning players. Getting impure lux is going to confuse anyone who didn't know the system changed, but everyone is going to struggle with using the leechbait for the first time- bait is one of the most unintuitive and finnicky systems in roguetown, and the leechbait can even spawn you a bear instead of the bug you need!
3. also it's kinda just gross and I think if you want to play a dignified surgeon you should have an alternative that doesn't involve  putting a giant bug in someone, even if it's almost six times as expensive.

Leechbait is just so much more efficient and getting 2 lux is pretty hard, so I think it'll still be preferred, but I think the variety is warranted.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Also probably shouldn't have because atomization, but in the middle of it I went "wait a second, lux is literally harder to get now, shouldn't demand be higher?" and I made it just a little more expensive, so that if sawbones want to steal people's lux (which is cool) then they have a lil bit more incentive to now that they need to purify it and it sux.
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
