### PR TITLE
Can remove your own Necra's Sight mark on objects via recast

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -359,7 +359,8 @@
 
 /obj/effect/proc_holder/spell/invoked/necras_sight/proc/add_to_scry(obj/O, mob/living/carbon/human/user)
 	if(O in marked_objects)
-		revert_cast()
+		marked_objects.Remove(O)
+		to_chat(user, span_info("You let the grave slip from your mind..."))
 		return
 	var/holyskill = user.get_skill_level(/datum/skill/magic/holy)
 	var/label = input(user, "Name this grave for your sight:", "Mark Holy Object") as text|null


### PR DESCRIPTION
## About The Pull Request

Allows Necrans (or anyone with Necra's Sight) to unmark a grave/psycross (via MMBing it again), instead of needing to fill their sight list to bump the oldest entry out.

## Testing Evidence

Verified that they were removed from the sight list properly, even if there are multiple locations marked.

## Why It's Good For The Game

Nice little QOL.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can now remove an object from your Necra's Sight list by re-casting the spell on the object.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
