### PR TITLE
feature: add rich coin pouch to migrant grenzel noble

### DIFF
--- a/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/grenzel_noble_roles.dm
@@ -56,6 +56,7 @@
 	beltl = /obj/item/rogueweapon/scabbard/sword
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
+		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
 		/obj/item/rogueweapon/huntingknife/idagger = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1,
 		/obj/item/paper/scroll/writ_of_esteem/grenzel = 1,


### PR DESCRIPTION
## About The Pull Request

fixes #688 by giving some well deserved coins to the noble from the envoy of grenzelhoft

## Testing Evidence

<img width="453" height="156" alt="image" src="https://github.com/user-attachments/assets/2773e3fc-a35c-4270-b4c7-8b317663a256" />

basically just adds a `/obj/item/storage/belt/rogue/pouch/coins/rich`

## Why It's Good For The Game
it makes sense given they are an envoy from the Emperor of Grenzelhoft acting in his name