### PR TITLE
Squire powercreep PR (They sucked, but not in the way you're thinking!)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -167,7 +167,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE
+		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -58,13 +58,14 @@
 		STATKEY_INT = 1,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/maces = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
@@ -110,6 +111,8 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
@@ -158,10 +161,14 @@
 	)
 	subclass_skills = list(
 		/datum/skill/combat/bows = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/crossbows = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/crossbows = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/slings = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/maces = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE
+		/datum/skill/combat/whipsflails = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,

--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -114,7 +114,7 @@
 			for(var/mob/living/thing in things_to_churn)
 				thing.apply_status_effect(/datum/status_effect/churned, user, debuff_power)
 		if(LAZYLEN(things_to_stun))
-			for(var/mob/living/thing in things_to_stun)
+			for(var/mob/living/thing in things_to_churn)
 				thing.Stun(100)
 				thing.Knockdown(50)
 				thing.emote("scream")

--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -114,7 +114,7 @@
 			for(var/mob/living/thing in things_to_churn)
 				thing.apply_status_effect(/datum/status_effect/churned, user, debuff_power)
 		if(LAZYLEN(things_to_stun))
-			for(var/mob/living/thing in things_to_churn)
+			for(var/mob/living/thing in things_to_stun)
 				thing.Stun(100)
 				thing.Knockdown(50)
 				thing.emote("scream")


### PR DESCRIPTION
## About The Pull Request

This aims to bring all three squire variants in line with one another, to reflect their adventurer counterpart (squire errant) and reflect their supposed knight promotions (somewhat, since those have expert weapons across the board and can't be reflected to squires 1:1) in weapon proficiency.

It also brings irregular up to par by giving them a third weapon choice and equalizing their wrestling to the other two. They need it the most, being a dodger, and don't have the STR to be a grappler anyhow.

Essentially, all squires now have 2 primary (journeyman) weapons, and 3 secondary (apprentice) weapons. Previously, they had to smack a dummy to achieve this. Dummy RP isn't good. To progress further, they can ask a knight to train them up to expert anyway, so this doesn't make them any stronger than they were before.

View changelog for exact changes here.

## Testing Evidence

it's all skill changes.

## Why It's Good For The Game

Squire variety is nice?
They're a weak combat class, let them have nice things.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: All squires have their skills equalized.
balance: Lancers get polearms&swords at Journeyman.
balance:  Lancers get knives, maces, and whips/flails at Apprentice.
balance:  Footman gets sword&maces at Journeyman.
balance:  Footman gets knives, polearms and whips/flails at Apprentice.
balance: Irregular gains wrestling up to Apprentice, from Novice.
balance: Irregular gains sling proficiency.
balance: Irregular gets knives&all ranged weapons at Journeyman.
balance: Irregular gets maces, swords, and polearms at Apprentice.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
