### PR TITLE
Update thug.dm

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -75,7 +75,7 @@
 			to_chat(H, span_warning("You're smarter than the rest, by a stone's throw - and you know better than to get up close and personal. Unlike most others, you can read."))
 			H.set_blindness(0)
 
-			H.change_stat(STATKEY_WIL, -2)
+			H.change_stat(STATKEY_STR, -2)
 			H.change_stat(STATKEY_CON, -2)
 			H.change_stat(STATKEY_SPD, 2)
 			H.change_stat(STATKEY_INT, 2)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -75,7 +75,6 @@
 			to_chat(H, span_warning("You're smarter than the rest, by a stone's throw - and you know better than to get up close and personal. Unlike most others, you can read."))
 			H.set_blindness(0)
 
-			H.change_stat(STATKEY_STR, -2)
 			H.change_stat(STATKEY_CON, -2)
 			H.change_stat(STATKEY_SPD, 2)
 			H.change_stat(STATKEY_INT, 2)


### PR DESCRIPTION
Changing stat nuke from WP to STR

## About The Pull Request

Miscreant is meant to be sneaky and fast, but you lose your breath the moment you try to run from danger like you should. After seeing stat balance of the other subclasses, I just removed the WP nuke while it still being in line with the rest of the thug classes.

## Testing Evidence

Its a 1 line change

## Why It's Good For The Game

Makes thug less AIDS to play, but still not power creeping in on adventurers and whatnot
