### PR TITLE
Playable skeleton tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -276,6 +276,7 @@ LICH SKELETONS
 	neck = /obj/item/clothing/neck/roguetown/coif
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
 	backl = /obj/item/storage/backpack/rogue/satchel
+	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
 	beltr = /obj/item/rogueweapon/stoneaxe/woodcut
 	beltl = /obj/item/rogueweapon/pick/copper

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -11,7 +11,7 @@ LICH SKELETONS
 	outfit = /datum/outfit/job/roguetown/greater_skeleton/lich
 
 /datum/outfit/job/roguetown/greater_skeleton/lich
-	cloak = /obj/item/clothing/cloak/half	//starts black, so they can be identified.
+	cloak = /obj/item/clothing/cloak/thief_cloak/yoruku
 	belt = /obj/item/storage/belt/rogue/leather/black
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 	backl = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -15,7 +15,6 @@ LICH SKELETONS
 	belt = /obj/item/storage/belt/rogue/leather/black
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/paalloy
 	backl = /obj/item/storage/backpack/rogue/satchel
-	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
 /datum/outfit/job/roguetown/greater_skeleton/lich/pre_equip(mob/living/carbon/human/H)
 	..()
@@ -62,6 +61,7 @@ LICH SKELETONS
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
+	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
 	backr = /obj/item/rogueweapon/shield/wood
 	beltl = /obj/item/quiver/javelin/paalloy
@@ -129,6 +129,7 @@ LICH SKELETONS
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/sandals/aalloy
+	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
 	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/padagger
 	H.adjust_blindness(-3)
@@ -195,6 +196,7 @@ LICH SKELETONS
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/paalloy
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/aalloy
+	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
 	H.adjust_blindness(-3)
 	var/weapons = list("Greatsword", "Bardiche", "Grand Mace", "Mace + Shield","Spear", "Warhammer + Shield")

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -194,6 +194,7 @@ LICH SKELETONS
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/guard/paalloy
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/paalloy
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/half/paalloy
+	pants = /obj/item/clothing/under/roguetown/chainlegs/kilt/paalloy
 	neck = /obj/item/clothing/neck/roguetown/gorget/paalloy
 	shoes = /obj/item/clothing/shoes/roguetown/boots/aalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -73,12 +73,15 @@ LICH SKELETONS
 		if("Gladius")
 			beltr = /obj/item/rogueweapon/sword/short/gladius/pagladius
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+			beltl = /obj/item/rogueweapon/scabbard
 		if("Kopesh")
 			beltr = /obj/item/rogueweapon/sword/sabre/palloy
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+			beltl = /obj/item/rogueweapon/scabbard
 		if("Shortsword")
 			beltr = /obj/item/rogueweapon/sword/short/pashortsword
 			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
+			beltl = /obj/item/rogueweapon/scabbard
 		if("Axe")
 			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel/paaxe
 			H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -40,9 +40,9 @@ LICH SKELETONS
 
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/whipsflails, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/axes, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
@@ -72,22 +72,17 @@ LICH SKELETONS
 	switch(weapon_choice)
 		if("Gladius")
 			beltr = /obj/item/rogueweapon/sword/short/gladius/pagladius
-			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 			beltl = /obj/item/rogueweapon/scabbard
 		if("Kopesh")
 			beltr = /obj/item/rogueweapon/sword/sabre/palloy
-			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 			beltl = /obj/item/rogueweapon/scabbard
 		if("Shortsword")
 			beltr = /obj/item/rogueweapon/sword/short/pashortsword
-			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 			beltl = /obj/item/rogueweapon/scabbard
 		if("Axe")
 			beltr = /obj/item/rogueweapon/stoneaxe/woodcut/steel/paaxe
-			H.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
 		if("Flail")
 			beltr = /obj/item/rogueweapon/flail/sflail/paflail
-			H.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 
 	H.energy = H.max_energy
 
@@ -111,9 +106,9 @@ LICH SKELETONS
 
 	ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
 
