### PR TITLE
Throwing Rebalance Try 2

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -228,7 +228,7 @@
 	grid_height = 64
 	grid_width = 32
 	force = 20
-	throwforce = 32 //You ever had an axe thrown at you?
+	throwforce = 35 // Buffed to not fall behind javelins
 	throw_speed = 6 //Batarangs, baby.
 	max_integrity = 50 //Brittle design, hits hard, breaks quickly.
 	armor_penetration = 40 //On-par with steel tossblades.

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -692,7 +692,7 @@
 	desc = "Paradoxical; why is it called a blade when it is meant for tossing? Or is it the act of cutting post-toss that makes it a blade? ...Are arrows tossblades, too? </br>This dagger can be stowed away inside a pair of boots, permitting it to be quickly drawn when needed."
 	item_state = "bone_dagger"
 	force = 10
-	throwforce = 22
+	throwforce = 25
 	throw_speed = 4
 	max_integrity = 50
 	armor_penetration = 30
@@ -724,15 +724,15 @@
 	desc = "Chunks of frayed bronze, crudely sharpened into throwing daggers. You might be better off chucking the silverware at them, at this rate. </br>This dagger can be stowed away inside a pair of boots, permitting it to be quickly drawn when needed."
 	icon_state = "throw_knifea"
 	color = "#bb9696"
-	force = 7
-	throwforce = 16
+	force = 10
+	throwforce = 20
 	randomize_blade_int_on_init = TRUE
 
 /obj/item/rogueweapon/huntingknife/throwingknife/steel
 	name = "steel tossblade"
 	desc = "There are rumors of some sea-marauders loading these into metal tubes with explosive powder to launch then fast and far. Probably won't catch on. </br>This dagger can be stowed away inside a pair of boots, permitting it to be quickly drawn when needed."
 	item_state = "bone_dagger"
-	throwforce = 28
+	throwforce = 30
 	max_integrity = 100
 	armor_penetration = 40
 	icon_state = "throw_knifes"
@@ -749,7 +749,7 @@
 	desc = "A relative to the silver dagger; thinner, flimsier, but capable of being thrown with exceptional accuracy. Seasoned pursuers of unholy creechers oft-keep one hidden on themselves, just in case. </br>This dagger can be stowed away inside a pair of boots, permitting it to be quickly drawn when needed."
 	item_state = "bone_dagger"
 	force = 10
-	throwforce = 20
+	throwforce = 25
 	armor_penetration = 50
 	max_integrity = 150
 	wdefense = 3
@@ -774,7 +774,7 @@
 	desc = "An unconventional method of delivering silver to a heretic; but one PSYDON smiles at, all the same. Doubles as an actual knife in a pinch, though obviously not as well. </br>This dagger can be stowed away inside a pair of boots, permitting it to be quickly drawn when needed."
 	item_state = "bone_dagger"
 	force = 10
-	throwforce = 20
+	throwforce = 25
 	armor_penetration = 50
 	max_integrity = 150
 	wdefense = 3

--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -563,7 +563,7 @@
 //Javelins - Basically spears, but to get them working as proper javelins and able to fit in a bag, they are 'ammo'. (Maybe make an atlatl later?)
 //Only ammo casing, no 'projectiles'. You throw the casing, as weird as it is.
 /obj/item/ammo_casing/caseless/rogue/javelin
-	force = 14
+	force = 20
 	throw_speed = 3		//1 lower than throwing knives, it hits harder + embeds more.
 	name = "iron javelin"
 	desc = "A tool used for centuries, as early as recorded history. This one is tipped with a iron head; standard among militiamen and irregulars alike."
@@ -574,8 +574,8 @@
 	armor_penetration = 40					//Redfined because.. it's not a weapon, it's an 'arrow' basically.
 	max_integrity = 50						//Breaks semi-easy, stops constant re-use.
 	wdefense = 3							//Worse than a spear
-	thrown_bclass = BCLASS_STAB				//Knives are slash, lets try out stab and see if it's too strong in terms of wounding.
-	throwforce = 25							//throwing knife is 22, slightly better for being bulkier.
+	thrown_bclass = BCLASS_PICK				//Javelins should have one shared damage type, and it should be anti-armor
+	throwforce = 35							//It needs to be more like this to be worth using, it's too weak at its old value
 	possible_item_intents = list(/datum/intent/sword/thrust, /datum/intent/spear/bash, /datum/intent/spear/cut)	//Sword-thrust to avoid having 2 reach.
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 35, "embedded_fall_chance" = 10)	//Better than iron throwing knife by 10%
 	anvilrepair = /datum/skill/craft/weaponsmithing
@@ -598,20 +598,20 @@
 	name = "decrepit javelin"
 	desc = "A missile of frayed bronze. Before you is your weapon; that which rose Man out of the mud, and brought the Beasts of Old Syon to heel. When were you last aware of any other part of you? Do you recall seeing the world in any other way?"
 	icon_state = "ajavelin"
-	throwforce = 20
-	force = 9
+	throwforce = 25
+	force = 15
 	color = "#bb9696"
 	smeltresult = null // Override iron inherit
 	anvilrepair = null
 
 /obj/item/ammo_casing/caseless/rogue/javelin/steel
-	force = 16
+	force = 20
 	armor_penetration = 50
 	name = "steel javelin"
 	desc = "A tool used for centuries, as early as recorded history. This one is tipped with a steel head; perfect for piercing armor!"
 	icon_state = "javelin"
 	max_integrity = 100						//In-line with other stabbing weapons.
