### PR TITLE
Flambergelove: Toy with numbers on balance about flamberges & Grenzel Zwei!

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -1023,14 +1023,15 @@
 	desc = "A close relative of the Grenzelhoftian \"zweihander\", favored by Otavan nobility. The name comes from its unique, flame-shaped blade; a labor only surmountable by Psydonia's finest weaponsmiths."
 	icon_state = "steelflamberge"
 	max_blade_int = 200
+	max_integrity = 180
 	wdefense = 6
 
 /obj/item/rogueweapon/greatsword/grenz/flamberge/malum
 	name = "forgefiend flamberge"
 	desc = "This sword's creation took a riddle in its own making. A great sacrifice was made for a blade of perfect quality."
 	icon_state = "malumflamberge"
-	max_integrity = 200
-	max_blade_int = 200
+	max_integrity = 240
+	max_blade_int = 240
 
 /obj/item/rogueweapon/greatsword/grenz/flamberge/blacksteel
 	name = "blacksteel flamberge"


### PR DESCRIPTION
## About The Pull Request
So, fun fact:

Smiths can smith a *steel flamberge* for 3 iron ingots. It's like a zwei, but cooler.

Issue:
It was worse in every regard EXCEPT weapon defense than ANY of the other greatswords.

Deadass it had 130 integrity. **Decrepit greatsword has 150**.

So I tweaked the two flamberges (OG and Malum's) to better fit balance. The dreaded word.
- *Grenzel's Zwei* is still the OG of sustained damage. 4 weapon defense but **240** blade integrity means it can keep its bonus damage longer.
- *steel flamberge* is worse in every regard - EXCEPT weapon defense (6!)
- **Malum's flamberge** is better in sharpness, durability and defense, as Templars' blessed weapons intended.
- They all share the same dmg and intents.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Code lines. lines of code. numbers change.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Flamberges are sort of... ignored and, honestly, they're really fucking cool. This makes the steel flamberge be better than A LITERAL RUSTY GREATSWORD whilst still being balanced.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
