### PR TITLE
Bath Chamber lock ID change in Rockhill

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -5492,7 +5492,7 @@
 "bLc" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
-	lockid = "royal";
+	lockid = "heir";
 	name = "Bath Chamber"
 	},
 /turf/open/floor/rogue/tile/bath,


### PR DESCRIPTION
## About The Pull Request

Closes #649 by changing the `lockid` of the bath chamber door to `heir` now allowing the princes to utilize the bath chamber too

## Testing Evidence

<img width="608" height="534" alt="Screenshot_4" src="https://github.com/user-attachments/assets/62ffc7d9-9bf0-405c-80e2-9c665deec93d" />


## Why It's Good For The Game
let our princes goon 
