### PR TITLE
Fixes brassface vault on rockhill

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -18386,7 +18386,7 @@
 	locked = 1;
 	lockid = "nightman"
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault{
 	droning_sound_dusk = null;
 	droning_sound_night = null
@@ -39643,7 +39643,7 @@
 /obj/item/reagent_containers/powder/moondust,
 /obj/item/reagent_containers/glass/bottle/rogue/poison,
 /obj/item/reagent_containers/glass/bottle/rogue/emberwine,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault{
 	droning_sound_dusk = null;
 	droning_sound_night = null
@@ -46358,7 +46358,7 @@
 /obj/item/clothing/suit/roguetown/armor/plate/full/bikini,
 /obj/item/clothing/suit/roguetown/armor/leather/hide/bikini,
 /obj/item/clothing/suit/roguetown/armor/leather/studded/bikini,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault{
 	droning_sound_dusk = null;
 	droning_sound_night = null
@@ -47963,7 +47963,7 @@
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguecoin/silver/pile,
 /obj/item/roguekey/nightman,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault{
 	droning_sound_dusk = null;
 	droning_sound_night = null
@@ -49208,9 +49208,6 @@
 /obj/item/flashlight/flare/torch/lantern{
 	pixel_y = 12
 	},
-/obj/item/clothing/suit/roguetown/shirt/robe/white{
-	pixel_y = 6
-	},
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "wooden_floor2"
@@ -49865,7 +49862,7 @@
 /obj/item/clothing/neck/roguetown/cursed_collar,
 /obj/item/leash/chain,
 /obj/structure/rack/rogue/shelf/biggest,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault{
 	droning_sound_dusk = null;
 	droning_sound_night = null
@@ -55721,7 +55718,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "rSw" = (
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/outdoors/exposed/bath/vault{
 	droning_sound_dusk = null;
 	droning_sound_night = null


### PR DESCRIPTION
## About The Pull Request

Title! Turns out that the brassface checks for a specific tile instead of the area for... performance purposes.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="413" height="29" alt="image" src="https://github.com/user-attachments/assets/7070c7d1-3499-4f8d-b119-c029be5a0b99" />
<img width="252" height="220" alt="image" src="https://github.com/user-attachments/assets/52dc57e8-39d3-4abf-bf99-127ef4539501" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug fix!!!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
