### PR TITLE
Curtain Crafting Over Windows + Ignoredensity Variable

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -246,7 +246,7 @@
 				continue
 			if(R.structurecraft && istype(S, R.structurecraft))
 				continue
-			if(S.density)
+			if(S.density && !R.ignoredensity)
 				to_chat(user, span_warning("Something is in the way."))
 				return
 		for(var/obj/machinery/M in T)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -25,6 +25,7 @@
 	var/buildsame = FALSE //allows palisades to be built on top of each other just not the same dir
 	var/wallcraft = FALSE
 	var/diagonal = FALSE //allows diagonal structures to have their direction chosen.
+	var/ignoredensity = FALSE //if TRUE, allows crafting on top of dense structures (for curtains on walls/windows)
 	var/craftdiff = 1
 	var/sellprice = 0
 	/// Whether this recipe will be hidden from recipe books

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -1009,48 +1009,56 @@
 	result = /obj/structure/curtain
 	reqs = list(/obj/item/natural/cloth = 2)
 	craftdiff = 0
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtainblack
 	name = "curtain(black)"
 	result = /obj/structure/curtain/black
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtainblue
 	name = "curtain(blue)"
 	result = /obj/structure/curtain/blue
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtainbrown
 	name = "curtain(brown)"
 	result = /obj/structure/curtain/brown
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtaingreen
 	name = "curtain(green)"
 	result = /obj/structure/curtain/green
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtainmagenta
 	name = "curtain(magenta)"
 	result = /obj/structure/curtain/magenta
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtainpurple
 	name = "curtain(purple)"
 	result = /obj/structure/curtain/purple
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/curtainred
 	name = "curtain(red)"
 	result = /obj/structure/curtain/red
 	reqs = list(/obj/item/natural/cloth = 2, /obj/item/natural/silk= 1 )
 	craftdiff = 3
+	ignoredensity = TRUE
 
 /datum/crafting_recipe/roguetown/structure/apiary
 	name = "apiary"


### PR DESCRIPTION
## About The Pull Request
PORTS: https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1670

But this time the code base lacked ignoredensity so I added it as a variable. Curtains should be craftable over windows now, but not things like drying racks, and walls it's in front.

## Testing Evidence
<img width="1023" height="837" alt="curtain" src="https://github.com/user-attachments/assets/f99c6ba5-1eed-43a7-b3eb-733e114194cd" />

## Why It's Good For The Game
I use this way too much for decorating my towner house. You should too!
