### PR TITLE
95% of kazengun items now craftable

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/hangyaku.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/hangyaku.dm
@@ -39,7 +39,6 @@
 	H.adjust_blindness(-3)
 	has_loadout = TRUE
 	to_chat(H, span_warning("Rebel. Outlaw. Failure. Once, you served the upper echelons of Kazengun society as more than just a 'knight'- you were a champion, a beacon of virtue, a legend in the making. Now you wander distant Psydonia, seeking a fresh start... or fresh coin, at least."))
-	head = /obj/item/clothing/head/roguetown/helmet/heavy/kabuto
 	belt = /obj/item/storage/belt/rogue/leather/cloth
 	neck = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
 	cloak = /obj/item/clothing/cloak/kazengun
@@ -82,11 +81,13 @@
 	switch(armor_choice)
 		if("Heavy Armor")
 			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/roguetown/helmet/heavy/kabuto, SLOT_HEAD, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/plate/full/samsibsa, SLOT_ARMOR, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk, SLOT_SHIRT, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/roguetown/chainlegs, SLOT_PANTS, TRUE)
 		if("Medium Armor")
 			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+			H.equip_to_slot_or_del(new /obj/item/clothing/head/roguetown/helmet/kettle/jingasa, SLOT_HEAD, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/brigandine/haraate, SLOT_ARMOR, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/suit/roguetown/armor/gambeson/heavy, SLOT_SHIRT, TRUE)
 			H.equip_to_slot_or_del(new /obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun, SLOT_PANTS, TRUE)

--- a/code/modules/roguetown/roguecrafting/leather/leather.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather.dm
@@ -40,6 +40,22 @@
 	sellprice = 15
 	craftdiff = 2
 
