### PR TITLE
Paladin Starting Weapon Minor Rework

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -297,7 +297,7 @@
 		var/oaths = list("Cleric - Medicine & Mirth","Crusader - Silver Longsword")
 		var/oath_choice = input(H, "Choose your OATH.", "PROFESS YOUR BLESSINGS.") as anything in oaths
 		switch(oath_choice)
-			if("Cleric - Medicine & Mirth")
+			if("Cleric - Medicine, Mirth, & Mediocre Might")
 				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, SKILL_LEVEL_NOVICE, TRUE)
 				beltl = /obj/item/reagent_containers/glass/bottle/rogue/healthpot //No needles or cloth, but a basic potion of lifeblood - similar to the Sorcerer's manna potion. Take the 'Physician's Apprentice' virtue for that, uncapped skills, and more.
 				var/weapons = list("Longsword","Mace","Flail","Whip","Spear","Axe")


### PR DESCRIPTION
## About The Pull Request

Paladins who decide to start with a spear now get a great weapon strap.

If you choose to start with a Silvered Sword, you no longer get a second weapon.

If you choose to start with the lifeblood potion, you still get to choose a weapon.

## Testing Evidence

It Works Bro

## Why It's Good For The Game

Paladins getting a silvered sword AND another weapon is kind of weird, so they don't get that anymore.

Medicine and Mirth remains the same.

Spears now have a place to put them.
