### PR TITLE
Increases Rockhill MAA and vanguard slots by 2 each.

### DIFF
--- a/_maps/map_files/rockhill/map_adjustment_rockhill.dm
+++ b/_maps/map_files/rockhill/map_adjustment_rockhill.dm
@@ -11,7 +11,7 @@
 		/datum/job/roguetown/sergeant,
 		)
 	slot_adjust = list(
-		/datum/job/roguetown/manorguard = 4,//split with watchmen
+		/datum/job/roguetown/manorguard = 6,//split with watchmen
 		/datum/job/roguetown/warden = 4,//split with vanguard
 	)
 	title_adjust = list(
@@ -42,7 +42,7 @@
 		/datum/job/roguetown/rookie = "Odd-jobs, running messages, fixing dents and talking to locals; the City Watch can always use a spare pair of hands, eyes and ears. Assist your fellow city watchmen in dealing with threats - both within and without. \
 				Given a brief introduction in weapons and guardwork, the rest of your training is to be picked up on the job. \
 				Obey your superiors (everyone who isn't you) and show the nobles your respect. Keep an eye out, try to learn a thing or two, then one day you might live to make an adequate soldier."
-	
+
 	)
 	// species_adjust = list()
 	// sexes_adjust = list()

--- a/code/modules/jobs/job_types/roguetown/garrison/vanguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/vanguard.dm
@@ -3,8 +3,8 @@
 	flag = BOGGUARD
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 6
+	spawn_positions = 6
 	selection_color = JCOLOR_SOLDIER
 
 	allowed_sexes = list(MALE, FEMALE)
@@ -48,7 +48,7 @@
 /datum/advclass/vanguard/archer
 	name = "Vanguard Archer"
 	tutorial = "You are well versed in the ways of handling a bow. \
-	You will stand in the back, and protect the front with arrows."	
+	You will stand in the back, and protect the front with arrows."
 	outfit = /datum/outfit/job/roguetown/vanguard/archer
 	category_tags = list(CTAG_VANGUARD)
 	traits_applied = list(TRAIT_DODGEEXPERT)


### PR DESCRIPTION
## About The Pull Request
Just gives vanguard and man at arms 2 more slots on rockhill.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Do people even do this anymore? I wish, but mine is just like three lines.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Having the garrison split between 3 smaller roles seems to have put a dampener on camaraderie and coordination. Man at arms feels especially hit by this, since a lot of its design is for 8 people- hell, there's four different subclasses, for just four people now.  The replacement watch and vanguard roles range from debatably equal to definitely weaker, six slots isn't going to break anything. Or maybe it will, but if we can test +9 statpoints for wretches, we can test this.

Vanguard are the coughing babies of the garrison so I don't think I even need to justify +2 slots for them. They're arguably weaker than adventurers and numbers are the only thing they have going for them, maybe some slightly higher numbers will make that more fun to play as.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Man at arms and Vanguard both now have 6 slots on rockhill, up from 4.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
