### PR TITLE
refactor: enhance migrant countdown UI to match lobby countdown

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -544,8 +544,14 @@ SUBSYSTEM_DEF(migrants)
 			global_triumph_contributions[ckey] -= wave.type
 
 /datum/controller/subsystem/migrants/proc/update_ui()
+	var/countdown_text
+	if(!current_wave)
+		countdown_text = "The mist will clear out of the way in [time_until_next_wave / (1 SECONDS)] seconds..."
+	else
+		countdown_text = "They will arrive in [wave_timer / (1 SECONDS)] seconds..."
 	for(var/client/client as anything in get_all_migrants())
-		client.prefs.migrant.show_ui()
+		if(client?.mob)
+			client.mob << output(countdown_text, "migration.browser:update_migrant_countdown")
 
 /datum/controller/subsystem/migrants/proc/get_active_migrant_amount()
 	var/list/migrants = get_active_migrants()

--- a/code/datums/migrants/migrant_pref.dm
+++ b/code/datums/migrants/migrant_pref.dm
@@ -57,7 +57,7 @@
 	main_dat += "<div style='text-align: center; margin-bottom: 15px;'>Wandering fools: [current_migrants ? "\Roman[current_migrants]" : "None"]</div>"
 
 	if(!SSmigrants.current_wave)
-		main_dat += "<div style='text-align: center; margin-bottom: 15px;'>The mist will clear out of the way in [(SSmigrants.time_until_next_wave / (1 SECONDS))] seconds...</div>"
+		main_dat += "<div style='text-align: center; margin-bottom: 15px;' id='migrant_countdown'>The mist will clear out of the way in [(SSmigrants.time_until_next_wave / (1 SECONDS))] seconds...</div>"
 	else
 		var/datum/migrant_wave/wave = MIGRANT_WAVE(SSmigrants.current_wave)
 		main_dat += "<div style='text-align: center; font-weight: bold; margin-bottom: 10px;'>[wave.name]</div>"
@@ -87,7 +87,7 @@
 				triumph_bonus_string = " <span style='color: gold;'>(+[triumph_bonus])</span>"
 
 			main_dat += "<div style='text-align: center; margin: 5px 0;'><a href='byond://?src=[REF(src)];task=toggle_role_preference;role=[role_type]'>[role_name]</a> - \Roman[role_amount] [stars_string][triumph_bonus_string]</div>"
-		main_dat += "<div style='text-align: center; margin-top: 15px;'>They will arrive in [(SSmigrants.wave_timer / (1 SECONDS))] seconds...</div>"
+		main_dat += "<div style='text-align: center; margin-top: 15px;' id='migrant_countdown'>They will arrive in [(SSmigrants.wave_timer / (1 SECONDS))] seconds...</div>"
 
 	main_dat += "</div>"
 
@@ -220,6 +220,11 @@
 		</div>
 	</div>
 	<script>
+		function update_migrant_countdown(text) {
+			var el = document.getElementById("migrant_countdown");
+			if (el) el.innerHTML = text;
+		}
+
 		// Cookie functions
 		function setCookie(name, value, days) {
 			var expires = "";


### PR DESCRIPTION
## About The Pull Request

This is based on the changes made to the lobby previously on this [PR](https://github.com/Rotwood-Vale/Ratwood-2.0/pull/597), so I aim to make it that the migration window does not "flicker" when changing the countdown, much like how the lobby window functions now.

## Testing Evidence

![0c150b75d27c177feab42ff8e23a528c](https://github.com/user-attachments/assets/2b1b0947-642f-424c-9d9e-ee0fdc6d262c)

## Why It's Good For The Game
Quality of life adjustment