### PR TITLE
Embrace the Lunacy

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -37,12 +37,6 @@
 	H.adjust_skillrank(/datum/skill/craft/cooking, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/labor/fishing, 3, TRUE)
 
-// You see, the idea of a Demiurge Vampire Godchosen noble is FAR too Baldurs gate 3 and Divinity 2: Original sin for this world. It must be contained.
-	virtue_restrictions = list(
-        /datum/virtue/utility/noble,
-        /datum/virtue/combat/vampire,
-    )
-
 	// -- Start of section for god specific bonuses --
 	if(H.patron?.type == /datum/patron/inhumen/graggar)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)


### PR DESCRIPTION
it's a singular line of code that enables them as an option.

Why its good for the game: 

Lunacy Embracers are the cryptid choice of class for many players; and a fun basis template for heretic wretches; or insane pantheon followers.  

It will add roleplay to the game! People like options, and this is a pretty extreme choice for most.

Lunacy Embracers are **forced to be naked;** and generally speaking - they will inhabit the fringes of society; a choice that folk who prefer to avoid the centre of the map as minor-antags will likely take.
