### PR TITLE
Seperate Ambience Volume and Lobby Music Volume

### DIFF
--- a/code/controllers/subsystem/music_update.dm
+++ b/code/controllers/subsystem/music_update.dm
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(ambience)
 	if(!sexy_ambience)
 		return
 
-	SEND_SOUND(to_process.mob, sound(sexy_ambience, repeat = 0, wait = 0, volume = to_process.prefs.ambiencevol * 0.1, channel = CHANNEL_AMBIENCE))
+	SEND_SOUND(to_process.mob, sound(sexy_ambience, repeat = 0, wait = 0, volume = to_process.prefs.ambiencevol * 0.2, channel = CHANNEL_AMBIENCE))
 
 	ambience_listening_clients[to_process] = world.time + rand(current_area.min_ambience_cooldown, current_area.max_ambience_cooldown)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -326,7 +326,7 @@
 	UNTIL(SSticker.login_music) //wait for SSticker init to set the login music
 
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
-		SEND_SOUND(src, sound(SSticker.login_music, repeat = 1, wait = 0, volume = prefs.musicvol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
+		SEND_SOUND(src, sound(SSticker.login_music, repeat = 1, wait = 0, volume = prefs.lobbymusicvol, channel = CHANNEL_LOBBYMUSIC)) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(43100, 45100) //Frequency stuff only works with 45kbps oggs.

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -61,9 +61,9 @@
 		prefs.musicvol = vol
 		prefs.save_preferences()
 
-		mob.update_music_volume(CHANNEL_MUSIC, prefs.musicvol)
-		mob.update_music_volume(CHANNEL_LOBBYMUSIC, prefs.musicvol)
 		mob.update_music_volume(CHANNEL_ADMIN, prefs.musicvol)
+		mob.update_music_volume(CHANNEL_BUZZ, prefs.musicvol)
+		mob.update_music_volume(CHANNEL_CMUSIC, prefs.musicvol)
 
 
 /client/verb/show_rolls()
@@ -105,6 +105,24 @@
 		prefs.save_preferences()
 
 		mob.update_channel_volume(CHANNEL_AMBIENCE, prefs.ambiencevol)
+		mob.update_channel_volume(CHANNEL_MUSIC, prefs.ambiencevol)
+		mob.update_channel_volume(CHANNEL_RAIN, prefs.ambiencevol)
+
+/client/verb/change_lobby_music_vol()
+	set category = "Options"
+	set name = "ChangeLobbyMusicPower"
+
+	if(prefs)
+		var/vol = input(usr, "Current lobby music power: [prefs.lobbymusicvol]",, 100) as null|num
+		if(!vol)
+			if(vol != 0)
+				return
+		vol = min(vol, 100)
+		prefs.lobbymusicvol = vol
+		prefs.save_preferences()
+
+		if(isnewplayer(mob))
+			mob.update_music_volume(CHANNEL_LOBBYMUSIC, prefs.lobbymusicvol)
 /*
 /client/verb/help_rpguide()
 	set category = "Options"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -130,6 +130,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/widescreenpref = TRUE
 
 	var/musicvol = 50
+	var/lobbymusicvol = 50
 	var/ambiencevol = 50
 	var/mastervol = 50
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -203,6 +203,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["be_special"] 		>> be_special
 	S["triumphs"]			>> triumphs
 	S["musicvol"]			>> musicvol
+	S["lobbymusicvol"]		>> lobbymusicvol
 	S["ambiencevol"]		>> ambiencevol
 	S["anonymize"]			>> anonymize
 	S["masked_examine"]		>> masked_examine
@@ -324,6 +325,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["asaycolor"], asaycolor)
 	WRITE_FILE(S["triumphs"], triumphs)
 	WRITE_FILE(S["musicvol"], musicvol)
+	WRITE_FILE(S["lobbymusicvol"], lobbymusicvol)
 	WRITE_FILE(S["ambiencevol"], ambiencevol)
 	WRITE_FILE(S["anonymize"], anonymize)
 	WRITE_FILE(S["masked_examine"], masked_examine)

--- a/code/modules/droning/droning.dm
+++ b/code/modules/droning/droning.dm
@@ -173,7 +173,7 @@ SUBSYSTEM_DEF(droning)
 
 	if(!amb_sound_list)
 		return
-	var/sound/loop_sound = sound(pick(amb_sound_list), repeat = TRUE, wait = 0, channel = CHANNEL_MUSIC, volume = dreamer?.prefs.musicvol)
+	var/sound/loop_sound = sound(pick(amb_sound_list), repeat = TRUE, wait = 0, channel = CHANNEL_MUSIC, volume = dreamer?.prefs.ambiencevol)
 	SEND_SOUND(dreamer, loop_sound)
 	dreamer.loop_sound = TRUE
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

- Lobby music is now separate from in-game music.
- Adds 'ChangeLobbyMusicPower' option.
- Ambience and Music tracks are now separate.
- Adds 'ChangeAmbiencePower' option.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
Sorry these came out really quiet.

https://github.com/user-attachments/assets/ffa26f46-313c-4789-a8db-bcb9e034e21f


https://github.com/user-attachments/assets/04732d22-d40b-4f20-a04d-7ef710b25d83


## Why It's Good For The Game

This game has some really nice ambience, but most don't hear it because of the constantly looping music that most people have probably turned off. Now you can listen to your own music, but still get immersed in those nice spooky bog sounds, and hear that chill lobby music when it pops up if you want.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