+/datum/crafting_recipe/roguetown/leather/eastgloves1
+	name = "eastern black gloves"
+	result = list(/obj/item/clothing/gloves/roguetown/eastgloves1,
+	/obj/item/clothing/gloves/roguetown/eastgloves1)
+	reqs = list(/obj/item/natural/hide/cured = 1)
+	sellprice = 10
+	craftdiff = 2
+
+/datum/crafting_recipe/roguetown/leather/eastgloves2
+	name = "eastern stylish black gloves"
+	result = list(/obj/item/clothing/gloves/roguetown/eastgloves2,
+	/obj/item/clothing/gloves/roguetown/eastgloves2)
+	reqs = list(/obj/item/natural/hide/cured = 1)
+	sellprice = 10
+	craftdiff = 2
+
 /datum/crafting_recipe/roguetown/leather/gloves
 	name = "leather gloves"
 	result = list(/obj/item/clothing/gloves/roguetown/leather,
@@ -47,6 +63,7 @@
 	reqs = list(/obj/item/natural/hide/cured = 1)
 	sellprice = 10
 	craftdiff = 2
+
 
 /datum/crafting_recipe/roguetown/leather/heavygloves
 	name = "heavy leather gloves"

--- a/code/modules/roguetown/roguecrafting/leather/leather_armor_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_armor_recipes.dm
@@ -30,7 +30,7 @@
 	sellprice = 10
 	craftdiff = 2
 
-	/datum/crafting_recipe/roguetown/leather/armor/pants/eastern
+/datum/crafting_recipe/roguetown/leather/armor/pants/eastern
 	name = "eastern leather pants"
 	result = /obj/item/clothing/under/roguetown/trou/leather/eastern
 	reqs = list(/obj/item/natural/hide/cured = 2)
@@ -69,7 +69,7 @@
 	sellprice = 20
 	craftdiff = 4
 
-	/datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants/eastpants1
+/datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants/eastpants1
 	name = "eastern hardened leather black pants"
 	result = list(/obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1)
 	reqs = list(
@@ -80,7 +80,7 @@
 	sellprice = 20
 	craftdiff = 4
 
-		/datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants/eastpants2
+/datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants/eastpants2
 	name = "eastern hardened leather white pants"
 	result = list(/obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2)
 	reqs = list(

--- a/code/modules/roguetown/roguecrafting/leather/leather_armor_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_armor_recipes.dm
@@ -30,6 +30,13 @@
 	sellprice = 10
 	craftdiff = 2
 
+	/datum/crafting_recipe/roguetown/leather/armor/pants/eastern
+	name = "eastern leather pants"
+	result = /obj/item/clothing/under/roguetown/trou/leather/eastern
+	reqs = list(/obj/item/natural/hide/cured = 2)
+	sellprice = 10
+	craftdiff = 2
+
 /datum/crafting_recipe/roguetown/leather/armor/volfhelm
 	name = "volf helm"
 	result = list(/obj/item/clothing/head/roguetown/helmet/leather/volfhelm)
@@ -54,6 +61,28 @@
 /datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants
 	name = "hardened leather pants"
 	result = list(/obj/item/clothing/under/roguetown/heavy_leather_pants)
+	reqs = list(
+		/obj/item/natural/hide/cured = 3,
+		/obj/item/reagent_containers/food/snacks/tallow = 1,
+		/obj/item/natural/fibers = 1,
+		)
+	sellprice = 20
+	craftdiff = 4
+
+	/datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants/eastpants1
+	name = "eastern hardened leather black pants"
+	result = list(/obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants1)
+	reqs = list(
+		/obj/item/natural/hide/cured = 3,
+		/obj/item/reagent_containers/food/snacks/tallow = 1,
+		/obj/item/natural/fibers = 1,
+		)
+	sellprice = 20
+	craftdiff = 4
+
+		/datum/crafting_recipe/roguetown/leather/armor/heavy_leather_pants/eastpants2
+	name = "eastern hardened leather white pants"
+	result = list(/obj/item/clothing/under/roguetown/heavy_leather_pants/eastpants2)
 	reqs = list(
 		/obj/item/natural/hide/cured = 3,
 		/obj/item/reagent_containers/food/snacks/tallow = 1,

--- a/code/modules/roguetown/roguecrafting/leather/leather_footwear_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_footwear_recipes.dm
@@ -22,14 +22,14 @@
 	craftdiff = 3	//Same as the heavy leather gloves.
 
 /datum/crafting_recipe/roguetown/leather/footwear/boots_heavy/kazengun
-	name = "kazengun boots"
+	name = "eastern boots"
 	result = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/kazengun
 	reqs = list(/obj/item/natural/hide/cured = 1,
 				/obj/item/natural/fur = 1)
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/leather/footwear/boots_heavy/kazengunsandals
-	name = "kazengun sandals"
+	name = "eastern sandals"
 	result = /obj/item/clothing/shoes/roguetown/armor/rumaclan
 	reqs = list(/obj/item/natural/hide/cured = 1,
 				/obj/item/natural/fur = 1)

--- a/code/modules/roguetown/roguecrafting/leather/leather_footwear_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_footwear_recipes.dm
@@ -21,6 +21,20 @@
 				/obj/item/natural/fur = 1)
 	craftdiff = 3	//Same as the heavy leather gloves.
 
+/datum/crafting_recipe/roguetown/leather/footwear/boots_heavy/kazengun
+	name = "kazengun boots"
+	result = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/kazengun
+	reqs = list(/obj/item/natural/hide/cured = 1,
+				/obj/item/natural/fur = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/leather/footwear/boots_heavy/kazengunsandals
+	name = "kazengun sandals"
+	result = /obj/item/clothing/shoes/roguetown/armor/rumaclan
+	reqs = list(/obj/item/natural/hide/cured = 1,
+				/obj/item/natural/fur = 1)
+	craftdiff = 3
+
 /datum/crafting_recipe/roguetown/leather/footwear/boots_heavy_b
 	name = "dress boots"
 	result = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced/short

--- a/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
@@ -131,16 +131,6 @@
 	tools = list(/obj/item/needle)
 	craftdiff = 6	//Can be a bit strong, reduce to 5 if too high.
 
-/datum/crafting_recipe/roguetown/leather/unique/crafteast
-	name = "decorated dobo robe"
-	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast)
-	reqs = list(
-		/obj/item/natural/hide/cured = 2,
-		/obj/item/reagent_containers/food/snacks/tallow = 1,
-		/obj/item/natural/fibers = 2,
-		/obj/item/clothing/suit/roguetown/armor/basiceast = 1)
-	tools = list(/obj/item/needle)
-	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/leather/unique/captainrobe
 	name = "eastern flowery robe"

--- a/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
@@ -142,3 +142,13 @@
 	tools = list(/obj/item/needle)
 	craftdiff = 5
 
+/datum/crafting_recipe/roguetown/leather/unique/captainrobe
+	name = "eastern flowery robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe)
+	reqs = list(
+		/obj/item/natural/hide/cured = 4,
+		/obj/item/reagent_containers/food/snacks/tallow = 2,
+		/obj/item/natural/fibers = 4,
+		/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast = 1)
+	tools = list(/obj/item/needle)
+	craftdiff = 5

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -150,14 +150,14 @@
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/eastshirt1
-	name = "kazengun black shirt"
+	name = "eastern black shirt"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 1
 
 /datum/crafting_recipe/roguetown/sewing/eastshirt2
-	name = "kazengun white shirt"
+	name = "eastern white shirt"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
@@ -818,7 +818,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/eastcloak1
-	name = "cloudcutter's cloak"
+	name = "eastern cloudcutter's cloak"
 	result = /obj/item/clothing/cloak/eastcloak1
 	reqs = list(/obj/item/natural/cloth = 1,
 				/obj/item/natural/fibers = 1,
@@ -826,7 +826,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/eastcloak2
-	name = "leather cloak"
+	name = "eastern leather cloak"
 	result = /obj/item/clothing/cloak/eastcloak2
 	reqs = list(/obj/item/natural/cloth = 1,
 				/obj/item/natural/fibers = 1,
@@ -855,7 +855,7 @@
 	craftdiff = 3
 
 /datum/crafting_recipe/roguetown/sewing/hijab/kazengun
-	name = "kazengun shadowed hood"
+	name = "eastern shadowed hood"
 	result = list(/obj/item/clothing/head/roguetown/roguehood/shalal/hijab/yoruku)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
@@ -1344,13 +1344,13 @@
 /datum/crafting_recipe/roguetown/sewing/eastsuit2to1
 	name = "decorated to old dobo robe"
 	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit)
-	reqs = list(/obj/item/clothing/suit/roguetown/armor/crafteast)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast)
 	craftdiff = 0
 	
-/datum/crafting_recipe/roguetown/sewing/eastsuit2to1
+/datum/crafting_recipe/roguetown/sewing/eastsuit1to2
 	name = "old to decorated dobo robe"
 	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast)
-	reqs = list(/obj/item/clothing/suit/roguetown/armor/mentorsuit)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit)
 	craftdiff = 0
 	
 

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -149,6 +149,20 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 1
 
+/datum/crafting_recipe/roguetown/sewing/eastshirt1
+	name = "kazengun black shirt"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt1)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/sewing/eastshirt2
+	name = "kazengun white shirt"
+	result = list(/obj/item/clothing/suit/roguetown/shirt/undershirt/eastshirt2)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 1
+
 /datum/crafting_recipe/roguetown/sewing/clothtrou
 	name = "work trousers"
 	result = list(/obj/item/clothing/under/roguetown/trou)
