### PR TITLE
Naledi Vizier Tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -194,8 +194,9 @@
 		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
+		/datum/skill/magic/arcane = SKILL_LEVEL_NOVICE,
 	)
-	subclass_spellpoints = 0 // Override inheritance lol
+	subclass_spellpoints = 9
 
 /datum/outfit/job/roguetown/mercenary/warscholar_vizier
 	var/detailcolor
@@ -218,10 +219,16 @@
 		"BLACK" = "#242526"
 	))
 	to_chat(H, span_warning("You are a Naledi Vizier. Your research into miracles and holy incantations has lead you to esoteric magycks. Though psydonians have long struggled to channel their all-father's divinity, a combination of the saint's power may be similar enough."))
+	if(H.age == AGE_OLD)
+		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 3, TRUE)
+		H.change_stat(STATKEY_SPD, -1)
+		H.change_stat(STATKEY_INT, 1)
+		H.change_stat(STATKEY_PER, 1)
+		H.mind?.adjust_spellpoints(3)
 	r_hand = /obj/item/rogueweapon/woodstaff/naledi
-	armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
+	armor = /obj/item/clothing/suit/roguetown/shirt/robe/hierophant
 
-	mask = /obj/item/clothing/mask/rogue/lordmask/tarnished
+	mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
 	pants = /obj/item/clothing/under/roguetown/trou/leather
@@ -242,21 +249,19 @@
 		/obj/item/rogueweapon/huntingknife = 1,
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
-	
+
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, start_maxed = TRUE)	//Starts off maxed out.
 	if(H.mind)
 		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 		detailcolor = naledicolors[detailcolor]
 		H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/lesser_heal)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/arcynebolt) // Give them little bit of offensive power to make them less boring.
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/repulse) // A "defensive" spell to keep themselves safe
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/regression)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convergence)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stasis)
-	
+
 	H.merctype = 14
 
 

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -247,7 +247,8 @@
 	backpack_contents = list(
 		/obj/item/roguekey/mercenary = 1,
 		/obj/item/rogueweapon/huntingknife = 1,
-		/obj/item/rogueweapon/scabbard/sheath = 1
+		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/storage/belt/rogue/surgery_bag = 1
 		)
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
@@ -256,6 +257,7 @@
 		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 		detailcolor = naledicolors[detailcolor]
 		H.mind.RemoveSpell(/obj/effect/proc_holder/spell/invoked/lesser_heal)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/arcynebolt) // because other clerics get holy bolt and so you're not entirely pressured to take combat spells
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/regression)


### PR DESCRIPTION
## About The Pull Request

This is an attempt to bring the Naledian Vizier more in line with the other Naledi mercenary classes and make it both more interesting and viable to play. Also a tiny bit of flavor.

## Testing Evidence

![evidence01](https://github.com/user-attachments/assets/3a0d5047-a73a-4b68-b512-0858ba18845a)

## Why It's Good For The Game

Vizier, as it was before, was kind of just... Bad? Not just in terms of balance, but in feel and flavor. You're supposedly a mystic using weird and esoteric magics to emulate the divine and this showed in... Basically recycling cut content with sub-par stats and skills. You're just an objectively worse Astratan Cleric who can tangentially heal the undead.

Now? Well, you give up the sheer power, versatility, and scaling of the Hierophant for access to potent healing and a _small_ selection of spells. I don't have the skills to give them anything truly unique, but the tight spell budget - even with Old age and Arcane Potential - means you have to choose weird spells to get the most out of the class.

Plus, like an actual Vizier, you're not _supposed_ to be on the frontline. Your healing and spells should be focused keeping you near the _important_ people, not the common rabble.

Hiero and Pontifex are still the superior classes if you want to just frag, but now Vizier should at least be able to keep up with them _and_ you're no longer using a merc class with an adventurer-tier spread.

## Changelog

:cl:

- Gives Viziers their spellpoints back, but smol
- Viziers have their Naledi mask back. Now they, too, can be real djiin hunters.
- Viziers now have a Hierophant's kandys (but not the Hierophant gambeson) because the mages robes aren't extra enough, but Viziers aren't so extra to have their own fashion.
- Removed the Vizier's innate mage spells as they now have spellpoints.

:cl: