### PR TITLE
Fixes a runtime with the underworld lamp

### DIFF
--- a/code/modules/underworld/underworld.dm
+++ b/code/modules/underworld/underworld.dm
@@ -12,10 +12,9 @@
 /obj/item/flashlight/lantern/shrunken/update_brightness(mob/user = null)
 	if(on)
 		icon_state = "[initial(icon_state)]-on"
-		set_light(3, 3, 20, l_color = LIGHT_COLOR_BLOOD_MAGIC)
 	else
 		icon_state = initial(icon_state)
-		set_light(0)
+	set_light_on(on)
 
 /obj/structure/underworld/carriageman
 	name = "The Carriageman"


### PR DESCRIPTION
## About The Pull Request

The lamp was unnecessarily reapplying its light configuration instead of simply toggling emission, causing invalid light updates during initialization. The fix switches to set_light_on(), preserving existing light parameters and preventing the runtime.

## Testing Evidence

<img width="1365" height="767" alt="Screenshot 2026-01-11 215807" src="https://github.com/user-attachments/assets/ed683810-67ab-462b-8919-7dc01af42c07" />

## Why It's Good For The Game

Runtime bad

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
