### PR TITLE
Anti-Scrying Return

### DIFF
--- a/code/game/objects/items/rogueitems/magic.dm
+++ b/code/game/objects/items/rogueitems/magic.dm
@@ -73,7 +73,7 @@
 	if(!do_after(user, time_to_use, target = user))
 		to_chat(user, span_warning("I need to focus..."))
 		return
-	
+
 	var/success_chance = 0
 
 	var/break_on_fail = FALSE
@@ -143,12 +143,18 @@
 	if (target == null)
 		return
 
+//You're once more warned and the trait prevents scrying. It also tells you WHO is trying to scry you.
+	if(HAS_TRAIT(target, TRAIT_ANTISCRYING))
+		to_chat(user, span_warning("I peer into the ball, but an impenetrable fog shrouds [target.real_name]."))
+		to_chat(target, span_warning("My arcyne shroud shrieks in alarm! I can clearly see [user.real_name] staring into the fog!"))
+		return
+
 	if(!prob(success_chance))
 		on_failure(user, target, failure_severity)
 		if(break_on_fail)
 			failure_break(user)
 		return
-	
+
 	playsound(src, 'sound/magic/whiteflame.ogg', 100, TRUE)
 	scry(user, target)
 

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/nondetection.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/nondetection.dm
@@ -11,10 +11,10 @@
 	associated_skill = /datum/skill/magic/arcane
 	hand_path = /obj/item/melee/touch_attack/nondetection
 	spell_tier = 1
-	hide_charge_effect = TRUE 
+	hide_charge_effect = TRUE
 	// Nondetection shouldn't need an invocation
 	xp_gain = TRUE
-	cost = 1 // Shit, situational
+	cost = 1
 
 /obj/item/melee/touch_attack/nondetection
 	name = "\improper arcyne focus"


### PR DESCRIPTION
## About The Pull Request
Does as it says. Simply returns functionality to the trait. Additionally provides warning to the target of WHO is trying to scry them, same as if they had higher perception, albeit before that point, given this doesn't even let them get to the break / fail check state.

Near 1:1 of how it used to be. How AP has it, even, I think. I 'unno. I pulled the text and check from the old repo before positioning it elsewhere.

## Testing Evidence
<img width="474" height="42" alt="image" src="https://github.com/user-attachments/assets/feffb964-1545-4997-b194-53b52025072b" />

## Why It's Good For The Game
Actual broken mechanic. Next.