### PR TITLE
Sharpening no longer permanently reduces sharpness

### DIFF
--- a/code/game/objects/items/rogueweapons/integrity.dm
+++ b/code/game/objects/items/rogueweapons/integrity.dm
@@ -24,8 +24,8 @@
 	else	//If we're sending messages it should be sent to a mob
 		if(loc && ishuman(loc))
 			L = loc
-	
-	if(L && max_blade_int)	
+
+	if(L && max_blade_int)
 		var/ratio = blade_int / max_blade_int
 		var/newratio = (blade_int - amt) / max_blade_int
 		if(ratio > SHARPNESS_TIER1_THRESHOLD && newratio <= SHARPNESS_TIER1_THRESHOLD) //We are above the first threshold but are about to hit it.
@@ -38,7 +38,7 @@
 			if(L.STAINT > 9)
 				to_chat(L, span_userdanger("A chunk snapped off! \The [src]'s damage will decay much quicker now."))
 			playsound(L, 'sound/combat/sharpness_loss2.ogg', 100, TRUE)
-	
+
 	blade_int = blade_int - amt
 	if(blade_int <= 0)
 		blade_int = 0
@@ -110,7 +110,6 @@
 	playsound(src.loc, pick('sound/items/sharpen_long1.ogg','sound/items/sharpen_long2.ogg'), 100, TRUE)
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.visible_message(span_notice("[user] sharpens [src]!"))
-	degrade_bintegrity(0.5)
 	add_bintegrity((ST.sharpening_factor * factor), user)
 
 	if(prob(ST.spark_chance))


### PR DESCRIPTION

## About The Pull Request

As the title says, simply removes the proc that degrades maximum sharpness by 0.5 per sharpening attempt. One line change.

## Testing Evidence

<img width="379" height="282" alt="image" src="https://github.com/user-attachments/assets/be6a9977-8ccd-4203-a6e9-975155373cc5" />

Max sharpness remains the same even after being sharpened.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
One of the only mechanics in the game that incurs permanent integrity loss. Too insignificant to really put anyone at a disadvantage (especially if you use more efficient methods like a whetstone), but I also don't really see the point in having it around. This can permanently damage unique items that have sharpness as well.