### PR TITLE
removes recipe books from adv spawn

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -58,7 +58,6 @@
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/reagent_containers/food/snacks/rogue/meat/salami = 1,
 		/obj/item/reagent_containers/food/snacks/rogue/bread = 1,
 		/obj/item/reagent_containers/glass/bottle/rogue/beer = 1, //Plays into the classic stereotype of beer-loving monks and well-stocked pilgrims.
@@ -226,7 +225,6 @@
 	gloves = /obj/item/clothing/gloves/roguetown/chain
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch/metal = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		)
 	H.cmode_music = 'sound/music/cmode/church/combat_reckoning.ogg'
@@ -429,7 +427,6 @@
 	I.grant_inspiration(H, bard_tier = BARD_T2)
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	H.cmode_music = 'sound/music/cmode/church/combat_reckoning.ogg'
@@ -573,7 +570,6 @@
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/flashlight/flare/torch = 1,
-		/obj/item/recipe_book/survival = 1,
 		)
 	H.cmode_music = 'sound/music/cmode/church/combat_reckoning.ogg'
 	switch(H.patron?.type)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/eastern.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/eastern.dm
@@ -38,7 +38,6 @@
 	belt = /obj/item/storage/belt/rogue/leather/black
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/flashlight/flare/torch/lantern,
 		)
 	H.set_blindness(0)
@@ -95,7 +94,6 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/bomb/smoke = 3,
 		)
 	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/kazengun

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/naledi.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/naledi.dm
@@ -38,5 +38,4 @@
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	head = /obj/item/clothing/head/roguetown/roguehood/shalal/hijab/black
 	beltr = /obj/item/flashlight/flare/torch/lantern
-	backpack_contents = list(/obj/item/recipe_book/survival = 1,
-						/obj/item/rogueweapon/huntingknife = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/otava.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/otava.dm
@@ -41,5 +41,4 @@
 	head = /obj/item/clothing/head/roguetown/roguehood/psydon
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	beltl = /obj/item/rogueweapon/whip
-	backpack_contents = list(/obj/item/recipe_book/survival = 1,
-						/obj/item/rogueweapon/huntingknife = 1)
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/slavers.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/slavers.dm
@@ -46,7 +46,6 @@
 	beltr = /obj/item/rogueweapon/sword/long/shotel
 	backpack_contents = list(/obj/item/rope/chain = 2,
 							/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-							/obj/item/recipe_book/survival = 1,
 							/obj/item/rogueweapon/huntingknife = 1)
 
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/zybantu.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/zybantu.dm
@@ -51,8 +51,7 @@
 	cloak = /obj/item/clothing/cloak/cape/nomad
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	beltr = /obj/item/reagent_containers/glass/bottle/waterskin
-	backpack_contents = list(/obj/item/recipe_book/survival = 1,
-							/obj/item/rogueweapon/huntingknife = 1,
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife = 1,
 							/obj/item/rogueweapon/scabbard/sheath = 1)
 
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -44,7 +44,6 @@
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/spellbook_unfinished/pre_arcyne = 1,
 		/obj/item/roguegem/amethyst = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/recipe_book/magic = 1,
 		/obj/item/chalk = 1
@@ -94,7 +93,7 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
-	backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/recipe_book/survival = 1)
+	backpack_contents = list(/obj/item/flashlight/flare/torch = 1,)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/airblade)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
@@ -184,7 +183,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
 	beltr = /obj/item/rogueweapon/scabbard/sword
 	r_hand = /obj/item/rogueweapon/sword/sabre
-	backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/recipe_book/survival = 1)
+	backpack_contents = list(/obj/item/flashlight/flare/torch = 1)
 	var/datum/inspiration/I = new /datum/inspiration(H)
 	I.grant_inspiration(H, bard_tier = BARD_T2)
 	if(H.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -46,7 +46,7 @@
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/purple
 		cloak = /obj/item/clothing/cloak/raincloak/purple
-	backpack_contents = list(/obj/item/recipe_book/survival = 1) // Someone gonna argue it is sovlful to not have this but whatever
+	// backpack_contents = list(/obj/item/recipe_book/survival = 1)//superceded by tgui
 	var/turf/TU = get_turf(H)
 	if(TU)
 		new /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame/saddled(TU)
@@ -121,7 +121,6 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-		/obj/item/recipe_book/survival = 1,
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	var/turf/TU = get_turf(H)
@@ -202,7 +201,7 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backr = /obj/item/storage/backpack/rogue/satchel
-	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/armor_brush = 1, /obj/item/polishing_cream = 1, /obj/item/rogueweapon/hammer/iron = 1, /obj/item/recipe_book/survival = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/rogueweapon/scabbard/sheath = 1)
+	backpack_contents = list(/obj/item/storage/belt/rogue/pouch/coins/poor = 1, /obj/item/armor_brush = 1, /obj/item/polishing_cream = 1, /obj/item/rogueweapon/hammer/iron = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/rogueweapon/scabbard/sheath = 1)
 	if(H.mind)
 		var/armors = list("Light Armor","Medium Armor")
 		var/armor_choice = input(H, "Choose your armor.", "HOW WILL YOU LOOK WHEN YOU DIE") as anything in armors

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -50,7 +50,6 @@
 	backpack_contents = list(
 		/obj/item/bait = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	if(H.mind)
@@ -112,7 +111,6 @@
 	backr = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	H.set_blindness(0)
@@ -158,7 +156,6 @@
 	backpack_contents = list(
 		/obj/item/bomb = 4,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	H.set_blindness(0)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/rogue.dm
@@ -50,7 +50,6 @@
 	backpack_contents = list(
 		/obj/item/lockpick = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	if(H.mind)
@@ -117,7 +116,6 @@
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
 		/obj/item/lockpickring/mundane = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 
@@ -165,7 +163,6 @@
 	cloak = /obj/item/clothing/cloak/half/red
 	backpack_contents = list(
 		/obj/item/lockpick = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	var/datum/inspiration/I = new /datum/inspiration(H)
@@ -246,6 +243,5 @@
 		/obj/item/bomb = 1,
 		/obj/item/lockpick = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -102,7 +102,6 @@
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 
@@ -163,7 +162,6 @@
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 
@@ -252,7 +250,6 @@
 		backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/rogueweapon/huntingknife/bronze = 1,
@@ -327,7 +324,6 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-		/obj/item/recipe_book/survival = 1,
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	H.set_blindness(0)
@@ -523,7 +519,6 @@
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	backpack_contents = list(
 		/obj/item/flashlight/flare/torch/metal = 1,
-		/obj/item/recipe_book/survival = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/rogueweapon/huntingknife = 1, //Ensures that Exorcists who take the Shovel can still butcher wildlife. Minor oversight on my part.


### PR DESCRIPTION
## About The Pull Request

Removes the survival handbook from the backpack contents of adventurers.
I've left the other handbooks around for now because they are at least a bit more flavourful. Could probably also remove those too if people think it's a good idea.

## Testing Evidence
<img width="2084" height="960" alt="image" src="https://github.com/user-attachments/assets/12561899-5b09-4f95-bfcf-7753815279cd" />

## Why It's Good For The Game
<img width="1370" height="1365" alt="image" src="https://github.com/user-attachments/assets/7302b285-efac-4801-be21-210b4358eceb" />

These are made redundant by TGUI and just clutter the inventory unnecessarily.