### PR TITLE
Adjust class stats for blacksmith towner

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/blacksmith.dm
@@ -9,9 +9,10 @@
 	category_tags = list(CTAG_PILGRIM, CTAG_TOWNER)
 	traits_applied = list(TRAIT_TRAINED_SMITH, TRAIT_SMITHING_EXPERT)
 	subclass_stats = list(
-		STATKEY_WIL = 2,
-		STATKEY_CON = 2,
+		STATKEY_WIL = 1,
+		STATKEY_CON = 1,
 		STATKEY_STR = 1,
+		STATKEY_INT = 2,
 		STATKEY_LCK = 1,
 		STATKEY_SPD = -1
 	)


### PR DESCRIPTION
## About The Pull Request
removes a singular point of con and end from blacksmith, adds both to int
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
if this breaks the game I'm gonna shit myself
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
towner blacksmiths are in an odd spot, they have no way of realistically using the bonus con or end and if you wanted to be a hybrid class of combat and smithing you have the virtue right there.

Currently the biggest bottleneck in the towner smith gameplay loop is setting up a forge and learning 4 different smithing skills(which start already progressed) however this should cut down on the grind and allow them to spend downtime branching out to other skills as needed while also having smithing be set up earlier into the game.

My third and final reason is: Homesteader exists, 
<img width="1499" height="404" alt="image" src="https://github.com/user-attachments/assets/1f3fe580-d0cb-4733-93fa-647ff5ba1844" />
this class objectively mogs towner blacksmith with higher int and low starting smithing skills allowing them to set up and skill up faster, this would make towner blacksmith reach max smithing before homesteader while homesteader is able to have everything at a low level earlier

So you know when I said third and final reason why I did this? I lied
My fourth reason is that blacksmith used to have exclusivity on starting with blacksmithing but seeing as they lost that with blacksmith apprentice, it's cheapened the ability to start with blacksmithing, Now I know they have been compensated by making each one a level higher but in my opinion it's not enough.

TLDR: removes some slight combat capability from the class, adds 2 int which should speed up early game setting up allowing for them to reach max skills earlier or branch out
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
