### PR TITLE
Hand Buffs / Changes

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -421,6 +421,10 @@
 	max_integrity = 200
 	smeltresult = /obj/item/ingot/steel
 
+/obj/item/rogueweapon/huntingknife/idagger/dtace/Initialize()
+	. = ..()
+	AddElement(/datum/element/tipped_item)	//Lets you tip your weapon in poison
+
 /obj/item/rogueweapon/huntingknife/idagger/steel/parrying
 	name = "steel parrying dagger"
 	force = 12

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -87,7 +87,7 @@
 	else if(should_wear_masc_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_m
 	backpack_contents = list(
-		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/dtace = 1,//You don't get killer's ice for this because you're the gross swordsmaster and I HATE YOU!!!!
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/storage/keyring/hand = 1,
 	)
@@ -123,7 +123,7 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_LEGENDARY,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/tracking = SKILL_LEVEL_MASTER,//Huntmaster, but this was apprentice. You can powerlevel this easy, but that's a waste of sleeping.
 		/datum/skill/misc/sneaking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/stealing = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_MASTER, // not like they're gonna break into the vault.
@@ -136,6 +136,7 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/storage/keyring/hand = 1,
 		/obj/item/lockpickring/mundane = 1,
+		/obj/item/reagent_containers/glass/bottle/rogue/poison = 1,//Just like the wizard, since he can dip the blade.
 	)
 	if(H.dna.species.type in NON_DWARVEN_RACE_TYPES)
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/shadowrobe
@@ -161,7 +162,7 @@
 	outfit = /datum/outfit/job/roguetown/hand/advisor
 
 	category_tags = list(CTAG_HAND)
-	traits_applied = list(TRAIT_ALCHEMY_EXPERT, TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2)
+	traits_applied = list(TRAIT_ALCHEMY_EXPERT, TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3)
 	subclass_stats = list(
 		STATKEY_INT = 4,
 		STATKEY_PER = 3,
@@ -184,7 +185,7 @@
 		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
-		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
 	)
 
 //Advisor start. Trades combat skills for more knowledge and skills - for older hands, hands that don't do combat - people who wanna play wizened old advisors.
@@ -211,6 +212,11 @@
 		H.change_stat(STATKEY_INT, 1)
 		H.change_stat(STATKEY_PER, 1)
 		H.mind?.adjust_spellpoints(3)
+	//He gets far less spellpoints than any other equivalent caster. Give him a T4.
+	//Message, too. You'll be taking it anyways.
+	if(H.mind)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/recall)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
 
 
 ////////////////////

--- a/code/modules/spells/spell_types/wizard/utility/recall.dm
+++ b/code/modules/spells/spell_types/wizard/utility/recall.dm
@@ -1,4 +1,5 @@
 //Wizard teleportation. Intended to be locked to Magos / Lich. Don't hand this out.
+//Also given to the Hand mage subclass, now.
 //Pulled from SR, or wherever they got it. Cheers.
 /obj/effect/proc_holder/spell/self/recall
 	name = "Recall"


### PR DESCRIPTION
## About The Pull Request
Hand changes:
 - De Tace can now be dipped for poisons.
 - Advisor given Recall and Message now. This is compensation for very few spellpoints, to an equivalent caster.
 - Advisor is a T3 caster, up from T2. They're still stuck at 15 spellpoints, +3 from old, +3 from virtue.
 - Spymaster once again gets killer's ice. Dip that dagger for the funny moment, dagger man.
 - Spymaster made a master tracker, roundstart. You could farm this, but, ehh.... and he got huntmaster, too, so, why not?

## Testing Evidence
Multi-line change. Not tested. Once more another Carl slop PR.

## Why It's Good For The Game
The Hand is a very odd role. There'd been no real reason to play the other subclasses beyond Blademaster, nor any remote actual care given to Advisor in the face of everything else existing around it.
Hopefully with a free T4, in the form of recall, and the message spell as a token, Advisor will see more use.