### PR TITLE
Allows councillors to switch SCOMs to the garrison line

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomm.dm
@@ -176,7 +176,7 @@
 /obj/structure/roguemachine/scomm/MiddleClick(mob/living/carbon/human/user)
 	if(.)
 		return
-	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (user.job == "Watchman") || (user.job == "Warden") || (user.job == "Squire") || (user.job == "Marshal") || (user.job == "Grand Duke") || (user.job == "Knight Captain") || (user.job == "Grand Duchess") || (user.job == "Hand")))
+	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (user.job == "Watchman") || (user.job == "Warden") || (user.job == "Councillor") || (user.job == "Squire") || (user.job == "Marshal") || (user.job == "Grand Duke") || (user.job == "Knight Captain") || (user.job == "Grand Duchess") || (user.job == "Hand")))
 		if(alert("Would you like to swap lines or connect to a jabberline?",, "swap", "jabberline") != "jabberline")
 			garrisonline = !garrisonline
 			to_chat(user, span_info("I [garrisonline ? "connect to the garrison SCOMline" : "connect to the general SCOMLINE"]"))


### PR DESCRIPTION
## About The Pull Request
Just lets councillors use MMB to switch scoms to garrison line and back. nothing else.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="540" height="162" alt="image" src="https://github.com/user-attachments/assets/e761260b-82a3-410e-b460-1d823627d8f2" />

## Why It's Good For The Game
Councillor is kind of a weird role. On old Ratwood they were supposed to work with the Marshal; here, they seem designed mostly as "Be a petty annoyance with no responsibilities", like prince/princess, but their job description suggests they _can_ act as an aid to the steward/duke/guards. And while it's feasible to help the steward when they have the keys, it's harder to advise the duke or guards when you usually don't know what's going on. Scomline access is something you can't really get unless you start with it, but it's also something I think councillors would be trusted with. I think giving them the option to help the marshal / with garrison duties would be interesting and make the role slightly more distinguished from heir, at least.

On the other hand, it might be a bit annoying to have councillors trying to butt into garrison business all the time, and councillors shouldn't feel forced to keep an eye on it, so I didn't give them a houndstone. Maybe I should, but at least houndstones are something you CAN get in-game.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
