### PR TITLE
THE GREAT DEFLATION: Rebalances loot pouches of mammon-carrying NPCs

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -130,13 +130,15 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 	belt = /obj/item/storage/belt/rogue/leather/black
 	if(prob(5))
 		beltl = /obj/item/storage/belt/rogue/pouch/medicine
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	else
-		if(prob(20))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
-		else
+	switch(rand(1, 100))
+		if(1 to 50)
+			return
+		if(51 to 85)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(86 to 95)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
 	if(prob(60))
 		id = /obj/item/clothing/ring/silver
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron

--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 		beltl = /obj/item/storage/belt/rogue/pouch/medicine
 	switch(rand(1, 100))
 		if(1 to 50)
-			return
+			beltr = null
 		if(51 to 85)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(86 to 95)

--- a/code/modules/mob/living/carbon/human/npc/orc/orc.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc.dm
@@ -104,7 +104,7 @@
 		beltl = /obj/item/reagent_containers/glass/bottle/alchemical/healthpot
 	switch(rand(1, 100))
 		if(1 to 50)
-			return
+			beltr = null
 		if(51 to 95)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(96 to 100)

--- a/code/modules/mob/living/carbon/human/npc/orc/orc.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc.dm
@@ -102,10 +102,13 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	if(prob(5))
 		beltl = /obj/item/reagent_containers/glass/bottle/alchemical/healthpot
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	else
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+	switch(rand(1, 100))
+		if(1 to 50)
+			return
+		if(51 to 95)
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/gold
 

--- a/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
@@ -37,7 +37,7 @@
 		if(1 to 50)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(51 to 95)
-			return
+			beltr = null
 		if(96 to 100)
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 
@@ -86,7 +86,7 @@
 		if(1 to 50)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(1 to 95)
-			return
+			beltr = null
 		if(96 to 100)
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
@@ -127,7 +127,7 @@
 		if(1 to 50)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(51 to 95)
-			return
+			beltr = null
 		if(96 to 100)
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
@@ -172,7 +172,7 @@
 		if(1 to 50)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(51 to 95)
-			return
+			beltr = null
 		if(96 to 100)
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(50))

--- a/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc_outfits.dm
@@ -33,10 +33,13 @@
 		if(3)
 			l_hand = /obj/item/rogueweapon/mace/cudgel/copper
 	belt = /obj/item/storage/belt/rogue/leather/rope
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	if(prob(30))
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+	switch(rand(1, 100))
+		if(1 to 50)
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(51 to 95)
+			return
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 
 	H.STASTR = 11
 	H.STASPD = 8
@@ -79,10 +82,13 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	if(prob(5))
 		beltl = /obj/item/reagent_containers/glass/bottle/alchemical/healthpot
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	else
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+	switch(rand(1, 100))
+		if(1 to 50)
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(1 to 95)
+			return
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/gold
 
@@ -117,10 +123,13 @@
 	belt = /obj/item/storage/belt/rogue/leather/rope
 	if(prob(5))
 		beltl = /obj/item/reagent_containers/glass/bottle/alchemical/healthpot
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	else
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+	switch(rand(1, 100))
+		if(1 to 50)
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(51 to 95)
+			return
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/gold
 
@@ -159,10 +168,13 @@
 	belt = /obj/item/storage/belt/rogue/leather/
 	if(prob(30))
 		beltl = /obj/item/reagent_containers/glass/bottle/alchemical/healthpot
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	else
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
+	switch(rand(1, 100))
+		if(1 to 50)
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(51 to 95)
+			return
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(50))
 		id = /obj/item/clothing/ring/gold
 

--- a/code/modules/mob/living/carbon/human/npc/searaider.dm
+++ b/code/modules/mob/living/carbon/human/npc/searaider.dm
@@ -149,15 +149,18 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 			r_hand = /obj/item/rogueweapon/greataxe
 		if(4)
 			r_hand = /obj/item/rogueweapon/greatsword/zwei
-	if(prob(50))
-		belt = /obj/item/storage/belt/rogue/leather/rope
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	if(prob(50))
-		belt = /obj/item/storage/belt/rogue/leather/rope
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+	switch(rand(1, 100))
+		if(1 to 20)
+			belt = /obj/item/storage/belt/rogue/leather/rope
+		if(21 to 95)
+			belt = /obj/item/storage/belt/rogue/leather/rope
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if (96 to 100)
+			belt = /obj/item/storage/belt/rogue/leather/rope
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(10))
 		id = /obj/item/clothing/ring/gold
