### PR TITLE
Migrant TD QOL

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -4,10 +4,10 @@ SUBSYSTEM_DEF(migrants)
 	runlevels = RUNLEVEL_GAME
 	var/wave_number = 1
 	var/current_wave = null
-	var/time_until_next_wave = 2 MINUTES
+	var/time_until_next_wave = 90 SECONDS
 	var/wave_timer = 0
 
-	var/time_between_waves = 3 MINUTES
+	var/time_between_waves = 2 MINUTES
 	var/time_between_fail_wave = 90 SECONDS
 	var/wave_wait_time = 30 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Due to 20-50% TD, Migrants suffer from having to wait almost double or 1.5x the wait time to roll.

This reduces wait time between waves. (Literally only punishes people who use the migrant system)

It also reduces time of the FIRST wave from 120 to 90.

## Testing Evidence

Its just changing values

## Why It's Good For The Game

QOL for people who actually use the system. If you dont use the system this will NOT affect you. 
