### PR TITLE
Change Otavan Repentant's mask (No longer unremovable)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/otava.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/otava.dm
@@ -1,7 +1,7 @@
 /datum/advclass/foreigner/repentant
 	name = "Otavan Repentant"
 	tutorial = "An exile from the Holy See of Otava, accused of heresy and cast out of your homeland as penance. \
-	Some consider yours a fate worse than death; the metal alloy mask seared onto your face serving as a permanent reminder of your sins. \
+	Some consider yours a fate worse than death; your mind broken with nothing but the gospel of the Orthodoxy. \
 	You are a living example of what becomes of those who stand in defiance of the Otavan inquisition."
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/repentant
@@ -28,9 +28,9 @@
 /datum/outfit/job/roguetown/adventurer/repentant/pre_equip(mob/living/carbon/human/H)
 	..()
 	to_chat(H, span_warning("An exile from the Holy See of Otava, accused of heresy and cast out of your homeland as penance. \
-	Some consider yours a fate worse than death; the metal alloy mask seared onto your face serving as a permanent reminder of your sins. \
+	Some consider yours a fate worse than death; your mind broken with nothing but the gospel of the Orthodoxy. \
 	You are a living example of what becomes of those who stand in defiance of the Otavan inquisition."))
-	mask = /obj/item/clothing/mask/rogue/facemask/steel/paalloy/mad_touched
+	mask = /obj/item/clothing/mask/rogue/sack/psy
 	wrists = /obj/item/clothing/neck/roguetown/psicross
 	shirt = /obj/item/clothing/cloak/psydontabard
 	gloves = /obj/item/clothing/gloves/roguetown/chain/psydon


### PR DESCRIPTION
## About The Pull Request
The Otavan Repentant class starts with an ancient alloy mask that's cursed with nodrop. You can't take it off. It fits the vibe, but a few players told me it caused issues: can't drink from fountain/rivers with it, had weird interaction/clipping issues with the hood, and then the roleplay aspect where some people genuinely thought they were Bad Guys and tried to kill'em.

Instead, we replace it for a Psydonian sack mask. Do they lose face armor? Yeah. Is it at least more RP friendly? Probably!
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It's changing one line. Also some text.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Quality of Life change for the sake of the 2 (two) otavan repentant players so they can still play a slightly maddened man going thru penance.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