@@ -803,6 +817,22 @@
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
 
+/datum/crafting_recipe/roguetown/sewing/eastcloak1
+	name = "cloudcutter's cloak"
+	result = /obj/item/clothing/cloak/eastcloak1
+	reqs = list(/obj/item/natural/cloth = 1,
+				/obj/item/natural/fibers = 1,
+				/obj/item/natural/silk = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/sewing/eastcloak2
+	name = "leather cloak"
+	result = /obj/item/clothing/cloak/eastcloak2
+	reqs = list(/obj/item/natural/cloth = 1,
+				/obj/item/natural/fibers = 1,
+				/obj/item/natural/silk = 1)
+	craftdiff = 3
+	
 /datum/crafting_recipe/roguetown/sewing/undervestments
 	name = "undervestments"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/undershirt/priest)
@@ -820,6 +850,13 @@
 /datum/crafting_recipe/roguetown/sewing/hijab
 	name = "hijab"
 	result = list(/obj/item/clothing/head/roguetown/roguehood/shalal/hijab)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 1)
+	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/sewing/hijab/kazengun
+	name = "kazengun shadowed hood"
+	result = list(/obj/item/clothing/head/roguetown/roguehood/shalal/hijab/yoruku)
 	reqs = list(/obj/item/natural/cloth = 2,
 				/obj/item/natural/fibers = 1)
 	craftdiff = 3
