### PR TITLE
The Stairs Ascend: Stair QoL + Stamina Cost

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -152,11 +152,11 @@
 			while(P.pulling && isliving(P.pulling))
 				was_pulled_buckled = FALSE
 				pulling = P.pulling
+				if(pulling in P.buckled_mobs)
+					was_pulled_buckled = TRUE
 				P.stop_pulling()
 				pulling.forceMove(newtarg)
 				P.start_pulling(pulling, supress_message = TRUE)
-				if(pulling in P.buckled_mobs)
-					was_pulled_buckled = TRUE
 				if(was_pulled_buckled) // Assume this was a fireman carry since piggybacking is not a thing
 					P.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)
 				if(isliving(pulling))


### PR DESCRIPTION
## About The Pull Request

Stairs now cost a little bit of stamina when going UP, not down. Costs more when lying down.
Ladders are also affected.

No, you can't drain stamina from someone by dragging them up stairs / ladders.

Chain grabbed mobs now retain their grabbed mob / object as well.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Went to a staircase by the rockhill bridge (Low-town to regular town) and observed stamina cost.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

No more stair cheese / Z-level change spam.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
![kung-fu-panda](https://github.com/user-attachments/assets/a6ab2d57-3adf-41dd-97e9-eaf56f6b8661)

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
