### PR TITLE
Fixes LOOC being mutable

### DIFF
--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -98,14 +98,8 @@
 			var/turf/speakturf = get_turf(M)
 			var/turf/sourceturf = get_turf(usr)
 			if(wp == 1 && (M in range (7, src)))
-				to_chat(C,
-					type = MESSAGE_TYPE_OOC,
-					html = "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+				to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
 			else if(speakturf in get_hear(7, sourceturf))
-				to_chat(C,
-					type = MESSAGE_TYPE_OOC,
-					html = "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+				to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
 			else if(is_admin == 1)
-				to_chat(C,
-					type = MESSAGE_TYPE_OOC,
-					html = "<font color='["#003458"]'><b>(R) <span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+				to_chat(C, "<font color='["#003458"]'><b>(R) <span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")


### PR DESCRIPTION
## About The Pull Request
Muting OOC no longer mutes LOOC.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="781" height="626" alt="image" src="https://github.com/user-attachments/assets/6a9309d6-b379-4796-a411-e304ea31dcd1" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Just the other night we had an issue with people muting LOOC and ignoring people's preferences. want to know why it wasn't an issue before?
LOOC wasn't supposed to be mutable. 
Fatherless wanted it to be mutable. he made a PR for it. most people disliked it. 
https://github.com/Rotwood-Vale/Ratwood-2.0/pull/893
So he tried something else. he made a PR that claims it "sorts looc into an OOC subtype." he claims this was to make admin logs easier and cleaner to parse. This is bunk, no admins asked for this. He just did it because OOC was mutable, and by shuffling LOOC in with ooc, he was able to sneak in LOOC muting without anyone else knowing.
https://github.com/Rotwood-Vale/Ratwood-2.0/pull/925

Seems clear to me this feature wasn't supposed to be in the game. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
