### PR TITLE
The Humble PR In question

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -4,8 +4,8 @@
 	flag = DRUID
 	department_flag = CHURCHMEN
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 6
+	spawn_positions = 6
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES


### PR DESCRIPTION
Increases slots from 4 to 6

## About The Pull Request

It increases the Druid slots. It was requested by some people in OOC-Chat, and I figured I could at least put it up.



## Why It's Good For The Game

People really like the Druid RP faction; or they absolutely feel they are overpowered - due to their capacity to mog, trick and stun. Things that make them natural pranksters and annoying to deal with menaces; when played by the LRP. It remains one of the few roles that have to police and often keep themselves to a higher quality; or else face public hate and balance changes. 

They have been some of the most unexpectedly helpful to the church during lowpop and highpop; as they tend to be first-responders or scouts across the map.

With the introduction of refugees from various servers - it has yet again started to be maxed out as people consider making new PC's to fill the roles left bare. 

I understand that dendor 'cantor' and dendor 'missionairy' exist - and that an unlimited amount of 'druids' could exist in any round if people wanted, but I acknowledge there is a desire to have this role increased for the Roleplay of being a druid. Yes. it can sometimes be as simple as people wanting the name to say 'druid' vs cantor, or missionary. 

(I've also considered just making a druid template cleric for adventurers; to rectify the confusion/issue. I dont think classes that can 'do everything' as a gimmick work very well for lore reasons.)

**The RP quality for Druids has been really amazing,** from what I have seen thusfar. I think 5-6 druid slots would be the final amount.

I feel that 5-6 slots simulates the maximum you can imagine for a grove of druids and the size of our maps; lending to them being a prominent aspect of the landscape. 

