### PR TITLE
Hoardmaster Dusting

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1486,7 +1486,7 @@
 /obj/item/roguecoin/gold/pile,
 /obj/item/candle/candlestick/gold/lit,
 /turf/open/water/cleanshallow,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "lA" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/vampire_manor)
@@ -2292,7 +2292,7 @@
 	name = "Wall of Greed"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "tt" = (
 /turf/closed/wall/mineral/rogue/tent{
 	dir = 8
@@ -2773,7 +2773,7 @@
 "yp" = (
 /obj/item/roguecoin/gold/pile,
 /turf/open/water/cleanshallow,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "yq" = (
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
@@ -3246,7 +3246,7 @@
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "CO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/concrete,
@@ -3625,7 +3625,7 @@
 "Gk" = (
 /obj/structure/closet/crate/chest/gold,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "Gl" = (
 /turf/open/floor/rogue/metal/barograte/open,
 /area/rogue/indoors/eventarea)
@@ -3916,7 +3916,7 @@
 	name = "Wall of Greed"
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "Jx" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/eventarea)
@@ -4300,7 +4300,7 @@
 /obj/item/reagent_containers/glass/bowl/gold,
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "MA" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flashlight/flare/torch/metal,
@@ -4315,7 +4315,7 @@
 "MH" = (
 /obj/item/roguecoin/gold/pile,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "MJ" = (
 /obj/machinery/light/rogue/firebowl,
 /obj/structure/arcyne_wall{
@@ -4324,7 +4324,7 @@
 	name = "Wall of Greed"
 	},
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "MS" = (
 /obj/machinery/light/rogue/smelter/hiron,
 /turf/open/floor/rogue/cobble,
@@ -4552,9 +4552,8 @@
 "Pv" = (
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguestatue/gold,
-/obj/item/roguegem,
 /turf/open/floor/rogue/naturalstone,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "Px" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/bottle/alchemical{
@@ -4739,7 +4738,7 @@
 /obj/item/rogueweapon/sword/decorated,
 /obj/item/roguecoin/gold/pile,
 /turf/open/water/cleanshallow,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "QJ" = (
 /obj/structure/roguewindow,
 /turf/open/floor/rogue/twig,
@@ -4842,7 +4841,7 @@
 /obj/item/ingot/gold,
 /obj/item/roguecoin/gold/pile,
 /turf/open/water/cleanshallow,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "RH" = (
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors)
@@ -5285,7 +5284,7 @@
 	name = "Wall of Greed"
 	},
 /turf/open/floor/rogue/blocks,
-/area/rogue/indoors/banditcamp)
+/area/rogue/indoors/banditcamp/hoardmaster)
 "Wr" = (
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/eventarea)

--- a/code/__HELPERS/round_statistics.dm
+++ b/code/__HELPERS/round_statistics.dm
@@ -51,6 +51,7 @@
 #define STATS_DEADITES_ALIVE "deadites_alive"
 #define STATS_LUX_REVIVALS "lux_revivals"
 #define STATS_DODGES "dodges_made"
+#define STATS_GREED_DUSTED "consumed_by_greed"
 
 // Economic Statistics
 #define STATS_BATHMATRON_VAULT_INCOME "bath_vault_regular"
@@ -327,6 +328,7 @@ GLOBAL_LIST_INIT(azure_round_stats, list(
 	STATS_MAMMONS_DEPOSITED = 0,
 	STATS_MAMMONS_WITHDRAWN = 0,
 	STATS_STARTING_TREASURY = 0,
+	STATS_GREED_DUSTED = 0,
 ))
 
 GLOBAL_LIST_EMPTY(patron_follower_counts)

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -21,6 +21,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	var/holy_area = FALSE
 	var/cell_area = FALSE
 	var/ceiling_protected = FALSE //Prevents tunneling into these from above
+	var/hoardmaster_protected = FALSE//If a player enters, it ashes them. Your greed will consume you.
 
 /area/rogue/Entered(mob/living/carbon/human/guy)
 	. = ..()
@@ -36,6 +37,12 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 		guy.add_stress(/datum/stressevent/seeblessed)
 	if((src.holy_area == TRUE) && HAS_TRAIT(guy, TRAIT_OVERTHERETIC))//Heretics are punished for walking in the Church with rites buffs.
 		guy.apply_status_effect(/datum/status_effect/debuff/overt_punishment)
+	if((src.hoardmaster_protected == TRUE))//Your greed consumes you.
+		message_admins("[guy.real_name]([key_name(guy)]) was dusted by the Hoardmaster, at [ADMIN_JMP(src)]")
+		log_admin("[guy.real_name]([key_name(guy)]) was dusted by the Hoardmaster")
+		playsound(src, 'sound/misc/lava_death.ogg', 100, FALSE)
+		guy.dust()
+		GLOB.azure_round_stats[STATS_GREED_DUSTED]++
 
 /area/rogue/indoors
 	name = "indoors rt"
@@ -57,6 +64,13 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound = 'sound/music/area/banditcamp.ogg'
 	droning_sound_dusk = 'sound/music/area/banditcamp.ogg'
 	droning_sound_night = 'sound/music/area/banditcamp.ogg'
+
+/area/rogue/indoors/banditcamp/hoardmaster
+	name = "The Hoard"
+	icon_state = "rogue"
+	first_time_text = "A MISTAKE"
+	deathsight_message = "a place of greed and excess"
+	hoardmaster_protected = TRUE
 
 /area/rogue/indoors/vampire_manor
 	name = "Vampire Manor"
@@ -104,7 +118,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_night = 'sound/music/area/banditcamp.ogg'
 	first_time_text = "A Gathering of Thieves"
 	deathsight_message = "somewhere in the wilds"
-	
+
 /area/rogue/outdoors/banditcamp/exterior // Only use these around traveltiles - Constantine
 	name = "bandit camp outdoors"
 
@@ -141,7 +155,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	deathsight_message = "a twisted tangle of soaring peaks"
-	
+
 /area/rogue/outdoors/mountains/deception
 	name = "deception"
 	icon_state = "deception"

--- a/code/modules/client/round_end_panel.dm
+++ b/code/modules/client/round_end_panel.dm
@@ -109,7 +109,7 @@
 	// Centered container with left-aligned content
 	data += "<div style='text-align: center;'>"
 	data += "<div style='display: inline-block; text-align: left; margin-left: auto; margin-right: auto;'>"
-	
+
 	var/stat_is_object = GLOB.featured_stats[current_featured]["object_stat"]
 	var/stat_is_admin_only = GLOB.featured_stats[current_featured]["admin_only"]
 	var/has_entries = length(GLOB.featured_stats[current_featured]["entries"])
@@ -150,6 +150,7 @@
 	data += "<font color='#c24bc2'><span class='bold'>Drugs Snorted:</span></font> [GLOB.azure_round_stats[STATS_DRUGS_SNORTED]]<br>"
 	data += "<font color='#90a037'><span class='bold'>Laughs Had:</span></font> [GLOB.azure_round_stats[STATS_LAUGHS_MADE]]<br>"
 	data += "<font color='#f5c02e'><span class='bold'>Taxes Collected:</span></font> [GLOB.azure_round_stats[STATS_TAXES_COLLECTED]]<br>"
+	data += "<font color='#f37746'><span class='bold'>Consumed by Greed:</span></font> [GLOB.azure_round_stats[STATS_GREED_DUSTED]]<br>"
 	data += "</div>"
 
 	// Right column
@@ -256,7 +257,7 @@
 	data += "<div style='margin: 35px;'>"
 	switch(tab)
 		if("Gods")
-		
+
 			// Gods' Interventions Section
 			data += "<div>"
 			data += "<div style='text-align: center; color: #e0e0f0; font-size: 1.2em; margin-bottom: 10px;'>GODS' INTERVENTIONS</div>"
@@ -352,7 +353,7 @@
 
 				data += "</div>"
 
-		
+
 		if("Messages")
 			data += "<div style='display: table; width: 100%; table-layout: fixed;'>"
 			data += "<div style='display: table-row;'>"


### PR DESCRIPTION
## About The Pull Request
If you enter the Hoardmaster's hoard, it dusts you, ticks up a new end round statistic and alerts staff. A funny little mechanic to play into people breaking the walls. Earn your keep, reprobate, like bandits of old.

Logs, too, so abuse is readily apparent. Easy perma if folks are using it to dust another player.


## Testing Evidence
<img width="354" height="67" alt="image" src="https://github.com/user-attachments/assets/6b9652aa-1158-4ac0-9e21-e762fb8f6156" />

<img width="140" height="19" alt="image" src="https://github.com/user-attachments/assets/85e601bf-03f6-4eb9-9fcc-ab3fa638a9ab" />

## Why It's Good For The Game
This is a flavorful solution to an otherwise boring one, which is setting the walls to be indestructible.
Will it cause issues? I 'unno.