### PR TITLE
Mpreg vice

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -97,6 +97,7 @@
 #define TRAIT_WAGES_SUSPENDED "Wages Suspended" //Stops nerve master daily pay for this guy
 #define TRAIT_SCALEARMOR "Weathered Scales"//Mage armor, refluffed to scales.
 #define TRAIT_HEMOPHAGE "Hemophage"//You can drink blood for heals, but normal food and water makes you ill. Shitty vampire.
+#define TRAIT_BAOTHA_FERTILITY_BOON "Marked and shaped by Baotha" //Able to be impregnated, has permanent womb tattoo and stronger version of nympho vice
 
 //Hearthstone port (Tracking)
 #define TRAIT_PERFECT_TRACKER "Huntmaster" //Will always find any tracks and analyzes them perfectly.
@@ -242,7 +243,6 @@
 #define TRAIT_OVERTHERETIC "Overt Heretic"//Applied on someone who has rites buffs. Armour, rituos, etc.
 #define TRAIT_SPELL_DISPERSION "Barrier Dispersion"
 #define TRAIT_CONVICTION "Conviction" //Can hear Tennite prayers. Praying heals and provides nutrition.
-#define TRAIT_BAOTHA_FERTILITY_BOON "Marked and shaped by Baotha"
 #define TRAIT_STANDARD_BEARER "Standard Bearer"//Can use the keep's standard to provide buffs and rally the retinue.
 
 // Economic Roles Traits

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -748,17 +748,30 @@ GLOBAL_LIST_INIT(character_flaws, list(
 
 /datum/charflaw/marked_by_baotha
 	name = "Marked by Baotha"
-	desc = "Whether through intentionally seeking out heretical ritualists or against my will, I have been marked by Baotha. I am branded visibly on my groin and am able to be impregnated regardless of physical states that would usually prevent this"
+	desc = "Whether through intentionally seeking out heretical ritualists or against my will, I have been marked by Baotha. I am branded visibly on my groin and am able to be impregnated regardless of physical states that would usually prevent this. I will need to sate my new urges often to avoid stress..."
 
 /datum/charflaw/marked_by_baotha/on_mob_creation(mob/user)
+
 	var/mutable_appearance/marking_overlay = mutable_appearance('icons/roguetown/misc/baotha_marking.dmi', "marking_[user.gender == "male" ? "m" : "f"]", -BODY_LAYER)
 	user.add_overlay(marking_overlay)
+
 	spawn(40)
 
 	ADD_TRAIT(user, TRAIT_BAOTHA_FERTILITY_BOON, TRAIT_GENERIC)
+
 	var/obj/item/organ/vagina/vagina = user.getorganslot(ORGAN_SLOT_VAGINA)
 	if(vagina && !vagina.fertility)
 		vagina.fertility = TRUE
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+
+		// Add the adjusted Nymphomaniac addiction flaw
+		if(!H.has_flaw(/datum/charflaw/addiction/lovefiend))
+			var/datum/charflaw/addiction/lovefiend/L = new
+			L.time = 45
+			H.vices += L
+			L.on_mob_creation(H)
 
 /datum/charflaw/hemophage
 	name = "Hemophage (+1 TRI)"


### PR DESCRIPTION
## About The Pull Request

Adds 'Marked by Baotha' Vice. This uses the same code as the Baothan Mpreg ritual, and applies it to your character roundstart. This means the character has the groin marking and will be able to be impregnated regardless of genitalia. This is purely for RP/Flavour and should not affect balance in any way, it has been requested by some fellow freeks who want to have a character be cursed with this permanently. 

It now also applies a stronger version of the nymphomaniac trait. I wasn't sure the best way to do this, please take a look at the code, but from testing it seems to work as expected.

## Testing Evidence

<img width="370" height="342" alt="image" src="https://github.com/user-attachments/assets/aae307f1-dc3c-482b-b5be-887792f1379b" />

<img width="815" height="79" alt="image" src="https://github.com/user-attachments/assets/a8c5d410-a3e7-4edb-987d-5fd8acb912d4" />

<img width="379" height="140" alt="image" src="https://github.com/user-attachments/assets/5bb2409a-3a93-4ee4-ae65-50e7e2e9caed" />

<img width="432" height="91" alt="image" src="https://github.com/user-attachments/assets/8b5abc83-1329-4b3e-8f25-7ca95825da7e" />

(Groin tattoo marking visible) 
<img width="172" height="187" alt="image" src="https://github.com/user-attachments/assets/8371b8be-6f4a-4a4f-9790-2b681e0d3be3" />



## Why It's Good For The Game

Fun freek ERP options are good and don't negatively affect anyone else. I especially want this because we have no 'evil' ritualist classes beyond wretch, so the mpreg ritual is *really* quite difficult to actually get to use. 

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
