### PR TITLE
Adds social strata icon

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -84,9 +84,6 @@
 		if(SSticker.regentmob == src)
 			used_title = "[used_title]" + " Regent"
 		var/display_as_wanderer = FALSE
-		var/is_clergy = FALSE
-		var/is_jester = FALSE
-		var/is_druid = FALSE
 		if(observer_privilege)
 			used_name = real_name
 		if(migrant_type)
@@ -96,26 +93,38 @@
 			var/datum/job/J = SSjob.GetJob(job)
 			if(!J || J.wanderer_examine)
 				display_as_wanderer = TRUE
-			if(J.department_flag == CHURCHMEN) //There may be a better way to check who is clergy, but this will do for now
-				is_clergy = TRUE
-			if(J.title == "Jester")
-				is_jester = TRUE
-			if(J.title == "Druid")
-				is_druid = TRUE
+		var/rank_color = "#725D4C"
+		if(HAS_TRAIT(src, TRAIT_NOBLE) && social_rank < 4)
+			social_rank = SOCIAL_RANK_MINOR_NOBLE
+		switch(social_rank)
+			if(SOCIAL_RANK_PEASANT)
+				rank_color = "#91733B"
+			if(SOCIAL_RANK_YEOMAN)
+				rank_color = "#B1892A"
+			if(SOCIAL_RANK_MINOR_NOBLE)
+				rank_color = "#D09F19"
+			if(SOCIAL_RANK_NOBLE)
+				rank_color = "#ECB20A"
+			if(SOCIAL_RANK_ROYAL)
+				rank_color = "#FFBF00"
+		var/social_strata = "<a href='?src=[REF(src)];social_strata=1'><font color='[rank_color]'>⚜</font></A>"
+		var/display1
+		var/display2 = "[(!HAS_TRAIT(usr, TRAIT_OUTLANDER) && src.social_rank) ? "[social_strata]" : " "]"
 		if ((valid_headshot_link(src, headshot_link, TRUE)) && (user.client?.prefs.chatheadshot))
 			if(display_as_wanderer)
-				. = list(span_info("ø ------------ ø\n<img src=[headshot_link] width=100 height=100/>\nThis is <EM>[used_name]</EM>, the wandering [race_name]."))
+				display1 = span_info("ø ------------ ø\n<img src=[headshot_link] width=100 height=100/>\nThis is <EM>[used_name]</EM>, the wandering [race_name].")
 			else if(used_title)
-				. = list(span_info("ø ------------ ø\n<img src=[headshot_link] width=100 height=100/>\nThis is <EM>[used_name]</EM>, the [race_name] [used_title]."))
+				display1 = span_info("ø ------------ ø\n<img src=[headshot_link] width=100 height=100/>\nThis is <EM>[used_name]</EM>, the [race_name] [used_title].")
 			else
-				. = list(span_info("ø ------------ ø\n<img src=[headshot_link] width=100 height=100/>\nThis is the <EM>[used_name]</EM>, the [race_name]."))
+				display1 = span_info("ø ------------ ø\n<img src=[headshot_link] width=100 height=100/>\nThis is the <EM>[used_name]</EM>, the [race_name].")
 		else
 			if(display_as_wanderer)
-				. = list(span_info("ø ------------ ø\nThis is <EM>[used_name]</EM>, the wandering [race_name]."))
+				display1 = span_info("ø ------------ ø\nThis is <EM>[used_name]</EM>, the wandering [race_name].")
 			else if(used_title)
-				. = list(span_info("ø ------------ ø\nThis is <EM>[used_name]</EM>, the [race_name] [used_title]."))
+				display1 = span_info("ø ------------ ø\nThis is <EM>[used_name]</EM>, the [race_name] [used_title].")
 			else
-				. = list(span_info("ø ------------ ø\nThis is the <EM>[used_name]</EM>, the [race_name]."))
+				display1 = span_info("ø ------------ ø\nThis is the <EM>[used_name]</EM>, the [race_name].")
+		. = list("[display1] [display2]")	
 
 		if(HAS_TRAIT(src, TRAIT_WITCH))
 			if(HAS_TRAIT(user, TRAIT_NOBLE) || HAS_TRAIT(user, TRAIT_INQUISITION) || HAS_TRAIT(user, TRAIT_WITCH))
@@ -133,40 +142,6 @@
 				. += span_notice("A fellow noble.")
 			else
 				. += span_notice("A noble!")
