### PR TITLE
Adds Sui Dust to the Purity vendor

### DIFF
--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -256,7 +256,7 @@
 	held_items[/obj/item/clothing/mask/cigarette/rollie/mentha] = list("PRICE" = rand(6,11),"NAME" = "mentha zig")
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
 	held_items[/obj/item/storage/fancy/shhig] = list("PRICE" = rand(40,60), "NAME" = "Shhig brand premium zigs")
-	held_items[/obj/item/alch/transisdust] = list("PRICE" = rand(42,68), "NAME" = "sui dust")
+	held_items[/obj/item/alch/transisdust] = list("PRICE" = rand(80,120), "NAME" = "sui dust")
 	// azure peak addition start - lipstick
 	held_items[/obj/item/azure_lipstick] = list("PRICE" = rand(33,50),"NAME" = "red lipstick")
 	held_items[/obj/item/azure_lipstick/jade] = list("PRICE" = rand(33,50),"NAME" = "jade lipstick")


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin. adds the genderchange dust to the Purity vendor at the price of roughly the same as the other fancy vanity items like lipstick.

## Testing Evidence
<img width="359" height="374" alt="image" src="https://github.com/user-attachments/assets/41f51e4c-a41d-4e05-86fd-2b12a7e004ff" />


## Why It's Good For The Game

Sui Dust is purely an RP drug that is barred behind journeyman alchemy. Meaning it's at best a somewhat annoying timesink grind to attain and at worst not something you can even attain at all if you just want to have some HRT fun.  
As is, crafting it is the only way to attain Sui Dust. Having it in the purity vendor not only makes it accessible to the interested crowd in a way that lets them invest their earned coin throughout a round in order to get to enjoying the RP side of it longer. But it also shows them it's a thing in the first place. It took me two months of playing before I ever even heard of it and that's a travesty...