### PR TITLE
Adjusts runaway prisoner migrant wave downgrades

### DIFF
--- a/code/datums/migrants/migrant_waves/runaway_prisoners.dm
+++ b/code/datums/migrants/migrant_waves/runaway_prisoners.dm
@@ -26,7 +26,7 @@
 	shared_wave_type = /datum/migrant_wave/runaway_prisoners
 	downgrade_wave = /datum/migrant_wave/runaway_prisoners_down_three
 	roles = list(
-		/datum/migrant_role/runaway_prisoner = 3
+		/datum/migrant_role/runaway_prisoner = 2
 	)
 
 /datum/migrant_wave/runaway_prisoners_down_three
@@ -34,7 +34,7 @@
 	can_roll = FALSE
 	shared_wave_type = /datum/migrant_wave/runaway_prisoners
 	roles = list(
-		/datum/migrant_role/runaway_prisoner = 2
+		/datum/migrant_role/runaway_prisoner = 1
 	)
 
 /datum/migrant_role/runaway_prisoner


### PR DESCRIPTION
## About The Pull Request

Changes the slots for the Runaway Prisoner migrant wave progression to go 4, 3, 2, 1 instead of 4, 3, 3, 2
This allows for a singular player to spawn as a runaway prisoner rather than requiring at least two.

## Testing Evidence

Tis a single number change, sire

## Why It's Good For The Game

Very un-used migrant wave that I think wouldn't diminish the server for it to be playable solo in the case no one else readies. Might even be a fix? Depending on whether or not it was intended that you needed at least two people in the first place. 
