### PR TITLE
Acolytes Polearms skill Restoration

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -66,6 +66,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request

Acolytes. 0 Polearms -> 2 Polearms. Staves skill left at 2.

## Testing Evidence

<img width="1145" height="494" alt="dreamseeker_2026-01-23_00-10-18" src="https://github.com/user-attachments/assets/61497980-a0f4-43e2-8e2b-0cc493e496e3" />

## Why It's Good For The Game

Acolytes were given staves skill because our rebase was based on a half-finished version of the 'staves' skill implementation where the actual 'wooden staff' item is still a polearm. The only weapon that are actually using the 'staves' skill are the wooden quarterstaff and its metal-reinforced variants.

I'd sooner just see staves skill removed from the game and rolled back into polearms, but giving them the opportunity to use both at apprentice without having to smack a dummy for 5 minutes is probably fine.

Also fits in with Rockhill's design- the church armory has spears and wooden staves inside, which are both Polearms. Basically the only way an Acolyte gets use out of their staves skill is going out of their way to get one of these weird and difficult-to-create staff items that are for some reason different from our regular staff item that already exists.

I've seen some Acolytes go out of their way to get these special better staves- if they still want to do that, I've left it as an option. But let's allow them to use the items they actually start with.

tl;dr They start with polearms, apprentice polearms will let them skip the grind of dummy training to be able to use it.