### PR TITLE
Nutcracker Grammar Fix + Gulp Text Ambiguation 

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -290,7 +290,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_BEAUTIFUL_UNCANNY = span_info("<i>Some</i> would say my visage is an artwork created by the gods themselves; the others call me an unsettling abomination."),
 	TRAIT_BAD_MOOD = span_warning("Everything just seems to piss me off"),
 	TRAIT_LEAPER = "I can leap like a frog, landing where I want.",
-	TRAIT_NUTCRACKER = "I love kicking idiots on the nuts!",
+	TRAIT_NUTCRACKER = "I love kicking idiots in the nuts!",
 	TRAIT_SEEPRICES = "I can tell the prices of things down to the zenny.",
 	TRAIT_SEEPRICES_SHITTY = "I can tell the prices of things... <i>Kind of</i>.",
 	TRAIT_STRONGBITE = span_info("Stronger bites, critical bite attacks."),

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -1935,7 +1935,7 @@
 /datum/emote/living/gulp
 	key = "gulp"
 	key_third_person = "gulps"
-	message = "gulps nervously."
+	message = "gulps."
 	emote_type = EMOTE_AUDIBLE
 	show_runechat = TRUE
 


### PR DESCRIPTION
## About The Pull Request
- Makes 'kicking on the nuts' into 'kicking in the nuts'.
- Changes 'gulps nervously' to just 'gulps'.

## Testing Evidence
2 lines of code change. I made sure it ran regardless.

## Why It's Good For The Game
I changed these things a long time ago on SR and these grammar mistakes bother me. Also I don't just use the gulping emote for being nervous but for ERP reasons too.