@@ -1294,6 +1331,30 @@
 	craftdiff = 6
 	sellprice = 30
 
+/datum/crafting_recipe/roguetown/sewing/basiceast
+	name = "simple dobo robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast)
+	reqs = list(/obj/item/natural/cloth = 6,
+				/obj/item/natural/fibers = 4,
+				/obj/item/natural/silk = 1)
+	tools = list(/obj/item/needle)
+	craftdiff = 6
+	sellprice = 30
+
+/datum/crafting_recipe/roguetown/sewing/eastsuit2to1
+	name = "decorated to old dobo robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/crafteast)
+	craftdiff = 0
+	
+/datum/crafting_recipe/roguetown/sewing/eastsuit2to1
+	name = "old to decorated dobo robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast)
+	reqs = list(/obj/item/clothing/suit/roguetown/armor/mentorsuit)
+	craftdiff = 0
+	
+
+
 /datum/crafting_recipe/roguetown/sewing/spellsingerhat
 	name = "spellsinger hat"
 	result = list(/obj/item/clothing/head/roguetown/spellcasterhat)
@@ -1303,6 +1364,16 @@
 	tools = list(/obj/item/needle)
 	craftdiff = 6
 	sellprice = 20
+
+/datum/crafting_recipe/roguetown/sewing/mentorhat
+	name = "worn bamboo hat"
+	result = list(/obj/item/clothing/head/roguetown/mentorhat)
+	reqs = list(/obj/item/natural/cloth = 2,
+				/obj/item/natural/fibers = 2,
+				/obj/item/natural/silk = 4)
+	tools = list(/obj/item/needle)
+	craftdiff = 5
+	sellprice = 40
 
 /datum/crafting_recipe/roguetown/sewing/beekeeper
 	name = "beekeeper's hood"

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/kazengunite.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/kazengunite.dm
@@ -21,7 +21,7 @@
 /datum/anvil_recipe/kazengunite/jingasa
 	name = "Jingasa"
 	req_bar = /obj/item/ingot/steel
-	created_item=/obj/clothing/head/roguetown/helmet/kettle/jingasa
+	created_item = /obj/item/clothing/head/roguetown/helmet/kettle/jingasa
 
 /datum/anvil_recipe/kazengunite/halfmask
 	name = "Soldier's Half-Mask"
@@ -37,13 +37,13 @@
 	name = "Oni Mask (+1 Small Log)"
 	req_bar = /obj/item/ingot/iron
 	additional_items = list (/obj/item/grown/log/tree/small)
-	/obj/item/clothing/mask/rogue/facemask/yoruku_oni
+	created_item = /obj/item/clothing/mask/rogue/facemask/yoruku_oni
 
 /datum/anvil_recipe/kazengunite/kitsunemask
 	name = "Kitsune Mask (+1 Small Log)"
 	req_bar = /obj/item/ingot/iron
-additional_items = list (/obj/item/grown/log/tree/small)
-	/obj/item/clothing/mask/rogue/facemask/yoruku_kitsune
+	additional_items = list (/obj/item/grown/log/tree/small)
+	created_item = /obj/item/clothing/mask/rogue/facemask/yoruku_kitsune
 
 /datum/anvil_recipe/kazengunite/gorget
 	name = "Kazengunite Gorget"
@@ -88,23 +88,11 @@ additional_items = list (/obj/item/grown/log/tree/small)
 	req_blade = /obj/item/blade/steel_sword
 	created_item = /obj/item/rogueweapon/sword/short/kazengun
 
-/datum/anvil_recipe/kazenguniteweapons/hwando
-	name = "Hwando"
-	req_bar = /obj/item/ingot/steel
-	req_blade = /obj/item/blade/steel_sword
-	created_item = /obj/item/rogueweapon/sword/sabre/mulyeog
-
 /datum/anvil_recipe/kazenguniteweapons/ssangsudo
 	name = "Ssangsudo"
 	req_bar = /obj/item/ingot/steel
 	req_blade = /obj/item/blade/steel_sword
 	created_item = /obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo
