### PR TITLE
Lets try it; Adds DNR to Prince/ess

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -22,7 +22,7 @@
 	round_contrib_points = 3
 	social_rank = SOCIAL_RANK_ROYAL
 	cmode_music = 'sound/music/combat_noble.ogg'
-	job_traits = list(TRAIT_NOBLE)
+	job_traits = list(TRAIT_NOBLE, TRAIT_DNR)
 	job_subclasses = list(
 		/datum/advclass/heir/daring,
 		/datum/advclass/heir/bookworm,


### PR DESCRIPTION
## About The Pull Request

As it stands; the previous PR that was just merged today was merged. After unknowingly realizing that the PR was merged, I immediately realized that the PR did not achieve much, if anything, indicating that people are still too safe. In order to make things less safe, I've decided to add **TRAIT_DNR** to Prince/ess to encourage them to be viable targets for antagonists.

I understand this might be jarring but bandaids need to be pulled off--people need to stop feeling so safe which is why I've elected to do this.

Personally, I think we should go further and KC/Knight roles should get this (while maa and co dont) but i'll be crucified.
anyway behave or i'll mark comments as resolved.

## Testing Evidence

it compiles

## Why It's Good For The Game

See above.

## Changelog


:cl:
add: DNR to Prince
/:cl:
