### PR TITLE
Adds Arcyne T3 to Sojourner

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
@@ -14,7 +14,8 @@
 	subclass_social_rank = SOCIAL_RANK_MINOR_NOBLE
 	traits_applied = list(
 		TRAIT_MAGEARMOR,
-		TRAIT_ALCHEMY_EXPERT
+		TRAIT_ALCHEMY_EXPERT,
+		TRAIT_ARCYNE_T3,
 	)
 	subclass_stats = list(//This does not follow the typical 8 stat setup.
 		STATKEY_INT = 3,


### PR DESCRIPTION
## About The Pull Request

Adds the Tier 3 Arcyne trait to the Sojourner Orthodoxist subclass, removing a broken interaction.

If the Sojourner is missing an Arcyne trait of some tier, virtues like Arcyne Potential break when picked, alongside other spell point granters/admin shenanigans having no effect.  In Arcyne Potential's case, the virtue ends up correctly reading that the Sojourner has Arcane skill, and thus only rewards them spell points, incorrectly assuming they have a tier to actually select anything with, which in this case prevents the Sojourner from picking _any_ bonus spells with their points.

## Testing Evidence

<img width="2559" height="1420" alt="Arcyne Training Trait Applied" src="https://github.com/user-attachments/assets/4c39f704-bfad-475b-85d9-bb06efaa68c0" />
<img width="713" height="206" alt="Screenshot 2025-11-30 235622" src="https://github.com/user-attachments/assets/b9caadf9-1ae2-4c5c-9e9f-fa61fa2e80c0" />
<img width="943" height="544" alt="Picking Spells" src="https://github.com/user-attachments/assets/2bf4a200-71d5-47f9-9259-963682dd2281" />



## Why It's Good For The Game

This allows Sojourners with Arcane Potential to actually benefit from their virtue pick whilst similarly allows spell point granter items and other sources of spell points to actually provide value.

Tier 3 was picked due to the presence of spells such as Ice Shard, Greater Forcewall, Snap Freeze, and their unique Barrier spell, all of which seem like "Full Caster" style spells. This is an attempt to not disrupt the balance of the class too heavily whilst representing that they are, in fact, a Full Caster class like the Hierophant or Mage Apprentice.

Adjusting the tier is as simple as a number change if this proves to be a problem later on.
