### PR TITLE
Gives blunt weapons demolition modifiers

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -101,6 +101,7 @@
 	swingsound = BLUNTWOOSH_MED
 	minstr = 7
 	wdefense = 2
+	demolition_mod = 1.5
 	wbalance = WBALANCE_HEAVY
 	icon_angle_wielded = 50
 
@@ -349,6 +350,7 @@
 	smeltresult = /obj/item/ash
 	minstr = 7
 	wdefense = 5
+	demolition_mod = 1
 	wbalance = WBALANCE_NORMAL
 	associated_skill = /datum/skill/combat/swords
 	anvilrepair = /datum/skill/craft/carpentry
@@ -385,6 +387,7 @@
 	swingsound = BLUNTWOOSH_MED
 	minstr = 10
 	wdefense = 3
+	demolition_mod = 2
 	pixel_y = -16
 	pixel_x = -16
 	inhand_x_dimension = 64
@@ -506,6 +509,7 @@
 	wbalance = WBALANCE_HEAVY
 	smeltresult = /obj/item/ingot/iron
 	wdefense = 3
+	demolition_mod = 0.8 // You're not breaking much with this unless it's armor, the force is concentrated on a small area.
 
 /obj/item/rogueweapon/mace/warhammer/alloy
 	name = "decrepit warhammer"
@@ -612,7 +616,7 @@
 	minstr = 14
 	wdefense = 2
 	wdefense_wbonus = 1//3
-	demolition_mod = 1.25//Oh, yes...
+	demolition_mod = 2.25//Oh, yes... //Not as good as a woodcutter's axe but better than a stone axe
 	pixel_y = -16
 	pixel_x = -16
 	inhand_x_dimension = 64

--- a/code/modules/cargo/packsrogue/bandit/classes/Brigand.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Brigand.dm
@@ -394,7 +394,7 @@
 	contains = list(/obj/item/rogueweapon/sword/long)
 
 /datum/supply_pack/rogue/Brigand/krieg
-	name = "kriegmesser"
+	name = "Kriegmesser"
 	cost = 45
 	contains = list(/obj/item/rogueweapon/sword/long/kriegmesser)
 

--- a/code/modules/cargo/packsrogue/bandit/classes/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Sellsword.dm
@@ -259,7 +259,7 @@
 	contains = list(/obj/item/rogueweapon/sword/long)
 
 /datum/supply_pack/rogue/Sellsword/krieg
-	name = "kriegmesser"
+	name = "Kriegmesser"
 	cost = 40
 	contains = list(/obj/item/rogueweapon/sword/long/kriegmesser)
 


### PR DESCRIPTION
## About The Pull Request

Adds a relevant demolition modifier to the following
- Maces and subtypes - 1.5x demolition modifier
- Goden and subtypes - 2x demolition modifier
- Warhammer and subtypes - 0.8x demolition modifier
- Maul and subtypes - 2.25x demolition modifier

For reference, the stone axe has a 2x demolition modifier as do its subtypes. The woodcutters axe has a 2.5x demolition modifier. 

Also fixes a typo in one of my previous PRs

## Testing Evidence

Numberfuck PR

## Why It's Good For The Game

Felt a bit weird that the godendag, mauls, and maces don't actually knock down walls and doors very well. I've done demolition work IRL and I've never used an axe but I have used a sledgehammer plenty. The figures on the maul could probably be higher but since it has a higher damage than the woodcutter's axe AND a huge strength requirement I figured a 2.5x modifier would be too high.

Also the warhammer has a lower demolition modifier because it concentrates its force in a small area. If you try to bring down a wall or a door with a claw hammer you'll be there all fucking day.
 
