### PR TITLE
Drakian Snout Requirement

### DIFF
--- a/code/modules/client/customizer/customizers/organ/snout.dm
+++ b/code/modules/client/customizer/customizers/organ/snout.dm
@@ -13,6 +13,10 @@
 	default_disabled = FALSE
 	customizer_choices = list(/datum/customizer_choice/organ/snout/lizard)
 
+/datum/customizer/organ/snout/lizard/dracon
+	allows_disabling = FALSE//I HATE YOU!!!
+	default_disabled = FALSE
+
 /datum/customizer_choice/organ/snout/lizard
 	name = "Lizard Snout"
 	organ_type = /obj/item/organ/snout/lizard
@@ -166,6 +170,7 @@
 	allows_disabling = TRUE
 	default_disabled = TRUE
 	customizer_choices = list(/datum/customizer_choice/organ/snout/lamia)
+
 /datum/customizer/organ/snout/anthro/dullahan
 	allows_disabling = TRUE
 	default_disabled = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/dracon.dm
@@ -89,7 +89,7 @@
 		/datum/customizer/organ/wings/dracon,
 		/datum/customizer/organ/tail/lizard,
 		/datum/customizer/organ/tail_feature/lizard_spines,
-		/datum/customizer/organ/snout/lizard,
+		/datum/customizer/organ/snout/lizard/dracon,
 		/datum/customizer/organ/ears/lizard,
 		/datum/customizer/organ/frills/lizard,
 		/datum/customizer/organ/horns/humanoid,


### PR DESCRIPTION
## About The Pull Request
No more humen drakian hybrid abominations. Thanks.
Simply forces drakians to have a snout. You could remove it for some reason.

## Testing Evidence
It just works.

## Why It's Good For The Game
Off-white snoutless drakian with the +1STR boon.
Next.