### PR TITLE
Fixes Navaja defense not updating when unfolded

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -664,6 +664,7 @@
 	if(extended)
 		force = 20
 		wdefense = 6
+		wdefense_dynamic = 6
 		w_class = WEIGHT_CLASS_NORMAL
 		throwforce = 23
 		icon_state = "navaja_o"
@@ -681,6 +682,7 @@
 		attack_verb = list("stubbed", "poked")
 		sharpness = IS_BLUNT
 		wdefense = 2
+		wdefense_dynamic = 2
 		equip_delay_self = 0 SECONDS
 		unequip_delay_self = 0 SECONDS
 		inv_storage_delay = 0 SECONDS


### PR DESCRIPTION
## About The Pull Request
Makes Navaja update its weapon defense properly to 6 when u unfold it. and it go back to 2 when u fold it again.
Mostly taken from https://github.com/Azure-Peak/Azure-Peak/pull/4608
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="538" height="595" alt="image" src="https://github.com/user-attachments/assets/a0b889d7-1690-4054-997d-55be6ff215b8" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
