### PR TITLE
Fixes stress

### DIFF
--- a/code/modules/mob/living/carbon/stress.dm
+++ b/code/modules/mob/living/carbon/stress.dm
@@ -67,7 +67,7 @@ GLOBAL_LIST_INIT(stress_messages, world.file2list("strings/rt/stress_messages.tx
 		return
 	if (stat != CONSCIOUS) // oblivion preserves our stress, for better or worse. (read: life optimizations weewoo)
 		return
-	var/new_stress = 0
+	var/new_stress = get_stress_amount()
 	for(var/stressor_type in stressors)
 		var/datum/stressevent/event = stressors[stressor_type]
 		if(event.time_added + event.timer > world.time)


### PR DESCRIPTION
## About The Pull Request

Title! Turns out that one of the scarlet reach optimization port https://github.com/Rotwood-Vale/Ratwood-2.0/pull/264 (More specifically, https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1210) breaks stress! Since the new_stress variable is... for some reason set to 0 instead of actually getting the stress. And, honestly, it seems that stress is *still* broken on SR and nobody has reported or fixed it yet, so, I could see how this could happen.

Anyways, fixed.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="246" height="150" alt="image" src="https://github.com/user-attachments/assets/b97c49b8-7591-478c-b996-4187abd95cc7" />
<img width="265" height="69" alt="image" src="https://github.com/user-attachments/assets/e3ced651-86b8-42b4-a773-1d69789ac4ef" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug fix!!!!!!!!!!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
