### PR TITLE
Nightmaiden can operate the bathhouse peddler

### DIFF
--- a/code/modules/roguetown/roguemachine/vendor.dm
+++ b/code/modules/roguetown/roguemachine/vendor.dm
@@ -374,7 +374,7 @@
 	will_hawk = FALSE
 
 /obj/structure/roguemachine/vendor/bathhouse
-	keycontrol = "nightman"
+	keycontrol = "nightmaiden"//used to be nightman but it's nice for them to be able to stock the shelves too when the master isn't around
 
 /obj/structure/roguemachine/vendor/inn/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Changes the lock on the Bathhouse peddler to use the Nightmaiden key instead of Nightman

## Testing Evidence

one line...

## Why It's Good For The Game

Nice for them to be able to stock the shelves, especially when the nightman isn't around. Though nightmaster players might get annoyed at their whores for constantly stealing the merchandise so it's up for debate.