### PR TITLE
A Respectful Motion to Raise Adventurer Slots

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/adventurer.dm
@@ -8,8 +8,8 @@ GLOBAL_VAR_INIT(adventurer_hugbox_duration_still, 3 MINUTES)
 	flag = ADVENTURER
 	department_flag = WANDERERS
 	faction = "Station"
-	total_positions = 20
-	spawn_positions = 20
+	total_positions = 99
+	spawn_positions = 99
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Hero of nothing, a wanderer in foreign lands in search of fame and riches. Whatever led you to this fate is up to the wind to decide, and you've never fancied yourself for much other than the thrill. Some day your pride is going to catch up to you, and you're going to find out why most men don't end up in the annals of history."
 	class_categories = TRUE


### PR DESCRIPTION
## About The Pull Request

With the utmost respect and in a spirit of sincere civic duty I would like to resubmit a humble proposal to the honorable court of Ratwood players that adventurer slots be raised to 99.

This petition was previously denied. However the maintainer who rendered that decision has since departed. As such I believe the matter is worthy of renewed consideration: https://github.com/Rotwood-Vale/Ratwood-2.0/pull/847

On the first occasion I regret that I did not treat this grave and weighty matter with the solemnity it so clearly deserved. I therefore return now in my serious voice. There shall be no frivolity nor any conduct less than wholly serious in this discussion. There shall be only the seriousness that so serious a subject demands.


## Testing Evidence

Having submitted this PR to the scrutiny of multiple expert teams I am pleased to report that they were unanimous in their conclusion that it operates exactly as intended.

## Why It's Good For The Game

It is my humble opinion as a member of this serious and distinguished community that adventurers provide more to the average round than vagrants or towners. Under our current player count normal there are frequently not enough slots to go around, forcing people to lock into a role they don't care for or to disconnect.

I do not believe it is healthy for the game to block people from playing the roles they want to play most. This is a game after all and not an occupation.
