### PR TITLE
Combat Aware Removal

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -676,7 +676,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		var/output = "[inspec.Join()]"
 		if(!usr.client.prefs.no_examine_blocks)
 			output = examine_block(output)
-		to_chat(usr, output)	
+		to_chat(usr, output)
 
 /obj/item
 	var/simpleton_price = FALSE
@@ -1665,11 +1665,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			var/balloon_msg = "Peel! \Roman[ROUND_UP(peel_count)] <br><font color = '#8b7330'>[peeledpart[1]]!</font>"
 			var/has_guarded = HAS_TRAIT(owner, TRAIT_DECEIVING_MEEKNESS)
 			if(length(peeledpart) && !has_guarded)
-				filtered_balloon_alert(TRAIT_COMBAT_AWARE, balloon_msg)
+				perception_balloon_alert(balloon_msg, required_perception = 12)
 			else if(length(peeledpart) && has_guarded)
 				if(prob(10))
 					balloon_msg = "<i>Guarded...</i>"
-					filtered_balloon_alert(TRAIT_COMBAT_AWARE, balloon_msg)
+					perception_balloon_alert(balloon_msg, required_perception = 12)
 	else
 		last_peeled_limb = coveragezone
 		reset_peel()

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -12,7 +12,7 @@
 		addtimer(CALLBACK(src, PROC_REF(purge_bait)), 30 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		addtimer(CALLBACK(src, PROC_REF(expire_peel)), 60 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	if(!HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS))
-		filtered_balloon_alert(TRAIT_COMBAT_AWARE, (cmode ? ("<i><font color = '#831414'>Tense</font></i>") : ("<i><font color = '#c7c6c6'>Relaxed</font></i>")), y_offset = 32)
+		src.perception_balloon_alert((cmode ? ("<i><font color = '#831414'>Tense</font></i>") : ("<i><font color = '#c7c6c6'>Relaxed</font></i>")), y_offset = 32, required_perception = 10)
 
 /datum/rmb_intent/proc/special_attack(mob/living/user, atom/target)
 	return

--- a/code/modules/balloon_alert/balloon_alert.dm
+++ b/code/modules/balloon_alert/balloon_alert.dm
@@ -43,7 +43,7 @@
 	var/client/viewer_client = viewer?.client
 	if (isnull(viewer_client))
 		return
-	
+
 	if(!(viewer_client.prefs.floating_text_toggles & FLOATING_TEXT))
 		return
 
@@ -102,13 +102,20 @@
 ///Proc for creating a balloon alert that only someone with a specific trait would see.
 /atom/proc/filtered_balloon_alert(trait, text, x_offset, y_offset)
 	var/list/candidates = get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src, RECURSIVE_CONTENTS_CLIENT_MOBS)
-	if(trait)	
+	if(trait)
 		for(var/mob/living/carbon/human/H in candidates)
 			if(HAS_TRAIT(H, trait))
 				candidates -= H
 	else
 		CRASH("filtered_balloon_alert called without a trait, either it's an error or use balloon_alert instead.")
 
+	balloon_alert_to_viewers(text, null, DEFAULT_MESSAGE_RANGE, candidates, x_offset, y_offset)
+
+/atom/proc/perception_balloon_alert(text, required_perception = 10, x_offset, y_offset)
+	var/list/candidates = get_hearers_in_view(DEFAULT_MESSAGE_RANGE, src, RECURSIVE_CONTENTS_CLIENT_MOBS)
+	for(var/mob/living/carbon/human/H in candidates)
+		if(H.STAPER >= required_perception)
+			candidates -= H
 	balloon_alert_to_viewers(text, null, DEFAULT_MESSAGE_RANGE, candidates, x_offset, y_offset)
 
 #undef BALLOON_TEXT_CHAR_LIFETIME_INCREASE_MIN

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -536,7 +536,7 @@ BLIND     // can't see anything
 		text = "Armor <br><font color = '#a8705a'>sundered</font>"
 		y_offset = 30
 	if(text)
-		filtered_balloon_alert(TRAIT_COMBAT_AWARE, text, -20, y_offset)
+		perception_balloon_alert(text, -20, y_offset, required_perception = 13)
 	. = ..()
 
 /obj/proc/generate_tooltip(examine_text, showcrits)
