### PR TITLE
Acrobat Nerf

### DIFF
--- a/modular_azurepeak/virtues/movement.dm
+++ b/modular_azurepeak/virtues/movement.dm
@@ -1,7 +1,7 @@
 /datum/virtue/movement/acrobatic
 	name = "Acrobatic"
 	desc = "I have powerful legs, allowing me to land precisely where I want to, even with a running start."
-	added_traits = list(TRAIT_LEAPER, TRAIT_NOFALLDAMAGE1)
+	added_traits = list(TRAIT_LEAPER)
 
 /datum/virtue/movement/equestrian
 	name = "Equestrian"


### PR DESCRIPTION
## About The Pull Request
How did this slip back in?
Curious.
Simply removes the no Z fall damage once again from acrobat.

## Testing Evidence
One line change.

## Why It's Good For The Game
Parity returned this. It was never intended to slip back in.