### PR TITLE
Fixes sling charge time inversely affecting damage

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/slings.dm
+++ b/code/game/objects/items/rogueweapons/ranged/slings.dm
@@ -183,7 +183,7 @@
 		BB.bonus_accuracy += (user.get_skill_level(/datum/skill/combat/slings) * 5) // +5 per Sling level.
 		BB.damage *= damfactor
 		if(user.client.chargedprog < 100)
-			BB.damage = BB.damage - (BB.damage * (user.client.chargedprog / 100))
+			BB.damage -= (BB.damage * (user.client.chargedprog / 100))
 		else
 			BB.damage = BB.damage
 		BB.damage = BB.damage * (((user.STAPER / 1.25) + (user.STASTR / 5)) / 10) * damfactor + bonus_stone_force

--- a/code/game/objects/items/rogueweapons/ranged/slings.dm
+++ b/code/game/objects/items/rogueweapons/ranged/slings.dm
@@ -183,7 +183,7 @@
 		BB.bonus_accuracy += (user.get_skill_level(/datum/skill/combat/slings) * 5) // +5 per Sling level.
 		BB.damage *= damfactor
 		if(user.client.chargedprog < 100)
-			BB.damage -= (BB.damage * (user.client.chargedprog / 100))
+			BB.damage -= BB.damage - (BB.damage * (user.client.chargedprog / 100))
 		else
 			BB.damage = BB.damage
 		BB.damage = BB.damage * (((user.STAPER / 1.25) + (user.STASTR / 5)) / 10) * damfactor + bonus_stone_force


### PR DESCRIPTION
## About The Pull Request

Title, slings at current deal full damage with no charge time and lose damage with charge time. Implements a fix inspired by a suggestion from @CameronWoof in #1014 based on the formula for bows.

## Testing Evidence


https://github.com/user-attachments/assets/7a2d70f6-2f02-4051-9476-721fdcdb6b84


https://github.com/user-attachments/assets/671e167e-ca64-4e41-8c1e-da7d1a08b73f


## Why It's Good For The Game

Bug fix.