@@ -545,7 +545,7 @@ BLIND     // can't see anything
 /obj/item/clothing/generate_tooltip(examine_text, showcrits)
 	if(!armor)	// No armor
 		return examine_text
-	
+
 	// Fake armor
 	if(armor.getRating("slash") == 0 && armor.getRating("stab") == 0 && armor.getRating("blunt") == 0 && armor.getRating("piercing") == 0)
 		return examine_text
@@ -617,7 +617,7 @@ BLIND     // can't see anything
 
 // Handle clicks from chat to show the examine details
 /obj/item/clothing/Topic(href, href_list)
-	if(href_list["show_examine"]) 
+	if(href_list["show_examine"])
 		var/mob/user = usr
 		if(user)
 			to_chat(user, build_examine_detail(user, TRUE))

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -29,7 +29,6 @@
 		/datum/advclass/veteran/spy
 	)
 	job_traits = list(TRAIT_STEELHEARTED)
-	virtue_restrictions = list(/datum/virtue/combat/combat_aware)//given combat aware if old. Might hurt middle-aged vets, but middle aged vets don't suffer stat losses like old vets do
 
 /datum/job/roguetown/veteran/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
@@ -108,7 +107,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 		H.change_stat(STATKEY_WIL, 1)
-		ADD_TRAIT(H, TRAIT_COMBAT_AWARE, TRAIT_GENERIC)
 
 	H.adjust_blindness(-3)
 	if(H.mind)
@@ -187,7 +185,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
-		ADD_TRAIT(H, TRAIT_COMBAT_AWARE, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell
 
 /datum/advclass/veteran/calvaryman
@@ -252,7 +249,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
-		ADD_TRAIT(H, TRAIT_COMBAT_AWARE, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell
 
 	H.adjust_blindness(-3)
@@ -343,7 +339,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/axes, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE) // two handed weapons require a LOT of stamina.
-		ADD_TRAIT(H, TRAIT_COMBAT_AWARE, TRAIT_GENERIC)
 
 	H.adjust_blindness(-3)
 	if(H.mind)
@@ -428,7 +423,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/tracking, 6, TRUE)
 		H.change_stat(STATKEY_PER, 2)
-		ADD_TRAIT(H, TRAIT_COMBAT_AWARE, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell
 	H.cmode_music = 'sound/music/cmode/antag/combat_deadlyshadows.ogg' // so apparently this works for veteran, but not for advents. i dont know why.
 
@@ -502,5 +496,4 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 6, TRUE)
 		H.change_stat(STATKEY_SPD, 1) // You get -2 speed from being old. You are still in the negative stat wise from picking old.
 		H.change_stat(STATKEY_PER, 2) // You get -2 perception from being old. I want you to at least have a positive perception, to represent that you're observant. The highest perception you can get with this is a 13, so I think we'll be okayed.
-		ADD_TRAIT(H, TRAIT_COMBAT_AWARE, TRAIT_GENERIC)
 	H.verbs |= /mob/proc/haltyell

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -141,11 +141,11 @@
 			y_offset = BALLOON_Y_OFFSET_TIER3
 		if(text)
 			if(!HAS_TRAIT(H, TRAIT_DECEIVING_MEEKNESS))
-				H.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text, x_offset, y_offset)
+				H.perception_balloon_alert(text, x_offset, y_offset, required_perception = 13)
 			else
 				if(prob(10))
 					text = "<i>Tired...?</i>"
-					H.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text, x_offset, y_offset)
+					H.perception_balloon_alert(text, x_offset, y_offset, required_perception = 13)
 
 	if(stamina >= max_stamina)
 		stamina = max_stamina

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -943,24 +943,21 @@
 	if(!HAS_TRAIT(src, TRAIT_DECEIVING_MEEKNESS) && user != src)
 		if(isliving(user))
 			var/mob/living/L = user
