### PR TITLE
Jester Loadout Adjustments

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -30,8 +30,8 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	backr = /obj/item/rogue/instrument/trumpet
 	belt = /obj/item/storage/belt/rogue/leather/black
-	beltr = /obj/item/rogue/instrument/drum
-	beltl = /obj/item/storage/belt/rogue/pouch
+	beltr = /obj/item/storage/belt/rogue/pouch
+	beltl = /obj/item/rogue/instrument/drum
 	head = /obj/item/clothing/head/roguetown/jester
 	neck = /obj/item/clothing/neck/roguetown/coif
 	backpack_contents = list(/obj/item/storage/keyring/servant)


### PR DESCRIPTION
## About The Pull Request
Adds the following to the jester's loadout:
- Satchel on back (with keyring in the satchel).
- Trumpet on back.
- Drums on hips.

## Testing Evidence
<img width="949" height="323" alt="Jester" src="https://github.com/user-attachments/assets/e65d1af1-a8f9-48db-bc4f-6ab817d9caf4" />

## Why It's Good For The Game
I tried out jester for the first time in a long while. Not having a satchel sucked, and I'm not sure why they didn't get one as every other role does. And they start out with no coins so they can't really buy any other instruments if they wanted without well, stealing or whatever. I was thinking of adding a poor pouch to them but I'll let them stay poorer for now to encourage thieving for that coin.

Also, we got several new instruments, and the jester quarters has no trumpet which is often used in court stuff... plus the drums complete the fit and gives them more options as the court's entertainer.
