### PR TITLE
Allows grabs to silence through masks again

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1363,7 +1363,7 @@
 	if(mouth?.muteinmouth)
 		return FALSE
 	for(var/obj/item/grabbing/grab in grabbedby)
-		if((grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH) && (get_location_accessible(src, BODY_ZONE_PRECISE_MOUTH)))
+		if(grab.sublimb_grabbed == BODY_ZONE_PRECISE_MOUTH)
 			return FALSE
 	if(istype(loc, /turf/open/water) && !(mobility_flags & MOBILITY_STAND))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Direct revert of https://github.com/GeneralPantsuIsBadAtCoding/Azure-Peak/pull/3294 minus their coverage flag changes.

## Testing Evidence

One line change.

## Why It's Good For The Game

The same reasons used in the Azure Peak PR can be used for why this shouldn't be a thing. Players will often yell immediately when grabbed, without a way to silence those players, sneakily breaking into high security areas isn't feasible, nor is safely kidnapping combat roles without having to escalate to all out combat and either player getting skullcracked, and even then the player who isn't an antagonist can just scream for help and ruin the antagonists plans. 

This is not a good thing, players should not be punished for getting the drop on someone by making the dreaded combat roles even more resilient. You call it a 'grab meta' but the alternative is smashing your skull with a mace. 

As for spellcasters, they put out far too much DPS and have many ways to keep players at bay, they can continue to cast so long as they may speak, even when downed, even when stuttering in pain, covering their mouth as a means to shut them down is not often abused in the first place. I've seen plenty of frag clips from magic user's perspectives.

Besides, you can very reasonably slip your hand up under someone's visor to cover their mouth, same goes for steel masks. Strangling someone who is wearing dedicated neck armor, which is rigid, is far less believable so that has not been changed. 
