### PR TITLE
Adds Woodwalker to Ranger Wardens

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/bogguard.dm
@@ -46,7 +46,7 @@
 	tutorial = "You are a ranger, a hunter who volunteered to become a part of the wardens. You have great experience using bows."
 	outfit = /datum/outfit/job/roguetown/bogguardsman/ranger
 	category_tags = list(CTAG_WARDEN)
-	traits_applied = list(TRAIT_DODGEEXPERT)
+	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_WOODWALKER)//Adding woodwalker to rangers. Fits that they should be able to move through the treetops easier
 	subclass_stats = list(
 		STATKEY_PER = 2,//7 points weighted, same as MAA. They get temp buffs in the woods instead of in the city.
 		STATKEY_SPD = 2,


### PR DESCRIPTION
## About The Pull Request

Super basic, just grants the Warden Ranger Subclass the Woodwalker Trait.

## Testing Evidence

Tested on local build, compiles and runs as expected. 
<img width="600" height="160" alt="image" src="https://github.com/user-attachments/assets/c18b346b-c9d3-467a-b527-5bccb0105b2f" />
<img width="815" height="359" alt="image" src="https://github.com/user-attachments/assets/f2b300c3-ef6e-434f-877d-12a45dcb6f50" />


## Why It's Good For The Game

I think rangers should be able to do this, allows them to stay above fights and move through dense tree canopies to shoot down from above. 

(Yes this was in SR, but I think it's both thematic and fun)

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