-
-/datum/anvil_recipe/kazenguniteweapons/hooksword
-	name = "Hook Sword"
-	req_bar = /obj/item/ingot/steel
-	req_blade = /obj/item/blade/steel_sword
-	created_item = /obj/item/rogueweapon/sword/sabre/hook
 
 /datum/anvil_recipe/kazenguniteweapons/kanabo
 	name = "Kanabo (+1 Small Log)"
@@ -113,12 +101,6 @@ additional_items = list (/obj/item/grown/log/tree/small)
 	additional_items = list(/obj/item/grown/log/tree/small)
 	created_item = /obj/item/rogueweapon/mace/goden/kanabo
 
-
-/datum/anvil_recipe/kazenguniteweapons/scabbard
-	name = "Simple Kazengun Scabbard (+1 Small Log)"
-	req_bar = /obj/item/ingot/steel
-	additional_items = list (/obj/item/grown/log/tree/small)
-	created_item = /obj/item/rogueweapon/scabbard/sword/kazengun
 
 /datum/anvil_recipe/kazenguniteweapons/kodachiscabbard
 	name = "Plain Lacquer Scabbard (+1 Small Log)"

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/kazengunite.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/kazengunite.dm
@@ -18,25 +18,49 @@
 	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/head/roguetown/helmet/heavy/kabuto
 
+/datum/anvil_recipe/kazengunite/jingasa
+	name = "Jingasa"
+	req_bar = /obj/item/ingot/steel
+	created_item=/obj/clothing/head/roguetown/helmet/kettle/jingasa
 
 /datum/anvil_recipe/kazengunite/halfmask
 	name = "Soldier's Half-Mask"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/mask/rogue/facemask/steel/kazengun
 
+/datum/anvil_recipe/kazengunite/fullmask
+	name = "Full Ogre Mask"
+	req_bar = /obj/item/ingot/steel
+	created_item = /obj/item/clothing/mask/rogue/facemask/steel/kazengun/full
+
+/datum/anvil_recipe/kazengunite/onimask
+	name = "Oni Mask (+1 Small Log)"
+	req_bar = /obj/item/ingot/iron
+	additional_items = list (/obj/item/grown/log/tree/small)
+	/obj/item/clothing/mask/rogue/facemask/yoruku_oni
+
+/datum/anvil_recipe/kazengunite/kitsunemask
+	name = "Kitsune Mask (+1 Small Log)"
+	req_bar = /obj/item/ingot/iron
+additional_items = list (/obj/item/grown/log/tree/small)
+	/obj/item/clothing/mask/rogue/facemask/yoruku_kitsune
 
 /datum/anvil_recipe/kazengunite/gorget
 	name = "Kazengunite Gorget"
 	req_bar = /obj/item/ingot/steel
 	created_item = /obj/item/clothing/neck/roguetown/gorget/steel/kazengun
 
-
 /datum/anvil_recipe/kazengunite/samsibsa
-	name = "Samsibsa Scaleplate (+1 Half-Plate, Steel, +1 Steel, +2 Cured Leather)"
+	name = "Samsibsa Scaleplate (+1 Half-Plate, +1 Steel, +2 Cured Leather)"
 	req_bar = /obj/item/ingot/steel
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate, /obj/item/ingot/steel, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/full/samsibsa
 
+/datum/anvil_recipe/kazengunite/haraate
+	name = "Hansimhae Cuirass (+1 Steel, +2 Cloth)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list(/obj/item/ingot/steel, /obj/item/natural/cloth, /obj/item/natural/cloth)
+	created_item = /obj/item/clothing/suit/roguetown/armor/brigandine/haraate
 
 /datum/anvil_recipe/kazengunite/kote
 	name = "Jjajeungna Gauntlets"
@@ -44,10 +68,69 @@
 	created_item = /obj/item/clothing/gloves/roguetown/plate/kote
 
 
-/datum/anvil_recipe/kazengunite/ssangsudo
-	name = "Ssangsudo"
+/datum/anvil_recipe/kazenguniteweapons
+	abstract_type = /datum/anvil_recipe/kazenguniteweapons
 	appro_skill = /datum/skill/craft/weaponsmithing
 	i_type = "Weapons"
