### PR TITLE
Grenzel Boots for All Races

### DIFF
--- a/code/modules/clothing/rogueclothes/feet.dm
+++ b/code/modules/clothing/rogueclothes/feet.dm
@@ -252,7 +252,6 @@
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_TWIST)
 	armor = ARMOR_LEATHER_GOOD
-	allowed_race = NON_DWARVEN_RACE_TYPES
 	salvage_amount = 1
 	salvage_result = /obj/item/natural/hide/cured
 	sewrepair = TRUE


### PR DESCRIPTION
## About The Pull Request

Allows everyone to wear Grenzelhoft Boots. Previously Race locked to Non-Dwarven Races (whatever that means in the code xd)

## Testing Evidence

OMG DWARF GRENZEL????
<img width="70" height="93" alt="image" src="https://github.com/user-attachments/assets/b6f01dbc-1553-4c8b-b05c-aa72794d34bc" />


## Why It's Good For The Game

WHY WAS GRENZELHOFT RACELOCKED (Probably AP Lore)