### PR TITLE
Fixes resident virtue not making you not a foreigner

### DIFF
--- a/modular_azurepeak/_virtue.dm
+++ b/modular_azurepeak/_virtue.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_EMPTY(virtues)
 				recipient.adjust_skillrank(the_skill.type, increase_by, TRUE)
 			else
 				to_chat(recipient, span_notice("My Virtue cannot influence my skill with [lowertext(the_skill.name)] any further."))
-				
+
 
 /datum/virtue/proc/handle_stashed_items(mob/living/carbon/human/recipient)
 	if (!recipient.mind || !LAZYLEN(added_stashed_items))
@@ -63,14 +63,14 @@ GLOBAL_LIST_EMPTY(virtues)
 /datum/virtue/proc/handle_added_languages(mob/living/carbon/human/recipient)
 	if (!LAZYLEN(added_languages))
 		return
-	
+
 	for (var/language in added_languages)
 		recipient.grant_language(language)
 
 /datum/virtue/proc/handle_stats(mob/living/carbon/human/recipient)
 	if (!LAZYLEN(added_stats))
 		return
-	
+
 	for (var/stat in added_stats)
 		var/value = added_stats[stat]
 		recipient.change_stat(stat, value)
@@ -78,10 +78,10 @@ GLOBAL_LIST_EMPTY(virtues)
 /datum/virtue/proc/check_triumphs(mob/living/carbon/human/recipient)
 	if (!triumph_cost)
 		return TRUE
-	
+
 	if (!recipient.mind)
 		return FALSE
-	
+
 	// we should check to see if they have triumphs first but i can't be fucked
 	recipient.adjust_triumphs(-triumph_cost, FALSE)
 	return TRUE
@@ -100,6 +100,10 @@ GLOBAL_LIST_EMPTY(virtues)
 			SStreasury.generate_money_account(20, recipient)
 		else
 			SStreasury.create_bank_account(recipient, 20)
+	if(HAS_TRAIT(recipient, TRAIT_RESIDENT))
+		REMOVE_TRAIT(recipient, TRAIT_OUTLANDER, ADVENTURER_TRAIT)
+		REMOVE_TRAIT(recipient, TRAIT_OUTLANDER, JOB_TRAIT)
+		REMOVE_TRAIT(recipient, TRAIT_OUTLANDER, TRAIT_GENERIC)
 	record_featured_object_stat(FEATURED_STATS_VIRTUES, virtue_type.name)
 /datum/virtue/none
 	name = "None"


### PR DESCRIPTION
## About The Pull Request
Resident, the virtue which is supposed to make you not a foreigner, and previously did make you not a foreigner, stopped working due to azure parity BS. this makes it work again.
fixes https://github.com/Rotwood-Vale/Ratwood-2.0/issues/323 I am so moderately annoyed by this issue that I didn't know about till now
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="845" height="142" alt="image" src="https://github.com/user-attachments/assets/87526472-6f81-4d57-bc2c-6867aae0f282" />
<img width="855" height="196" alt="image" src="https://github.com/user-attachments/assets/a50231d7-ff4a-46ff-938a-f1bd74c9efa0" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I like when stuff works as intended

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
