### PR TITLE
Tweaks short-satchels

### DIFF
--- a/code/datums/components/storage/storage_types.dm
+++ b/code/datums/components/storage/storage_types.dm
@@ -5,6 +5,10 @@
 	screen_max_rows = 4
 	max_w_class = WEIGHT_CLASS_NORMAL
 
+/datum/component/storage/concrete/roguetown/satchelshort
+	screen_max_rows = 3
+	max_w_class = WEIGHT_CLASS_NORMAL
+
 /datum/component/storage/concrete/roguetown/backpack
 	screen_max_rows = 7
 	screen_max_columns = 5

--- a/code/modules/clothing/rogueclothes/storage/storage.dm
+++ b/code/modules/clothing/rogueclothes/storage/storage.dm
@@ -282,6 +282,7 @@
 	icon_state = "satchelshort"
 	item_state = "satchelshort"
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_HIP //Implement a check in the future that prevents more than one being worn at once.
+	component_type = /datum/component/storage/concrete/roguetown/satchelshort
 
 /obj/item/storage/backpack/rogue/satchel/beltpack
 	name = "beltpack" //Satchel that fits on the cloak or belt slot. Should be exceptionally rare for on-spawn loadouts, unless a flag's added to make it incompatable with regular satchels.


### PR DESCRIPTION
## About The Pull Request

Makes short-satchels have slightly less capacity (3x3 instead of 3x4) than regular satchels, making them a sidegrade instead of a direct upgrade.

## Testing Evidence
<img width="1372" height="850" alt="image" src="https://github.com/user-attachments/assets/3b342a49-1a6d-4d06-958b-0ab72b7b8dea" />

## Why It's Good For The Game

Being placed on the hip is a significant bonus in convenience, and I think it'd make sense to have a trade-off. Makes sense to me.