### PR TITLE
Nerfs miner

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/miner.dm
@@ -46,7 +46,7 @@
 	backl = /obj/item/storage/backpack/rogue/backpack
 	backpack_contents = list(
 						/obj/item/flint = 1,
-						/obj/item/flashlight/flare/torch = 1,
+						/obj/item/flashlight/flare/torch/lantern = 1,
 						/obj/item/rogueweapon/chisel = 1,
 						/obj/item/rogueweapon/hammer/wood = 1,
 						/obj/item/recipe_book/survival = 1,


### PR DESCRIPTION
## About The Pull Request

Miners straight up had more stats than other towners, people realized that mining skill translated into iron warpick skill so the number of fragging miners has going up considerably, this PR removes the +2 con so they are a +5 towner instead of +7, you don't need con for mining. Also, this removes the secondary ore bag and gives them a lantern roundstart since they need light to use their superpower.

## Testing Evidence

<img width="272" height="349" alt="image" src="https://github.com/user-attachments/assets/64f6cf1e-8a12-43f3-8bc6-fda62f91615d" />

## Why It's Good For The Game

Honestly picking towners for frag potential is rather whack.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
