### PR TITLE
Hedge knight hoardmaster overhaul

### DIFF
--- a/code/modules/cargo/packsrogue/Knight.dm
+++ b/code/modules/cargo/packsrogue/Knight.dm
@@ -193,6 +193,11 @@
 	cost = 20
 	contains = list(/obj/item/rogueweapon/sword/long/death)
 
+/datum/supply_pack/rogue/Knight/krieg
+	name = "Kriegmesser"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/sword/long/kriegmesser)
+
 /datum/supply_pack/rogue/Knight/Zweihandersword
 	name = "Zweihander"
 	cost = 40

--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -88,6 +88,11 @@
 	cost = 40
 	contains = list(/obj/item/rogueweapon/sword/long)
 
+/datum/supply_pack/rogue/sellsword/krieg
+	name = "kriegmesser"
+	cost = 40
+	contains = list(/obj/item/rogueweapon/sword/long/kriegmesser)
+
 /datum/supply_pack/rogue/Sellsword/sflail
 	name = "Steel Flail"
 	cost = 20


### PR DESCRIPTION
## About The Pull Request

Adds - Halberd, billhook, steel mace, warhammer, silver warhammer, padded coif, visored sallet, and slitted kettle helm.

changes - cost of silver mace reduced as it was abnormally high, cost of steel gorget reduced as it does the same thing as a bervor and dosent need to be higher (noob trap or unchanged from long ago?).

removes - Iron gorget as its not needed and is bloat.
## Testing Evidence

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a1b493be-9e46-43ac-b97f-02766d4b2b0d" />

## Why It's Good For The Game

More options good, limited options bad. Hedgeknight was lacking many weapon options for the subclasses.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