-			if(L.STAINT > 9 && L.STAPER > 9)
-				if(HAS_TRAIT(src, TRAIT_COMBAT_AWARE))
-					. += span_warning("<i>They look battle-aware.</i>")
-				if(HAS_TRAIT(user, TRAIT_COMBAT_AWARE))
-					var/userheld = user.get_active_held_item()
-					var/srcheld = get_active_held_item()
-					var/datum/skill/user_skill = /datum/skill/combat/unarmed	//default
-					var/datum/skill/src_skill = /datum/skill/combat/unarmed
-					if(userheld)
-						var/obj/item/I = userheld
-						if(I.associated_skill)
-							user_skill = I.associated_skill
-					if(srcheld)
-						var/obj/item/I = srcheld
-						if(I.associated_skill)
-							src_skill = I.associated_skill
-					var/skilldiff = user.get_skill_level(user_skill) - get_skill_level(src_skill)
-					. += "<font size = 3><i>[skilldiff_report(skilldiff)] in my wielded skill than they are in theirs.</i></font>"
+			if(L.STAINT > 9 && L.STAPER >= 14)
+				var/userheld = user.get_active_held_item()
+				var/srcheld = get_active_held_item()
+				var/datum/skill/user_skill = /datum/skill/combat/unarmed	//default
+				var/datum/skill/src_skill = /datum/skill/combat/unarmed
+				if(userheld)
+					var/obj/item/I = userheld
+					if(I.associated_skill)
+						user_skill = I.associated_skill
+				if(srcheld)
+					var/obj/item/I = srcheld
+					if(I.associated_skill)
+						src_skill = I.associated_skill
+				var/skilldiff = user.get_skill_level(user_skill) - get_skill_level(src_skill)
+				. += "<font size = 3><i>[skilldiff_report(skilldiff)] in my wielded skill than they are in theirs.</i></font>"
 
 
 	if(ishuman(user))
@@ -1177,4 +1174,3 @@
 			gang_text = span_userdanger ("Blortz Volves scum! Enemy!")
 
 	return gang_text
-

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1306,7 +1306,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		log_combat(user, target, "punched")
 		if(ishuman(user) && user.mind)
 			var/text = "[bodyzone2readablezone(selzone)]..."
-			user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
+			user.perception_balloon_alert(text, required_perception = 12)
 
 		if(!nodmg)
 			if(user.limb_destroyer)
@@ -1582,7 +1582,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 			if(ishuman(user) && user.mind)
 				var/text = "[bodyzone2readablezone(selzone)]..."
-				user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
+				user.perception_balloon_alert(text, required_perception = 12)
 
 			user.do_attack_animation_simple(target, ATTACK_EFFECT_KICK, TRUE)
 			if(!nodmg)
@@ -1850,9 +1850,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
 			if(prob(10))
 				text = "<i>I can't tell...</i>"
-				user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
+				user.perception_balloon_alert(text, required_perception = 12)
 		else
-			user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
+			user.perception_balloon_alert(text, required_perception = 12)
 
 	var/armor_block = H.run_armor_check(selzone, I.d_type, "", "",pen, damage = Iforce, blade_dulling=bladec, peeldivisor = user.used_intent.peel_divisor, intdamfactor = used_intfactor, used_weapon = I)
 

--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -267,7 +267,7 @@
 			user.visible_message(span_warning("<b>[user]</b> clips [src]'s weapon!"))
 			playsound(user, 'sound/misc/weapon_clip.ogg', 100)
 
