### PR TITLE
Armor Blocks Poison

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -530,3 +530,4 @@
 //Roguetown-specific
 #define  COMSIG_MOB_ON_KICK	"mob_on_kick"	//from /mob/living/proc/try_kick(atom/A). This is for when the src has done a kick.
 #define  COMSIG_MOB_KICKED	"mob_kicked"	//from /datum/species/proc/kicked(mob/living/carbon/human/user, mob/living/carbon/human/target). This is for when the mob has BEEN kicked.
+#define COMSIG_ITEM_ARMOR_BLOCKED "item_armor_blocked"	//from /mob/living/proc/run_armor_check(): sent to used_weapon when armor fully absorbs a hit

--- a/code/datums/elements/tipped_item.dm
+++ b/code/datums/elements/tipped_item.dm
@@ -1,5 +1,6 @@
 /datum/element/tipped_item
 	element_flags = ELEMENT_DETACH
+	var/blocked_by_armor = FALSE
 
 /datum/element/tipped_item/Attach(atom/movable/target, amount)
 	. = ..()
@@ -10,10 +11,11 @@
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_PRE_ATTACK, PROC_REF(check_dip))
 	RegisterSignal(target, COMSIG_ITEM_AFTERATTACK, PROC_REF(try_inject))
+	RegisterSignal(target, COMSIG_ITEM_ARMOR_BLOCKED, PROC_REF(on_armor_blocked))
 
 /datum/element/tipped_item/Detach(datum/source)
 	. = ..()
-	UnregisterSignal(source, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_ATTACK_OBJ, COMSIG_ITEM_AFTERATTACK))
+	UnregisterSignal(source, list(COMSIG_PARENT_EXAMINE, COMSIG_ITEM_PRE_ATTACK, COMSIG_ITEM_AFTERATTACK, COMSIG_ITEM_ARMOR_BLOCKED))
 
 /datum/element/tipped_item/proc/check_dip(obj/item/dipper, obj/item/reagent_containers/attacked_container, mob/living/attacker, params)
 	SIGNAL_HANDLER
@@ -37,10 +39,18 @@
 	attacker.visible_message(span_danger("[attacker] dips \the [dipper] in \the [attacked_container]!"), "You dip \the [dipper] in \the [attacked_container]!", vision_distance = 2)
 	log_combat(attacker, dipper, "poisoned", addition="with [reagentlog]")
 
+/datum/element/tipped_item/proc/on_armor_blocked(obj/item/source)
+	SIGNAL_HANDLER
+	blocked_by_armor = TRUE
+
 /datum/element/tipped_item/proc/try_inject(obj/item/source, atom/target, mob/user, proximity_flag, click_parameters)
 	var/reagentlog2 = source.reagents
 	if(!proximity_flag)
 		return
+	if(blocked_by_armor)
+		blocked_by_armor = FALSE
+		return
+	blocked_by_armor = FALSE
 	if(isliving(target))
 		log_combat(user, target, "poisoned", addition="with [reagentlog2]")
 		source.reagents.trans_to(target, 1, transfered_by = user)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -12,6 +12,9 @@
 	else if(armor >= 100)
 		if(absorb_text)
 			to_chat(src, span_notice("[absorb_text]"))
+		var/obj/item/blocked_weapon = used_weapon
+		if(blocked_weapon)
+			SEND_SIGNAL(blocked_weapon, COMSIG_ITEM_ARMOR_BLOCKED)
 //		else
 //			to_chat(src, span_notice("My armor absorbs the blow!"))
 	else if(armor > 0)


### PR DESCRIPTION
## About The Pull Request

Poisoned weapons no longer inject when blocked by armor.

## Testing Evidence

Runtimes are unrelated to this PR.
<img width="1307" height="1037" alt="image" src="https://github.com/user-attachments/assets/533b3dd5-812a-4a56-a41a-7abf73f5fcc6" />

## Why It's Good For The Game

Poisoned weapons should have never been able to inject through armor and it's a massive oversight that they did.
