### PR TITLE
Leaves Layering Fix

### DIFF
--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -270,6 +270,7 @@
 	icon_state = "center-leaf1"
 	density = FALSE
 	max_integrity = 10
+	plane = FLOOR_PLANE
 
 /obj/structure/flora/newleaf/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR fixes a rendering bug that made leaves (such as from trees, or in the case of Rockhill, being used as decoration around the Druid's grove) rendering on a plane above items and some mobs, which made combat and stuff unwieldy. The "plane" value was not being set appropriately for leaves, now it is.

## Testing Evidence

Before: 
<img width="185" height="136" alt="dreamseeker_2026-01-23_03-22-39" src="https://github.com/user-attachments/assets/c896ef8c-9028-45c4-82ac-9dbd2078fc95" />

After: 
<img width="325" height="243" alt="dreamseeker_2026-01-23_03-42-08" src="https://github.com/user-attachments/assets/4322b58e-7a82-4b42-8817-5b43c901453e" />


## Why It's Good For The Game

Fixes a bug. No more dropping things in a tree/in the druid's grove and having to alt+click to find them. No more being unable to see mobs on the floor in the grove. Bugfixes good.