-	if(mind && user.mind && HAS_TRAIT(src, TRAIT_COMBAT_AWARE))
+	if(mind && user.mind && L.STAPER >= 12)
 		var/text = "[bodyzone2readablezone(user.zone_selected)]..."
 		if(HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
 			if(prob(10))

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -249,7 +249,7 @@
 				used_weapon.take_damage(intdam, BRUTE, used_weapon.d_type)
 				used_weapon.remove_bintegrity(sharp_loss, user)
 
-			if(mind && user.mind && HAS_TRAIT(src, TRAIT_COMBAT_AWARE))
+			if(mind && user.mind && H.STAPER >= 12)
 				var/text = "[bodyzone2readablezone(user.zone_selected)]..."
 				if(HAS_TRAIT(user, TRAIT_DECEIVING_MEEKNESS))
 					if(prob(10))

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -434,11 +434,11 @@
 			return
 	playsound(C.loc, "genblunt", 100, FALSE, -1)
 	C.next_attack_msg.Cut()
-	if(isdoll(C)) 
+	if(isdoll(C))
 		armor_block = C.getarmor(sublimb_grabbed, "blunt")
 		if(armor_block > 1)
 			C.apply_damage(damage, BRUTE, limb_grabbed, armor_block)
-	else 
+	else
 		armor_block = C.run_armor_check(limb_grabbed, "blunt")
 		C.apply_damage(damage, BRUTE, limb_grabbed, armor_block)
 	limb_grabbed.bodypart_attacked_by(BCLASS_TWIST, damage, user, sublimb_grabbed, crit_message = TRUE)
@@ -455,12 +455,12 @@
 		limb_grabbed.drop_limb(TRUE)
 	if(ishuman(user) && user.mind)
 		var/text = "[bodyzone2readablezone(user.zone_selected)]..."
-		user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
+		user.perception_balloon_alert(text, required_perception = 12)
 
 	if(limb_grabbed.body_zone == sublimb_grabbed && isdoll(C))
 		var/mob/living/carbon/human/target = C
 		armor_block = target.getarmor(sublimb_grabbed, "slash")
-		
+
 		if(armor_block >= 1)
 			target.visible_message(span_danger("[target]'s [parse_zone(sublimb_grabbed)] fails to be twisted off!"), \
 				span_danger("[user] tries to twist my [parse_zone(sublimb_grabbed)] out of it's socket but the armor keeps it in place!"))
@@ -472,7 +472,7 @@
 		to_chat(user, span_warning("I begin popping [target]'s [parse_zone(sublimb_grabbed)] out of socket."))
 
 		var/delay = (sublimb_grabbed == BODY_ZONE_HEAD) ? 100 : 6
-		
+
 		if(do_after(user, delay, target = target))
 			target.visible_message(span_danger("[target]'s [parse_zone(sublimb_grabbed)] has been popped out of socket!"), \
 				span_userdanger("My [parse_zone(sublimb_grabbed)] has been popped out of socket!"))
@@ -485,7 +485,7 @@
 
 			qdel(src)
 			user.put_in_active_hand(limb_grabbed)
-	  
+
 	// Dealing damage to the head beforehand is intentional.
 	if(limb_grabbed.body_zone == BODY_ZONE_HEAD && isdullahan(C))
 		var/mob/living/carbon/human/target = C
@@ -663,7 +663,7 @@
 	log_combat(user, C, "limbsmashed [limb_grabbed] ")
 	if(ishuman(user) && user.mind)
 		var/text = "[bodyzone2readablezone(user.zone_selected)]..."
-		user.filtered_balloon_alert(TRAIT_COMBAT_AWARE, text)
+		user.perception_balloon_alert(text, required_perception = 12)
 
 /datum/intent/grab
 	unarmed = TRUE

--- a/modular_azurepeak/code/game/objects/items/quiver.dm
+++ b/modular_azurepeak/code/game/objects/items/quiver.dm
@@ -78,8 +78,8 @@
 					arrows -= AR
 					B.attackby(AR, loc, params)
 					if(ismob(loc))
-						var/mob/M = loc
-						if(HAS_TRAIT(M, TRAIT_COMBAT_AWARE))
+						var/mob/living/M = loc
+						if(ishuman(M) && M.STAPER >= 14)
 							M.balloon_alert(M, "[length(arrows)] left...")
 					break
 		return

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -170,6 +170,7 @@
 	desc = "Whether it's by having an annoying sibling that kept prodding me with a stick, or years of study and observation, I've become adept at both parrying and dodging stronger opponents, by learning their moves and studying them."
 	added_traits = list(TRAIT_SENTINELOFWITS)
 
+/*
 /datum/virtue/combat/combat_aware
 	name = "Combat Aware"
 	desc = "The opponent's flick of their wrist. The sound of maille snapping. The desperate breath as the opponent's stamina wanes. All of this is made more clear to you through intuition or experience."
@@ -178,6 +179,7 @@
 
 /datum/virtue/combat/combat_aware/apply_to_human(mob/living/carbon/human/recipient)
 	recipient.verbs += /mob/living/carbon/human/proc/togglecombatawareness
+*/
 
 /datum/virtue/combat/tough_hide
 	name = "Natural Armor"


### PR DESCRIPTION
## About The Pull Request

Removes combat aware virtue, retains its functionality with perception based gates.
10 PER to see someone entering / exiting combat mode.
12 PER to see where someone was aiming when they attacked.
14 PER to see skill comparisons on examine & count arrows.

## Testing Evidence

Functioned appropriately on my localhost.

## Why It's Good For The Game

These features should be integrated into the combat system, not separated by a virtue.