-	throwforce = 28							//Equal to steel knife BUT this has peircing damage type so..
+	throwforce = 40							//It's a fucking javelin, not a knife it needs more damage to compensate
 	thrown_bclass = BCLASS_PICK				//Bypasses crit protection better than stabbing. Makes it better against heavy-targets.
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 45, "embedded_fall_chance" = 10) //Better than steel throwing knife by 10%
 	smeltresult = null // 1 Ingot = 2 Javelins
@@ -627,7 +627,7 @@
 	desc = "A tool used for centuries, as early as recorded history. This one appears to be tipped with a silver head. Decorative, perhaps.. or for some sort of specialized hunter."
 	icon_state = "sjavelin"
 	is_silver = TRUE
-	throwforce = 25							//Less than steel because it's.. silver. Good at killing vampires/WW's still.
+	throwforce = 30							//Less than steel because it's.. silver. Good at killing vampires/WW's still.
 	armor_penetration = 60
 	thrown_bclass = BCLASS_PICK				//Bypasses crit protection better than stabbing. Makes it better against heavy-targets.
 	smeltresult = /obj/item/ingot/silver // 2 ingots = 2 javelins so this can smelt.

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/weapons.dm
@@ -144,16 +144,16 @@
 	created_item = /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 
 /datum/anvil_recipe/weapons/aalloy/tossblade
-	name = "Tossblades, Decrepit (x4)"
+	name = "Tossblades, Decrepit (x5)"
 	req_bar = /obj/item/ingot/aalloy
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/aalloy
-	createditem_num = 4
+	createditem_num = 5
 
 /datum/anvil_recipe/weapons/paalloy/tossblade
-	name = "Tossblades, Ancient (x4)"
+	name = "Tossblades, Ancient (x5)"
 	req_bar = /obj/item/ingot/purifiedaalloy
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/steel/palloy
-	createditem_num = 4
+	createditem_num = 5
 
 /datum/anvil_recipe/weapons/aalloy/gsw
 	name = "Greatsword, Decrepit (+2 Alloy)"
@@ -434,7 +434,7 @@
 	req_bar = /obj/item/ingot/iron
 	req_blade = /obj/item/blade/iron_knife
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife
-	createditem_num = 4
+	createditem_num = 5
 
 /datum/anvil_recipe/weapons/iron/javelin
 	name = "Javelin, Iron (+1 Small Log) (x2)"
@@ -491,10 +491,11 @@
 	created_item = /obj/item/rogueweapon/knuckles
 
 /datum/anvil_recipe/weapons/steel/hurlbat
-	name = "Hurlbat"
+	name = "Hurlbats (x2)"
 	req_bar = /obj/item/ingot/steel
 	req_blade = /obj/item/blade/steel_axe
 	created_item = /obj/item/rogueweapon/stoneaxe/hurlbat
+	createditem_num = 2
 
 /datum/anvil_recipe/weapons/steel/rapier
 	name = "Rapier, Steel"
@@ -710,11 +711,11 @@
 	created_item = /obj/item/rogueweapon/spear/lance
 
 /datum/anvil_recipe/weapons/steel/tossblade
-	name = "Tossblade, Steel (x4)"
+	name = "Tossblades, Steel (x5)"
 	req_bar = /obj/item/ingot/steel
 	req_blade = /obj/item/blade/steel_knife
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/steel
-	createditem_num = 4
+	createditem_num = 5
 
 /datum/anvil_recipe/weapons/steel/javelin
 	name = "Javelin, Steel (+1 Small Log) (x2)"
@@ -884,16 +885,15 @@
 	created_item = /obj/item/rogueweapon/whip/silver
 
 /datum/anvil_recipe/weapons/silver/tossblade
-	name = "Tossblades, Silver (+1 Silver)"
+	name = "Tossblades, Silver (x5)"
 	req_bar = /obj/item/ingot/silver
-	additional_items = list(/obj/item/ingot/silver)
 	created_item = /obj/item/rogueweapon/huntingknife/throwingknife/silver
-	createditem_num = 4
+	createditem_num = 5
 
 /datum/anvil_recipe/weapons/silver/javelin
-	name = "Javelins, Silver (+1 Silver, Small Log)"
+	name = "Javelins, Silver (+1 Small Log) (x2)"
 	req_bar = /obj/item/ingot/silver
-	additional_items = list(/obj/item/ingot/silver, /obj/item/grown/log/tree/small)
+	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/ammo_casing/caseless/rogue/javelin/silver
 	createditem_num = 2
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

This PR is intended to beef up several throwing weapons a little bit (Tossblades, Hurlbats, and Javelins) while also ensuring they maintain distinct identities with clear use cases and drawbacks compared to each other. This is also why it increases the number of tossblades to five (that you can reload a tossblade from empty with one ingot) and increases the number of hurlbats to two (that you can fill a bandolier with two ingots).

This is because that Javelins were hardly any better than tossblades, while also being harder to utilize and carry (what with the expectation being you sacrifice a hip or back slot for their quiver).

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

https://youtu.be/zfxMotWTdco

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

I feel this is good for the game because it creates more variance among the throwing weapons and encourages them to be used more often than as a gimmick, or because you just happened to spawn with them as part of your kit.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
