### PR TITLE
Changes Vagabond's Examine Title into Beggar

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -1,5 +1,6 @@
 /datum/advclass
 	var/name
+	var/examine_name			// Optional. Different name shown when examining (defaults to name if not set)
 	var/list/classes
 	var/outfit
 	var/tutorial = "Choose me!"

--- a/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/orphan.dm
@@ -1,5 +1,5 @@
 /datum/job/roguetown/orphan
-	title = "Beggar"
+	title = "Vagabond"
 	flag = ORPHAN
 	department_flag = YOUNGFOLK
 	faction = "Station"
@@ -17,6 +17,7 @@
 	min_pq = -30
 	max_pq = null
 	round_contrib_points = 2
+	advjob_examine = TRUE
 
 	cmode_music = 'sound/music/combat_bum.ogg'
 	job_subclasses = list(

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond.dm
@@ -6,7 +6,7 @@
 	allowed_races = RACES_ALL_KINDS
 
 	advclass_cat_rolls = list(CTAG_VAGABOND = 20)
-	advjob_examine = FALSE
+	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
 	job_reopens_slots_on_death = TRUE
 	same_job_respawn_delay = 10 SECONDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/beggar.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/beggar.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_beggar
 	name = "Beggar"
+	examine_name = "Beggar"
 	tutorial = "You are without coin and without worth. The pity of others is your bread, and their mercy is your butter. Having sat by waystones and watched many a traveller pass in the hopes for alms, you've nursed a surprising talent for thievery, and have even cajoled knowledge of lockpicking out of an especially sentimental rogue."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/busker.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/busker.dm
@@ -1,5 +1,6 @@
 /datum/advclass/busker
 	name = "Busker"
+	examine_name = "Beggar"
 	tutorial = "You've lost pretty much everything - everything but your instrument and an adequate ability to play it. Maybe a jaunty tune will send a few zennies your way - whether through pitied gratitute, or by distracting long enough for you to swipe a coinpurse."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/courier.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/courier.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_courier
 	name = "Ambushed Courier"
+	examine_name = "Beggar"
 	tutorial = "Entrusted with a message of great import, your fortunes fell by the roadside at the behest of a group of Matthiosian scum. Bereft of mount and master, you now wander the realm for purpose and sustenance."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/deprived.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/deprived.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_deprived
 	name = "Deprived"
+	examine_name = "Beggar"
 	tutorial = "You have nothing left but your trusty shield and club - war took away everything you had but will you manage to reclaim what was yours or succumb to the horrors of Psydonia."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/destitute_scholar.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/destitute_scholar.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_scholar
 	name = "Destitute Scholar"
+	examine_name = "Beggar"
 	tutorial = "Knowledge is often both a boon and a curse. Whatever you know has left you with little to your name but your wits, and even then..."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/goatherd.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/goatherd.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_goatherd
 	name = "Lone Goatherd"
+	examine_name = "Beggar"
 	tutorial = "Having lost your idyllic pastoral existence, only a solitary member of your herd now remains as a reminder of what was. Is your sole charge a friend, or is it food? You decide."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/runner.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/runner.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_runner
 	name = "Rumbled Runner"
+	examine_name = "Beggar"
 	tutorial = "Ferrying messages in the dark is a dangerous profession at the best of times. You're lucky to have made it out of your last predicament alive, but all you have now is some rags and your trusty feet."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/the_original.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/the_original.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_original
 	name = "The Vagabond"
+	examine_name = "Vagabond"
 	tutorial = "Fate's twists and turns lead many towards a wanderer's life. Find your fortunes in the shadows or in the pockets of another."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/unraveled.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/unraveled.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_unraveled
     name = "The Unraveled"
+    examine_name = "Beggar"
     tutorial = "Once you sought to understand the mind’s decay — now you live within it, a wandering physician bound to his own affliction."
     allowed_sexes = list(MALE, FEMALE)
     allowed_races = RACES_NO_CONSTRUCT

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/wanted.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/wanted.dm
@@ -1,5 +1,6 @@
 /datum/advclass/vagabond_wanted
 	name = "Wanted"
+	examine_name = "Beggar"
 	tutorial = "The long arm of the law reaches out for you - are you slippery enough to evade its grip this time, or is your head destined to end up in an Excidium's maw?"
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -1030,7 +1030,11 @@
 		var/datum/migrant_role/migrant = MIGRANT_ROLE(migrant_type)
 		used_title = migrant.name
 		if(migrant.advjob_examine && advjob)
-			used_title = advjob
+			var/datum/advclass/AC = SSrole_class_handler.get_advclass_by_name(advjob)
+			if(AC?.examine_name)
+				used_title = AC.examine_name
+			else
+				used_title = advjob
 	else if(job)
 		var/datum/job/J = SSjob.GetJob(job)
 		if(!J)
@@ -1039,7 +1043,11 @@
 		if(J.f_title && (pronouns == SHE_HER || pronouns == THEY_THEM_F))
 			used_title = J.f_title
 		if(J.advjob_examine && advjob)
-			used_title = advjob
+			var/datum/advclass/AC = SSrole_class_handler.get_advclass_by_name(advjob)
+			if(AC?.examine_name)
+				used_title = AC.examine_name
+			else
+				used_title = advjob
 	return used_title
 
 ///Is the passed in mob a ghost with admin powers, doesn't check for AI interact like isAdminGhost() used to


### PR DESCRIPTION
## About The Pull Request

Adds an `examine_name` variable to `_advclass.dm` so it is possible to have different examine names separate from the name of the advanced class. They're all changed to "Beggar" except for:
Excommunicated is just "Excommunicated"
Exiled Apprentice is just "Exiled Apprentice"
and The Vagabond is just "Vagabond"

## Testing Evidence

<img width="727" height="95" alt="image" src="https://github.com/user-attachments/assets/1363f491-7406-4350-9dbd-9d4b9eac6786" />

## Why It's Good For The Game

After playing Vagabond a bit, and if you aren't wearing anything but rags, most assume you are an adventurer or refugee, and not someone that should be well known in the town as low-born scum dirt. Despite the title 'Beggar' not completely applying to every character or sub-role, I feel it's still a fitting title given how most would view them, and hits a lot harder than 'Vagabond' which feels too official and close to bandit. 

Vagabonds aren't 'wanderers'. They're from the town.

Plus it's a classic.