### PR TITLE
Attempts to fix one runtime related to books

### DIFF
--- a/code/modules/library/random_books.dm
+++ b/code/modules/library/random_books.dm
@@ -3,9 +3,6 @@
 
 /obj/item/book/manual/random/Initialize()
 	..()
-	var/static/banned_books = list(/obj/item/book/manual/random)
-	var/newtype = pick(subtypesof(/obj/item/book/manual) - banned_books)
-	new newtype(loc)
 	return INITIALIZE_HINT_QDEL
 
 /obj/item/book/random


### PR DESCRIPTION
## About The Pull Request

Basically, a runtime is happening because the game tries to turn a “random manual” into a real manual during world startup, but there are no real manuals available to choose from. The code asks BYOND to randomly pick one manual type, explicitly excluding the random placeholder itself, and ends up with an empty list.

## Testing Evidence

<img width="1080" height="508" alt="image" src="https://github.com/user-attachments/assets/147068db-e5bf-4fea-a8e1-ab0aee0070cb" />
## Why It's Good For The Game

Runtimes are bad, one less is good.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
