### PR TITLE
Stay in your lane.

### DIFF
--- a/code/modules/roguetown/roguemachine/hoardmaster.dm
+++ b/code/modules/roguetown/roguemachine/hoardmaster.dm
@@ -112,7 +112,10 @@
 			unlocked_cats+="Iconoclast"
 		if("Pioneer")
 			unlocked_cats+="Pioneer"
-   
+
+	if(!(current_cat in unlocked_cats))
+		current_cat = "1"
+
 	if(current_cat == "1")
 		contents += "<center>"
 		for(var/X in unlocked_cats)


### PR DESCRIPTION
## About The Pull Request
Simply prevents bandits from accessing another menu they don't have access to. Such as a Knave opening the Sawbones' menu, or a Brigand accessing a Hedge Knight's. Etc.

Actual bug fix.

## Testing Evidence

https://github.com/user-attachments/assets/3f7aeec4-14f1-4177-904a-40270fa54085


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
You can't have your Sawbones leave their menu open, so you can buy six quadrillion starsugar unimpeded.