-		
+
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
 	H.STASPD = 9
 	H.STACON = rand(10,12) //so their limbs no longer pop off like a skeleton

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -72,7 +72,7 @@
 			if(1 to 50)
 				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 			if(51 to 95)
-				return
+				beltr = null
 			if(96 to 100)
 				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
@@ -115,7 +115,7 @@
 			if(1 to 50)
 				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 			if(51 to 95)
-				return
+				beltr = null
 			if(96 to 100)
 				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
@@ -165,7 +165,7 @@
 			if(1 to 50)
 				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 			if(51 to 95)
-				return
+				beltr = null
 			if(96 to 100)
 				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
@@ -203,7 +203,7 @@
 			if(1 to 50)
 				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 			if(51 to 95)
-				return
+				beltr = null
 			if(96 to 100)
 				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
@@ -271,7 +271,7 @@
 			if(1 to 50)
 				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 			if(51 to 95)
-				return
+				beltr = null
 			if(96 to 100)
 				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits.dm
@@ -68,10 +68,13 @@
 		pants = /obj/item/clothing/under/roguetown/loincloth
 	if(prob(5))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-		else
-			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		switch(rand(1, 100))
+			if(1 to 50)
+				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+			if(51 to 95)
+				return
+			if(96 to 100)
+				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/aalloy
 	var/weapon_choice = rand(1, 4)
@@ -108,10 +111,13 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/aalloy
 	if(prob(20))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-		else
-			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		switch(rand(1, 100))
+			if(1 to 50)
+				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+			if(51 to 95)
+				return
+			if(96 to 100)
+				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/aalloy
 	var/weapon_choice = rand(1, 4)
@@ -155,10 +161,13 @@
 		r_hand = /obj/item/rogueweapon/knuckles/aknuckles
 	if(prob(20))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-		else
-			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		switch(rand(1, 100))
+			if(1 to 50)
+				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+			if(51 to 95)
+				return
+			if(96 to 100)
+				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/aalloy
 	H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
@@ -190,11 +199,13 @@
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron/aalloy
 	gloves = /obj/item/clothing/gloves/roguetown/chain/aalloy
 	if(prob(30))
-		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-		else
-			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		switch(rand(1, 100))
+			if(1 to 50)
+				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+			if(51 to 95)
+				return
+			if(96 to 100)
+				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/aalloy
 	if(prob(33)) // 33% chance of shield, so ranged don't get screwed over entirely
@@ -253,13 +264,16 @@
 			r_hand = /obj/item/rogueweapon/greatsword/aalloy
 		else
 			r_hand = /obj/item/rogueweapon/mace/goden/aalloy
-	
+
 	if(prob(60))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-		else
-			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		switch(rand(1, 100))
+			if(1 to 50)
+				beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+			if(51 to 95)
+				return
+			if(96 to 100)
+				beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 	if(prob(5))
 		id = /obj/item/clothing/ring/aalloy
 	H.adjust_skillrank(/datum/skill/combat/polearms, 4, TRUE)
@@ -313,7 +327,7 @@
 		r_hand = /obj/item/rogueweapon/flail/aflail
 	if(prob(40))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
+		if(prob(10))
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 		else
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
@@ -356,7 +370,7 @@
 		pants = /obj/item/clothing/under/roguetown/loincloth
 	if(prob(20))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
+		if(prob(20))
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 		else
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
@@ -410,7 +424,7 @@
 		r_hand = /obj/item/rogueweapon/shovel/aalloy
 	if(prob(40))
 		belt = /obj/item/storage/belt/rogue/leather/rope
-		if(prob(50))
+		if(prob(10))
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 		else
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/

--- a/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 		if(1 to 50)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if (51 to 85)
-			return
+			beltr = null
 		if (86 to 95)
 			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
 		if (96 to 100)
@@ -127,7 +127,7 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 		r_hand = /obj/item/rogueweapon/stoneaxe/handaxe
 	if(prob(20))
 		r_hand = /obj/item/rogueweapon/pick/militia
