### PR TITLE
Removes Revenant Nobility and Resident Restriction

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dullahan/dullahan.dm
@@ -120,7 +120,7 @@
 		/datum/language/common,
 	)
 
-	restricted_virtues = list(/datum/virtue/utility/noble, /datum/virtue/utility/deathless, /datum/virtue/utility/resident)
+	restricted_virtues = list(/datum/virtue/utility/deathless)
 
 	stress_examine = TRUE
 	stress_desc = span_red("Accursed. I should keep my distance...")


### PR DESCRIPTION
## About The Pull Request
After the racism PR, revenants have access to towner and noble roles, so this is a leftover.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Just removes two trait restrictions from a list. Compiles.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Revenants can already play nobles and towners, so these restrictions dont apply in most cases outside of customization. Doesnt let them play royalty still, as was intended.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
