### PR TITLE
Crit Resist Tweaks

### DIFF
--- a/code/__DEFINES/roguetown/combat.dm
+++ b/code/__DEFINES/roguetown/combat.dm
@@ -20,9 +20,9 @@ Medical defines
 /*
 	Critical Resistance Defines
 */
-// Normal classes are guaranteed 4 resists, NPC 2, noblood / revenant 1
-#define CRIT_RESISTANCE_STACKS_PLAYER 4
-#define CRIT_RESISTANCE_STACKS_NPC 1
+// Normal classes are guaranteed 3 resists, NPC 2, noblood / revenant 1
+#define CRIT_RESISTANCE_STACKS_PLAYER 3
+#define CRIT_RESISTANCE_STACKS_NPC 2
 #define CRIT_RESISTANCE_STACKS_OP 1 // Noblood / Revenant etc.
-#define CRIT_RESISTANCE_EFFECTIVE_BLEEDRATE 0.5 // How much CR reduce bleedrate by
+#define CRIT_RESISTANCE_EFFECTIVE_BLEEDRATE 0.9 // How much CR reduce bleedrate by. Inverse values are higher. Was 0.5, now 0.9.
 #define CRIT_RESISTANCE_TIMER_CD 30 SECONDS // Cooldown between guaranteed CR procs. DOES NOT APPLY TO DISMEMBERMENT.


### PR DESCRIPTION
## About The Pull Request
Two nerfs, one NPC buff.

Basically, bloodloss is trivial for a crit resist user at the moment. They're still obnoxious to deal with.

Whereas before it was a 50% reduction to bleeding, now it's a 10% reduction to bleeding. This doesn't touch CON bleed stack reduction, which already stacked on top of that 50% and made it near impossible to bleed someone out at 15CON, which is the cap for bleed reduction unless I'm mistaken.

Additionally, it also drops one guaranteed crit resist stack, so it's three, as opposed to four now.

Lastly, this provides NPCs with crit resist an additional charge, up to two from one, so they're more impactful if they have this trait.

The NPCs effected:
 - Madmen.
 - Zizo Constructs.
 - Orc Berserkers.
 - Sissean Jailors.
 - Primordials.
 - Abyssal creechurs.
 - Dragons.
 - Driders, I guess. Not sure if they even exist.

I think that's all the NPCs touched, but I could be mistaken, and it doesn't really matter for Primordials onwards, to the same degree, which are simple mobs.

## Testing Evidence
It just works.

## Why It's Good For The Game
Crit resist isn't nearly as bad as it once was, arguably. But that bleed resist is absurd.