### PR TITLE
Wildkin origins

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -60,11 +60,11 @@
 		)
 	race_bonus = list()
 	custom_selection = list(
-		"+1 CON +1 PER (Physical Origin)" = STATKEY_CON, STATKEY_PER,
-		"+1 WIL +1 FOR (Spiritual Origin)" = STATKEY_WIL,STATKEY_LCK,
-		"Aquatic Origin (Waterbreathing)" = TRAIT_WATERBREATHING,
-		"Mammalian Origin (Keen Ears)" = TRAIT_KEENEARS,
-		"Avian Origin (Wings)" = TRAIT_WING_BOUND,
+		"Wildkins Curse (+1 PER +1 CON)" = STATKEY_PER,STATKEY_CON,
+		"Aquatic Origin (Waterbreathing, Seadrinker)" = TRAIT_WATERBREATHING,TRAIT_SEA_DRINKER,
+		"Beastly Origin (Keen Ears, Wild Eater)" = TRAIT_KEENEARS,TRAIT_WILD_EATER,
+		"Winged Origin (Wing-Bound)" = TRAIT_WING_BOUND,
+		"Chitinous Origin (Venomous, Webwalk)" = TRAIT_VENOMOUS,TRAIT_WEBWALK,
 		)
 	enflamed_icon = "widefire"
 	organs = list(


### PR DESCRIPTION
## About The Pull Request

This adds the capacity for wildkin to choose from a variety of traits; all of which are meant to give them the ability to simulate their special species traits.  You get the traits or you get the stats; because stats and traits will make you everything else; and that's why dendor has to nerf you, okay kitten? 



Water Wildkin can do water thing. (Not as statistically optimal as an axian.) 
You can make a bird that has limited bird capacity. (I always dream of an avian race.. but it isnt real..)
Scary Bugs with scary bug features for the bug-players (Another cool race just waiting to happen man..)
Generic beeste with beeste traits

- Similiar PR for Verminfolk with other unique traits TBA if @ProbablyCarl doesnt kill meeeee

<img width="772" height="167" alt="image" src="https://github.com/user-attachments/assets/c06521c0-41e7-444d-84f6-51352edf028f" />
