### PR TITLE
Rewords the AP trait descriptors from 'Physical Feature: New Descriptions.'

### DIFF
--- a/code/datums/mob_descriptors/descriptors/trait.dm
+++ b/code/datums/mob_descriptors/descriptors/trait.dm
@@ -2,152 +2,133 @@
 	abstract_type = /datum/mob_descriptor/trait
 	slot = MOB_DESCRIPTOR_SLOT_TRAIT
 
-/datum/mob_descriptor/trait/moderate
-	name = "Moderate"
-	prefix = "is very"
-
 /datum/mob_descriptor/trait/mundane
 	name = "Mundane"
-	prefix = "is very"
+	prefix = "is rather"
 
 /datum/mob_descriptor/trait/middling
 	name = "Middling"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/tall
 	name = "Tall"
-	prefix = "is very"
+	prefix = "looks rather"
 
 /datum/mob_descriptor/trait/short
 	name = "Short"
-	prefix = "is very"
+	prefix = "looks rather"
 
 /datum/mob_descriptor/trait/dainty
 	name = "Dainty"
-	prefix = "is very"
+	prefix = "looks quite"
 
 /datum/mob_descriptor/trait/towering
 	name = "Towering"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/giant
 	name = "Giant"
-	prefix = "is a"
+	prefix = "looks like a"
 
 /datum/mob_descriptor/trait/tiny
 	name = "Tiny"
-	prefix = "is very"
+	prefix = "looks quite"
 
 /datum/mob_descriptor/trait/stout
 	name = "Stout"
-	prefix = "is very"
+	prefix = "looks rather"
 
 /datum/mob_descriptor/trait/cadaverous
 	name = "Cadaverous"
-	prefix = "is very"
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/lanky
 	name = "Lanky"
-	prefix = "is very"
+	prefix = "looks quite"
 
 /datum/mob_descriptor/trait/wide
 	name = "Wide"
-	prefix = "is very"
+	prefix = "looks rather"
 
 /datum/mob_descriptor/trait/thin
 	name = "Thin"
-	prefix = "is very"
-
-/datum/mob_descriptor/trait/zardish
-	name = "Zardish"
-	prefix = "is very"
-
+	prefix = "looks rather"
 
 /datum/mob_descriptor/trait/lupian
 	name = "Lupian"
-	prefix = "is very"
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/venardic
 	name = "Venardic"
-	prefix = "is very"
-
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/feline
 	name = "Feline"
-	prefix = "is very"
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/elven
-	name = "Elven"
-	prefix = "is very"
+	name = "Elvish"
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/rousley
 	name = "Rousley"
-	prefix = "is very"
-
-/datum/mob_descriptor/trait/blessed
-	name = "Blessed"
-	prefix = "is very"
-
-/datum/mob_descriptor/trait/accursed
-	name = "Accursed"
-	prefix = "is a"
+	prefix = "looks quite"
 
 /datum/mob_descriptor/trait/aquatic
 	name = "Aquatic"
-	prefix = "is very"
-
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/horned
 	name = "Horned"
-	prefix = "is very"
+	prefix = "looks"
 
 /datum/mob_descriptor/trait/snoutly
 	name = "Snoutly"
-	prefix = "is very"
+	prefix = "looks quite"
 
 /datum/mob_descriptor/trait/tailed
 	name = "Tailed"
-	prefix = "is very"
+	prefix = "is" // "He is tailed" This sucks so much ass
 
 /datum/mob_descriptor/trait/fanged
 	name = "Fanged"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/tusked
 	name = "Tusked"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/clawed
 	name = "Clawed"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/furred
 	name = "Furred"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/feathered
 	name = "Feathered"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/scaly
 	name = "Scaly"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/crimson
 	name = "Crimson"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/cerulean
 	name = "Cerulean"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/emerald
 	name = "Emerald"
-	prefix = "is very"
+	prefix = "is"
 
 /datum/mob_descriptor/trait/amber
 	name = "Amber"
-	prefix = "is very"
+	prefix = "is"
 
 
 

--- a/code/modules/client/descriptors/descriptor_choice.dm
+++ b/code/modules/client/descriptors/descriptor_choice.dm
@@ -279,9 +279,8 @@
 	)
 /datum/descriptor_choice/trait
 	name = "Physical Descriptor"
-	default_descriptor = /datum/mob_descriptor/trait/moderate
+	default_descriptor = /datum/mob_descriptor/trait/mundane
 	descriptors = list(
-		/datum/mob_descriptor/trait/moderate,
 		/datum/mob_descriptor/trait/mundane,
 		/datum/mob_descriptor/trait/middling,
 		/datum/mob_descriptor/trait/tall,
@@ -295,14 +294,11 @@
 		/datum/mob_descriptor/trait/lanky,
 		/datum/mob_descriptor/trait/wide,
 		/datum/mob_descriptor/trait/thin,
-		/datum/mob_descriptor/trait/zardish,
 		/datum/mob_descriptor/trait/lupian,
 		/datum/mob_descriptor/trait/venardic,
 		/datum/mob_descriptor/trait/feline,
 		/datum/mob_descriptor/trait/elven,
 		/datum/mob_descriptor/trait/rousley,
-		/datum/mob_descriptor/trait/blessed,
-		/datum/mob_descriptor/trait/accursed,
 		/datum/mob_descriptor/trait/aquatic,
 		/datum/mob_descriptor/trait/horned,
 		/datum/mob_descriptor/trait/snoutly,
@@ -316,8 +312,7 @@
 		/datum/mob_descriptor/trait/crimson,
 		/datum/mob_descriptor/trait/cerulean,
 		/datum/mob_descriptor/trait/emerald,
-		/datum/mob_descriptor/trait/amber,
-
+		/datum/mob_descriptor/trait/amber
 	)
 
 /datum/descriptor_choice/skin_all


### PR DESCRIPTION
## About The Pull Request

~~Revert of https://github.com/Azure-Peak/Azure-Peak/pull/4148 while retaining the additional descriptors for other values~~

Rewords the descriptors so they don't sound stupid.

## Testing Evidence

All code.

## Why It's Good For The Game

Because it is pretty stupid examining someone and seeing "He is very moderate" or "She is very tailed" 
Physical descriptors are great but this is just redundant and almost always seemingly out of place. 

<img width="234" height="56" alt="image" src="https://github.com/user-attachments/assets/c97fe31d-fe10-4520-82e9-6a2d2fe1c303" />
<img width="293" height="59" alt="image" src="https://github.com/user-attachments/assets/4900bcd3-9248-4081-b7b9-c2a11adf5bcb" />
<img width="225" height="67" alt="image" src="https://github.com/user-attachments/assets/a880b366-7a57-49f1-a7ac-e914c8a45ecd" />
<img width="217" height="51" alt="image" src="https://github.com/user-attachments/assets/94fd812b-bddb-4da8-bfcb-6501b08d9dc9" />
<img width="587" height="583" alt="image" src="https://github.com/user-attachments/assets/d35f73ec-937b-4862-95b9-28b9f3bf22f5" />

Actual descriptors, they do not sit right at all. 

When players are masked they look kind of neat, for example, highlighting someone might have them appear as 'Fanged Rogue' or 'Furred Blaggard' and-

Actually as I'm writing this I think it'd be better to keep them invisible and retain it as a bit of flavor when highlighting over someone. 