### PR TITLE
lets you wear a pouch in a cloak slot

### DIFF
--- a/code/modules/clothing/rogueclothes/storage/pouch.dm
+++ b/code/modules/clothing/rogueclothes/storage/pouch.dm
@@ -5,7 +5,7 @@
 	mob_overlay_icon = null
 	icon_state = "pouch"
 	item_state = "pouch"
-	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK
+	slot_flags = ITEM_SLOT_HIP|ITEM_SLOT_NECK|ITEM_SLOT_CLOAK
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("whips", "lashes")
 	max_integrity = 300


### PR DESCRIPTION
## About The Pull Request

lets you wear a pouch in a cloak slot

## Testing Evidence
<img width="1246" height="496" alt="image" src="https://github.com/user-attachments/assets/a9ed82de-9e7d-4722-914b-bb017fb43815" />

## Why It's Good For The Game

It's nice to have the option to not cover up your armor with a concealing sprite without sacrificing valuable inventory space. All cloaks give a 2x2 inventory currently - the pouch is *slightly* less convenient. So it's not really a buff. Moreso a cosmetic option.

People were using bugged cloaks with missing sprites (fitted coat or the shadow cloak/duelist cape after rightclicking them before they were fixed) to have the effect of 4 inventory slots without the visible sprite change. This lets them do that without using a bug

## Changelog
:cl:
qol: can carry a pouch in your cloak slot
/:cl:
