### PR TITLE
Sojourner Virtue Nerf

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sojourner.dm
@@ -15,7 +15,7 @@
 	traits_applied = list(
 		TRAIT_MAGEARMOR,
 		TRAIT_ALCHEMY_EXPERT,
-		TRAIT_ARCYNE_T3,
+		TRAIT_ARCYNE_T1,//They're not meant to get more spellpoints. If they do, via Arcyne virtue, for example, T1 only.
 	)
 	subclass_stats = list(//This does not follow the typical 8 stat setup.
 		STATKEY_INT = 3,
@@ -38,9 +38,8 @@
 	subclass_stashed_items = list(
 		"Tome of Psydon" = /obj/item/book/rogue/bibble/psy
 	)
-	extra_context = "This subclass has multiple unique spells, including one in the form of an 'arcyne barrier'. So long as it's active, the user is immune to magic, yet still capable of casting it."
-
-	virtue_restrictions = list(/datum/virtue/combat/magical_potential)
+	extra_context = "This subclass has multiple unique spells, including one in the form of an 'arcyne barrier'. \
+	So long as it's active, the user is immune to magic, yet still capable of casting it."
 
 /datum/outfit/job/roguetown/sojourner
 	job_bitflag = BITFLAG_HOLY_WARRIOR
@@ -73,7 +72,7 @@
 	head = /obj/item/clothing/head/roguetown/roguehood/sojourner
 	mask = /obj/item/clothing/mask/rogue/lordmask/naledi/sojourner
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/cloth/naledi
-	neck = /obj/item/clothing/neck/roguetown/psicross/g //Naledians covet gold far more than the Orthodoxists cover silver. Emphasizes their nature as 'visitors', more-so than anything else.
+	neck = /obj/item/clothing/neck/roguetown/psicross/g //Naledians covet gold far more than typical Orthodoxists covet silver.
 	id = /obj/item/clothing/ring/signet
 	r_hand = /obj/item/rogueweapon/woodstaff/sojourner//A very questionable spear. No pen. Middling CDR on cast.
 	shoes = /obj/item/clothing/shoes/roguetown/boots/psydonboots


### PR DESCRIPTION
## About The Pull Request
A revert, of sorts, of #382.

I never intended for Sojourners to get more than any spells they'd already had.
Arcyne Potential is whatever, given it was only handing out T1, alongside +3 spellpoints.

Having them with T3 is absolutely absurd. Giving anti-magic wizards stuff like gravity, rebuke, acid splash, blink, arcane bolt(when they already have a sidegrade), etc...

It's not good. That's not at all what was intended for the class. If you want a liquid spellpoint caster, you play something else. The entirety of Sojourner is built around a very specific purpose (being super, super powerful support), and T3 spells pulls away from that to such a degree that makes them better than most mages. Something they'd already had claim to. Even with one combat spell from those 3 spellpoints, at T3.

Made doubly worse by the fact that they've three unique spells as is, with two being offensive, and one defensive. They're already super powerful and unique. They do not need more.

## Testing Evidence
It just works.
## Why It's Good For The Game
Read the about section.
Additionally, my comments within the file itself:
```
//These guys get miracles AND a set of pre-learned spells AND anti-magic.
//They don't need much else. They're stupid powerful.
//Do not numberfuck them if you can help it. I beg you.

//Now we do the spells. If this turns out to be absurd, we tone it back. Simple as. But with poor stats and skills...
//This is 26 spellpoints in total, not counting their unique barrier, normally unobtanium, at 6, which puts it to 32.
//For context, Heirophant gets 25 total, with 6 of those being liquid free spellpoints.
```
They already rival a lot of casters, without contest.
One of the worst stat and skill lines in the game _for a reason_.