### PR TITLE
Auto punctuation

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -185,6 +185,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(!message)
 		return
 
+	message = ensure_terminal_punctuation(message)
+
 	// Allow sign languages and other tongueless speech to bypass the vocal speech check
 	var/using_tongueless_speech = language && (initial(language.flags) & TONGUELESS_SPEECH)
 	if(!can_speak_vocal(message) && !using_tongueless_speech)
@@ -647,6 +649,15 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	message = capitalize(message)
 
 	return message
+
+/mob/living/proc/ensure_terminal_punctuation(message)
+	var/trimmed = trim_right(message)
+	if(!trimmed)
+		return message
+	var/last_char = copytext_char(trimmed, -1)
+	if(last_char == "." || last_char == "!" || last_char == "?" || last_char == "~")
+		return message
+	return "[trimmed]."
 
 /mob/living/proc/radio(message, message_mode, list/spans, language)
 	switch(message_mode)


### PR DESCRIPTION
## About The Pull Request

Automatically forces your say to end with a . if it does not already end with a ! ? ~ or .

## Testing Evidence

<img width="1492" height="835" alt="image" src="https://github.com/user-attachments/assets/3154c8cf-1a32-4f91-bbfb-057f66b6476e" />
<img width="1077" height="670" alt="image" src="https://github.com/user-attachments/assets/216464d2-0a5c-40f4-98e1-bade82eacc7f" />

## Why It's Good For The Game

whenever someone doesn't properly punctuate my round is ruined

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
