### PR TITLE
Fixes dynamic wounds

### DIFF
--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -372,6 +372,9 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 	var/oldname = name
 	if(length(severity_names))
 		for(var/sevname in severity_names)
+			if(!bleed_rate) //if it's a hematoma, use whp for naming
+				if(severity_names[sevname] <= whp)
+					newname = sevname
 			if(severity_names[sevname] <= bleed_rate)
 				newname = sevname
 	name = "[newname  ? "[newname] " : ""][initial(name)]"	//[adjective] [name], aka, "gnarly slash" or "slash"

--- a/code/datums/wounds/types/bruises.dm
+++ b/code/datums/wounds/types/bruises.dm
@@ -49,7 +49,12 @@
 	can_sew = FALSE
 	can_cauterize = FALSE
 	passive_healing = 0.5
-	severity_names = list()
+	severity_names = list(
+		"minor" = 20,
+		"moderate" = 60,
+		"big" = 120,
+		"massive" = 180
+	)
 
 //Bruise Omniwounds
 //Vaguely: Hella painful. No bleeding. No armor interactions. Every hit also increases its self heal by a little bit.

--- a/code/datums/wounds/types/punctures.dm
+++ b/code/datums/wounds/types/punctures.dm
@@ -71,7 +71,7 @@
 /datum/wound/dynamic/puncture/upgrade(dam, armor)
 	whp += (dam * PUNC_UPG_WHPRATE)
 	if(!armor)
-		set_bleed_rate(PUNC_UPG_CLAMP_RAW)
+		set_bleed_rate(bleed_rate + PUNC_UPG_CLAMP_RAW)
 	else
 		switch(dam)
 			if(1 to 4)

--- a/code/datums/wounds/types/slashes.dm
+++ b/code/datums/wounds/types/slashes.dm
@@ -195,6 +195,12 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = FALSE	//Ouch owie oof
+	severity_names = list(
+		"light" = 5,
+		"deep" = 10,
+		"gnarly" = 15,
+		"lethal" = 20,
+	)
 
 //Lashing (Whip) Omniwounds
 //Vaguely: Painful, huge bleeds, but nearly nothing at all through any armor.
@@ -235,6 +241,12 @@
 	mob_overlay = "cut"
 	can_sew = TRUE
 	can_cauterize = FALSE	//Ouch owie oof
+	severity_names = list(
+		"light" = 5,
+		"deep" = 10,
+		"gnarly" = 15,
+		"lethal" = 20,
+	)
 
 //Special Punish omniwounds for whip (or anything else if desired) intent.
 //Vaguely: Really very giga painful. Not very bleedy. Can still be sewn!


### PR DESCRIPTION
## About The Pull Request

Title! Here's the problems:
Lashings and floggings had no severity names, which meant that their names never upgraded and informed you on how the wound was getting worse.
Hematomas had no bleedrate (which is what determined severity) *and* no names, now, they do!
Punctures set the bleeding to the upgrade ret when stabbing someone unarmored, instead of adding the upgrade rate to the bleedrate. Now this works as intended, and stabbing someone unarmored won't lower their bleeding down back to 1.3.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="516" height="306" alt="image" src="https://github.com/user-attachments/assets/2042c66f-b4b1-4aa5-b8cf-113d8b142dd0" />
<img width="468" height="241" alt="image" src="https://github.com/user-attachments/assets/ab097bbb-4887-4f93-a720-49f6858afb07" />
<img width="547" height="220" alt="image" src="https://github.com/user-attachments/assets/65acfd01-da7a-4ee7-89fc-d9078c533a0f" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug fix!!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
