### PR TITLE
Dye Bin Preview

### DIFF
--- a/code/modules/roguetown/roguejobs/tailor/dyer.dm
+++ b/code/modules/roguetown/roguejobs/tailor/dyer.dm
@@ -187,7 +187,7 @@ var/global/list/pridelist = list(
 				worn_preview.Blend(altdetail_overlay, ICON_OVERLAY)
 			
 			//Add sleeved parts if they exist (for cloaks).
-			if(clothing_item.sleeved && "[worn_state]" in icon_states(clothing_item.sleeved))
+			if(clothing_item.sleeved && ("[worn_state]" in icon_states(clothing_item.sleeved)))
 				// check if r_ and l_ prefixed states exist before trying to use them
 				if("r_[worn_state]" in icon_states(clothing_item.sleeved))
 					var/icon/r_sleeve = new /icon()


### PR DESCRIPTION
## About The Pull Request

- Adds a preview of the offmob and onmob SOUTH sprites with the dye bin's selected colors.
- Adds separate 'Apply new color' buttons for each color.
- 'Apply new color' button no longer automatically ejects unless there is a singular color.

## Testing Evidence

<img width="498" height="636" alt="image" src="https://github.com/user-attachments/assets/3ffd7c26-1827-4479-b8dd-5b9b1fb00c62" />

## Why It's Good For The Game

Just makes it easier to use, now you can see what it's going to look like before you dye it on and off your mob.


<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
