### PR TITLE
Mordhau(altgrip) can be wielded now!

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1431,7 +1431,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	. = ..()
 	if(twohands_required)
 		return
-	if(wielded) //Trying to unwield it
+	if(wielded) //Trying to unwield it. Ratwood edit. Original: (altgripped || wielded) 
 		ungrip(user)
 		return
 	if(alt_intents && !gripped_intents)


### PR DESCRIPTION
## About The Pull Request

A cheap code change made by my trial and error to make the algrip able to be wielded with both hands.

## Testing Evidence
The video is a bit old from pre-infamous parity pr, but the evidence is basically the same since it just is a piece of code removal that prevented the altgrip from being wielded. However, as you see in the video, if you try to unwield during altgrip, the weapon returns to its normal state. I know this is cheap code change but this went very effective somehow.

https://github.com/user-attachments/assets/8e8c05f0-0847-4cc8-9145-f06dd2422384



## Why It's Good For The Game

A lot of people have asked for the mordhau grip to be wielded for most blades.  This will significantly benefit greatsword's family as they're the ones that suffer more from one-handed mordhau grip.

The reason of why I decided to not force the altgrip to autowield is to let people still able to altgrip their long blades in one-handed while they still have a free hand to carry a shield or if they lack of another free hand to wield the blade.... by the blade.