### PR TITLE
Makes Riding Actually Trainable

### DIFF
--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -45,8 +45,9 @@
 		return TRUE
 	if(HAS_TRAIT(src, TRAIT_INFINITE_ENERGY))
 		return TRUE
-	if(m_intent == MOVE_INTENT_RUN && isnull(buckled) && (mobility_flags & MOBILITY_STAND))
-		mind && mind.add_sleep_experience(/datum/skill/misc/athletics, (STAINT*0.02))
+	if(m_intent == MOVE_INTENT_RUN && (mobility_flags & MOBILITY_STAND))
+		if(isnull(buckled))
+			mind && mind.add_sleep_experience(/datum/skill/misc/athletics, (STAINT*0.02))
 	energy += added
 	if(energy > max_energy)
 		energy = max_energy


### PR DESCRIPTION
## About The Pull Request
Riding XP is now gained every 5 tiles you move via RUN intent on your mount. It is scaled off your INT like all skills, giving you 0.1 XP for every INT you have (for example, 20 gives you 2 XP).

## Testing Evidence
<img width="1178" height="760" alt="ridingxp" src="https://github.com/user-attachments/assets/8f923c3d-2530-408a-9e2c-32c5d434b49c" />

## Why It's Good For The Game
The riding skill could not be trained at all, for some reason. This is a solution to that. Instead of how running works where you are constantly getting XP and based off stamina depletion or something, you are earning XP based off distance traveled while running on your mount. This means you'll have to actively zoom around and do circuits or something to train it, as it should be when learning how to ride. Also, it takes a while to get skills like athletics. Hopefully we see people using more mounts, now that people can actually learn how to ride instead of praying for a dream to get novice or use equestrian and then rush the archivist to train to journeyman.