### PR TITLE
Resident Virtue Spawn Fix + Known People

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -889,6 +889,10 @@ SUBSYSTEM_DEF(job)
 				destination = pick(GLOB.jobspawn_overrides["Towner"])
 				destination.JoinPlayerHere(M, FALSE)
 				return
+			if(latejoin_trackers.len)
+				destination = pick(latejoin_trackers)
+				destination.JoinPlayerHere(M, buckle)
+				return
 			if(spawn_resident_in_tavern(H))
 				return
 	if(M.mind && M.mind.assigned_role && length(GLOB.jobspawn_overrides[M.mind.assigned_role])) //We're doing something special today.

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -693,35 +693,45 @@ SUBSYSTEM_DEF(job)
 
 	//If we joined at roundstart we should be positioned at our workstation
 	if(!joined_late)
-		var/obj/S = null
-		for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
-			if(sloc.name != rank)
-				continue
-			if(locate(/mob/living) in sloc.loc)
-				continue
-			S = sloc
-			sloc.used = TRUE
-			break
-		if(!S)
+		var/spawn_rank = rank
+		var/handled_resident_spawn = FALSE
+		if(istype(H, /mob/living/carbon/human))
+			if(should_use_towner_spawn(H, M?.client))
+				if(spawn_resident_in_tavern(H))
+					handled_resident_spawn = TRUE
+				else
+					spawn_rank = "Towner"
+
+		if(!handled_resident_spawn)
+			var/obj/S = null
 			for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
-				if(sloc.name != rank)
+				if(sloc.name != spawn_rank)
+					continue
+				if(locate(/mob/living) in sloc.loc)
 					continue
 				S = sloc
 				sloc.used = TRUE
 				break
-		if(!S)//danger will robinson something went wrong
-			log_game("Could not find a landmark for [rank]!!!!!!")
-			for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
-				S = sloc
-				sloc.used = TRUE
-				break
-		if(length(GLOB.jobspawn_overrides[rank]))
-			S = pick(GLOB.jobspawn_overrides[rank])
-		if(S)
-			S.JoinPlayerHere(H, FALSE)
-		if(!S) //if there isn't a spawnpoint send them to latejoin, if there's no latejoin go yell at your mapper
-			log_world("Couldn't find a round start spawn point for [rank]")
-			SendToLateJoin(H)
+			if(!S)
+				for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
+					if(sloc.name != spawn_rank)
+						continue
+					S = sloc
+					sloc.used = TRUE
+					break
+			if(!S)//danger will robinson something went wrong
+				log_game("Could not find a landmark for [spawn_rank]!!!!!!")
+				for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
+					S = sloc
+					sloc.used = TRUE
+					break
+			if(length(GLOB.jobspawn_overrides[spawn_rank]))
+				S = pick(GLOB.jobspawn_overrides[spawn_rank])
+			if(S)
+				S.JoinPlayerHere(H, FALSE)
+			if(!S) //if there isn't a spawnpoint send them to latejoin, if there's no latejoin go yell at your mapper
+				log_world("Couldn't find a round start spawn point for [spawn_rank]")
+				SendToLateJoin(H)
 
 
 	if(H.mind)
@@ -872,6 +882,15 @@ SUBSYSTEM_DEF(job)
 
 /datum/controller/subsystem/job/proc/SendToLateJoin(mob/M, buckle = TRUE)
 	var/atom/destination
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(should_use_towner_spawn(H))
+			if(length(GLOB.jobspawn_overrides["Towner"]))
+				destination = pick(GLOB.jobspawn_overrides["Towner"])
+				destination.JoinPlayerHere(M, FALSE)
+				return
+			if(spawn_resident_in_tavern(H))
+				return
 	if(M.mind && M.mind.assigned_role && length(GLOB.jobspawn_overrides[M.mind.assigned_role])) //We're doing something special today.
 		destination = pick(GLOB.jobspawn_overrides[M.mind.assigned_role])
 		destination.JoinPlayerHere(M, FALSE)
