### PR TITLE
Adds dropshrink and offsets to a few items

### DIFF
--- a/code/game/objects/items/rogueitems/parasols.dm
+++ b/code/game/objects/items/rogueitems/parasols.dm
@@ -19,6 +19,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	grid_width = 32
 	grid_height = 64
+	dropshrink = 0.8
 
 /obj/item/rogueweapon/mace/parasol/New()
 	..()
@@ -40,6 +41,9 @@
 	sellprice = 45 // Takes master sewing and silk to create
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
+	pixel_x = -16
+	pixel_y = -16
+	dropshrink = 0.8
 
 /obj/item/rogueweapon/mace/parasol/noble/New()
 	..()

--- a/code/game/objects/items/smokebox.dm
+++ b/code/game/objects/items/smokebox.dm
@@ -5,6 +5,7 @@
 	icon_state = "smokebox"
 	item_state = "smokebox"
 	icon_type = "smoke"
+	dropshrink = 0.7
 
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0


### PR DESCRIPTION
## About The Pull Request

Adds dropshrink to parasols and shhig boxes, as well as adjusting the offset on the noble parasol so that it's placed in the middle of the square instead of the top right corner

## Testing Evidence

<img width="431" height="449" alt="image" src="https://github.com/user-attachments/assets/e684e25a-7feb-4709-942a-c78f90fb34f9" />

## Why It's Good For The Game

Better visuals, less clutter.