### PR TITLE
Fixes Witch's Bat Form Shapeshift

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -129,6 +129,30 @@
 	shifted_speed_increase = 0.75
 	show_true_name = FALSE
 
+/obj/effect/proc_holder/spell/targeted/shapeshift/bat/witch
+	name = "Bat Form"
+	overlay_state = "bat_transform"
+	knockout_on_death = 15 SECONDS
+	shifted_speed_increase = 0.75
+	show_true_name = FALSE
+	desc = ""
+	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/witch
+	show_true_name = FALSE
+
+/mob/living/simple_animal/hostile/retaliate/bat/witch
+	name = "bat"
+	desc = ""
+	icon_state = "bat"
+	icon_living = "bat"
+	icon_dead = "bat_dead"
+	icon_gib = "bat_dead"
+	speak_emote = list("squeak")
+	base_intents = list(/datum/intent/unarmed/help)
+	harm_intent_damage = 0
+	melee_damage_lower = 0
+	melee_damage_upper = 0
+	fly_time = 3 SECONDS
+
 /obj/effect/proc_holder/spell/targeted/shapeshift/cat
 	name = "Cat Form"
 	desc = ""


### PR DESCRIPTION
## About The Pull Request
The bat form option actually didnt have a pre-defined shape, so it used the parent spell's list of shapes to pick from- Of which were some things that were not just unintended, but somewhat strong
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles, ran on a debug server and it does exactly what it does for zad form.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bug fixes :>
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
