### PR TITLE
Maneater problems

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -107,7 +107,7 @@
 		victim.flash_fullscreen("redflash3")
 		playsound(loc, list('sound/vo/mobs/plant/attack (1).ogg','sound/vo/mobs/plant/attack (2).ogg','sound/vo/mobs/plant/attack (3).ogg','sound/vo/mobs/plant/attack (4).ogg'), 100, FALSE, -1)
 		if(prob(chew_factor * 15))
-			victim.adjustBruteLoss(50)
+			victim.adjustBruteLoss(20)
 			limb.add_wound(/datum/wound/fracture)
 			seednutrition += 25
 			if(!victim.mind)


### PR DESCRIPTION
## About The Pull Request
Removes the ability for man-eaters to take away people's limbs. 
It instead dislocates the limb and adds a wound to it.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1900" height="963" alt="image" src="https://github.com/user-attachments/assets/ff472e56-7839-4a6e-a236-c27aab855a41" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Removes one of the most hated mechanics in the game, a mechanic that people only deal with when they are alone, away from the town. It's stupid, and not much is lost from removing the limb-removing part.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
