### PR TITLE
Updates SR Witch Transformation

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -162,6 +162,8 @@
 	shapeshift_type = /mob/living/simple_animal/pet/cat/witch_shifted
 	convert_damage = FALSE
 	do_gib = FALSE
+	shifted_speed_increase = 1.35
+	show_true_name = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/cat/black
 	shapeshift_type = /mob/living/simple_animal/pet/cat/rogue/black/witch_shifted
@@ -179,6 +181,7 @@
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/rogue/wolf/witch_shifted
 	convert_damage = FALSE
 	do_gib = FALSE
+	show_true_name = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/witch_shifted
 	name = "lesser volf"
@@ -226,7 +229,9 @@
 	die_with_shapeshifted_form =  FALSE
 	do_gib = FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat
-	knockout_on_death = 30 SECONDS
+	knockout_on_death = 15 SECONDS
+	shifted_speed_increase = 0.75 //25% slower than normal walking speed
+	show_true_name = FALSE
 
 /obj/effect/proc_holder/spell/targeted/shapeshift/witch/crow
 	name = "Zad Form"
@@ -239,5 +244,7 @@
 	die_with_shapeshifted_form =  FALSE
 	do_gib = FALSE
 	knockout_on_death = 15 SECONDS
+	shifted_speed_increase = 0.75 //25% slower than normal walking speed
+	show_true_name = FALSE
 	shapeshift_type = /mob/living/simple_animal/hostile/retaliate/bat/crow
 	sound = 'sound/vo/mobs/bird/birdfly.ogg'


### PR DESCRIPTION
## About The Pull Request
The port of SR's witch transformation change at https://github.com/Rotwood-Vale/Ratwood-2.0/pull/270 wasnt the whole port and had some missing balancing
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="932" height="717" alt="image" src="https://github.com/user-attachments/assets/62198fb1-8eac-4951-bea0-3b1485033098" />
<img width="1251" height="774" alt="image" src="https://github.com/user-attachments/assets/49ab9106-f14d-4ac2-8eb8-38cf4540af11" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Adds in the transformation announcement that was missing, gives the transform and revert form processes a multi second CD. Its just more polish, and completes what was already approved with the initial PR.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
