### PR TITLE
Gives the silver property to most silver items

### DIFF
--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -125,11 +125,18 @@
 	start_lit = TRUE
 	icon_state = "skullcandle_lit"
 
-/obj/item/candle/candlestick/gold
-	name = "three-stick gold candlestick"
+/obj/item/candle/candlestick
+	name = "parent candlestick"
 	icon = 'icons/roguetown/items/lighting.dmi'
 	icon_state = "gcandelabra"
 	infinite = TRUE
+	desc = "The parent candlestick that gave all of the little, real candlesticks their traits. You should not be seeing this, report this."
+	possible_item_intents = list(/datum/intent/use, /datum/intent/hit) //so you can bash someone's head in with a candlestick
+	force = 12 //slightly higher than a silver goblet, good improvised weapon, it even has a handle!
+
+/obj/item/candle/candlestick/gold
+	name = "three-stick gold candlestick"
+	icon_state = "gcandelabra"
 	sellprice = 40
 
 /obj/item/candle/candlestick/gold/update_icon()
@@ -141,10 +148,9 @@
 
 /obj/item/candle/candlestick/silver
 	name = "three-stick silver candlestick"
-	icon = 'icons/roguetown/items/lighting.dmi'
 	icon_state = "scandelabra"
-	infinite = TRUE
 	sellprice = 60
+	is_silver = TRUE
 
 /obj/item/candle/candlestick/silver/update_icon()
 	icon_state = "scandelabra[lit ? "_lit" : ""]"
@@ -155,9 +161,7 @@
 
 /obj/item/candle/candlestick/gold/single
 	name = "one-stick gold candlestick"
-	icon = 'icons/roguetown/items/lighting.dmi'
 	icon_state = "singlegcandelabra"
-	infinite = TRUE
 	sellprice = 30
 
 /obj/item/candle/candlestick/gold/single/update_icon()
@@ -169,9 +173,7 @@
 
 /obj/item/candle/candlestick/silver/single
 	name = "one-stick silver candlestick"
-	icon = 'icons/roguetown/items/lighting.dmi'
 	icon_state = "singlescandelabra"
-	infinite = TRUE
 	sellprice = 50
 
 /obj/item/candle/candlestick/silver/single/update_icon()
@@ -183,9 +185,7 @@
 
 /obj/item/candle/gold
 	name = "gold candle"
-	icon = 'icons/roguetown/items/lighting.dmi'
 	icon_state = "gcandle"
-	infinite = TRUE
 	sellprice = 30
 
 /obj/item/candle/gold/update_icon()
@@ -201,6 +201,7 @@
 	icon_state = "scandle"
 	infinite = TRUE
 	sellprice = 50
+	is_silver = TRUE
 
 /obj/item/candle/silver/update_icon()
 	icon_state = "scandle[lit ? "_lit" : ""]"

--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -283,6 +283,7 @@ Inquisitorial armory down here
 	force = 30
 	var/next_smoke
 	var/smoke_interval = 2 SECONDS
+	is_silver = TRUE //container uses the same color palette as blessed silver and it also contains part of the comet syon
 
 /obj/item/flashlight/flare/torch/lantern/psycenser/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/rogueclothes/armor/chainmail.dm
+++ b/code/modules/clothing/rogueclothes/armor/chainmail.dm
@@ -89,6 +89,7 @@
 	item_state = "ornatehauberk"
 	max_integrity = ARMOR_INT_CHEST_PLATE_PSYDON
 	smeltresult = /obj/item/ingot/silverblessed
+	is_silver = TRUE
 
 /obj/item/clothing/suit/roguetown/armor/chainmail/bikini
 	name = "chainmail corslet"	// corslet, from the old French 'cors' or bodice, with the diminutive 'let', used to describe lightweight military armor since 1500. Chosen here to replace 'bikini', an extreme anachronism.

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -202,6 +202,7 @@
 	body_parts_covered = COVERAGE_FULL // Less durability than proper plate, more expensive to manufacture, and accurate to the sprite.
 
 	max_integrity = ARMOR_INT_CHEST_PLATE_PSYDON
+	is_silver = TRUE
 
 /obj/item/clothing/suit/roguetown/armor/plate/fluted/ornate/equipped(mob/living/user, slot)
 	. = ..()
@@ -287,6 +288,7 @@
 	smeltresult = /obj/item/ingot/silverblessed
 
 	max_integrity = ARMOR_INT_CHEST_PLATE_PSYDON
+	is_silver = TRUE
 
 	/// Whether the user has the Heavy Armour Trait prior to donning.
 	var/traited = FALSE
@@ -494,6 +496,7 @@
 	smeltresult = /obj/item/ingot/silverblessed
 	icon_state = "ornatechestplate"
 	item_state = "ornatechestplate"
+	is_silver = TRUE
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/aalloy
 	name = "decrepit cuirass"
@@ -523,6 +526,7 @@
 	icon_state = "ornatecuirass"
 	desc = "A beautiful steel cuirass, fitted with tassets for additional coverage. Strips of blessed silver have been meticulously incorporated into the fluting; a laborous decoration that denotes it as originating from the Order of the Silver Psycross. </br>'..the feeling of Aeon's grasp upon your shoulders, imparting the world's burden unto flesh and bone..' </br>... </br>With some blessed silver and a blacksmith's assistance, I can turn this cuirass into a set of half-plate armor."
 	smeltresult = /obj/item/ingot/silverblessed
