### PR TITLE
Lowers spawnrate of trees in bog

### DIFF
--- a/code/modules/roguetown/mapgen/bog.dm
+++ b/code/modules/roguetown/mapgen/bog.dm
@@ -15,7 +15,7 @@
 	clusterCheckFlags = CLUSTER_CHECK_NONE
 	allowed_turfs = list(/turf/open/floor/rogue/dirt)
 	excluded_turfs = list(/turf/open/floor/rogue/dirt/road)
-	spawnableAtoms = list(/obj/structure/flora/newtree = 30,
+	spawnableAtoms = list(/obj/structure/flora/newtree = 5,
 							/obj/structure/flora/roguegrass/bush = 10,
 							/obj/structure/flora/roguegrass = 26,
 							/obj/structure/flora/roguegrass/maneater = 13,

--- a/code/modules/roguetown/mapgen/bograt.dm
+++ b/code/modules/roguetown/mapgen/bograt.dm
@@ -28,7 +28,7 @@
 	allowed_turfs = list(/turf/open/floor/rogue/dirt, /turf/open/floor/rogue/grass, /turf/open/floor/rogue/grassred, /turf/open/floor/rogue/grassyel, /turf/open/floor/rogue/grasscold, /turf/open/floor/rogue/grassgrey)
 	excluded_turfs = list(/turf/open/floor/rogue/dirt/road)
 	spawnableAtoms = list(/obj/structure/flora/newtree = 2,
-							/obj/structure/flora/roguetree= 8,
+							/obj/structure/flora/roguetree= 2,
 							/obj/structure/flora/roguegrass/bush = 5,
 							/obj/structure/flora/roguegrass = 8,
 							/obj/structure/flora/roguegrass/maneater = 2,


### PR DESCRIPTION
## About The Pull Request
Combines with manually placed trees, current spawnrate makes small islands of land  in bog almost impassable, with most of their tiles covered in trees and rest by bushes and other things
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
varedit
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
makes bog at least somehow passable
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
