### PR TITLE
Ports over Triumphs at Night from AP

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -96,12 +96,11 @@ SUBSYSTEM_DEF(nightshift)
 				apply_status_effect(/datum/status_effect/debuff/vamp_dreams)
 			if(HAS_TRAIT(src, TRAIT_NIGHT_OWL) && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 				apply_status_effect(/datum/status_effect/debuff/sleepytime)
-			if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA) || HAS_TRAIT(src, TRAIT_NOSLEEP))
-				handle_sleep_triumphs()
 		if("dusk")
 			SEND_SIGNAL(src, COMSIG_MOB_DUSKED)
 		if("night")
 			SEND_SIGNAL(src, COMSIG_MOB_NIGHTED)
+			handle_sleep_triumphs()
 			if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA) || HAS_TRAIT(src, TRAIT_NOSLEEP))
 				return ..()
 			if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
@@ -122,7 +121,7 @@ SUBSYSTEM_DEF(nightshift)
 	if(mind.assigned_role != "Unassigned" && istype(mind.assigned_role, /datum/job) && (mind.assigned_role.title in towner_jobs)) //If you play a towner-related role, you get an additonal triumph
 		triumphs_to_add++
 	adjust_triumphs(triumphs_to_add)
-	to_chat(src, span_danger("Nights Survived: \Roman[allmig_reward]"))
+	to_chat(src, span_danger("Days Survived: \Roman[allmig_reward]"))
 
 /mob/living/carbon/human
 	var/survived_cycles = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -53,7 +53,6 @@
 				remove_stress(/datum/stressevent/sleepytime)
 				if(mind)
 					mind.sleep_adv.advance_cycle()
-					handle_sleep_triumphs()
 	if(leprosy == 1)
 		adjustToxLoss(2)
 	else if(leprosy == 2)


### PR DESCRIPTION
## About The Pull Request
Ports: https://github.com/Azure-Peak/Azure-Peak/pull/6199

Reasons:
Pros:
Literally roleplayers are not forced to go and sleep to gain triumphs, cutting roleplay short.

Cons:
Literally none. Triumphs are used for RP reason usually.

Reasons to still sleep.
Sleep is STILL the only way to have good active stamina regen and minor healing for most people.

Its the ONLY way to gain skill above apprentice.
## Testing Evidence

None. It genuinely shouldn't break anything or else AP wouldn't have full merged it. I did not see any bugfixes for it. 

## Why It's Good For The Game

Roleplay is good. Let people not have to interrupt chatting, sex, etc by needing to sleep for arbitrary roleplay currency.