### PR TITLE
[BUG FIX] Mending and lesser mending now works as intended.

### DIFF
--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -27,6 +27,7 @@
 /obj/effect/proc_holder/spell/invoked/mending/cast(list/targets, mob/living/user)
 	if(!istype(targets[1], /obj/item))
 		to_chat(user, span_warning("There is no item here!"))
+		revert_cast()
 		return
 
 	var/obj/item/I = targets[1]
@@ -40,11 +41,9 @@
 		revert_cast()
 		return
 
-	int_bonus = (user.STAINT * 0.01)
-	repair_percent += int_bonus
-	repair_percent *= I.max_integrity
+	var/repair_amount = (repair_percent + (user.STAINT * 0.01)) * I.max_integrity
 
-	I.obj_integrity = min(I.obj_integrity + repair_percent, I.max_integrity)
+	I.obj_integrity = min(I.obj_integrity + repair_amount, I.max_integrity)
 	user.visible_message(span_info("[I] glows in a faint mending light."))
 	playsound(I, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
 
@@ -54,7 +53,6 @@
 		if(I.body_parts_covered_dynamic != I.body_parts_covered)
 			I.repair_coverage()
 			to_chat(user, span_info("[I]'s shorn layers mend together."))
-		revert_cast()
 
 
 /obj/effect/proc_holder/spell/invoked/mending/lesser


### PR DESCRIPTION
## About The Pull Request

The **Mending** skill (and its **lesser** version) was bugged before - it had _no cooldown_ and performed a _full integrity repair_.
The first bug was caused by an _extra_ **revert_cast()** call.
The second bug resulted from a flaw in how the repair value was rewritten. This allowed you to press the skill twice: the first press would increase the intended value, and every subsequent cast would use incorrectly large numbers.

## Testing Evidence
As you can see below, now it properly works and goes on a cooldown. It scales with an INT stat. 
Lesser version has base (10 + INT)% and normal one has (20+INT)% amount of integrity repaired. 
On the screen you can see a lesser version being used, it repaired 27%. 
I already checked normal version, it also repairs 10% more. 
I'm not really sure why it repaired 27% instead of 25% since this character has only 15 int, but I think it was caused by the rules of values rounding in the code... 
<img width="1341" height="984" alt="image" src="https://github.com/user-attachments/assets/8f40270c-f37b-4455-926d-8c0d597da935" />

## Why It's Good For The Game

People won't be able to abuse this bug, especially with the heretic ritual armor.
Mending only costs 2 points and you can learn it with the arcyne virtue - being able to repair armor for free like that is not how it was supposed to work.
