### PR TITLE
Buffs the amount of light you can sneak in with sneak skill

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -597,7 +597,7 @@
 	var/light_threshold = rogue_sneaking_light_threshhold
 	if(mind)
 		used_time = max(used_time - (get_skill_level(/datum/skill/misc/sneaking) * 8), 0)
-		light_threshold += (get_skill_level(/datum/skill/misc/sneaking) / 200)
+		light_threshold += (get_skill_level(/datum/skill/misc/sneaking) / 20)
 
 	if(rogue_sneaking || reset) //If sneaking, check if they should be revealed
 		var/should_reveal = FALSE


### PR DESCRIPTION
## About The Pull Request
Buffs the amount of light you can sneak in with sneak skill
I changed the formula from level/200 to level/20
200 would mean that a legendary sneak skill gives you +0.03 to the amount of light you can sneak in.
At 20 it gives +0.3 to the amount.

Keep in mind the baseline is 0.15, and kneestingers emit light to 0.43 light count. This means a legendary sneaker can now sneak next to kneestingers.

Still might be too weak imo
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/88c02c9e-f5e2-4f8e-9e52-d95088737c1e


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Seems like a math mistake to me tbh.
Makes sneak skill somewhat relevant, even if the changes are a bit minor (Should possibly be buffed again)
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
