### PR TITLE
Added Combat Skill Scaling to shovel types.

### DIFF
--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -12,6 +12,7 @@
 	wlength = WLENGTH_LONG
 	w_class = WEIGHT_CLASS_BULKY
 	tool_behaviour = TOOL_SHOVEL
+	associated_skill = /datum/skill/combat/maces
 	slot_flags = ITEM_SLOT_BACK
 	swingsound = list('sound/combat/wooshes/blunt/shovel_swing.ogg','sound/combat/wooshes/blunt/shovel_swing2.ogg')
 	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'


### PR DESCRIPTION
I fixed this a long time ago, must have gotten lost somewhere. it fix's shovel having no skill scale what-so ever. so now it can be used as a very very shitty weapon. but less shitty for if ya have mace skills


-added mace skill scaling to shovel and shovel accessories (entire shovel path should be covered IE all variants)


good for game-

only tool that didnt use some form of skill scale.