### PR TITLE
Removes Passive Stockpile Generation

### DIFF
--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -88,9 +88,11 @@ SUBSYSTEM_DEF(treasury)
 						X.demand += rand(5,15)
 					if(X.demand > initial(X.demand))
 						X.demand -= rand(5,15)
+/*
 			for(var/datum/roguestock/stockpile/A in stockpile_datums) //Generate some remote resources
 				A.held_items[2] += A.passive_generation
 				A.held_items[2] = min(A.held_items[2],10) //To a maximum of 10
+*/
 		var/area/A = GLOB.areas_by_type[/area/rogue/indoors/town/vault]
 		for(var/obj/structure/roguemachine/vaultbank/VB in A)
 			if(istype(VB))


### PR DESCRIPTION
## About The Pull Request

Removes passive stockpile generation.

## Testing Evidence

Compiled & tested on localhost.

<img width="546" height="240" alt="image" src="https://github.com/user-attachments/assets/c71f05dc-9478-4641-819c-caa21cf3dbc6" />

## Why It's Good For The Game

What's the point of towners if the stockpile makes resources on its own? I think we'll be OK without this.

## Changelog

:cl:
del: Removed passive stockpile generation.
/:cl:
