### PR TITLE
Remove '+1 PER' from Combat Aware description as it is no longer true

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -173,7 +173,7 @@
 /datum/virtue/combat/combat_aware
 	name = "Combat Aware"
 	desc = "The opponent's flick of their wrist. The sound of maille snapping. The desperate breath as the opponent's stamina wanes. All of this is made more clear to you through intuition or experience."
-	custom_text = "Shows a lot more combat information via floating text. +1 PER. Has a toggle."
+	custom_text = "Shows a lot more combat information via floating text. Has a toggle."
 	added_traits = list(TRAIT_COMBAT_AWARE)
 
 /datum/virtue/combat/combat_aware/apply_to_human(mob/living/carbon/human/recipient)


### PR DESCRIPTION
## About The Pull Request

title

## Testing Evidence

changed a string of text

## Why It's Good For The Game

Whoops

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
