### PR TITLE
Give Sissean's More Vaginas

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lizardfolk.dm
@@ -86,7 +86,7 @@
 		/datum/customizer/organ/testicles/anthro,
 		/datum/customizer/organ/penis/anthro,
 		/datum/customizer/organ/breasts/animal,
-		/datum/customizer/organ/vagina/animal,
+		/datum/customizer/organ/vagina/anthro,
 		)
 	body_marking_sets = list(
 		/datum/body_marking_set/none,


### PR DESCRIPTION
One word change, so Sissean's have cloacas available in the character creator.

## About The Pull Request

Changes vagina/animal to vagina/anthro in the lizardfolk customization options, letting snake people finally have snake bits. 

## Testing Evidence

um uh one word change.

## Why It's Good For The Game

Sisseans have access to all penis types in the game; why not all vaginas as well? The game is unplayable if my snake anthro can't have anatomical genitals. 
<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
