### PR TITLE
Pumpkin Lanterns fit on hip

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -422,7 +422,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	light_color = "#ffb272ff"
 	on = FALSE
-	slot_flags = null
+	slot_flags = ITEM_SLOT_HIP
 	force = 1
 	on_damage = 3
 	wdefense = 1 //The pumpkin has a chance of getting in the way of strikes.


### PR DESCRIPTION
## About The Pull Request

lets you put pumpkin lanterns on your hip, basically.

if for some odd reason it's intentional for pumpkins to not fit in the hip slot then it's fine.

## Testing Evidence

singular line change.

## Why It's Good For The Game

pumpkin lamp good
