### PR TITLE
Wrastling Rebuff

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -207,7 +207,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(5))
+			if(user.badluck(2))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -238,7 +238,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(10))
+			if(user.badluck(4))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -285,7 +285,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(5))
+			if(user.badluck(2))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -297,7 +297,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(10))
+			if(user.badluck(4))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -309,7 +309,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(10))
+			if(user.badluck(4))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -322,7 +322,7 @@
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE
-			if(user.badluck(10))
+			if(user.badluck(4))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -359,7 +359,7 @@
 						M.visible_message(span_danger("[user] pins [M] to the ground!"), \
 							span_userdanger("[user] pins me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 			else
-				if(user.badluck(10))
+				if(user.badluck(4))
 					badluckmessage(user)
 					user.stop_pulling()
 					return FALSE
@@ -372,7 +372,7 @@
 					M.visible_message(span_warning("[user] tries to shove [M]!"), \
 									span_danger("[user] tries to shove me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 		if(/datum/intent/grab/disarm)
-			if(user.badluck(10))
+			if(user.badluck(4))
 				badluckmessage(user)
 				user.stop_pulling()
 				return FALSE
@@ -417,7 +417,7 @@
 				return
 
 /obj/item/grabbing/proc/twistlimb(mob/living/user) //implies limb_grabbed and sublimb are things
-	if(user.badluck(5))
+	if(user.badluck(2))
 		badluckmessage(user)
 		user.stop_pulling()
 		return
@@ -549,7 +549,7 @@
 /obj/item/grabbing/attack_turf(turf/T, mob/living/user)
 	if(!valid_check())
 		return
-	if(user.badluck(5))
+	if(user.badluck(2))
 		badluckmessage(user)
 		user.stop_pulling()
 		return
@@ -585,7 +585,7 @@
 /obj/item/grabbing/attack_obj(obj/O, mob/living/user)
 	if(!valid_check())
 		return
-	if(user.badluck(5))
+	if(user.badluck(2))
 		badluckmessage(user)
 		user.stop_pulling()
 		return
@@ -605,7 +605,7 @@
 
 
 /obj/item/grabbing/proc/smashlimb(atom/A, mob/living/user) //implies limb_grabbed and sublimb are things
-	if(user.badluck(10))
+	if(user.badluck(4))
 		badluckmessage(user)
 		user.stop_pulling()
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -523,6 +523,19 @@
 		O.update_hands(src)
 		update_grab_intents()
 
+//Free resists ahead.
+//This is STUPID strong.
+//We're stuck with it for economy reasons.
+//As of now, you get a free resist if either is met:
+// - Grabbed character skill at master or higher(5).
+// - Grabbing character skill at journeymen or lower(3).
+	if(isliving(AM))
+		var/mob/living/M = AM
+		if(M.mind)
+			if(M.cmode && M.stat == CONSCIOUS && !M.restrained(ignore_grab = TRUE))
+				if(M.get_skill_level(/datum/skill/combat/wrestling) >= 5 || src.get_skill_level(/datum/skill/combat/wrestling) <= 3)
+					M.resist_grab(freeresist = TRUE) //Automatically attempt to break a passive grab if defender's combat mode is on. Anti-grabspam measure.
+
 /mob/living/proc/is_limb_covered(obj/item/bodypart/limb)
 	if(!limb)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Wrastle changes:
 - Returns free resists for skill disparity, with values set out in #62.
 - Nukes luck based chance for grab dropping across the board, though keeps it as an element. We'll remove it altogether if it's still abysmally awful.

## Testing Evidence
Slop PR. Not tested.

## Why It's Good For The Game
See #62 for why grapples are important. I liked the skill disparity to mark classes specifically intended for wrastle gameplay, with those unintended for it suffering heavily. It was a very simple change.

Additionally, Zezus Pyst grappling is abysmal with how easy it is to just fuck yourself with those RNG chances. We'll need to nuke it altogether as a thing if it continues to be awful. Seriously. Wildly awful. We're back to bleeding folks out and delimbing / skullcracking nonstop to capture.