### PR TITLE
Sword's Bash Intent soft un-nerf.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -107,7 +107,8 @@
 	attack_verb = list("bashes", "strikes")
 	penfactor = BLUNT_DEFAULT_PENFACTOR
 	damfactor = 1.2
-	swingdelay = 12
+	swingdelay = 13
+	clickcd = 13
 	item_d_type = "blunt"
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
 


### PR DESCRIPTION
## About The Pull Request

After parity( #253 ), both non-blunt strike and sword's bash intent have become copypaste of each other. This PR what it does is slightly un-nerf the changes from the parity no one asked for with increased damange modifier from 0.8 to 1.2 plus a small click delay.

Also Bash intent has been renamed from "pomel bash" to "crossguard bash".

## Testing Evidence

It will work, trust me.

## Why It's Good For The Game

I think I don't need to explain why is this good for the game. After noticing sword's bash intent became non-blunt strike 2.0, I felt the urge to make this PR to make it different again.