### PR TITLE
Renames 'Slurbow' to 'Handcrossbow'

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/crossbows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/crossbows.dm
@@ -188,10 +188,10 @@
 
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
-	name = "slurbow"
+	name = "hand crossbow"
 	desc = "A lighter weight crossbow with a distinct barrel shroud holding the bolt in place. Light enough to arm by hand. <br>They're popular among among highwaymen and the patrolling lamplighters of Otava."
 	icon = 'icons/roguetown/weapons/misc32.dmi'
-	icon_state = "slurbow0"
+	icon_state = "slurbow"
 	item_state = "slurbow"
 	possible_item_intents = list(/datum/intent/shoot/crossbow/slurbow, /datum/intent/arc/crossbow/slurbow, INTENT_GENERIC)
 	chargingspeed = 20

--- a/code/modules/cargo/packsrogue/bandit/classes/Knave.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Knave.dm
@@ -173,7 +173,7 @@
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow)
 
 /datum/supply_pack/rogue/Knave/slurbow
-	name = "Slurbow"
+	name = "Hand Crossbow"
 	cost = 40
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow)
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/crocs.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/crocs.dm
@@ -193,10 +193,10 @@
 			H.put_in_hands(new /obj/item/bait/spider, TRUE)
 		if("I'm a foot-soldier")
 			H.adjust_skillrank_up_to(/datum/skill/misc/athletics, SKILL_LEVEL_EXPERT, TRUE)
-	var/weapons = list("Slurbow","Shortbow","Dual Daggers")
+	var/weapons = list("Hand Crossbow","Shortbow","Dual Daggers")
 	var/weapon_choice = input(H, "Choose your weapon.", "How do you kill?") as anything in weapons
 	switch(weapon_choice)
-		if("Slurbow")
+		if("Hand Crossbow")
 			H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_EXPERT, TRUE)
 			H.put_in_hands(new /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/quiver/bolts/, SLOT_BACK_R, TRUE)


### PR DESCRIPTION
## About The Pull Request
As per title.

## Testing Evidence

<img width="349" height="251" alt="image" src="https://github.com/user-attachments/assets/a9a39e29-8fde-4ac3-b429-bd89795aa805" />

## Why It's Good For The Game

While I do understand that 'Slurbow' IS a real term and that there IS a wikipedia page for it, the fact is that *nobody would know that*. Slurbow is a weird name that causes a lot of confusion, while Hand Crossbow is both more familiar and clearly communicates what it is without unintentionally suggesting anything false.
