### PR TITLE
Nervelocks now list your account balance

### DIFF
--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -56,7 +56,7 @@
 		if(amt > 5)
 			choicez += "SILVER"
 		choicez += "BRONZE"
-		var/selection = input(user, "Make a Selection", src) as null|anything in choicez
+		var/selection = input(user, "You have [amt] mammon in your account. Choose which currency you'd like to withdraw.", src) as null|anything in choicez
 		if(!selection)
 			return
 		amt = SStreasury.bank_accounts[H]
@@ -65,7 +65,7 @@
 			mod = 10
 		if(selection == "SILVER")
 			mod = 5
-		var/coin_amt = input(user, "There is [SStreasury.treasury_value] mammon in the treasury. You may withdraw [floor(amt/mod)] [selection] COINS from your account.", src) as null|num
+		var/coin_amt = input(user, "There is [SStreasury.treasury_value] mammon in the treasury, and [amt] mammon in your account. You may withdraw [floor(amt/mod)] [selection] COINS from your account.", src) as null|num
 		coin_amt = round(coin_amt)
 		if(coin_amt < 1)
 			return


### PR DESCRIPTION
## About The Pull Request

I was irritated by the way nervelocks sort of obscure your actual balance by having you check how many zennies you can withdraw to figure it out. It now lists your balance up-front in the menu where you choose what denomination to withdraw.

## Testing Evidence

<img width="328" height="182" alt="image2" src="https://github.com/user-attachments/assets/21c5b22d-10df-49d4-8df6-4514dd96ae48" />
<img width="313" height="284" alt="image" src="https://github.com/user-attachments/assets/89d85b0a-1844-4b36-9a36-fea08f663470" />


## Why It's Good For The Game

Just saves players the extra step and reduces some menu-ing required to deal with currency. 
