### PR TITLE
Harpy Customization Fixes and Adds

### DIFF
--- a/code/modules/client/customizer/customizers/organ/wings.dm
+++ b/code/modules/client/customizer/customizers/organ/wings.dm
@@ -121,6 +121,9 @@
 	name = "Harpy Wings"
 	organ_type = /obj/item/organ/wings/harpy
 	sprite_accessories = list(
+		/datum/sprite_accessory/wings/wide/harpywings,
+		/datum/sprite_accessory/wings/wide/harpywingsalt1,
+		/datum/sprite_accessory/wings/wide/harpywingsalt2,
 		/datum/sprite_accessory/wings/wide/harpywings_top,
 		/datum/sprite_accessory/wings/wide/harpywingsalt1_top,
 		/datum/sprite_accessory/wings/wide/harpywingsalt2_top,
@@ -130,4 +133,8 @@
 		/datum/sprite_accessory/wings/large/harpyfolded,
 		/datum/sprite_accessory/wings/large/harpyowl,
 		/datum/sprite_accessory/wings/large/harpybat_alt,
+		/datum/sprite_accessory/wings/feathery,
+		/datum/sprite_accessory/wings/featheryv2,
+		/datum/sprite_accessory/wings/huge/angel,
+
 	)

--- a/code/modules/mob/living/carbon/human/species_types/furry/harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/harpy.dm
@@ -117,12 +117,13 @@
 		/datum/body_marking/bun,
 	)
 	descriptor_choices = list(
+		/datum/descriptor_choice/trait,
+		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/height,
 		/datum/descriptor_choice/body,
-		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/face,
 		/datum/descriptor_choice/face_exp,
-		/datum/descriptor_choice/skin_harpy,
+		/datum/descriptor_choice/skin_all,
 		/datum/descriptor_choice/voice,
 		/datum/descriptor_choice/prominent_one_wild,
 		/datum/descriptor_choice/prominent_two_wild,


### PR DESCRIPTION
## About The Pull Request
Fixes the invisible descriptors for harpies and adds the other harpy wing types as well as other feathered fings.

The issue in question was if you had descriptors set up it would just show as " Man/Woman" or similar. This fixes that, and gives access to the rest of the descriptors.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles, the descriptors work as desired, and the wings are present in customization.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
QoL customization, and also fixes a slightly ugly issue.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