-	if(prob(25))	
+	if(prob(25))
 		l_hand = /obj/item/rogueweapon/shield/wood
 	if(prob(10))
 		l_hand = /obj/item/rogueweapon/huntingknife/idagger

--- a/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
@@ -98,13 +98,15 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	belt = /obj/item/storage/belt/rogue/leather
 	if(prob(5))
 		beltl = /obj/item/storage/belt/rogue/pouch/medicine
-	if(prob(50))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	else
-		if(prob(10))
-			beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
-		else
+	switch(rand(1, 100))
+		if(1 to 50)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if (51 to 85)
+			return
+		if (86 to 95)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
+		if (96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
 	if(prob(10))
 		id = /obj/item/clothing/ring/gold
 	H.STASTR = rand(12,14) //GENDER EQUALITY!!

--- a/code/modules/mob/living/carbon/human/npc/thief.dm
+++ b/code/modules/mob/living/carbon/human/npc/thief.dm
@@ -134,10 +134,10 @@
 		if(51 to 60)
 			beltl = /obj/item/lockpickring/mundane
 		if(61 to 100)
-			return
+			beltl = null
 	switch(rand(1, 100))
 		if(1 to 40)
-			return
+			beltr = null
 		if(41 to 85)
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
 		if(86 to 95)

--- a/code/modules/mob/living/carbon/human/npc/thief.dm
+++ b/code/modules/mob/living/carbon/human/npc/thief.dm
@@ -128,16 +128,22 @@
 	if(prob(50))
 		l_hand = /obj/item/rogueweapon/huntingknife/copper
 	belt = /obj/item/storage/belt/rogue/leather/
-	if(prob(50))
-		beltl = /obj/item/lockpick
-	if(prob(10))
-		beltl = /obj/item/lockpickring/mundane
-	if(prob(80))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/
-	if(prob(30))
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
-	if(prob(20))
-		beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
+	switch(rand(1, 100))
+		if(1 to 50)
+			beltl = /obj/item/lockpick
+		if(51 to 60)
+			beltl = /obj/item/lockpickring/mundane
+		if(61 to 100)
+			return
+	switch(rand(1, 100))
+		if(1 to 40)
+			return
+		if(41 to 85)
+			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor/
+		if(86 to 95)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/
+		if(96 to 100)
+			beltr = /obj/item/storage/belt/rogue/pouch/treasure/lucky
 	if(prob(5))
 		id = /obj/item/clothing/ring/gold
 	H.STASTR = 11


### PR DESCRIPTION
## About The Pull Request
As part of a series of PRs toning down easily and commonly abused sources of massive inflation, rebalances the loot tables of pouches in pouch-carrying NPCs that spawn in the wild. This basically means skeletons, brigands, vikings, orcs and the like. Dungeon loot, income from heads, and the contents of loot pouches haven't changed, only your chances of getting different spawns on the various NPCs. You will still be able to **get** rare lucky loot spawns off of them, but they will no longer be consistently throwing extremely valuable golden items at you, and you now have a chance of getting nothing instead of being able to grind up rooster chicks for hundreds and hundreds of mammon. Did you know you could get multiple hundreds of mammon from a single one of these brigand spawns?
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
The killing field of my testing:
<img width="1229" height="851" alt="dreamseeker_CNAol9plJj" src="https://github.com/user-attachments/assets/29da45a7-f634-4a8b-9b3b-7b5dc427ce61" />

Also wandered around in wilderness areas killing carbon mobs for like an hour checking all the pouches.
<img width="1230" height="1226" alt="dreamseeker_bPHtFtmbqg" src="https://github.com/user-attachments/assets/2175b266-3db0-4184-bada-c9b671207f8e" />

I even still got one lucky pouch!
<img width="1235" height="1227" alt="dreamseeker_d7YPOkq8DV" src="https://github.com/user-attachments/assets/36e3a62c-e650-498b-acaa-c6acfb7acad1" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
These are NPCs that already guard massively lucrative dungeon loot and spawn in contracts that also make you money on top of their loot, and are designed to be an enemy encounter, not a free money farm. Massive sources of inflation have been widely discussed on the discord and this has been mentioned as a borderline exploit for getting incredibly rich in minutes for beating frankly very easy battles. Frankly, the amount of money you could make off a single one of these encounters (and honestly, still can) is obscene.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

:cl:
balance: Rebalances pouch loot of common NPCs that carry mammon
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
