### PR TITLE
Brings Arcyne Barrier AC In Line With All Summoned Armor Barriers

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_barrier.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_barrier.dm
@@ -51,7 +51,7 @@
 	sleeved = null
 	boobed = FALSE
 	flags_inv = null
-	armor_class = ARMOR_CLASS_LIGHT
+	armor_class = ARMOR_CLASS_NONE
 	blade_dulling = DULLING_BASHCHOP
 	blocksound = PLATEHIT
 	armor = ARMOR_BARRIER//20 across the board, except fire and acid, get 30.


### PR DESCRIPTION
## About The Pull Request
Title
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Variable change, it compiles
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Conjure armor and dragonhide both have armor_class_none, I just missed this one
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
