### PR TITLE
Monk Loadouts

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -31,7 +31,7 @@
 	)
 	extra_context = "This subclass can choose from multiple disciplines. \
 	The further your chosen discipline strays from unarmed combat, however, the greater your skills in fistfighting and wrestling will atrophy. \
-	Taking a Quarterstaff removes your speed bonus in exchange for strength, providing 'Critical Resistance' and removing the 'Expert Dodger' trait."
+	Your vow determines your overall speed, strength and provided trait for dodge expert or critical resistance."
 
 /datum/outfit/job/roguetown/adventurer/cleric
 	allowed_patrons = ALL_PATRONS


### PR DESCRIPTION
## About The Pull Request
Simply separates the monk setups into loadouts. That being, weapons are different from the stat/trait selection. We'd people who wanted dodge expert staves, for some reason. Others who want crit resist punching, for obvious reasons. Etc. Whatever. This was requested by a few people, and it's such a simple thing with so few people touching it, that it shouldn't be a big deal.

Also removes the Missionary chalk, since they can't actually do rites.
## Testing Evidence
<img width="247" height="96" alt="image" src="https://github.com/user-attachments/assets/06f63984-bb22-4344-9eef-e45e5a6d3d01" />

## Why It's Good For The Game
Funny player choice or something. I 'unno. It's cool though.