### PR TITLE
lets knights pick old again

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
@@ -7,7 +7,7 @@
 	spawn_positions = 2
 	allowed_races = RACES_TOLERATED_UP
 	allowed_sexes = list(MALE, FEMALE)
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "Having proven yourself both loyal and capable, you have been knighted to serve the realm as the royal family's sentry. \
 	You listen to your Liege, the Marshal, and the Knight Captain, defending your Lord and realm - the last beacon of chivalry in these dark times. \
 	You're wholly dedicated to the standing Regent and their safety. Do not fail."


### PR DESCRIPTION
## About The Pull Request
This PR _restores_ the ability for knights to be old.

## Testing Evidence
It will work.

## Why It's Good For The Game
It makes sense. A knight's skill comes from experience, and knights are career soldiers.
It's for roleplay.
"But what if we're attacked and we have an old knight instead of a delicious adult fragger?"
IDFK dude he still has master and full plate and a cracked statline don't ask me