### PR TITLE
You can now grind up and snort mana crystals

### DIFF
--- a/code/game/objects/items/rogueitems/magic/magic_resources.dm
+++ b/code/game/objects/items/rogueitems/magic/magic_resources.dm
@@ -84,6 +84,8 @@
 	icon_state = "manacrystal"
 	desc = "A crystal made of mana, woven into an artifical structure."
 	w_class = WEIGHT_CLASS_SMALL
+	grind_results = list(/datum/reagent/medicine/manapot = 20)
+	mill_result = /obj/item/reagent_containers/powder/mana
 
 /obj/item/magic/artifact
 	name = "runed artifact"

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -156,6 +156,17 @@
 	volume = 1
 	sellprice = 0
 
+/obj/item/reagent_containers/powder/mana
+	name = "sparkling blue powder"
+	desc = ""
+	gender = PLURAL
+	icon_state = "flour"
+	color = "#00b7ff"
+	list_reagents = list(/datum/reagent/medicine/manapot = 12)
+	grind_results = list(/datum/reagent/medicine/manapot = 12)
+	volume = 12
+	sellprice = 0
+
 /obj/item/reagent_containers/powder/rocknut
 	name = "rocknut powder"
 	desc = ""


### PR DESCRIPTION
## About The Pull Request

Mana crystals can be ground in a millstone to create mana powder. Mana powder can be snorted to get an instant hit of mana-potion. Fun!

Might need to tweak the numbers; I was just eyeballing how many units of manapotion is appropriate.

## Testing Evidence

<img width="493" height="376" alt="image" src="https://github.com/user-attachments/assets/d638df09-0590-42f7-9a1f-6781775875da" />
Here I am grinding manacrystals in a mill

<img width="1162" height="709" alt="image" src="https://github.com/user-attachments/assets/41a260cb-79a5-49d6-a369-d8d538108453" />
And as the powder is snorted, the blue bar is refiled!


## Why It's Good For The Game

I thought it'd be funny.