### PR TITLE
Return of Refugee | Fluff Corrections

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -289,7 +289,6 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_ABSOLVER		"CAT_ABSOLVER"		// For Absolver (sub)class
 #define CTAG_COURTAGENT		"CAT_COURTAGENT"	// Court agent classes
 #define CTAG_WRETCH			"CAT_WRETCH"		// Wretch classes untethered from adventurer
-#define CTAG_TRADER			"CAT_TRADER"		// Trader classes untethered from adventurer
 #define CTAG_LSKELETON		"CAT_LSKELETON"		// Lich Fortified Skeleton classes
 #define CTAG_NSKELETON		"CAT_NSKELETON"		// Necromancer Greater Skeleton classes
 #define CTAG_LICKER_WRETCH  "CAT_LICKER_WRETCH" // Licker wretch. Nuff said.

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -80,7 +80,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 /obj/effect/landmark/start/adventurerlate
 	name = "Adventurerlate"
 	icon_state = "arrow"
-	jobspawn_override = list("Skeleton", "Pilgrim", "Adventurer", "Migrant","Trader")
+	jobspawn_override = list("Skeleton", "Pilgrim", "Adventurer", "Migrant", "Refugee")
 	delete_after_roundstart = FALSE
 
 /obj/effect/landmark/start/banditlate
@@ -392,9 +392,11 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	name = "Adventurer"
 	icon_state = "arrow"
 
+//Remove this at some point. Vestigial.
 /obj/effect/landmark/start/trader
-	name = "Trader"
+	name = "Refugee"
 	icon_state = "arrow"
+//End of remove.
 
 /obj/effect/landmark/start/courtagent
 	name = "Court Agent"

--- a/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
@@ -25,3 +25,4 @@
 	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
 	same_job_respawn_delay = 0
+

--- a/code/modules/jobs/job_types/roguetown/church/keeper.dm
+++ b/code/modules/jobs/job_types/roguetown/church/keeper.dm
@@ -1,6 +1,6 @@
 /datum/job/roguetown/keeper
 	title = "Keeper"
-	tutorial = "Disfigured, shunned, or simply filled with purpose and dedication for Pestra. Some of you are horrifically mutated, disfigured, or diseased. No matter, even the pretty ones feel the toll as it leaves their strength atrophied. Someone has to harvest the holy blood required to purify lux and perpetuate Pestra's gift of medicine. Unfortunately, that's you. That's correct, I'm the one tasked with protecting the sacred Heart Beast of Pestra here. To study it and empower it so that Pestra's medicine may blossom even in the furthest reaches of Azure. Keep in mind you are NOT directly affiliated with the church of the see, the local bishop is not your boss. You answer to the sect of Pestra foremost."
+	tutorial = "Disfigured, shunned, or simply filled with purpose and dedication for Pestra. Some of you are horrifically mutated, disfigured, or diseased. No matter, even the pretty ones feel the toll as it leaves their strength atrophied. Someone has to harvest the holy blood required to purify lux and perpetuate Pestra's gift of medicine. Unfortunately, that's you. That's correct, I'm the one tasked with protecting the sacred Heart Beast of Pestra here. To study it and empower it so that Pestra's medicine may blossom even in the furthest reaches of Ferentia. Keep in mind you are NOT directly affiliated with the church of the see, the local bishop is not your boss. You answer to the sect of Pestra foremost."
 	flag = KEEPER
 	department_flag = CHURCHMEN
 	faction = "Station"
@@ -29,7 +29,7 @@
 
 /datum/advclass/keeper
 	name = "Keeper"
-	tutorial = "Disfigured, shunned, or simply filled with purpose and dedication for Pestra. Some of you are horrifically mutated, disfigured, or diseased. No matter, even the pretty ones feel the toll as it leaves their strength atrophied. Someone has to harvest the holy blood required to purify lux and perpetuate Pestra's gift of medicine. Unfortunately, that's you. That's correct, I'm the one tasked with protecting the sacred Heart Beast of Pestra here. To study it and empower it so that Pestra's medicine may blossom even in the furthest reaches of Azure. Keep in mind you are NOT directly affiliated with the church of the see, the local bishop is not your boss. You answer to the followers of Pestra foremost."
+	tutorial = "Disfigured, shunned, or simply filled with purpose and dedication for Pestra. Some of you are horrifically mutated, disfigured, or diseased. No matter, even the pretty ones feel the toll as it leaves their strength atrophied. Someone has to harvest the holy blood required to purify lux and perpetuate Pestra's gift of medicine. Unfortunately, that's you. That's correct, I'm the one tasked with protecting the sacred Heart Beast of Pestra here. To study it and empower it so that Pestra's medicine may blossom even in the furthest reaches of Ferentia. Keep in mind you are NOT directly affiliated with the church of the see, the local bishop is not your boss. You answer to the followers of Pestra foremost."
 	outfit = /datum/outfit/job/roguetown/keeper/basic
 	category_tags = list(CTAG_KEEPER)
 	// No perception as to dissuade picking statpacks to negate the strength penalty.

