### PR TITLE
Sack Bag Name Fix

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -131,7 +131,7 @@
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/survival/bag
-	name = "bag"
+	name = "sack"
 	result = /obj/item/storage/roguebag/crafted
 	reqs = list(
 		/obj/item/natural/fibers = 1,


### PR DESCRIPTION
## About The Pull Request

Renames "bag" to "sack" in crafting menu.

## Testing Evidence
<img width="293" height="184" alt="image" src="https://github.com/user-attachments/assets/a03a57f8-6257-450d-b24f-a6151245443c" />


## Why It's Good For The Game

Naming consistency is important! Name the craft menu the same as the item's name!
