### PR TITLE
Grindstones Restore Max Integrity

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -482,7 +482,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(href_list["explainsharpness"])
 		to_chat(usr, span_info("Bladed weapons have sharpness. At [SHARPNESS_TIER1_THRESHOLD * 100]%, damage factor and strength damage starts to fall off gradually. \n\
 		At [SHARPNESS_TIER1_FLOOR * 100]%, strength and damage factor no longer applies. Below [SHARPNESS_TIER2_THRESHOLD * 100]%, the base damage value also starts to decline\n\
-		Sharpness declines by [SHARPNESS_ONHIT_DECAY] on parry for bladed weapon."))
+		Sharpness declines by [SHARPNESS_ONHIT_DECAY] on parry for bladed weapon.\n\
+		A grindstone can restore max sharpness, whereas other sources will degrade 0.5 max integrity per sharpening."))
 
 	if(href_list["explaindurability"])
 		to_chat(usr, span_info("How durable your item is. On weapons, [INTEG_PARRY_DECAY] is lost on parry on a main hand bladed weapon. \n\
@@ -1431,7 +1432,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	. = ..()
 	if(twohands_required)
 		return
-	if(wielded) //Trying to unwield it. Ratwood edit. Original: (altgripped || wielded) 
+	if(wielded) //Trying to unwield it. Ratwood edit. Original: (altgripped || wielded)
 		ungrip(user)
 		return
 	if(alt_intents && !gripped_intents)

--- a/code/game/objects/items/rogueweapons/integrity.dm
+++ b/code/game/objects/items/rogueweapons/integrity.dm
@@ -24,8 +24,8 @@
 	else	//If we're sending messages it should be sent to a mob
 		if(loc && ishuman(loc))
 			L = loc
-	
-	if(L && max_blade_int)	
+
+	if(L && max_blade_int)
 		var/ratio = blade_int / max_blade_int
 		var/newratio = (blade_int - amt) / max_blade_int
 		if(ratio > SHARPNESS_TIER1_THRESHOLD && newratio <= SHARPNESS_TIER1_THRESHOLD) //We are above the first threshold but are about to hit it.
@@ -38,7 +38,7 @@
 			if(L.STAINT > 9)
 				to_chat(L, span_userdanger("A chunk snapped off! \The [src]'s damage will decay much quicker now."))
 			playsound(L, 'sound/combat/sharpness_loss2.ogg', 100, TRUE)
-	
+
 	blade_int = blade_int - amt
 	if(blade_int <= 0)
 		blade_int = 0
@@ -118,3 +118,9 @@
 		var/turf/front = get_step(user,user.dir)
 		S.set_up(1, 1, front)
 		S.start()
+
+//Could do without being a proc, but just in case this is expanded later.
+//Just used for grindstones, currently, to restore quality of a blade.
+/obj/item/proc/restore_bintegrity()
+	max_blade_int = initial(max_blade_int)//Given it's reduced above.
+	blade_int = initial(max_blade_int)//Now return it.

--- a/code/modules/roguetown/roguejobs/blacksmith/grindwheel.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/grindwheel.dm
@@ -12,7 +12,7 @@
 	if(I.max_blade_int)
 		playsound(loc,'sound/foley/grindblade.ogg', 100, FALSE)
 		if(do_after(user, 41, target = src))
-			I.add_bintegrity(999, user)
+			I.restore_bintegrity()
 		return
 	if(istype(I, /obj/item/grown/log/tree/small))
 		var/skill_level = user.get_skill_level(/datum/skill/craft/carpentry)


### PR DESCRIPTION
## About The Pull Request
Exactly as it says in the title.
A grindstone can now return a weapon to its initial state of sharpness. No longer do you have to toss aside a katar after a small bit of use, or a unique weapon because it's effectively worthless after some repairs and sharpening.

Includes a tutorialization of this in weapon tips, too.

## Testing Evidence
Before & After grindwheel use.
<img width="299" height="28" alt="image" src="https://github.com/user-attachments/assets/aaf80e62-13c3-4682-9ef2-5c8d2bec4df2" />
<img width="289" height="25" alt="image" src="https://github.com/user-attachments/assets/bb09d947-d215-47cf-be33-c76395b2a3b9" />
Actual tutorialization of this mechanic.
<img width="509" height="151" alt="image" src="https://github.com/user-attachments/assets/7051d038-c803-40da-8953-d00a427e1bc4" />

## Why It's Good For The Game
Do I really need to explain this?