-
-		//Social rank
-		if(social_rank && !HAS_TRAIT(user, TRAIT_OUTLANDER))
-			var/examiner_rank = user.social_rank
-			var/rank_name
-			if(HAS_TRAIT(src, TRAIT_NOBLE) && social_rank < 4) //anyone with the noble trait that wasn't a noble is now at least a minor noble
-				social_rank = SOCIAL_RANK_MINOR_NOBLE
-			switch(social_rank)
-				if(SOCIAL_RANK_DIRT)
-					rank_name = "dirt"
-				if(SOCIAL_RANK_PEASANT)
-					rank_name = "a peasant"
-				if(SOCIAL_RANK_YEOMAN)
-					rank_name = "a yeoman"
-				if(SOCIAL_RANK_MINOR_NOBLE)
-					rank_name = is_clergy ? "low clergy" : "a minor noble"
-				if(SOCIAL_RANK_NOBLE)
-					rank_name = is_clergy ? "clergy" : "a noble"
-				if(SOCIAL_RANK_ROYAL)
-					rank_name = is_clergy ? "head of the clergy" : "royalty"
-			if(HAS_TRAIT(src, TRAIT_DISGRACED_NOBLE))
-				rank_name = "a disgraced noble"
-				social_rank = 3
-			if(is_jester)
-				rank_name = "the jester"
-			if(is_druid)
-				rank_name = "a druid"
-			if(social_rank > examiner_rank)
-				. += span_notice("This persons social standing is equivalent to <EM>[rank_name]</EM>, they are my better.")
-			if(social_rank == examiner_rank)
-				. += span_notice("This person social standing is equivalent to <EM>[rank_name]</EM>, they are my equal.")
-			if(social_rank < examiner_rank)
-				. += span_notice("This person social standing is equivalent to <EM>[rank_name]</EM>, they are my lesser.")
-
 		// Leashed pet status effect message
 		if(has_status_effect(/datum/status_effect/leash_pet))
 			. += span_warning("A leash is hooked to their collar. They are being led like a pet.")

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -94,6 +94,51 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		popup.open()
 		return
 
+		//Social rank
+	if(href_list["social_strata"])
+		var/is_clergy = FALSE
+		var/is_jester = FALSE
+		var/is_druid = FALSE
+		if(job)
+			var/datum/job/J = SSjob.GetJob(job)
+			if(J.department_flag == CHURCHMEN) //There may be a better way to check who is clergy, but this will do for now
+				is_clergy = TRUE
+			if(J.title == "Jester")
+				is_jester = TRUE
+			if(J.title == "Druid")
+				is_druid = TRUE
+		if(social_rank && !HAS_TRAIT(src, TRAIT_OUTLANDER))
+			var/examiner_rank = usr.social_rank
+			var/rank_name
+			if(HAS_TRAIT(src, TRAIT_NOBLE) && social_rank < 4) //anyone with the noble trait that wasn't a noble is now at least a minor noble
+				social_rank = SOCIAL_RANK_MINOR_NOBLE
+			switch(social_rank)
+				if(SOCIAL_RANK_DIRT)
+					rank_name = "dirt"
+				if(SOCIAL_RANK_PEASANT)
+					rank_name = "a peasant"
+				if(SOCIAL_RANK_YEOMAN)
+					rank_name = "a yeoman"
+				if(SOCIAL_RANK_MINOR_NOBLE)
+					rank_name = is_clergy ? "low clergy" : "a minor noble"
+				if(SOCIAL_RANK_NOBLE)
+					rank_name = is_clergy ? "clergy" : "a noble"
+				if(SOCIAL_RANK_ROYAL)
+					rank_name = is_clergy ? "head of the clergy" : "royalty"
+			if(HAS_TRAIT(src, TRAIT_DISGRACED_NOBLE))
+				rank_name = "a disgraced noble"
+				social_rank = 3
+			if(is_jester)
+				rank_name = "the jester"
+			if(is_druid)
+				rank_name = "a druid"
+			if(social_rank > examiner_rank)
+				to_chat(usr, span_notice("This persons social standing is equivalent to <EM>[rank_name]</EM>, they are my better."))
+			if(social_rank == examiner_rank)
+				to_chat(usr, span_notice("This person social standing is equivalent to <EM>[rank_name]</EM>, they are my equal."))
+			if(social_rank < examiner_rank)
+				to_chat(usr, span_notice("This person social standing is equivalent to <EM>[rank_name]</EM>, they are my lesser."))
+
 	if(href_list["reveal_cosmetic"])
 		if(mind && mind.cosmetic_class_title)
 			var/actual_job = job ? job : "Unknown"


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1423, which hides the social status under an icon so it doesn't appear on every single examine. This icon's color depends on the social level.

I've also hidden the icon on people with no social status.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="209" height="140" alt="image" src="https://github.com/user-attachments/assets/9ba23957-2614-4d1a-9198-3ec5288f3597" />
<img width="194" height="91" alt="image" src="https://github.com/user-attachments/assets/ce1a67f0-8d4b-4929-ad9e-2a76db50a092" />
<img width="411" height="51" alt="image" src="https://github.com/user-attachments/assets/92eceb83-b11a-41f5-9ef8-60f5d9e34d7b" />
<img width="175" height="110" alt="image" src="https://github.com/user-attachments/assets/c4236346-42a7-4bf4-8c55-063ecbb990f6" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Neater, less clustered examine text box!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
