### PR TITLE
Adjust Ruma Clan Gun-in stats for the mercenary subclass

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
@@ -12,9 +12,9 @@
 	subclass_stats = list(
 		STATKEY_CON = 3,
 		STATKEY_WIL = 3,
-		STATKEY_STR = 2,
+		STATKEY_STR = -1,
 		STATKEY_PER = 1,
-		STATKEY_SPD = -1
+		STATKEY_SPD = 2
 	)
 	subclass_skills = list(
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Given the loadout of the gun-in, I believe it would better to make an adjustment in SPEED and STRENGTH.

Basically, we will be changing the -1 SPD into -1 STR

And the buff of +2 STR to +2 SPD

This change is made given the gimmick of the subclass. They are given a SWIFT balance weapon on spawn, which basically uses your SPEED compared to weapons that often use STR.

I don't think this will break or make this class too overpowered, and this may have been but an oversight from the past; and hoping this would at least give this class some love.

## Testing Evidence

<img width="273" height="146" alt="image" src="https://github.com/user-attachments/assets/f853840a-2869-4f0a-9a63-5e613860f1ea" />

## Why It's Good For The Game
Fixes an oversight(?)