+	is_silver = TRUE
 
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron
 	name = "iron breastplate"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -335,6 +335,7 @@
 	icon_state = "psydonbarbute"
 	item_state = "psydonbarbute"
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDESNOUT
+	smeltresult = /obj/item/ingot/silver
 
 /obj/item/clothing/head/roguetown/helmet/heavy/psydonbarbute/getonmobprop(tag)
 	if(tag)

--- a/code/modules/clothing/rogueclothes/rings.dm
+++ b/code/modules/clothing/rogueclothes/rings.dm
@@ -19,6 +19,7 @@
 	name = "silver ring"
 	icon_state = "ring_s"
 	sellprice = 33
+	is_silver = TRUE
 
 /obj/item/clothing/ring/aalloy
 	name = "decrepit ring"
@@ -153,6 +154,7 @@
 	icon_state = "signet_silver"
 	desc = "A ring of blessed silver, bearing the Archbishop's symbol. By dipping it in melted redtallow, it can seal writs of religious importance."
 	sellprice = 90
+	is_silver = TRUE
 
 /obj/item/clothing/ring/signet/attack_right(mob/user)
 	. = ..()
@@ -256,6 +258,7 @@
 	desc = "A simple silver wedding band complete with an ornate design of a lover's name."
 	icon_state = "s_ring_wedding"
 	sellprice = 3	//You don't get to smelt this down or sell it. No free mams for a loadout item.
+	is_silver = TRUE
 	var/choicename = FALSE
 	var/choicedesc = FALSE
 

--- a/code/modules/clothing/rogueclothes/storage/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage/storage.dm
@@ -64,6 +64,7 @@
 	sellprice = 30
 	sewrepair = FALSE
 	anvilrepair = /datum/skill/craft/armorsmithing
+	is_silver = TRUE
 
 /obj/item/storage/belt/rogue/leather/battleskirt
 	name = "cloth military skirt"

--- a/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/ingredients.dm
@@ -111,6 +111,7 @@
 	major_pot = /datum/alch_cauldron_recipe/strong_antidote
 	med_pot = /datum/alch_cauldron_recipe/antidote
 	minor_pot = /datum/alch_cauldron_recipe/big_health_potion
+	is_silver = TRUE
 
 /obj/item/alch/magicdust
 	name = "pure essentia"

--- a/modular/Neu_Food/code/cookware/bowl.dm
+++ b/modular/Neu_Food/code/cookware/bowl.dm
@@ -37,6 +37,7 @@
 	name = "silver bowl"
 	icon_state = "bowl_silver"
 	sellprice = 96
+	is_silver = TRUE
 
 /obj/item/reagent_containers/glass/bowl/tin
 	name = "tin bowl"

--- a/modular/Neu_Food/code/cookware/fork.dm
+++ b/modular/Neu_Food/code/cookware/fork.dm
@@ -32,3 +32,4 @@
 	name = "silver fork"
 	icon_state = "fork_silver"
 	sellprice = 24
+	is_silver = TRUE

--- a/modular/Neu_Food/code/cookware/platter.dm
+++ b/modular/Neu_Food/code/cookware/platter.dm
@@ -131,6 +131,7 @@ What it does:
 	desc = "A fancy silver plate often used by the nobility as a symbol of class."
 	icon_state = "platter_silver"
 	sellprice = 48
+	is_silver = TRUE
 
 /obj/item/cooking/platter/gold
 	name = "gold platter"

--- a/modular/Neu_Food/code/cookware/spoon.dm
+++ b/modular/Neu_Food/code/cookware/spoon.dm
@@ -32,6 +32,7 @@
 	name = "silver spoon"
 	icon_state = "spoon_silver"
 	sellprice = 24
+	is_silver = TRUE
 
 // NUKE THIS FUCKING TYPEPATH WHEN WE HAVE TIME
 /obj/item/kitchen/spoon/plastic


### PR DESCRIPTION
## About The Pull Request

So, on my recent vampire experiences, I've come to find out there's a lot of silver items that do not act as silver. I doubt this is intentional considering how we have things such as goblets and amulets burning vampires when they pick them up, but things such as silver candlesticks, silver rings or **blessed silver plate armor** doesn't. Either way, this PR gives most of the silver items (excluding silver coins) the is_silver property, which will burn any vampires when picking it up or being hit by it.

I've also given a strike intent to candlesticks (same as the lampterns or silver goblets) since they're one of the few items that could realistically be used to hit someone as an improvised weapon (or vampire detector)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="288" height="417" alt="image" src="https://github.com/user-attachments/assets/782ca395-1413-44ae-a253-e6f247b59909" />

All of the silver that now burns vampires (All vampires used on this testing evidence were hurt, but later absolved and annointed)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Bug fix...? Either way, with the sudden influx of vampires, I do think it's good to make silver consistently burn vampires instead of it only being applied to weapons and some specific items (quicksilver, silver amulet, silver goblets and silver statues)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
