### PR TITLE
Swap INT values for heavy knight and royal champion

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_champion.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_champion.dm
@@ -9,7 +9,7 @@
 	category_tags = list(CTAG_ROYALGUARD)
 	subclass_stats = list(
 		STATKEY_STR = 1,
-		STATKEY_INT = 1,
+		STATKEY_INT = 3,
 		STATKEY_WIL = 2,
 		STATKEY_SPD = 2,
 	)

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
@@ -8,7 +8,7 @@
 	traits_applied = list(TRAIT_HEAVYARMOR)
 	subclass_stats = list(
 		STATKEY_STR = 3,//Heavy hitters. Less con/end, high strength.
-		STATKEY_INT = 3,
+		STATKEY_INT = 1,
 		STATKEY_CON = 1,
 		STATKEY_WIL = 1,
 		STATKEY_SPD = -1,

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
@@ -9,8 +9,8 @@
 	subclass_stats = list(
 		STATKEY_STR = 3,//Heavy hitters. Less con/end, high strength.
 		STATKEY_INT = 1,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1,
+		STATKEY_CON = 2,
+		STATKEY_WIL = 2,
 		STATKEY_SPD = -1,
 	)
 	subclass_skills = list(


### PR DESCRIPTION
## About The Pull Request

This is literally just a simple numberswap. it swaps the INT values between royal champion and heavy knight subclass

## Testing Evidence

<img width="454" height="76" alt="image" src="https://github.com/user-attachments/assets/4ac0c9a2-f290-4212-a77d-6925c2abbaef" />
It compiles! (I don't know why it wouldn't)

## Why It's Good For The Game

Right, in simple terms, heavy knight is already the most evidently powerful class of knight compared to other subclasses. It's given immediate heavy armor, buffs to it's str and con. it's only downside is -1 SPD, which will rarely make a difference in a fight.

Royal champion, on the other hand, is intended to be more of a duelist subclass of knight. Which INT plays a much heavier role, it doesn't make sense the royal champion, allegedly meant to be the best with the blade, can be out-feinted by your average heavy knight player. This just swaps the INT values.
