### PR TITLE
Slightly buffs mordhau once more.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -116,6 +116,8 @@
 	clickcd = 13
 	item_d_type = "blunt"
 	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR
+	blunt_chipping = TRUE
+	blunt_chip_strength = BLUNT_CHIP_MINUSCULE
 
 /datum/intent/rend
 	name = "rend"


### PR DESCRIPTION
## About The Pull Request

Removes the attack delay from the longblades' altgrip bash. Click delay stays.

## Testing Evidence

Should work, trust me.

## Why It's Good For The Game

My original intention on one of my lasts PR's touching the Altgrip was to balance the longswords' bash intent enough to still be inferior than blunt weapons' strikes, but I think mordhau grip ended up being a bit more worse than used to be. I hope with this small change the altgrip looks better now.

What do you say?