@@ -934,7 +953,7 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/has_restricted_vice(datum/preferences/prefs, datum/job/job)
 	if(!length(job.vice_restrictions))
 		return FALSE
-	
+
 	// Check new vice system (vice1-vice5)
 	if(prefs.vice1?.type in job.vice_restrictions)
 		return TRUE
@@ -952,3 +971,152 @@ SUBSYSTEM_DEF(job)
 		return TRUE
 	
 	return FALSE
+
+/datum/controller/subsystem/job/proc/should_use_towner_spawn(mob/living/carbon/human/H, client/fallback_client)
+	if(!H)
+		return FALSE
+
+	var/assigned_role = H.mind?.assigned_role || H.job
+	if(!(assigned_role in list("Adventurer", "Mercenary", "Court Agent")))
+		return FALSE
+
+	if(HAS_TRAIT(H, TRAIT_RESIDENT))
+		return TRUE
+
+	var/client/C = H.client || fallback_client
+	var/datum/preferences/P = C?.prefs
+	if(!P)
+		return FALSE
+
+	if(istype(P.virtue, /datum/virtue/utility/resident))
+		return TRUE
+
+	if(P.statpack?.name == "Virtuous" && istype(P.virtuetwo, /datum/virtue/utility/resident))
+		return TRUE
+
+	return FALSE
+
+/datum/controller/subsystem/job/proc/spawn_resident_in_tavern(mob/living/carbon/human/H)
+	if(!H)
+		return FALSE
+
+	var/area/spawn_area
+	for(var/area/A in world)
+		if(istype(A, /area/rogue/indoors/town/tavern))
+			spawn_area = A
+			break
+
+	if(!spawn_area)
+		return FALSE
+
+	var/list/possible_chairs = list()
+	for(var/obj/structure/chair/wood/rogue/C in spawn_area)
+		var/turf/T = get_turf(C)
+		if(!is_valid_resident_tavern_turf(T))
+			continue
+		possible_chairs += C
+
+	if(length(possible_chairs))
+		possible_chairs = shuffle(possible_chairs)
+		for(var/obj/structure/chair/wood/rogue/chosen_chair in possible_chairs)
+			var/turf/chair_turf = get_turf(chosen_chair)
+			if(!chair_turf)
+				continue
+
+			if(!(locate(/mob/living) in chair_turf))
+				H.forceMove(chair_turf)
+				return TRUE
+
+			var/turf/adjacent_turf = get_valid_adjacent_resident_turf(chair_turf)
+			if(adjacent_turf)
+				H.forceMove(adjacent_turf)
+				return TRUE
+
+	var/list/possible_spawns = list()
+	for(var/turf/T in spawn_area)
+		if(!is_valid_resident_tavern_turf(T))
+			continue
+		possible_spawns += T
+
+	if(length(possible_spawns))
+		H.forceMove(pick(possible_spawns))
+		return TRUE
+
+	return FALSE
+
+/datum/controller/subsystem/job/proc/get_valid_adjacent_resident_turf(turf/origin)
+	if(!origin)
+		return null
+
+	for(var/direction in list(NORTH, SOUTH, EAST, WEST))
+		var/turf/T = get_step(origin, direction)
+		if(!is_valid_resident_tavern_turf(T))
+			continue
+		return T
+
+	return null
+
+/datum/controller/subsystem/job/proc/is_valid_resident_tavern_turf(turf/T)
+	if(!T || T.density || T.is_blocked_turf(FALSE))
+		return FALSE
+
+	if(locate(/mob/living) in T)
+		return FALSE
+
+	if(!istype(get_area(T), /area/rogue/indoors/town/tavern))
+		return FALSE
+
+	var/map_name = SSmapping?.config?.map_name
+	if(map_name == "Dun Manor")
+		if(T.z != 3 || T.y <= 70)
+			return FALSE
+	else if(map_name == "Dun World")
+		if(T.z != 3 || T.y <= 234)
+			return FALSE
+
+	var/open_neighbors = 0
+	for(var/direction in list(NORTH, SOUTH, EAST, WEST))
+		var/turf/N = get_step(T, direction)
+		if(!N || N.density || N.is_blocked_turf(FALSE))
+			continue
+		open_neighbors++
+
+	return open_neighbors >= 2
+
+/datum/controller/subsystem/job/proc/sync_resident_wanderer_knowledge(mob/living/carbon/human/H, include_pref = FALSE)
+	if(!H?.mind)
+		return
+
+	var/assigned_role = H.mind.assigned_role || H.job
+	var/is_resident_wanderer = FALSE
+
+	if(assigned_role in list("Adventurer", "Mercenary", "Court Agent"))
+		if(HAS_TRAIT(H, TRAIT_RESIDENT))
+			is_resident_wanderer = TRUE
+		else if(include_pref && should_use_towner_spawn(H, H.client))
+			is_resident_wanderer = TRUE
+
+	if(is_resident_wanderer)
+		for(var/mob/living/carbon/human/other in GLOB.human_list)
+			if(other == H || !other.mind)
+				continue
+
+			var/other_role = other.mind.assigned_role || other.job
+			if(other_role == "Towner")
+				H.mind.i_know_person(other.mind)
+				H.mind.person_knows_me(other.mind)
+				continue
+
+			if((other_role in list("Adventurer", "Mercenary", "Court Agent")) && HAS_TRAIT(other, TRAIT_RESIDENT))
+				H.mind.i_know_person(other.mind)
+				H.mind.person_knows_me(other.mind)
+
+	else if(assigned_role == "Towner")
+		for(var/mob/living/carbon/human/other in GLOB.human_list)
+			if(other == H || !other.mind)
+				continue
+
+			var/other_role = other.mind.assigned_role || other.job
+			if((other_role in list("Adventurer", "Mercenary", "Court Agent")) && HAS_TRAIT(other, TRAIT_RESIDENT))
+				H.mind.i_know_person(other.mind)
+				H.mind.person_knows_me(other.mind)