-	H.adjust_skillrank(/datum/skill/combat/bows , 4, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/crossbows, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/slings, 4, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/bows , 5, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/crossbows, 5, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/slings, 5, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
@@ -143,19 +138,15 @@ LICH SKELETONS
 		if("Recurve Bow")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 			beltl = /obj/item/quiver/paalloy
-			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		if("Crossbow")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
 			beltl = /obj/item/quiver/bolts/paalloy
-			H.adjust_skillrank(/datum/skill/combat/crossbows, 1, TRUE)
 		if("Yew Longbow")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 			beltl = /obj/item/quiver/paalloy
-			H.adjust_skillrank(/datum/skill/combat/bows, 1, TRUE)
 		if("Sling")
 			l_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
 			beltl = /obj/item/quiver/sling/paalloy
-			H.adjust_skillrank(/datum/skill/combat/slings, 1, TRUE)
 
 	H.energy = H.max_energy
 
@@ -179,9 +170,9 @@ LICH SKELETONS
 
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 
-	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/shields, 4, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/unarmed, 2, TRUE)
@@ -203,32 +194,25 @@ LICH SKELETONS
 	gloves = /obj/item/clothing/gloves/roguetown/chain/paalloy
 
 	H.adjust_blindness(-3)
-	var/weapons = list("Greatsword", "Bardiche", "Grand Mace", "Mace + Shield","Spear", "Warhammer + Shield")
+	var/weapons = list("Greatsword", "Bardiche", "Grand Mace", "Mace + Shield","Spear + Shield", "Warhammer + Shield")
 	var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	H.set_blindness(0)
 	switch(weapon_choice)
 		if("Greatsword")
 			r_hand = /obj/item/rogueweapon/greatsword/paalloy
-			H.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Bardiche")
 			r_hand = /obj/item/rogueweapon/halberd/bardiche/paalloy
-			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 		if("Grand Mace")
 			r_hand = /obj/item/rogueweapon/mace/goden/steel/paalloy
-			H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
 		if("Mace + Shield")
 			r_hand = /obj/item/rogueweapon/mace/steel/palloy
 			l_hand = /obj/item/rogueweapon/shield/wood
-			H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-		if("Spear")
+		if("Spear + Shield")
 			r_hand = /obj/item/rogueweapon/spear/paalloy
-			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 			l_hand = /obj/item/rogueweapon/shield/wood
 		if("Warhammer + Shield")
 			r_hand = /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 			l_hand = /obj/item/rogueweapon/shield/wood
-			H.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
-			H.adjust_skillrank(/datum/skill/combat/shields, 1, TRUE)
 
 	H.energy = H.max_energy
 
@@ -254,6 +238,7 @@ LICH SKELETONS
 
 	H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
+	H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/bows , 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/slings, 2, TRUE)
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 2, TRUE)

--- a/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/lich_skeleton.dm
@@ -223,6 +223,7 @@ LICH SKELETONS
 		if("Spear")
 			r_hand = /obj/item/rogueweapon/spear/paalloy
 			H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
+			l_hand = /obj/item/rogueweapon/shield/wood
 		if("Warhammer + Shield")
 			r_hand = /obj/item/rogueweapon/mace/warhammer/steel/paalloy
 			l_hand = /obj/item/rogueweapon/shield/wood


### PR DESCRIPTION
## About The Pull Request

1 - Stops you from spawning double chain gloves
2 - Gives leg clothing to the bulwark which otherwise had nothing in the leg slot
3 - Changes the cloak from a half-cloak to a black rapscallion's shawl
4 - Gives the sword-users scabbards
5 - Adds a shield to the bulwark's 'spear' option
6 - Gives all skeletons equal weapon skill in their possible weapons rather than their weapon skill depending on what they selected at spawn.

## Testing Evidence

I'm pretty confident that it'll work and also it's hard to test things as a skeleton!

## Why It's Good For The Game

1 - Fixes a bug
2 - Was weird they didn't get anything in the leg slot but do get things in the arms slot
3 - Half-cloaks always looked weird to me, the shawl feels more skeleton-y
4 - Think it was an oversight
5 -  should make it a little more competitive with the other great-weapon options
6 - Makes skeletons less reliant on specifically the weapon they started with and are more able to scavenge and steal. Also means you aren't so penalised for picking anything other than sword in case you get the zizo armour summoned on you - you'd have to pick the greatsword else you'd be stuck with Apprentice swords.

## Changelog
:cl:
fix: stops skeletons spawning double chain gloves
balance: gives leg clothing to the bulwark which otherwise had nothing in the leg slot
-changes the cloak from a half-cloak to a black rapscallion's shawl
-gives the sword-users scabbards
-adds a shield to the bulwark's 'spear' option
-gives all skeletons equal weapon skill in their possible weapons rather than their weapon skill depending on what they selected at spawn.
/:cl:
