### PR TITLE
Adventure + Wretch max

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = PEASANTS
 	faction = "Station"
-	total_positions = 20
-	spawn_positions = 20
+	total_positions = 40
+	spawn_positions = 40
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Hero of nothing, a wanderer in foreign lands in search of fame and riches. Whatever led you to this fate is up to the wind to decide, and you've never fancied yourself for much other than the thrill. Some day your pride is going to catch up to you, and you're going to find out why most men don't end up in the annals of history."
 	class_categories = TRUE

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -100,8 +100,8 @@
 		var/extra = floor((player_count - 40) / 10)
 		slots += extra
 
-	//5 slots minimum, 10 maximum.
-	slots = min(slots, 10)
+	//5 slots minimum, 15 maximum.
+	slots = min(slots, 15)
 
 	wretch_job.total_positions = slots
 	wretch_job.spawn_positions = slots


### PR DESCRIPTION
## About The Pull Request
+ Increase the pop for adventures to 40
+ Makes the max to 15 for wretches, while they use the same 10 players to one wretch, scaling
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
N/A
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The adventures are pretty much the default "class" that people can play, joining and seeing every role being taken, with max adventures usually leads with the player saying "fuck it" and doing something else.

I think the scaling is fine with the wretches, so we do not have to worry about more wretch slots being added.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
