### PR TITLE
feat: add storyteller to round info tab

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -791,6 +791,8 @@ GLOBAL_VAR_INIT(mobids, 1)
 				stat(null, "Next Map: [cached.map_name]")
 			stat(null, "ROUND ID: [GLOB.rogue_round_id ? GLOB.rogue_round_id : "NULL"]")
 			stat(null, "ROUND TIME: [time2text(STATION_TIME_PASSED(), "hh:mm:ss", 0)] [world.time - SSticker.round_start_time]")
+			stat(null, "STORYTELLER: [SSgamemode.current_storyteller.name]")
+
 			if(SSgamemode.roundvoteend)
 				stat("ROUND END: [DisplayTimeText(time_left)]")
 			if(client?.holder)


### PR DESCRIPTION
## About The Pull Request

Based on a [suggestion](https://discord.com/channels/1240735983276654733/1465842298654035989) by Discord, this PR adds the current storyteller to the Round Info tab for players.

## Testing Evidence

<img width="309" height="119" alt="image" src="https://github.com/user-attachments/assets/43ba9ad1-e21b-4404-9d7a-fca9822b2d3d" />

## Why It's Good For The Game
quality of life
