### PR TITLE
Add fire resistance to coifs

### DIFF
--- a/code/__DEFINES/roguetown/armor_defines.dm
+++ b/code/__DEFINES/roguetown/armor_defines.dm
@@ -88,6 +88,7 @@
 #define ARMOR_PADDED_BAD list("blunt" = 50, "slash" = 30, "stab" = 20, "piercing" = 40, "fire" = 0, "acid" = 0)
 #define ARMOR_PADDED list("blunt" = 70, "slash" = 40, "stab" = 30, "piercing" = 50, "fire" = 0, "acid" = 0)
 #define ARMOR_PADDED_GOOD list("blunt" = 90, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 0, "acid" = 0)
+#define ARMOR_PADDED_GOOD_PLUS_FIRE list("blunt" = 90, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 15, "acid" = 0)
 
 // Leather should always be 10 less than their padded counterparts for piercing but is good vs arrows still.
 #define ARMOR_LEATHER list("blunt" = 60, "slash" = 50, "stab" = 40, "piercing" = 30, "fire" = 0, "acid" = 0)

--- a/code/__DEFINES/roguetown/armor_defines.dm
+++ b/code/__DEFINES/roguetown/armor_defines.dm
@@ -88,7 +88,6 @@
 #define ARMOR_PADDED_BAD list("blunt" = 50, "slash" = 30, "stab" = 20, "piercing" = 40, "fire" = 0, "acid" = 0)
 #define ARMOR_PADDED list("blunt" = 70, "slash" = 40, "stab" = 30, "piercing" = 50, "fire" = 0, "acid" = 0)
 #define ARMOR_PADDED_GOOD list("blunt" = 90, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 0, "acid" = 0)
-#define ARMOR_PADDED_GOOD_PLUS_FIRE list("blunt" = 90, "slash" = 50, "stab" = 50, "piercing" = 80, "fire" = 15, "acid" = 0)
 
 // Leather should always be 10 less than their padded counterparts for piercing but is good vs arrows still.
 #define ARMOR_LEATHER list("blunt" = 60, "slash" = 50, "stab" = 40, "piercing" = 30, "fire" = 0, "acid" = 0)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -76,7 +76,7 @@
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD|MOUTH
-	armor = ARMOR_PADDED_GOOD //full padded gambeson basically
+	armor = ARMOR_PADDED_GOOD_PLUS_FIRE //full padded gambeson basically
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -49,6 +49,7 @@
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE
 	sewrepair = TRUE
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/neck/roguetown/coif/padded
 	name = "padded coif"
@@ -76,7 +77,7 @@
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HEAD
 	blocksound = SOFTHIT
 	body_parts_covered = NECK|HAIR|EARS|HEAD|MOUTH
-	armor = ARMOR_PADDED_GOOD_PLUS_FIRE //full padded gambeson basically
+	armor = ARMOR_PADDED_GOOD //full padded gambeson basically
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT)
 	adjustable = CAN_CADJUST
 	toggle_icon_state = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR adjusts the resistance stats for all coifs to have fire resistance.

<img width="118" height="117" alt="image" src="https://github.com/user-attachments/assets/e6b6f04b-40cd-42d9-967d-3b2eb52edaa7" />

## Testing Evidence

I've tested this by igniting my character on fire via a fire trap and extinguishing by crawling to a water tile.

This is comparing original heavily padded coif stats vs new change.

<img width="454" height="490" alt="beforeafter" src="https://github.com/user-attachments/assets/a62ce84a-50e1-4bc5-87e0-fb253f5d481e" />

This is two same species characters naked except wearing the coifs.
Left is original stats right is new stats.

<img width="646" height="467" alt="stats" src="https://github.com/user-attachments/assets/cade3c61-d3cd-4f08-8cba-6214d4f6e037" />

## Why It's Good For The Game

I feel the heavily padded coifs would take a bit longer to burn, and should have a minor fire damage buff.