### PR TITLE
Removes knuckles punch intent integrity damage bonus

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -36,7 +36,7 @@
 	swingdelay = 0
 	icon_state = "inpunch"
 	item_d_type = "blunt"
-	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR // This might be a mistake
+	intent_intdamage_factor = 1
 	//We want chipping, m'lord.
 	blunt_chipping = TRUE
 	blunt_chip_strength = BLUNT_CHIP_WEAK

--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -36,6 +36,7 @@
 	swingdelay = 0
 	icon_state = "inpunch"
 	item_d_type = "blunt"
+	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR // This might be a mistake
 	//We want chipping, m'lord.
 	blunt_chipping = TRUE
 	blunt_chip_strength = BLUNT_CHIP_WEAK

--- a/code/game/objects/items/rogueweapons/melee/unarmed.dm
+++ b/code/game/objects/items/rogueweapons/melee/unarmed.dm
@@ -36,7 +36,6 @@
 	swingdelay = 0
 	icon_state = "inpunch"
 	item_d_type = "blunt"
-	intent_intdamage_factor = BLUNT_DEFAULT_INT_DAMAGEFACTOR // This might be a mistake
 	//We want chipping, m'lord.
 	blunt_chipping = TRUE
 	blunt_chip_strength = BLUNT_CHIP_WEAK


### PR DESCRIPTION
## About The Pull Request
Removes the modifier that adds 40% integrity damage to knuckles punch intent.
As the comment states, tis was a mistake.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
One line change that compiles.
<img width="490" height="140" alt="image" src="https://github.com/user-attachments/assets/3ed87bbb-e8d2-4dda-8b5c-fbe57457c6bb" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Knuckles are above almost any other weapon in relative time-to-kill(or skull crack in this case), barring exposed armor circumstances. Due to the way helmet armor works, the ease of which unarmed classes can obliterate swarthes of people relative to other combatants in the game is simply stupid. A disciple or berzerker can cause more damage in combat than 3 other combatants of any given class. Considering this and the fact that unarmed classes likely have the highest number of people with master skill level (a bygone relic when unarmed was significantly weaker/useless), unarmed users have unparalelled ease to attack people, bypass parrys or dodges and obliterate peoples skulls.

They're so good that many players of classes typically not expected to wield unarmed weapons have gone around using them alongside a shield or just plain grappling and smacking heads in - because they are that good.

This is an admittingly lazy but simple fix that reduces the effective integrity damage they can do, reducing time to kill significantly, putting them more in line with other weapons considering their quick attack speed.

This comes from significant experience playing otavan orthodoxist disciple, as well as seeing what unarmed users on the antagonist side can do. It's fun to play, but absolutely mindnumbing to everyone else. In theory, you can counter these users, in reality they have builds that allow them to sustain much more abuse and thus it hardly matters if you get a bait or block off- they'll just keep coming at you. Playing literally anything else in combat feels like playing hard mode whenever a grappler or knuckles user is around. The sheer disparity between strong unarmed classes and everything else is to the point that when I play a disciple? I have absolutely 100% confidence that I can win a fight against pretty much any player on the server. No class should give anyone that level of certainty, ever.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Knuckles punch intent no longer recieves a 40% bonus integrity damage modifier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
