### PR TITLE
Dirt Digging QoL

### DIFF
--- a/code/game/turfs/open/floor/roguefloor.dm
+++ b/code/game/turfs/open/floor/roguefloor.dm
@@ -543,6 +543,30 @@
 			qdel(I)
 	.=..()
 
+/turf/open/floor/rogue/dirt/MiddleClick(mob/user, params)
+	. = ..()
+	if(!isliving(user))
+		return
+	
+	var/mob/living/L = user
+	if(L.stat != CONSCIOUS)
+		return
+	
+	// Check if the user is holding a shovel
+	var/obj/item/rogueweapon/shovel/S = L.get_active_held_item()
+	if(!istype(S))
+		return
+	
+	// Check if in scoop intent
+	if(L.used_intent.type != /datum/intent/shovelscoop)
+		return
+	
+	// Call the shovel's autodig proc
+	if(S.start_autodig(L, src))
+		return TRUE
+	
+	return FALSE
+
 /turf/open/floor/rogue/dirt/Destroy()
 	if(holie)
 		QDEL_NULL(holie)

--- a/code/modules/roguetown/roguejobs/gravedigger/tools.dm
+++ b/code/modules/roguetown/roguejobs/gravedigger/tools.dm
@@ -64,7 +64,6 @@
 	if(user.used_intent.type == /datum/intent/shovelscoop)
 		if(istype(T, /turf/open/floor/rogue/dirt))
 			var/turf/open/floor/rogue/dirt/D = T
-			var/start_digging = !heldclod && !D.holie // Check if we should start the digging loop
 			
 			if(heldclod)
 				if(D.holie && D.holie.stage < 4)
@@ -90,43 +89,6 @@
 					heldclod = new(src)
 					playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
 					update_icon()
-				
-				// Start continuous digging loop
-				if(start_digging && heldclod)
-					user.visible_message(span_notice("[user] begins digging on [T]..."))
-					while(do_after(user, 1 SECONDS, target = T))
-						D = get_turf(T)
-						if(!(istype(D, /turf/open/floor/rogue/dirt)))
-							break
-						if(!(user.mobility_flags & MOBILITY_STAND))
-							to_chat(user, span_warning("You are knocked down and stop digging."))
-							break
-						
-						user.changeNext_move(user.used_intent.clickcd)
-						if(max_blade_int)
-							remove_bintegrity(2)
-						
-						// Fill the hole with the clod we have
-						if(heldclod && D.holie)
-							D.holie.attackby(src, user)
-							playsound(D,'sound/items/empty_shovel.ogg', 100, TRUE)
-						
-						// Dig a new hole on the same tile
-						D = get_turf(T)
-						if(istype(D, /turf/open/floor/rogue/dirt))
-							if(!D.holie)  // Only dig if there's no existing hole
-								if(istype(D, /turf/open/floor/rogue/dirt/road))
-									new /obj/structure/closet/dirthole(D)
-								else
-									D.ChangeTurf(/turf/open/floor/rogue/dirt/road, flags = CHANGETURF_INHERIT_AIR)
-								if(!heldclod)
-									heldclod = new(src)
-								playsound(D,'sound/items/dig_shovel.ogg', 100, TRUE)
-								update_icon()
-							else
-								break  // Something went wrong, exit loop
-						else
-							break
 			return
 		if(heldclod)
 			if(istype(T, /turf/open/water))
@@ -143,6 +105,64 @@
 			return
 		return
 	. = ..()
+
+/obj/item/rogueweapon/shovel/proc/start_autodig(mob/living/L, turf/T)
+	if(!isliving(L) || !istype(T, /turf/open/floor/rogue/dirt))
+		return FALSE
+	
+	var/turf/open/floor/rogue/dirt/D = T
+	var/start_digging = !heldclod && !D.holie
+	
+	if(!start_digging)
+		return FALSE
+	
+	L.visible_message(span_notice("[L] begins digging on [T]..."))
+	// Do the first dig
+	if(!heldclod)
+		if(istype(T, /turf/open/floor/rogue/dirt/road))
+			new /obj/structure/closet/dirthole(T)
+		else
+			T.ChangeTurf(/turf/open/floor/rogue/dirt/road, flags = CHANGETURF_INHERIT_AIR)
+		heldclod = new(src)
+		playsound(T,'sound/items/dig_shovel.ogg', 100, TRUE)
+		update_icon()
+	
+	// Start the continuous loop
+	while(do_after(L, 1 SECONDS, target = T))
+		D = get_turf(T)
+		if(!(istype(D, /turf/open/floor/rogue/dirt)))
+			break
+		if(!(L.mobility_flags & MOBILITY_STAND))
+			to_chat(L, span_warning("You are knocked down and stop digging."))
+			break
+		
+		L.changeNext_move(L.used_intent.clickcd)
+		if(max_blade_int)
+			remove_bintegrity(2)
+		
+		// Fill the hole with the clod we have
+		if(heldclod && D.holie)
+			D.holie.attackby(src, L)
+			playsound(D,'sound/items/empty_shovel.ogg', 100, TRUE)
+		
+		// Dig a new hole on the same tile
+		D = get_turf(T)
+		if(istype(D, /turf/open/floor/rogue/dirt))
+			if(!D.holie)  // Only dig if there's no existing hole
+				if(istype(D, /turf/open/floor/rogue/dirt/road))
+					new /obj/structure/closet/dirthole(D)
+				else
+					D.ChangeTurf(/turf/open/floor/rogue/dirt/road, flags = CHANGETURF_INHERIT_AIR)
+				if(!heldclod)
+					heldclod = new(src)
+				playsound(D,'sound/items/dig_shovel.ogg', 100, TRUE)
+				update_icon()
+			else
+				break
+		else
+			break
+	
+	return TRUE
 
 /obj/item/rogueweapon/shovel/getonmobprop(tag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Adds a do_after for digging on muddy and regular tiles. You can trigger it by middle clicking a dirt or mud tile that has no hole!

## Testing Evidence
<img width="285" height="214" alt="dig" src="https://github.com/user-attachments/assets/78da64b5-590f-4214-90d9-50c13a1ba657" />

## Why It's Good For The Game
I am a fisher and I am digging a hole. Diggy, diggy hole... Okay but seriously I'm tired of spam clicking holes to get bait and rocks/clay. And if you're a grave digger you can sidestep to stop the process and dig a pit as usual. Everyone wins.