--- a/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/villager.dm
@@ -42,6 +42,12 @@
 		/datum/advclass/woodworker
 	)
 
+/datum/job/roguetown/villager/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		SSjob.sync_resident_wanderer_knowledge(H)
+
 /*
 /datum/job/roguetown/adventurer/villager/New()
 	. = ..()

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -45,51 +45,35 @@
 	added_traits = list(TRAIT_RESIDENT)
 
 /datum/virtue/utility/resident/apply_to_human(mob/living/carbon/human/recipient)
-	var/mapswitch = 0
-	if(SSmapping.config.map_name == "Dun Manor")
-		mapswitch = 1
-	else if(SSmapping.config.map_name == "Dun World")
-		mapswitch = 2
-
-	if(mapswitch == 0)
+	if(!recipient?.mind)
 		return
-	if(recipient.mind?.assigned_role == "Adventurer" || recipient.mind?.assigned_role == "Mercenary" || recipient.mind?.assigned_role == "Court Agent")
-		// Find tavern area for spawning
-		var/area/spawn_area
-		for(var/area/A in world)
-			if(istype(A, /area/rogue/indoors/town/tavern))
-				spawn_area = A
-				break
 
-		if(spawn_area)
-			var/target_z = 3 //ground floor of tavern for dun manor / world
-			var/target_y = 70 //dun manor
-			var/list/possible_chairs = list()
+	var/assigned_role = recipient.mind.assigned_role
+	if(!(assigned_role in list("Adventurer", "Mercenary", "Court Agent")))
+		return
 
-			if(mapswitch == 2)
-				target_y = 234 //dun world huge
+	sync_towner_knowledge(recipient)
+	SSjob.sync_resident_wanderer_knowledge(recipient, TRUE)
 
-			for(var/obj/structure/chair/C in spawn_area)
-				//z-level 3, wooden chair, and Y > north of tavern backrooms
-				var/turf/T = get_turf(C)
-				if(T && T.z == target_z && T.y > target_y && istype(C, /obj/structure/chair/wood/rogue) && !T.density && !T.is_blocked_turf(FALSE))
-					possible_chairs += C
+/datum/virtue/utility/resident/proc/sync_towner_knowledge(mob/living/carbon/human/recipient)
+	if(!recipient?.mind)
+		return
 
-			if(length(possible_chairs))
-				var/obj/structure/chair/chosen_chair = pick(possible_chairs)
-				recipient.forceMove(get_turf(chosen_chair))
-				chosen_chair.buckle_mob(recipient)
-				to_chat(recipient, span_notice("As a resident of the vale, you find yourself seated at a chair in the local tavern."))
-			else
-				var/list/possible_spawns = list()
-				for(var/turf/T in spawn_area)
-					if(T.z == target_z && T.y > (target_y + 4) && !T.density && !T.is_blocked_turf(FALSE))
-						possible_spawns += T
+	var/datum/job/roguetown/villager/towner_job = SSjob.GetJob("Towner")
+	if(!towner_job)
+		return
 
-				if(length(possible_spawns))
-					var/turf/spawn_loc = pick(possible_spawns)
-					recipient.forceMove(spawn_loc)
-					to_chat(recipient, span_notice("As a resident of the vale, you find yourself in the local tavern."))
+	for(var/X in towner_job.peopleknowme)
+		for(var/datum/mind/MF in get_minds(X))
+			if(isnull(recipient.mind?.special_role) && (MF?.special_role in list(ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT, ROLE_LICH, ROLE_WRETCH, ROLE_UNBOUND_DEATHKNIGHT)))
+				continue
+			recipient.mind.person_knows_me(MF)
+
+	for(var/X in towner_job.peopleiknow)
+		for(var/datum/mind/MF in get_minds(X))
+			if(isnull(recipient.mind?.special_role) && (MF?.special_role in list(ROLE_VAMPIRE, ROLE_NBEAST, ROLE_BANDIT, ROLE_LICH, ROLE_WRETCH, ROLE_UNBOUND_DEATHKNIGHT)))
+				continue
+			recipient.mind.i_know_person(MF)
 
 /datum/virtue/utility/failed_squire
 	name = "Failed Squire"


### PR DESCRIPTION
## TM FIRST
**Report any weird spawning behavior. Should be fine though.**

## About The Pull Request
- Potentially fixes resident virtue's spawning for adventurer, court agent, and mercenaries.
- Fixes the known list for resident virtue takers.
- Stops the forced buckle on spawn when on a chair.

## Testing Evidence
Tested on Rockhill & Dun World map. It worked.
<img width="1122" height="792" alt="tavspawn1" src="https://github.com/user-attachments/assets/8100bb9e-fb9d-4582-a114-419449ac04ae" />
<img width="1066" height="728" alt="tavspawn2" src="https://github.com/user-attachments/assets/8d8dc143-90e4-4277-87ce-9bfb3f4037e4" />
<img width="739" height="734" alt="tavspawn3" src="https://github.com/user-attachments/assets/5b328391-df8f-436e-9184-1716d55be30e" />

## Why It's Good For The Game
This should fix the bug. Basically spawning in with the resident virtue should work like a towner spawning in now, as if the resident virtue takers were actually you know, residents. Before the virtue was spawning adventurers/etc in the adventurer zone. It was a pain in the butt having to walk through the bog or whatever to go claim a house. And part of the benefit of the resident virtue is skipping the journey.

## Changelog
:cl:
fix: Adventurer / Court Agents / Mercenaries with the resident virtue now actually spawn in town, and get their known list populated by others that are locals too. It works just like how towners spawn. Also stops players from being force buckled on chairs when spawning in.
/:cl: