### PR TITLE
Dukes and Merchants spawn with a single pistol

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/firearms/arquebus.dm
+++ b/code/game/objects/items/rogueweapons/ranged/firearms/arquebus.dm
@@ -29,6 +29,8 @@
 	grid_height = 32
 	grid_width = 96
 	experimental_onhip = TRUE
+	pixel_x = 0
+	pixel_y = 0
 
 /obj/item/gun/ballistic/firearm/arquebus_pistol/getonmobprop(tag)
 	. = ..()

--- a/code/game/objects/items/rogueweapons/ranged/firearms/firearm_base.dm
+++ b/code/game/objects/items/rogueweapons/ranged/firearms/firearm_base.dm
@@ -63,7 +63,7 @@ At least, it should. Fingers crossed.
 	cartridge_wording = "musketball"
 	load_sound = list('modular_helmsguard/sound/arquebus/musketload.ogg')
 	fire_sound = list('modular_helmsguard/sound/arquebus/arquefire.ogg')
-	anvilrepair = /datum/skill/craft/blacksmithing
+	anvilrepair = /datum/skill/craft/engineering
 	smeltresult = /obj/item/ingot/steel
 	bolt_type = BOLT_TYPE_NO_BOLT
 	casing_ejector = FALSE

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -72,7 +72,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	cloak = /obj/item/clothing/cloak/lordcloak
 	belt = /obj/item/storage/belt/rogue/leather/plaquegold
 	beltl = /obj/item/storage/keyring/lord
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	id = /obj/item/scomstone/garrison
 
 /datum/outfit/job/roguetown/lord/pre_equip(mob/living/carbon/human/H)
@@ -139,6 +138,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/warrior/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1)
 	if(H.age == AGE_OLD)
 		H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 
@@ -168,6 +168,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT, // Weapons suitable for defending yourself as a merchant.
+		/datum/skill/combat/firearms = SKILL_LEVEL_EXPERT, // Weapons suitable for defending yourself as a merchant.
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
@@ -182,6 +183,11 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/merchant/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
+	beltr = /obj/item/gun/ballistic/firearm/arquebus_pistol
+	backr = /obj/item/storage/backpack/rogue/satchel
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/quiver/bullet/lead,
+		/obj/item/powderflask,)
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/appraise/secular)
 
@@ -253,7 +259,13 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/outfit/job/roguetown/lord/inbred/pre_equip(mob/living/carbon/human/H)
 	..()
 	l_hand = /obj/item/rogueweapon/lordscepter
+	backr = /obj/item/storage/backpack/rogue/satchel
+	beltr = /obj/item/gun/ballistic/firearm/arquebus_pistol
+	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
+		/obj/item/quiver/bullet/lead,
+		/obj/item/powderflask,)
 	H.adjust_skillrank(/datum/skill/combat/crossbows, pick(0,1), TRUE)
+	H.adjust_skillrank(/datum/skill/combat/firearms, pick(0,1), TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, pick(0,0,1), TRUE)
 	H.adjust_skillrank(/datum/skill/misc/athletics, pick(0,1), TRUE)
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/merchant.dm
@@ -31,7 +31,7 @@
 	name = "Merchant"
 	tutorial = "You were born into wealth, learning from before you could talk about the basics of mathematics. \
 	Counting coins is a simple pleasure for any person, but you've made it an art form. \
-	These people are addicted to your wares, and you are the literal beating heart of this economy: \
+	These people are addicted to your wares, and you are the true beating heart of this economy: \
 	Don't let these filth-covered troglodytes ever forget that."
 	outfit = /datum/outfit/job/roguetown/merchant/basic
 	category_tags = list(CTAG_MERCH)
@@ -44,6 +44,7 @@
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/firearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/bows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
@@ -60,13 +61,18 @@
 /datum/outfit/job/roguetown/merchant/basic/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.adjust_blindness(-3)
-	backpack_contents = list(/obj/item/rogueweapon/huntingknife/idagger/navaja)
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/idagger/navaja,
+		/obj/item/quiver/bullet/lead,
+		/obj/item/powderflask,
+	)
 	neck = /obj/item/clothing/neck/roguetown/horus
 	armor = /obj/item/clothing/suit/roguetown/shirt/robe/merchant
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor
 	pants = /obj/item/clothing/under/roguetown/tights/sailor
 	belt = /obj/item/storage/belt/rogue/leather/rope
-	beltl = /obj/item/storage/keyring/merchant
+	wrists = /obj/item/storage/keyring/merchant
+	beltl = /obj/item/gun/ballistic/firearm/arquebus_pistol
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	id = /obj/item/clothing/ring/gold
 	backr = /obj/item/storage/backpack/rogue/satchel


### PR DESCRIPTION
Also fixes dukes spawning with two daggers!

## About The Pull Request

Puts a pistol (along with bullets and powder (and possibly a satchel to store them in)) in the inventories of the Grand Duke's Merchant and Inbred subclass (but not the warrior or magocrat subclasses) and the Merchant, along with some firearm skill for the merchant-duke and merchant (but not the inbred duke, they don't actually know how to use that thing)

Also comes with a tiny tweak of fixing the pistol's pixel offset, and making them repaired with engineering instead of blacksmithing
Also fixes the way that dukes always would spawn with two knives.

## Testing Evidence

<img width="2233" height="864" alt="image" src="https://github.com/user-attachments/assets/deaca192-a581-47e3-9f0d-becb50dde45c" />
<img width="2210" height="1106" alt="image" src="https://github.com/user-attachments/assets/df78805f-e31e-43af-a81d-5a5797d5fb65" />


## Why It's Good For The Game

Guns are cool and fun and exciting! And we've already gone through all the effort of porting them in, it's just a matter of implementing. The Merchant and Duke are important roles and it's nice to have a suitably flavourful form of self-defence for them.