### PR TITLE
Underwear now hides your NSFW gallery

### DIFF
--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -50,7 +50,7 @@
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder
-		if(!(holder.wear_armor && holder.wear_armor.flags_inv) && !(holder.wear_shirt && holder.wear_shirt.flags_inv))
+		if(!(holder.wear_armor && holder.wear_armor.flags_inv) && !(holder.wear_shirt && holder.wear_shirt.flags_inv) && !(holder_human.underwear))
 			is_naked = TRUE
 		obscured = ((!isobserver(user)) && !holder_human.client?.prefs?.masked_examine) && ((holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE)))
 		flavor_text = obscured ? "Obscured" : holder.flavortext


### PR DESCRIPTION
## About The Pull Request

 Just as the title says. When you examine a nude character, you won't be able to see their NSFW gallery while their underwear is on.

## Testing Evidence

You can clearly see that the NSFW page is not accessible, when underwear is on and vice versa.

<img width="1146" height="795" alt="image" src="https://github.com/user-attachments/assets/407fd756-2662-42f4-8157-b1ed4ee92233" />

<img width="1184" height="890" alt="image" src="https://github.com/user-attachments/assets/951174bc-faf9-45c6-a267-a2dcf4c050bb" />

## Why It's Good For The Game

If people don't want to be exposed, they can just setup their underwear in the character loadout. Why it's also good? It helps to avoid unnecessary troubles in situations, where people have no other choice, but to undress someone else, for example -> medicine (even though with the changes we can finally heal people while aiming at their head, some are not aware about it and still try to undress them and aim at the body); taking captive, so they can take off their armor and not expose them publicly.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
