### PR TITLE
Changes skill leveling for ranged implements to be consistent with other skills.

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/ammo.dm
@@ -97,7 +97,7 @@
 		if(T.stat != DEAD) // If theyre alive
 			skill_multiplier = 4
 
-	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT))
+	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/crossbows, SKILL_LEVEL_LEGENDARY))
 		L.mind.add_sleep_experience(/datum/skill/combat/crossbows, L.STAINT * skill_multiplier)
 
 //arrows ฅ^•ﻌ•^ฅ
@@ -190,7 +190,7 @@
 		if(T.stat != DEAD) // If theyre alive
 			skill_multiplier = 4
 
-	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/bows, SKILL_LEVEL_EXPERT))
+	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/bows, SKILL_LEVEL_LEGENDARY))
 		L.mind.add_sleep_experience(/datum/skill/combat/bows, L.STAINT * skill_multiplier)
 
 /obj/projectile/bullet/reusable/arrow/blunt


### PR DESCRIPTION
## About The Pull Request

Changes the maximum skill ceiling for crossbows and bows from EXPERT to LEGENDARY so that they match slings as well.

## Testing Evidence

<img width="1398" height="727" alt="image" src="https://github.com/user-attachments/assets/1422161d-07d3-487d-be45-16be6153d61d" />
After some successful bowmanship, the change works without a problem, as it's a mere edit of two lines.

## Why It's Good For The Game

The skill ceiling should be consistent with how other combat skills are leveled up. Slings can be leveled up to legendary but not crossbows and bows; this simple change rectifies that oversight.
As an alternative; a custom trait could be made to give experience past EXPERT to 'ranged' classes.
I would be eager to try and create one if that would be more satisfactory to others. Might need a hand in implementing it, though.