### PR TITLE
Remove Justicar's Sight

### DIFF
--- a/code/datums/gods/patrons/divine/ravox.dm
+++ b/code/datums/gods/patrons/divine/ravox.dm
@@ -3,7 +3,7 @@
 	domain = "Justice, Battle, Glory, Righteous Fury"
 	desc = "The Glorious Justice plays as foil to Astrata's Order, preventing the world from being ruled by the Sun's Tyranny. He is an impartial God who exists solely to enforce Divine Justice. His followers are often misguided in their pursuit of such."
 	worshippers = "Warriors, Mercenaries, Knights, Seekers of Justice"
-	mob_traits = list(TRAIT_SHARPER_BLADES, TRAIT_JUSTICARSIGHT)
+	mob_traits = list(TRAIT_SHARPER_BLADES)
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/tug_of_war			= CLERIC_T0,
 					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,


### PR DESCRIPTION
## About The Pull Request
Ravox gets two traits: one makes weapons lose sharpness slower. Cool!

The other is the Validhunt Sight.
Whenever you examine someone's face (therefore, *mask off*), you CAN and WILL see if they have a bounty on their head. It leads to very much little RP - and mostly just going "mask off 321 mask off now now" then killing you.

At least have the decency to RP and actually analyze your targets.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Its removing a single trait bruh
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Validhunt sight does not incite RP - it's just a way to lock on someone and think about how to efficiently break their legs to take them to get paid. At least go to an excidium and get the scroll and actually cross-check people by appearances.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
