### PR TITLE
Bandit Revival Chair Fluid Obtainable

### DIFF
--- a/code/modules/cargo/packsrogue/bandit/Medicaments.dm
+++ b/code/modules/cargo/packsrogue/bandit/Medicaments.dm
@@ -37,6 +37,11 @@
 	cost = 200
 	contains = list(/obj/item/reagent_containers/glass/bottle/alchemical/rogue/rotcure)
 
+/datum/supply_pack/rogue/Medicaments/frankenbrew
+	name = "Frankenbrew"
+	cost = 200
+	contains = list(/obj/item/reagent_containers/glass/bottle/frankenbrew)
+
 /datum/supply_pack/rogue/Medicaments/emberwine
 	name = "Emberwine"
 	cost =	150	// It makes a good poison but its moreso to goon with. 


### PR DESCRIPTION
## About The Pull Request

Adds frankenstein brew to the medication Hoardmaster stomach.

## Testing Evidence

Compile:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4c2abb6d-5894-4a3a-84a5-cce7faccdf8b" />

In game:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/49898239-3b88-41ef-b8e5-75ed628c3a47" />

## Why It's Good For The Game

They have a chair.... Yet cannot get more fluid? The chair comes with I think enough to revive one or two bandits max. Really doesn't make sense to me why they cannot just buy more if its balanced, I argue 200 favor is balanced for a bottle(willing to negotiate). This is balanced by the cost and the fact that even if you have the fluid it still requires you to have medical skill to operate the chair. Therefore, without a sawbones some unlucky bastard will have to grind medicine.

Also, keep and townies get to be revived for free so don't see an issue with it.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
