### PR TITLE
Adds the hounskull to the hedge knight vendor

### DIFF
--- a/code/modules/cargo/packsrogue/bandit/classes/Knight.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Knight.dm
@@ -28,6 +28,11 @@
 	cost = 40
 	contains = list(/obj/item/clothing/head/roguetown/helmet/bascinet/pigface)
 
+/datum/supply_pack/rogue/Brigand/hbascinet
+	name = "Hounskull Bascinet"
+	cost = 40
+	contains = list(/obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull)
+
 /datum/supply_pack/rogue/Knight/knighthelm
 	name = "Knight's Helmet"
 	cost = 40

--- a/code/modules/cargo/packsrogue/bandit/classes/Knight.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Knight.dm
@@ -28,7 +28,7 @@
 	cost = 40
 	contains = list(/obj/item/clothing/head/roguetown/helmet/bascinet/pigface)
 
-/datum/supply_pack/rogue/Brigand/hbascinet
+/datum/supply_pack/rogue/Knight/hbascinet
 	name = "Hounskull Bascinet"
 	cost = 40
 	contains = list(/obj/item/clothing/head/roguetown/helmet/bascinet/pigface/hounskull)


### PR DESCRIPTION
## About The Pull Request

Title, adds the hounskull bascinet to the hedge knight's hordemaster at the same price as the pigface.

## Testing Evidence

<img width="1235" height="643" alt="image" src="https://github.com/user-attachments/assets/35d03b76-653b-41df-86c7-3ad62bba7f91" />

## Why It's Good For The Game

They already get the pigface bascinet, the hounskull is a more handsome reskin. It's a rather knightly helmet. No balance implications.