--- a/code/modules/jobs/job_types/roguetown/trader/brewer.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/brewer.dm
@@ -5,7 +5,7 @@
 	subclass_social_rank = SOCIAL_RANK_PEASANT
 	traits_applied = list(TRAIT_CICERONE, TRAIT_HOMESTEAD_EXPERT)
 	class_select_category = CLASS_CAT_TRADER
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 1,

--- a/code/modules/jobs/job_types/roguetown/trader/cuisiner.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/cuisiner.dm
@@ -6,7 +6,7 @@
 	subclass_social_rank = SOCIAL_RANK_PEASANT
 	traits_applied = list(TRAIT_GOODLOVER, TRAIT_HOMESTEAD_EXPERT)
 	class_select_category = CLASS_CAT_TRADER
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 1,

--- a/code/modules/jobs/job_types/roguetown/trader/doomsayer.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/doomsayer.dm
@@ -3,7 +3,7 @@
 	tutorial = "THE WORLD IS ENDING!!! At least, that's what you want your clients to believe. You'll offer them a safe place in the new world, of course - built by yours truly."
 	outfit = /datum/outfit/job/roguetown/adventurer/doomsayer
 	subclass_social_rank = SOCIAL_RANK_PEASANT
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	class_select_category = CLASS_CAT_TRADER
 	traits_applied = list(TRAIT_PSYCHOSIS, TRAIT_HOMESTEAD_EXPERT)
 	subclass_stats = list(

--- a/code/modules/jobs/job_types/roguetown/trader/harlequin.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/harlequin.dm
@@ -6,7 +6,7 @@
 	subclass_social_rank = SOCIAL_RANK_PEASANT
 	traits_applied = list(TRAIT_NUTCRACKER, TRAIT_HOMESTEAD_EXPERT)
 	class_select_category = CLASS_CAT_TRADER
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	subclass_stats = list(
 		STATKEY_SPD = 2,
 		STATKEY_PER = 1,

--- a/code/modules/jobs/job_types/roguetown/trader/jeweler.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/jeweler.dm
@@ -3,7 +3,7 @@
 	tutorial = "You make your coin peddling exotic jewelry, gems, and shiny things."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	class_select_category = CLASS_CAT_TRADER
 	traits_applied = list(TRAIT_TRAINED_SMITH, TRAIT_SMITHING_EXPERT)
 	outfit = /datum/outfit/job/roguetown/adventurer/trader

--- a/code/modules/jobs/job_types/roguetown/trader/peddler.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/peddler.dm
@@ -4,7 +4,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/peddler
 	subclass_social_rank = SOCIAL_RANK_PEASANT
 	class_select_category = CLASS_CAT_TRADER
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	traits_applied = list(TRAIT_MEDICINE_EXPERT, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
 		STATKEY_INT = 3,

--- a/code/modules/jobs/job_types/roguetown/trader/scholar.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/scholar.dm
@@ -5,7 +5,7 @@
 	subclass_social_rank = SOCIAL_RANK_YEOMAN
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ALCHEMY_EXPERT)
 	class_select_category = CLASS_CAT_TRADER
-	category_tags = list(CTAG_TRADER, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_PER = 1,

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(peasant_positions, list(
 	"Bathhouse Attendant",
 	"Prisoner",
 	"Beggar",
-	"Trader",
+	"Refugee",
 	"Pilgrim",
 ))
 
@@ -178,9 +178,9 @@ GLOBAL_LIST_INIT(roguefight_positions, list(
 
 //This list is used to prevent the duke from stripping nobility from certain jobs that aren't intrinsically a part of the town.
 GLOBAL_LIST_INIT(foreign_positions, list(
-	"Adventurer", 
-	"Mercenary", 
-	"Bandit", 
+	"Adventurer",
+	"Mercenary",
+	"Bandit",
 	"Wretch",
 	"Inquisitor",
 	"Suitor",

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1694,7 +1694,6 @@
 #include "code\modules\jobs\job_types\roguetown\adventurer\assassin.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\bandit.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\pilgrim.dm"
-#include "code\modules\jobs\job_types\roguetown\adventurer\trader.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\villager.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\wretch.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\_advclass.dm"


### PR DESCRIPTION
## About The Pull Request
Removes Trader. Folds its stuff into Refugee.
Refugee once more has spawn points.

Also, changes 'Azure' to 'Ferentia' for heartbeast keepers. Y'know, the place we're at. Wild.

## Testing Evidence
It just works. I tested it locally but forgot to grab screenshots.

## Why It's Good For The Game
Parity un-fuckery. Once again.