### PR TITLE
Bless crops and Aquatic compulsion nerf

### DIFF
--- a/code/datums/skills/labor.dm
+++ b/code/datums/skills/labor.dm
@@ -44,7 +44,8 @@
 	max_untraited_level = SKILL_LEVEL_APPRENTICE
 	trait_uncap = list(TRAIT_HOMESTEAD_EXPERT = SKILL_LEVEL_LEGENDARY,
 	TRAIT_SURVIVAL_EXPERT = SKILL_LEVEL_LEGENDARY,
-	TRAIT_SELF_SUSTENANCE = SKILL_LEVEL_JOURNEYMAN)
+	TRAIT_SELF_SUSTENANCE = SKILL_LEVEL_JOURNEYMAN,
+	TRAIT_ABYSSOR_SWIM = SKILL_LEVEL_JOURNEYMAN) // so abyssorites that REALLY need the fish can get them after a bit of training
 
 /datum/skill/labor/butchering
 	name = "Butchering"

--- a/code/datums/sleep_adv/sleep_adv.dm
+++ b/code/datums/sleep_adv/sleep_adv.dm
@@ -417,6 +417,8 @@ GLOBAL_LIST_INIT(cross_training_map, list(
 	if(HAS_TRAIT(mind.current, TRAIT_STUDENT))
 		REMOVE_TRAIT(mind.current, TRAIT_STUDENT, TRAIT_GENERIC)
 		to_chat(mind.current, span_nicegreen("I feel that I can be educated in a skill once more."))
+	if(mind.aquatic_compulsion_uses)
+		mind.aquatic_compulsion_uses = 0
 	close_ui()
 
 /datum/sleep_adv/Topic(href, list/href_list)

--- a/code/modules/farming/soil.dm
+++ b/code/modules/farming/soil.dm
@@ -302,7 +302,7 @@ GLOBAL_LIST_EMPTY(soil_list)
 	update_icon()
 
 /obj/structure/soil/proc/bless_soil()
-	blessed_time = 15 MINUTES
+	blessed_time = 5 MINUTES //average growth + produce time, without accounting for faster growth, lets you practically forget about the plant
 	// It's a miracle! Plant comes back to life when blessed by Dendor
 	if(plant && plant_dead)
 		plant_dead = FALSE

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -128,7 +128,7 @@
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	recharge_time = 30 SECONDS
+	recharge_time = 10 SECONDS
 	miracle = TRUE
 	devotion_cost = 10
 	//Horrendous carry-over from fishing code
@@ -145,8 +145,15 @@
 		"ceruleanFishingMod" = 0 // 1 on cerulean aril, 0 on everything else
 	)
 
+/datum/mind
+	var/aquatic_compulsion_uses = 0
+
 /obj/effect/proc_holder/spell/invoked/aquatic_compulsion/cast(list/targets, mob/user = usr)
 	. = ..()
+	if(user.mind.aquatic_compulsion_uses >= 12)
+		to_chat(user, span_warning("The fishes recognize my call and reject it... perhaps I should rest and let some time pass."))
+		revert_cast()
+		return FALSE
 	if(isturf(targets[1]))
 		var/turf/T = targets[1]
 		var/A
@@ -171,6 +178,7 @@
 			playsound(T, 'sound/foley/footsteps/FTWAT_1.ogg', 100)
 			teleport_to_dream(user, 10000, 1)
 			user.visible_message("<font color='yellow'>[user] makes a beckoning gesture at [T]!</font>")
+			user.mind.aquatic_compulsion_uses++
 			return TRUE
 		else
 			revert_cast()

--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -128,7 +128,7 @@
 	invocation_type = "shout"
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = TRUE
-	recharge_time = 10 SECONDS
+	recharge_time = 30 SECONDS
 	miracle = TRUE
 	devotion_cost = 10
 	//Horrendous carry-over from fishing code

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -5,7 +5,7 @@
 	range = 5
 	overlay_state = "blesscrop"
 	releasedrain = 30
-	recharge_time = 5 MINUTES
+	recharge_time = 3 MINUTES
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	max_targets = 0
 	cast_without_targets = TRUE

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -5,7 +5,7 @@
 	range = 5
 	overlay_state = "blesscrop"
 	releasedrain = 30
-	recharge_time = 30 SECONDS
+	recharge_time = 5 MINUTES
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	max_targets = 0
 	cast_without_targets = TRUE
@@ -20,12 +20,13 @@
 	. = ..()
 	var/growed = FALSE
 	var/amount_blessed = 0
-	for(var/obj/structure/soil/soil in view(4))
+	var/caster_skill = user.get_skill_level(/datum/skill/magic/holy)
+	for(var/obj/structure/soil/soil in view(3))
 		soil.bless_soil()
 		growed = TRUE
 		amount_blessed++
-		// Blessed only up to 5 crops
-		if(amount_blessed >= 5)
+		// Blessed only up to the caster's skill level
+		if(amount_blessed >= caster_skill)
 			break
 	if(growed)
 		visible_message(span_green("[usr] blesses the nearby crops with Dendor's Favour!"))

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	var/growed = FALSE
 	var/amount_blessed = 0
-	var/caster_skill = user.get_skill_level(/datum/skill/magic/holy)
+	var/caster_skill = max(user.get_skill_level(/datum/skill/magic/holy), 3)
 	for(var/obj/structure/soil/soil in view(3))
 		soil.bless_soil()
 		growed = TRUE


### PR DESCRIPTION
## About The Pull Request 

Bless crops changes:
- Blessings now last 5 minutes instead of 15
- The amount of crops blessed now scales off miracle skill, with a minimum of 3 and a maximum of 6
- Blessing crops now has a 3 minute cooldown, practically limiting the amount of crops you could have blessed at the same time depending on your skill, rather than being able to bless an entire field for 15 minutes in 2 minutes like it was previously.
- Range decreased from 4 to 3 to avoid accidentally blessing a crop that's very far away, now that blessings are more limited.

Aquatic compulsion changes:
- There's now a maximum amount of fish you can get per day. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1222" height="597" alt="image" src="https://github.com/user-attachments/assets/1422f565-fb7c-4adf-9e0a-ee0da57baa1b" />
<img width="973" height="565" alt="image" src="https://github.com/user-attachments/assets/86a702ec-4bd0-4a94-b53a-bdbc89dc0449" />

<img width="1124" height="631" alt="image" src="https://github.com/user-attachments/assets/95c3d06e-c246-4a9a-a87f-9632d6aa97ae" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game


Just to get everyone on the same page, the T0 cleric spell that everyone could get did the following:
Feeds hungry plants
Waters thirsty plants
Revives dead plants
Grows plants 2 minutes worth instantly
Removes weeds for 15 minutes
Heals plants for 15 minutes at twice the rate of damage they take, making them effectively immortal
Grows plants twice as fast for 15 minutes
60% lower nutriment needed for 15 minutes

...this could be casted every 30 seconds. For 5 plants. At a trivial devotion cost. 

If you're planning to do any kind of farming it's hard to justify to NOT take it, since it practically means you get 6 minutes worth of farming done every single minute (2x speed + 2x 2 minute speed ups + no need to obtain food for the plants) **FIVE PLANTS AT A TIME**. 
It's not uncommon to see an innkeeper or cook, or even random dendorite cleric manage to grow more crops than a soilson team usually would by simply picking dendor as a patron and choosing devotee, and druids just being better, faster, stronger and cooler farmers is a meme by this point.

Meanwhile, abyssor's Aquatic Compulsion removes any need for materials for fishing (No rod or bait needed), any RNG from lack of skill, any wait or interactivity from it (garaunteed fish every 10 seconds) **AND** is faster than novice fishing.

While this is not as big of an issue as the farming, I've noticed certain people end up using this practically as either a food printer or money printer, every fish sells for 6 mammon at the stockpile, meaning that by spending just 5 minutes of standing still staring at the ocean, interacting with nobody and nothing, you can already reach 180 mammon worth of fish, or practically enough to feed a large chunk of the church and anybody se that comes to ask for some. If anything, I think it rewards behavior that contributes absolutely nothing to the round (other than fish) too well.

Hopefully these two changes make normal fishing/farming a more valuable and interesting thing, rather than being at a big and constant disadvantage for *not* picking these two "meta" casts.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bless Crops now only blesses a certain amount of crops depending on caster skill
balance: Blessed Crops only last 5 minutes blessed
balance: Bless Crops cooldown increased to 3 minutes
balance: Aquatic Compulsion now has a maximum amount of fish that can be called per day.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
