### PR TITLE
Remove keeper key from apothecary

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/apothecary.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/apothecary.dm
@@ -70,8 +70,7 @@
 		/obj/item/natural/worms/leech/cheele = 1,
 		/obj/item/recipe_book/alchemy = 1,
 		/obj/item/clothing/mask/rogue/physician = 1,
-		/obj/item/storage/keyring = 1,
-		/obj/item/roguekey/keeper = 1
+		/obj/item/storage/keyring = 1
 	)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)


### PR DESCRIPTION
## About The Pull Request

Title, and yes this is a salt PR

## Testing Evidence

1 line change

## Why It's Good For The Game

I spawned as a keeper only to learn that an apothecary used their copy of the key to do the entire heart-beast gameplay loop by themselves. GO PLAY KEEPER IF YOU WANT THIS. The court phys retains their keys to the place.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
