### PR TITLE
Changes Adv/Pilgrim weight to 20

### DIFF
--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -15,7 +15,7 @@
 	/// If defined, this is the maximum amount of times this wave can spawn
 	var/max_spawns = null
 	/// The relative probability this wave will be picked, from all available waves
-	var/weight = 100
+	var/weight = 20
 	/// Name of the latejoin spawn landmark for the wave to decide where to spawn
 	var/spawn_landmark = "Pilgrim"
 	/// Text to greet all players in the wave with


### PR DESCRIPTION
## About The Pull Request

Reduces Adventurer and Pilgrim Wave weight to 20 from 100. Kind of surprising it was set this high. 

## Testing Evidence

<img width="470" height="411" alt="image" src="https://github.com/user-attachments/assets/aac95eea-9da6-407f-ae60-f01229561ff7" />

## Why It's Good For The Game

Both of these are kind of 'meh' Migrations. Lowering their chance makes it better for the rest of the migration parties.