### PR TITLE
City Watch Armor Nerf

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -655,7 +655,7 @@
 	item_state = "citywatch"
 	blocksound = PLATEHIT
 	body_parts_covered = CHEST|GROIN|VITALS
-	max_integrity = ARMOR_INT_CHEST_PLATE_STEEL
+	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE
 	armor_class = ARMOR_CLASS_MEDIUM
 	smelt_bar_num = 2
 	sewrepair = FALSE


### PR DESCRIPTION
## About The Pull Request

Changes the integrity value of the citywatch chest armor from ARMOR_INT_CHEST_PLATE_STEEL (500) to ARMOR_INT_CHEST_PLATE_BRIGANDINE (350).

## Testing Evidence

Define change, take my word for it.

## Why It's Good For The Game

Currently, city watch chest armor has an unprecedented 500 integrity, the same as half or full plate(!), traditionally reserved for heavy armor. A city watchman's outer armor will take as many hits to get through as a knight's! This makes it the second most durable medium armor, below only blacksteel at 600, and considerably higher than the next best and usually best craftable, brigandine, at 350. This is inconsistent with usual armor design and not something a 4-slot garrison role needs immediate access to. With this new value, there's at least something to upgrade to for extra arm coverage if you want it, and it's still much better than a regular cuirass.