### PR TITLE
Dungeoneer mapping fixes

### DIFF
--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -38398,7 +38398,6 @@
 /area/rogue/outdoors/mountains)
 "joo" = (
 /obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/warden)
 "joq" = (
@@ -53431,6 +53430,7 @@
 "mOe" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "mOr" = (
@@ -77782,6 +77782,7 @@
 /area/rogue/outdoors/beach/forest/hamlet)
 "sKJ" = (
 /obj/structure/bed/rogue/shit,
+/obj/effect/landmark/start/prisonerr,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "sKK" = (


### PR DESCRIPTION
## About The Pull Request

i've been playing dungeoneer recently and noticed that dun world's cells just don't proc the dungeoneer's trait, and places where it'd make sense to just don't work either

also fixes the prisoners to spawn inside the watchhouse dungeon and not the warden one

this is my first time actually doing any mapping so if i fucked up lmk

## Testing Evidence

<img width="1777" height="1000" alt="image" src="https://github.com/user-attachments/assets/00a1fdfe-a954-4ae7-94b7-19c219152dcc" />
<img width="1777" height="1000" alt="image" src="https://github.com/user-attachments/assets/61c3683f-1d5e-40d7-a1ba-f929d70402d0" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/163b5900-0c5b-44d8-af3d-ec5fc3bf66eb" />

## Why It's Good For The Game

helps dungeoneers do their dungeoning job in the dungeons 🙏🙏
