### PR TITLE
Druid's resurrection spell changes 

### DIFF
--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -557,12 +557,14 @@
 	desc = "Revive the target at a cost, cast on yourself to check.<br>Targets speed and constitution will be sapped for a time."
 	//Herbs that have to do with intelligence mostly. Easier to remember.
 	required_items = list(
-		/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 3,
+		/obj/item/reagent_containers/food/snacks/grown/manabloom = 3,
+        /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 3,
 		/obj/item/alch/mentha = 3,
 		/obj/item/reagent_containers/food/snacks/grown/rogue/swampweed = 3
 	)
 	alt_required_items = list(
-		/obj/item/reagent_containers/food/snacks/rogue/meat/steak = 3,
+		/obj/item/reagent_containers/food/snacks/grown/manabloom = 3,
+        /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1,
 		/obj/item/reagent_containers/food/snacks/grown/rogue/swampweed = 1
 	)
 	debuff_type = /datum/status_effect/debuff/dendor_revival


### PR DESCRIPTION
## About The Pull Request
A simple change of making druid's resurrection spell to use Fyritius and manabloom instead of meat  
## Testing Evidence
<img width="1920" height="986" alt="2025-12-29" src="https://github.com/user-attachments/assets/1e02f7a7-acfa-4150-adb9-a6579d79eaa4" />
i spawned the items and tested the spell again but i forgot to take screenshots but it seems to be working correctly 


## Why It's Good For The Game
since druids cant trigger ambushes  and their tools are more fit to growing herbs and flowers i thought this would be a nice addition to them as Fyritius can prove to be a valuable tool for the church as well as the spell is very specific in what kind of meat it needs (cant use fish meat,volf meat, cabbit meat,chicken meat or spider meat) , and the Fyritius can aid the church as well 