### PR TITLE
Adjusts steel messer and falchion

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -916,11 +916,12 @@
 /obj/item/rogueweapon/sword/short/falchion
 	name = "falchion"
 	desc = "A single-edged sword that is similar to a messer in appearance, its origins trace back to Otava. An implement of commoners and knights alike. It's good for cutting and thrusting."
-	force = 20
+	force = 22
 	icon_state = "falchion"
 	wdefense = 6
 	w_class = WEIGHT_CLASS_BULKY // Did not fit in a bag before path rework. Does not fit in a bag now either.
 	sheathe_icon = "falchion"
+	max_blade_int = 250
 
 /obj/item/rogueweapon/sword/short/gladius
 	name = "gladius"
@@ -1018,14 +1019,15 @@
 	)
 
 /obj/item/rogueweapon/sword/short/messer
-	name = "messer"
+	name = "steel messer"
 	desc = "A \"Großesmesser\" of disputed Grenzel origin, meaning greatknife. It's a basic single-edge sword for civilian and military use. It excels at slicing and chopping, and it's made of steel. \
 	It can fill the exact function of a hunting sword, this one is more durable."
 	icon_state = "smesser"
-	force = 22	//Same damage as the iron messer
-	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/sword/thrust, /datum/intent/axe/chop, /datum/intent/sword/peel)
-	minstr = 5
-	wdefense = 4
+	force = 24	//Hunting sword + 4
+	max_blade_int = 250	//Sword + 50
+	possible_item_intents = list(/datum/intent/sword/cut/sabre, /datum/intent/rend/krieg, /datum/intent/axe/chop, /datum/intent/sword/peel)	//Krieg rend does not change from regular rend apart from dealing 20% damage to integrity
+	minstr = 6	// Hunting sword +2
+	wdefense = 4	//Hunting sword +2
 
 /obj/item/rogueweapon/sword/short/messer/iron
 	name = "hunting sword"


### PR DESCRIPTION
## About The Pull Request
Have you ever had a reason to use a steel messer? Just because you found it, or you made one? It doesn't really do anything. It's one of those things that was added early on and never changed, so it just kind of fell behind as another sword that's weak and doesn't do anything special.

This gives the regular steel messer a rend intent (replacing thrust), 50 more sharpness, and 4 more force (to a total of 24) to make it a fair upgrade of the hunting sword, or possible sidegrade of the maciejowski. It also ups the falchion's damage by 2 and increases its sharpness by 50, 'cause it deserves a lil love too.
## Testing Evidence
It's slop, sire.
Numbersjakked on VSC, like paying ten bucks for a hotdog.

## Why It's Good For The Game
The steel messer, like some other weapons in the game, was left to rot with nothing to make it stand out from the rest of the (massive) arsenal of swords available. It wasn't special then, and it sure as shit isn't any more special now. 
This PR wants to rectify that by making it more like a sidearm option of the kriegsmesser, trading its regular sword thrust for rend and making it more durable overall.
There are no real balance implications, and this won't really "shake" the meta. It's making a sub-optimal choice more optimal. The same argument can be made for the falchion.