### PR TITLE
Gives halberd cuts the same damage mod as the bardiche

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -70,7 +70,7 @@
 	sharpness_penalty = 2
 
 /datum/intent/spear/cut/halberd
-	damfactor = 0.9
+	damfactor = 1.2
 
 /datum/intent/spear/cut/scythe
 	reach = 3


### PR DESCRIPTION
## About The Pull Request

Gives halberd cuts the same 1.2 damage modifier as bardiche cuts, up from 0.9.

## Testing Evidence

One line, take my word for it

## Why It's Good For The Game

The bardiche, the iron variant of the halberd, shouldn't have a better cut than it does, considering both of them are giant axes. As it stands, the halberd is one of the worst steel polearms, with poor throwforce, poor cuts, and only a bad chop and the usual spear stab to make up for it. It does nothing exceptionally well. This should make the halberd more versatile and viable as a weapon pick.