### PR TITLE
fix: unable to spawn with silver belt as character with silver weakness

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -176,6 +176,9 @@
 /datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	pre_equip(H, visualsOnly)
 
+	// Replace silver items with non-silver alternatives for characters with silver weakness
+	handle_silver_weakness(H)
+
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)
 		H.equip_to_slot_or_del(new pants(H),SLOT_PANTS, TRUE)
@@ -276,6 +279,19 @@
 
 	H.update_body()
 	return TRUE
+
+
+/datum/outfit/proc/handle_silver_weakness(mob/living/carbon/human/H)
+	if(!H || !HAS_TRAIT(H, TRAIT_SILVER_WEAK))
+		return
+	
+	if(belt)
+		var/obj/item/checked_belt = new belt()
+		var/is_silver_belt = (checked_belt.is_silver || checked_belt.smeltresult == /obj/item/ingot/silver)
+		qdel(checked_belt)
+		
+		if(is_silver_belt)
+			belt = /obj/item/storage/belt/rogue/leather/black
 
 /datum/outfit/proc/move_storage(obj/item/new_item, turf/T)
 	if(new_item.forceMove(T))


### PR DESCRIPTION
## About The Pull Request

This PR fixes #598 which prevents characters with silver belt from spawning if they have silver weakness (this will not validate other items such as necklaces, rings, armor and etc...)

## Testing Evidence

<img width="594" height="533" alt="image" src="https://github.com/user-attachments/assets/7dabb0c6-e387-46e4-9614-27e6cc0c4a37" />

### Spawned as Court Magician, replaced the usual belt with black belt with all items.

## Why It's Good For The Game

It fixes a small oversight which often required admin intervention