+	craftdiff = SKILL_LEVEL_MASTER
+	req_trait = TRAIT_KAZENGUNITE_SMITH
+	hides_from_books = TRUE
+
+/datum/anvil_recipe/kazenguniteweapons/tanto
+	name = "Tanto"
+	req_bar = /obj/item/ingot/steel
+	req_blade = /obj/item/blade/steel_knife
+	created_item = /obj/item/rogueweapon/huntingknife/idagger/steel/kazengun
+
+/datum/anvil_recipe/kazenguniteweapons/kodachi
+	name = "Kodachi"
+	req_bar = /obj/item/ingot/steel
+	req_blade = /obj/item/blade/steel_sword
+	created_item = /obj/item/rogueweapon/sword/short/kazengun
+
+/datum/anvil_recipe/kazenguniteweapons/hwando
+	name = "Hwando"
+	req_bar = /obj/item/ingot/steel
+	req_blade = /obj/item/blade/steel_sword
+	created_item = /obj/item/rogueweapon/sword/sabre/mulyeog
+
+/datum/anvil_recipe/kazenguniteweapons/ssangsudo
+	name = "Ssangsudo"
 	req_bar = /obj/item/ingot/steel
 	req_blade = /obj/item/blade/steel_sword
 	created_item = /obj/item/rogueweapon/sword/long/kriegmesser/ssangsudo
+
+/datum/anvil_recipe/kazenguniteweapons/hooksword
+	name = "Hook Sword"
+	req_bar = /obj/item/ingot/steel
+	req_blade = /obj/item/blade/steel_sword
+	created_item = /obj/item/rogueweapon/sword/sabre/hook
+
+/datum/anvil_recipe/kazenguniteweapons/kanabo
+	name = "Kanabo (+1 Small Log)"
+	req_bar = /obj/item/ingot/steel
+	req_blade = /obj/item/blade/steel_mace
+	additional_items = list(/obj/item/grown/log/tree/small)
+	created_item = /obj/item/rogueweapon/mace/goden/kanabo
+
+
+/datum/anvil_recipe/kazenguniteweapons/scabbard
+	name = "Simple Kazengun Scabbard (+1 Small Log)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list (/obj/item/grown/log/tree/small)
+	created_item = /obj/item/rogueweapon/scabbard/sword/kazengun
+
+/datum/anvil_recipe/kazenguniteweapons/kodachiscabbard
+	name = "Plain Lacquer Scabbard (+1 Small Log)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list (/obj/item/grown/log/tree/small)
+	created_item = /obj/item/rogueweapon/scabbard/sword/kazengun/kodachi
+
+/datum/anvil_recipe/kazenguniteweapons/sheath
+	name = "Plain Lacquer Sheath (+1 Small Log)"
+	req_bar = /obj/item/ingot/steel
+	additional_items = list (/obj/item/grown/log/tree/small)
+	created_item = /obj/item/rogueweapon/scabbard/sheath/kazengun
+
+
+


### PR DESCRIPTION
## About The Pull Request

makes almost everything that is kazengunese craftable (except for distinct ruma clan equipment such as the specific ruma clan swords and scabbards). this includes shirts, pants, gloves, shoes, light armors, medium armor and medium helmet, masks, and the weapons such as the dagger (tanto), shortsword (kodachi), sabre (hwando), goedendag (kanabo) and hook swords (shuang gou). scabbards included as well (doubling as shields).

attention has been paid towards balancing and stats in regards to costs and i _think_ it should be fine but im more than willing to hear input about balancing since that was a chief concern of mine

## Testing Evidence

<img width="330" height="114" alt="image" src="https://github.com/user-attachments/assets/ed09176a-efcc-4508-bb1a-f280006f1abe" />

## Why It's Good For The Game

theres a lot of really cool equipment and clothes that mostly never sees the light of day due to exclusivity. for example, the kazengunese medium helmet, a kettle equivalent called a jingasa, is only found on the hangyaku-chonin mercenary subclass which ive never seen in months of playing here. i think itll just help people playing kazengunese characters really get into the feel for it when they can have proper clothes and equipment

also not even going to lie the main motivation for this pr is so i can larp as some of the samurai heroes from for honor

## Changelog

:cl:
add: almost every kazengunese item to crafting menus
balance: gave hangyaku-kounen medium armor choice the medium helmet, previously medium armor choice got the heavy helmet by default
code: added abstract weapon type thing to kazengun crafting recipe file, mirroring the armor abstract thing
/:cl: