### PR TITLE
Removes Instant Death from Dolls

### DIFF
--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -105,7 +105,6 @@
 
 /datum/wound/fracture/head/brain
 	name = "depressed cranial fracture"
-	severity = WOUND_SEVERITY_FATAL
 	crit_message = list(
 		"The cranium is punctured!",
 		"The cranium is pierced!",
@@ -115,6 +114,11 @@
 	bleed_rate = 10		// Aooouuugh.. my brain..
 	knockout = 20
 	paralysis = TRUE
+
+/datum/wound/fracture/head/eyes/on_mob_gain(mob/living/affected)
+	. = ..()
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && (!isconstruct(human_mob)))
+		affected.death()
 
 /datum/wound/fracture/head/eyes
 	name = "orbital fracture"
@@ -141,7 +145,6 @@
 
 /datum/wound/fracture/head/ears
 	name = "temporal fracture"
-	severity = WOUND_SEVERITY_FATAL
 	crit_message = list(
 		"The orbital bone is punctured!",
 		"The temporal bone is pierced!",
@@ -159,6 +162,8 @@
 	affected.confused += 25	//Drunk-walk effect, basically.
 	affected.dizziness += 25
 	ADD_TRAIT(affected, TRAIT_DEAF, "[type]")
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && (!isconstruct(human_mob)))
+		affected.death()
 
 /datum/wound/fracture/head/ears/on_mob_loss(mob/living/affected)
 	. = ..()
@@ -232,7 +237,7 @@
 	if(iscarbon(affected))
 		var/mob/living/carbon/carbon_affected = affected
 		carbon_affected.update_disabled_bodyparts()
-	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && (!isconstruct(human_mob)))
 		affected.death()
 
 /datum/wound/fracture/neck/on_mob_loss(mob/living/affected)

--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -71,7 +71,6 @@
 	/// Most head fractures are serious enough to cause paralysis.
 	var/paralysis = TRUE
 	/// Some head fractures instantly kill you if you have critical weakness. Others won't.
-	mortal = TRUE
 	/// Some head fractures will knock your lights out, if not flat-out paralyze you.
 	var/knockout = 10	//10 tick knockout (1 sec)
 
@@ -87,6 +86,9 @@
 		if(iscarbon(affected))
 			var/mob/living/carbon/carbon_affected = affected
 			carbon_affected.update_disabled_bodyparts()
+	var/mob/living/carbon/CA = affected
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && !isconstruct(CA))
+		affected.death()
 
 /datum/wound/fracture/head/on_mob_loss(mob/living/affected)
 	. = ..()
@@ -113,11 +115,16 @@
 	embed_chance = 100	// Didn't we remove embeding..?
 	bleed_rate = 10		// Aooouuugh.. my brain..
 	knockout = 20
-	paralysis = TRUE
 
-/datum/wound/fracture/head/eyes/on_mob_gain(mob/living/affected)
+/datum/wound/fracture/head/brain/on_mob_gain(mob/living/affected)
 	. = ..()
-	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && (!isconstruct(human_mob)))
+	ADD_TRAIT(affected, TRAIT_PARALYSIS, "[type]")
+	ADD_TRAIT(affected, TRAIT_NOPAIN, "[type]")
+	if(iscarbon(affected))
+		var/mob/living/carbon/carbon_affected = affected
+		carbon_affected.update_disabled_bodyparts()
+	var/mob/living/carbon/CA = affected
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && !isconstruct(CA))
 		affected.death()
 
 /datum/wound/fracture/head/eyes
@@ -162,7 +169,8 @@
 	affected.confused += 25	//Drunk-walk effect, basically.
 	affected.dizziness += 25
 	ADD_TRAIT(affected, TRAIT_DEAF, "[type]")
-	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && (!isconstruct(human_mob)))
+	var/mob/living/carbon/CA = affected
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && !isconstruct(CA))
 		affected.death()
 
 /datum/wound/fracture/head/ears/on_mob_loss(mob/living/affected)
@@ -205,7 +213,7 @@
 	)
 	mortal = FALSE
 	whp = 50
-	bleed_rate = 5				//Lower than others, still bad though. 
+	bleed_rate = 5				//Lower than others, still bad though.
 	clotting_threshold = 0.3	//Slightly higher still
 	clotting_rate = 0.1			//Slower clotting, not bad though for bleeder wound.
 
@@ -237,7 +245,8 @@
 	if(iscarbon(affected))
 		var/mob/living/carbon/carbon_affected = affected
 		carbon_affected.update_disabled_bodyparts()
-	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && (!isconstruct(human_mob)))
+	var/mob/living/carbon/CA = affected
+	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS) && !isconstruct(CA))
 		affected.death()
 
 /datum/wound/fracture/neck/on_mob_loss(mob/living/affected)
@@ -267,7 +276,7 @@
 	affected.Immobilize(15)		//Stuns you, major downside
 	if(istype(affected, /mob/living/carbon)) // Intended for PVE skeletons
 		var/mob/living/carbon/CA = affected
-		if(HAS_TRAIT(CA, TRAIT_CRITICAL_WEAKNESS) && (NOBLOOD in CA.dna.species.species_traits))
+		if(HAS_TRAIT(CA, TRAIT_CRITICAL_WEAKNESS) && (NOBLOOD in CA.dna.species.species_traits) && !isconstruct(CA))
 			CA.death()
 
 /datum/wound/fracture/chest/on_life()


### PR DESCRIPTION
## About The Pull Request

If a doll gets head cracked, they instantly die. I removed it.

## Testing Evidence
Compile:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/705e21bd-44a2-46bf-93ec-23a4557ad329" />

Yes, I tested if skull cracks still kill regular crit-weakness players. Everything still works the same unless if you're a construct.

## Why It's Good For The Game

So, imagine you are playing as a race with already a fuckton of downsides. Can't drink red, blue, sleep, or even look good if you chose the male body(I seen that shit). Then, out of no where a man just clocks you in the back of the head and he has 18 STR so your just laid out on the ground dead. He is still just beating on you because in his mind you're just unconscious, nah. It was already over before it started.

Now, truthfully. This is not the main reason why I made the PR. While this scenario is entirely made up, I have had some even funnier ones ingame. The main fucking issue is the church. Oh my fucking god, have you ever explained how to revive your character 5 times in looc and even told them to pull the hammer out of your satchel that you came in with. I understand I'm skull cracked so my race is obscured, I get that. But if you can still cut me open and surgery doesn't progress, maybe you should step back and be like "hmmm, they are rejecting my miracles and surgery yet I can still use them on them, why?" Instead of the usual "Man, this guy still isn't healin', keep fucking blasting them with this holy spirit." 10/10, would sit in the church for an hour and a half again.

I just want to say, as I know majority of people cannot read cues. I am not shitting on the church, or even mad at them. I think its funny and im making a joke. However, this wastes everyone's time so I'm pushing to remove it. Maybe if artificer had more role depth I'd love to leave it in but....That isn't the case. Dying as a construct is too much of a pain in the ass right now.

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
