### PR TITLE
Bandage examining tells bandage status

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_examine.dm
+++ b/code/modules/surgery/bodyparts/bodypart_examine.dm
@@ -99,9 +99,15 @@
 			bodypart_status += "<B>Wounds:</B>"
 			if(bandage)
 				var/usedclass = "notice"
+				var/extratext = ""
 				if(bandage.return_blood_DNA())
 					usedclass = "bloody"
-				bodypart_status += "<a href='?src=[owner_ref];bandage=[REF(bandage)];bandaged_limb=[REF(src)]' class='[usedclass]'>Bandaged</a>"
+					extratext = " (bloodied)"
+				else if(istype(bandage, /obj/item/natural/cloth))
+					var/obj/item/natural/cloth/cloth = bandage
+					if(cloth.medicine_amount)
+						extratext = " (medicated)"
+				bodypart_status += "<a href='?src=[owner_ref];bandage=[REF(bandage)];bandaged_limb=[REF(src)]' class='[usedclass]'>Bandaged[extratext]</a>"
 			if(!bandage || observer_privilege)
 				for(var/datum/wound/wound as anything in wounds)
 					if(wound == null)
@@ -205,10 +211,16 @@
 			status += "<a href='?src=[owner_ref];embedded_limb=[REF(src)];embedded_object=[REF(embedded)];' class='info'>[uppertext(embedded.name)]</a>"
 
 	if(bandage)
+		var/usedclass = "info"
+		var/extratext = ""
 		if(HAS_BLOOD_DNA(bandage))
-			status += "<a href='?src=[owner_ref];bandaged_limb=[REF(src)];bandage=[REF(bandage)]' class='bloody'>[uppertext(bandage.name)]</a>"
-		else
-			status += "<a href='?src=[owner_ref];bandaged_limb=[REF(src)];bandage=[REF(bandage)]' class='info'>[uppertext(bandage.name)]</a>"
+			usedclass = "bloody"
+			extratext = " (bloodied)"
+		else if(istype(bandage, /obj/item/natural/cloth))
+			var/obj/item/natural/cloth/cloth = bandage
+			if(cloth.medicine_amount)
+				extratext = " (medicated)"
+		status += "<a href='?src=[owner_ref];bandaged_limb=[REF(src)];bandage=[REF(bandage)]' class='[usedclass]'>[uppertext(bandage.name)][extratext]</a>"
 
 	if(disabled)
 		status += span_deadsay("CRIPPLED")


### PR DESCRIPTION
## About The Pull Request

Examining yourself or using secular diagnosis now tells you the status of the bandage! Either medicated or bloodied. Credit goes to this port of my previous bandage PRs, all credit to them: https://github.com/Azure-Peak/Azure-Peak/pull/5075<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="273" height="146" alt="image" src="https://github.com/user-attachments/assets/c60992b9-cf03-496a-bd27-6f6e8dce89d6" />
<img width="241" height="174" alt="image" src="https://github.com/user-attachments/assets/ff392dad-5b5c-4a68-8f65-08cd511c0d61" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Easier way to tell when bandages are bloody or medicated when examining! They're supposed to be different colors but... since they're clickable the color doesn't show, so, this is a way more clear way of showing it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
