### PR TITLE
Ironchads can forgo jman weapon skills for expert shields

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -329,7 +329,7 @@
 	H.dna.species.soundpack_m = new /datum/voicepack/male/warrior()
 	H.set_blindness(0)
 	if(H.mind)
-		var/weapons = list("Executioner's Sword","Warhammer + Shield","Flail + Shield","Lucerne","Greataxe")
+		var/weapons = list("Executioner's Sword","Warhammer + Shield","Flail + Shield","Lucerne","Greataxe","DEFENSE IS ALL THAT MATTERS")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Executioner's Sword")
@@ -353,6 +353,9 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/greataxe
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("DEFENSE IS ALL THAT MATTERS")
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_EXPERT, TRUE)
+				l_hand = /obj/item/rogueweapon/shield/atgervi
 
 /datum/advclass/sfighter/mhunter
 	name = "Exorcist"


### PR DESCRIPTION
## About The Pull Request

This PR gives Ironchads the option to forgo journeyman weapon skills in exchange for expert shields, since defence mastery is the core gimmick of the class.

## Testing Evidence

1 line change

## Why It's Good For The Game

It gives the Ironchad a unique niche as a role that excels at defense but not much else. Honestly that is what it probably should have been from the start.