### PR TITLE
[PORT] Ropes and Helping Hands for climbing

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -222,3 +222,27 @@
 		if(EAST)
 			pixel_x = 4
 	. = ..()
+
+/obj/structure/rope_ladder
+	name = "rope"
+	desc = "A length of rope that has been lowered against a surface to allow climbing."
+	icon = 'icons/roguetown/misc/structure.dmi'
+	icon_state = "pillar"
+	anchored = TRUE
+	obj_flags = BLOCK_Z_OUT_DOWN
+	max_integrity = 50
+	blade_dulling = DULLING_BASHCHOP
+
+
+/obj/structure/rope_ladder/MouseDrop(atom/over)
+	if(usr != over)
+		return ..()
+	var/mob/living/living_user = usr
+	if(!Adjacent(living_user))
+		return
+	living_user.visible_message(span_notice("[living_user] begins removing the rope ladder from the wall..."), span_notice("You begin removing the rope ladder from the wall..."))
+	if(do_after(living_user, 5 SECONDS, TRUE, src))
+		var/obj/item/rope/rope = new(src.loc)
+		living_user.put_in_hands(rope)
+		living_user.visible_message(span_notice("[living_user] removes the rope ladder from the wall."), span_notice("You remove the rope ladder from the wall."))
+		qdel(src)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -277,6 +277,34 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 
 /turf/open/transparent/openspace/attackby(obj/item/C, mob/user, params)
 	..()
+	if(C.type == /obj/item/rope && isliving(user))
+		var/mob/living/living_user = user
+		living_user.visible_message(span_notice("[living_user] begins to lay down a rope for climbing..."), span_notice("I begin to lay down a rope for climbing..."))
+		if(do_after(living_user, 3 SECONDS, TRUE, target = src))
+			var/turf/target = get_step_multiz(src, DOWN)
+			if(!target)
+				to_chat(living_user, span_warning("There's nowhere to tie the rope here."))
+				return
+			var/obj/structure/rope_ladder/rope = new(target)
+			if(living_user.wallpressed)
+				rope.dir = living_user.dir
+			else
+				rope.dir = get_dir(src, living_user)
+				if(!(rope.dir in GLOB.cardinals))
+					rope.dir = living_user.dir
+			switch(rope.dir)
+				if(NORTH)
+					rope.pixel_y = 20
+				if(SOUTH)
+					rope.layer = ABOVE_MOB_LAYER
+				if(WEST)
+					rope.pixel_x = -12
+				if(EAST)
+					rope.pixel_x = 12
+			living_user.visible_message(span_notice("[living_user] secures the rope to the surface below."), span_notice("I secure the rope to the surface below."))
+			playsound(living_user, 'sound/foley/trap.ogg', 100, TRUE)
+			qdel(C)
+		return
 	if(!CanBuildHere())
 		return
 


### PR DESCRIPTION
## About The Pull Request
Ports rope climbing and helping hands
from https://github.com/Azure-Peak/Azure-Peak/pull/5265
"You can now lower a rope to help someone below you climb. This works similarly to a rope ladder. Click on an open turf from above to lay down the rope. Drag the rope onto yourself to retrieve it. (+5 climbing skill)
Standing atop a tamed animal now gives you the same climbing bonus as standing on a table or a chair. (+1 climbing skill)
Having another human in your turf, with combat mode disabled, will also give you a climbing boost. (+1 climbing skill)"

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
having ropes that you can drop down to let others climb up, as well as being able to boost someone up is a nice feature for movement to have within the game.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
