### PR TITLE
Smelter Amount Edits

### DIFF
--- a/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/smelter.dm
@@ -247,15 +247,15 @@
 			blacksteelalloy = blacksteelalloy + 2
 
 	if(steelalloycoal == 1 && steelalloyiron == 3)
-		max_contained_items = 3
-		alloy = /obj/item/ingot/steel
+		max_contained_items = 4
+		alloy = /obj/item/ingot/steel // 3 bars is an awkward number to work with, considering most people order things that need 2 bars
 	else if(bronzealloy == 7)
 		alloy = /obj/item/ingot/bronze
 	else if(purifiedalloy == 11)
-		max_contained_items = 2
-		alloy = /obj/item/ingot/purifiedaalloy // 3 aaslag, 1 gold, makes 2 purified alloy.
+		max_contained_items = 4
+		alloy = /obj/item/ingot/purifiedaalloy // 3 aaslag, 1 gold, makes 4 purified alloy, 2 is too few to be worth doing anything with
 	else if(blacksteelalloy == 7)
-		max_contained_items = 1 // Blacksteel is supposed to be rare and inefficient. 3 steel and 1 silver into one.
+		max_contained_items = 2 // 1 ingot is too few to do anything meaningful with and makes prices too high to sell anything
 		alloy = /obj/item/ingot/blacksteel
 	else
 		alloy = null


### PR DESCRIPTION
## About The Pull Request

This PR is meant to address the amount of bars received from smelting recipes. I felt that as they are now, they are not very good and do not make for a good experience for the smith, or the smith's customers.

## Testing Evidence

(https://youtu.be/lIhV6kts-Gw)

## Why It's Good For The Game

I will argue for each of these buffs in turn.

Steel to four - This is how it was back in Old Ratwood, and in many places besides. Reducing it to 3 is one of those things that have happened as a result of Re-basing to AP's code. 4 ingots is a useful amount to work with in one blow, 3 is not so useful. You are rarely going to need 'odd' amounts of bars, and you will often need 'even' amounts given how many objects require two bars, or how many single object recipes someone wants to buy at once.

Ancient Alloy to four - This was previously set at two, and the number one reason people ordered this was to have Artificer Half-Plate engineered for them. This requires three bars meaning that you must go through the process of producing Ancient Alloy _twice_ if you want to produce a single item. This is immensely annoying, and time consuming. Not to mention it drives up the costs for ancient alloy to the point that players will not want to buy objects made from this material.

Blacksteel to two - Long, long ago back in Stonekeep it was four bars of blacksteel from a smelt. I am not saying we should go back to this, it would make blacksteel **too** plentiful. However, right now it is impossible to get a workable mount of blacksteel or offer it at a price that is good for the average player and good for the players running the smithy. A single bar is also not useful for making equipment, and can basically only be used as fodder to make treasures with rather than items that add to a player's progression. Changing it to two is my notion of a compromise between the ancient plentiful blacksteel, and keeping it as is where it's so rare, and so controlled that there's not enough of it to go around.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
