### PR TITLE
Minor churn undead bugfix

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -114,7 +114,7 @@
 			for(var/mob/living/thing in things_to_churn)
 				thing.apply_status_effect(/datum/status_effect/churned, user, debuff_power)
 		if(LAZYLEN(things_to_stun))
-			for(var/mob/living/thing in things_to_churn)
+			for(var/mob/living/thing in things_to_stun)
 				thing.Stun(100)
 				thing.Knockdown(50)
 				thing.emote("scream")


### PR DESCRIPTION
## About The Pull Request

5 letter fix to prevent necran anihilating vampires

## Testing Evidence

deline said it would work
it's five letters

## Why It's Good For The Game

vampires will no longer be giganuked as hard due to a bug

## Changelog


:cl:
fix: Fixed churn undead affecting vampires harder than expected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
