### PR TITLE
Reinforced Hood Vendor Tweaks

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -60,3 +60,10 @@
 	name = "Heavy Padded Coif"
 	cost = 35 // Equivalent to a padded gambeson on the head, so pricier
 	contains = list(/obj/item/clothing/neck/roguetown/coif/heavypadding)
+
+/datum/supply_pack/rogue/light_armor/reinforced_hood
+	name = "Reinforced Hood"
+	cost = 40 //It's armour. Quite good, given layering, too. Someone else can adjust this. EDIT: I'm someone else. If it's such good armor, let's make it as expensive as the other good armor in its class, like the padded gambeson. Steel mask is probably better, you're buying this if you want swag.
+	contains = list(
+					/obj/item/clothing/head/roguetown/roguehood/reinforced,
+				)

--- a/code/modules/cargo/packsrogue/merchant/wardrobe.dm
+++ b/code/modules/cargo/packsrogue/merchant/wardrobe.dm
@@ -145,10 +145,4 @@
 					/obj/item/clothing/mask/rogue/exoticsilkmask,
 				)
 
-/datum/supply_pack/rogue/wardrobe/reinforced_hood
-	name = "Reinforced Hood"
-	cost = 120//It's armour. Quite good, given layering, too. Someone else can adjust this.
-	contains = list(
-					/obj/item/clothing/head/roguetown/roguehood/reinforced,
-				)
 


### PR DESCRIPTION
## About The Pull Request

Moves the Reinforced Hood from the "wardrobe" section of the Goldface/Tailor Silverface to "light armor" instead, because that's what it is. Also drastically reduces the price. Doesn't touch armor values or integrity at all.

## Testing Evidence

<img width="522" height="481" alt="2025-12-23_20-14-52" src="https://github.com/user-attachments/assets/1ce19fe0-c74f-427a-b977-c20a721b0cc8" />
<img width="511" height="476" alt="2025-12-23_20-14-43" src="https://github.com/user-attachments/assets/b665a8f8-5925-4e5a-9465-16444155695b" />


## Why It's Good For The Game

The reinforced hood is decent armor, but it's still light armor with low integrity- in its current state, the steel mask is often less than half the price, while being a way better option for the slot. Having it be more accessible will allow for more people to wear it, which is good because hoods have swag.

It's also just a way more sensical price. Why would fur and cloth be more expensive than steel helmets? Why would it be in the wardrobe section when it's light armor, etc.