### PR TITLE
Another Druid resurrection spell change

### DIFF
--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -554,13 +554,11 @@
 	//Herbs that have to do with intelligence mostly. Easier to remember.
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/grown/manabloom = 3,
-        /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 3,
 		/obj/item/alch/mentha = 3,
 		/obj/item/reagent_containers/food/snacks/grown/rogue/swampweed = 3
 	)
 	alt_required_items = list(
 		/obj/item/reagent_containers/food/snacks/grown/manabloom = 3,
-        /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1,
 		/obj/item/reagent_containers/food/snacks/grown/rogue/swampweed = 1
 	)
 	debuff_type = /datum/status_effect/debuff/dendor_revival


### PR DESCRIPTION


## About The Pull Request
after feedback from fellow Dendorites it seems that Fyritius is too hard to grab for non druid followers. thus im gonna make this easier and just make it need 9 items at most. those being the mentha,swampweed and manabloom .
## Testing Evidence
so far so good as i tested the spell and it works but forgot to take screenshots.
## Why It's Good For The Game
Fyritius as much as it is useful for the church, doesnt change the fact its hard to get hold of one but also easily cultivated but then again after feedback, gonna reduce the cost of this spell to be easier for fellow dendorites.
