### PR TITLE
Sexual Harassment (Examine Flavor)

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -483,33 +483,34 @@ GLOBAL_VAR_INIT(mobids, 1)
 	if(isliving(src) && src.m_intent != MOVE_INTENT_SNEAK && src.stat != DEAD)
 		var/message = "[src] looks at"
 		var/target = "\the [A]"
+		var/zone_text = parse_zone(zone_selected)
+		var/mob/living/T = A
 		if(!isturf(A))
 			if(A == src)
 				message = "[src] looks over"
 				target = "themselves"
+			else if (isliving(A) && iscarbon(T) && T != src && zone_selected == BODY_ZONE_PRECISE_GROIN && abs(src.loc.x - T.loc.x) <= 1 && abs(src.loc.y - T.loc.y) <= 1)
+				var/atom/front_turf = get_step(T, T.dir)
+				var/atom/behind_turf = get_step(T, turn(T.dir, 180))
+				var/atom/side_left = get_step(T, turn(T.dir, 90))
+				var/atom/side_right = get_step(T, turn(T.dir, 270))
+				if(behind_turf && src.loc && behind_turf.z == src.loc.z && abs(behind_turf.x - src.loc.x) <= 1 && abs(behind_turf.y - src.loc.y) == 0)
+					zone_text = "ass"
+				else if((side_left && src.loc && side_left.z == src.loc.z && abs(side_left.x - src.loc.x) == 0 && abs(side_left.y - src.loc.y) == 0) || (side_right && src.loc && side_right.z == src.loc.z && abs(side_right.x - src.loc.x) == 0 && abs(side_right.y - src.loc.y) == 0))
+					zone_text = "hips"
+				else if(front_turf && src.loc && front_turf.z == src.loc.z && abs(front_turf.x - src.loc.x) <= 1 && abs(front_turf.y - src.loc.y) == 0)
+					zone_text = "crotch"
+				target = "[T]'s [zone_text]"
 			else if(A.loc == src)
 				target = "[src.p_their()] [A.name]"
 			else if(A.loc.loc == src)
 				message = "[src] looks into"
 				target = "[src.p_their()] [A.loc.name]"
 			else if(isliving(A) && src.cmode)
-				var/mob/living/T = A
 				if(!iscarbon(T))
 					target = "\the [T.name]'s [T.simple_limb_hit(zone_selected)]"
 				if(iscarbon(T) && T != src)
-					var/zone_text = parse_zone(zone_selected)
-					if(zone_selected == BODY_ZONE_PRECISE_GROIN)
-						var/atom/front_turf = get_step(T, T.dir)
-						var/atom/behind_turf = get_step(T, turn(T.dir, 180))
-						var/atom/side_left = get_step(T, turn(T.dir, 90))
-						var/atom/side_right = get_step(T, turn(T.dir, 270))
-						if(behind_turf && src.loc && behind_turf.z == src.loc.z && abs(behind_turf.x - src.loc.x) <= 1 && abs(behind_turf.y - src.loc.y) == 0)
-							zone_text = "ass"
-						else if((side_left && src.loc && side_left.z == src.loc.z && abs(side_left.x - src.loc.x) == 0 && abs(side_left.y - src.loc.y) == 0) || (side_right && src.loc && side_right.z == src.loc.z && abs(side_right.x - src.loc.x) == 0 && abs(side_right.y - src.loc.y) == 0))
-							zone_text = "hips"
-						else if(front_turf && src.loc && front_turf.z == src.loc.z && abs(front_turf.x - src.loc.x) <= 1 && abs(front_turf.y - src.loc.y) == 0)
-							zone_text = "crotch"
-					target = "[T]'s [zone_text]"
+					target = "[T]'s [parse_zone(zone_selected)]"
 			if(m_intent != MOVE_INTENT_SNEAK)
 				visible_message(span_emote("[message] [target]."))
 


### PR DESCRIPTION
## About The Pull Request

lets you.. uh.. look at peoples asses... n' dicks, and hips. hell yeah.

if you're 1 tile adjacent to a living player, and targetting groin, on examine it will run the usual checks, but before it reaches any of the other else ifs, the game will check if you're 1 tile adjacent of them, including diagonals.

when you are one tile adjacent, it'll check where exactly you're at in comparison to the player (infront, diagonally infront, to the side, behind, diagonally behind) and set the target (ass/crotch/hips).

before it's done it'll do the usual sneaking check, and then send the examine message. this shouldn't fuck up anything because of how many checks the initial else if statement performs. if you're in combat mode and do the same thing it'll still work because you're close enough, otherwise it goes to the last check.

i think old RW had this feature? so i brought it back.

## Testing Evidence

<img width="190" height="55" alt="image" src="https://github.com/user-attachments/assets/3fc44d07-e608-4fed-93fd-d3f8d0843b61" />
<img width="155" height="53" alt="image" src="https://github.com/user-attachments/assets/a0a7b0a7-2f42-4de9-bb54-0a633fbfac08" />
<img width="178" height="72" alt="image" src="https://github.com/user-attachments/assets/01a8528c-c4e5-4a3f-9304-3ff28fdcbc00" />


## Why It's Good For The Game

you get to look at twink butts and stuff and i don't have to bring back ratwood's old bodypart examining where you're staring at everybody's chest (i didn't really like it)
