### PR TITLE
Squire prefs

### DIFF
--- a/code/__HELPERS/cloaksetup.dm
+++ b/code/__HELPERS/cloaksetup.dm
@@ -54,7 +54,7 @@
 	if(!mind || mind.assigned_role != "Squire")
 		return
 
-	var/list/gameplay_preferences = list("RP", "Combat", "No Preference")
+	var/list/gameplay_preferences = list("RP", "Combat", "Role Training/I'm New", "No Preference")
 	var/selected_preference = input(src, "Choose your preferred Squire Experience", "SQUIRE PREFERENCE") as null|anything in gameplay_preferences
 	if(!(selected_preference in gameplay_preferences))
 		selected_preference = "No Preference"

--- a/code/__HELPERS/cloaksetup.dm
+++ b/code/__HELPERS/cloaksetup.dm
@@ -46,3 +46,16 @@
 	else
 		cloak_choice.name = "[name_index] [cloak_choice.name] ([namesplit[1]])"
 	src.equip_to_slot_or_del(cloak_choice, SLOT_CLOAK)
+
+/mob/proc/squire_gameplay_preference_setup()
+	if(!client)
+		addtimer(CALLBACK(src, PROC_REF(squire_gameplay_preference_setup)), 50)
+		return
+	if(!mind || mind.assigned_role != "Squire")
+		return
+
+	var/list/gameplay_preferences = list("RP", "Combat", "No Preference")
+	var/selected_preference = input(src, "Choose your preferred Squire Experience", "SQUIRE PREFERENCE") as null|anything in gameplay_preferences
+	if(!(selected_preference in gameplay_preferences))
+		selected_preference = "No Preference"
+	mind.squire_gameplay_preference = selected_preference

--- a/code/__HELPERS/cloaksetup.dm
+++ b/code/__HELPERS/cloaksetup.dm
@@ -55,7 +55,7 @@
 		return
 
 	var/list/gameplay_preferences = list("RP", "Combat", "Role Training/I'm New", "No Preference")
-	var/selected_preference = input(src, "Choose your preferred Squire Experience", "SQUIRE PREFERENCE") as null|anything in gameplay_preferences
+	var/selected_preference = input(src, "Choose your preferred playstyle\n\nPlease note this is not guaranteed, it is just to indicate to knights what sort of experience you prefer. You will still be expected to fulfill all of the duties of a Squire!", "SQUIRE PREFERENCE") as null|anything in gameplay_preferences
 	if(!(selected_preference in gameplay_preferences))
 		selected_preference = "No Preference"
 	mind.squire_gameplay_preference = selected_preference

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -65,6 +65,7 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	//Knight squire vars.
 	var/mob/living/carbon/knight = null
 	var/mob/living/carbon/squire = null
+	var/squire_gameplay_preference = "No Preference"
 
 	var/linglink
 	var/datum/martial_art/martial_art

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -66,6 +66,8 @@ GLOBAL_LIST_EMPTY(personal_objective_minds)
 	var/mob/living/carbon/knight = null
 	var/mob/living/carbon/squire = null
 	var/squire_gameplay_preference = "No Preference"
+	var/squire_bond_cooldown_until = 0
+	var/suppress_next_squire_bond_loss_stress = FALSE
 
 	var/linglink
 	var/datum/martial_art/martial_art

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
@@ -70,6 +70,7 @@
 /datum/outfit/job/roguetown/knight/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/take_squire
+	H.verbs |= /mob/living/carbon/human/proc/end_squire_connection
 
 /mob/living/carbon/human/proc/take_squire()
 	set name = "Take Squire"
@@ -79,12 +80,18 @@
 		return
 	if(!mind)
 		return
+	if(mind.squire_bond_cooldown_until > world.time)
+		to_chat(src, span_warning("I must wait [DisplayTimeText(mind.squire_bond_cooldown_until - world.time)] before taking another squire."))
+		return
 
 	if(!src.mind.squire)
 		var/list/folksnearby = list()
 		for(var/mob/living/carbon/human/potential_squires in (view(1)))
 			if(potential_squires.job == "Squire")
 				folksnearby += potential_squires
+		if(!length(folksnearby))
+			to_chat(src, span_warning("No eligible squires are close enough to take into service."))
+			return
 		var/target = input(src, "Take as Squire") as null|anything in folksnearby
 		if(istype(target, /mob/living/carbon))
 			var/mob/living/carbon/guy = target
@@ -94,6 +101,12 @@
 				return
 			if(!guy.mind)
 				return
+			if(guy.mind.knight)
+				to_chat(src, span_warning("[guy] is already sworn to a knight."))
+				return
+			if(guy.mind.squire_bond_cooldown_until > world.time)
+				to_chat(src, span_warning("[guy] must wait [DisplayTimeText(guy.mind.squire_bond_cooldown_until - world.time)] before swearing a new oath."))
+				return
 			src.say("Are you not my squire, [guy]?")
 
 			var/prompt = alert(guy, "Do wish to be [src]'s squire?", "Squire", "Aye, m'lord!", "Nae, m'lord!")
@@ -102,6 +115,8 @@
 				return
 
 			else
+				if(src.mind.squire || guy.mind.knight)
+					return
 				guy.say("It is as you say, [src], I am your squire.")
 				guy.mind.knight = src
 				src.mind.squire = guy
@@ -110,6 +125,69 @@
 				new_squire.knight = src
 				new_knight.squire = guy
 				src.verbs -= /mob/living/carbon/human/proc/take_squire//You get one chance at actually retaining this guy. Sorry, buddy.
+
+/mob/living/carbon/human/proc/end_squire_connection()
+	set name = "End Squire Bond"
+	set category = "Noble"
+	var/static/squire_bond_cooldown_duration = 5 MINUTES
+
+	if(stat)
+		return
+	if(!mind)
+		return
+	if(mind.assigned_role != "Knight" && mind.assigned_role != "Squire")
+		return
+
+	var/mob/living/carbon/human/linked = null
+	if(ishuman(mind.squire))
+		linked = mind.squire
+	else if(ishuman(mind.knight))
+		linked = mind.knight
+
+	if(!linked)
+		to_chat(src, span_warning("I am not bound by oath to a knight or squire."))
+		return
+
+	if(alert(src, "End your oath with [linked]?", "Oath of Service", "End Bond", "Keep Bond") != "End Bond")
+		return
+	if(mind)
+		mind.suppress_next_squire_bond_loss_stress = TRUE
+		mind.squire_bond_cooldown_until = world.time + squire_bond_cooldown_duration
+	if(linked.mind)
+		linked.mind.suppress_next_squire_bond_loss_stress = TRUE
+		linked.mind.squire_bond_cooldown_until = world.time + squire_bond_cooldown_duration
+
+	if(mind.assigned_role == "Knight")
+		if(!has_status_effect(/datum/status_effect/buff/knight_prox))
+			mind.squire = null
+			if(linked.mind)
+				linked.mind.knight = null
+			if(linked.has_status_effect(/datum/status_effect/buff/squire_prox))
+				linked.remove_status_effect(/datum/status_effect/buff/squire_prox)
+			else
+				mind.suppress_next_squire_bond_loss_stress = FALSE
+				if(linked.mind)
+					linked.mind.suppress_next_squire_bond_loss_stress = FALSE
+		remove_status_effect(/datum/status_effect/buff/knight_prox)
+		verbs |= /mob/living/carbon/human/proc/take_squire
+		to_chat(src, span_notice("I release [linked] from my service."))
+		if(linked != src)
+			to_chat(linked, span_notice("[src] has ended your oath of service."))
+	else
+		if(!has_status_effect(/datum/status_effect/buff/squire_prox))
+			mind.knight = null
+			if(linked.mind)
+				linked.mind.squire = null
+			if(linked.has_status_effect(/datum/status_effect/buff/knight_prox))
+				linked.remove_status_effect(/datum/status_effect/buff/knight_prox)
+			else
+				mind.suppress_next_squire_bond_loss_stress = FALSE
+				if(linked.mind)
+					linked.mind.suppress_next_squire_bond_loss_stress = FALSE
+		remove_status_effect(/datum/status_effect/buff/squire_prox)
+		to_chat(src, span_notice("I am no longer in [linked]'s service."))
+		if(linked != src)
+			to_chat(linked, span_notice("[src] has ended their oath of service."))
 
 /*
 Firstly, the squire's buffs and boons or whatever.
@@ -137,7 +215,10 @@ Firstly, the squire's buffs and boons or whatever.
 
 /datum/status_effect/buff/squire_prox/on_remove()
 	owner.mind.knight = null
-	owner.add_stress(/datum/stressevent/lost_knight)
+	if(owner.mind?.suppress_next_squire_bond_loss_stress)
+		owner.mind.suppress_next_squire_bond_loss_stress = FALSE
+	else
+		owner.add_stress(/datum/stressevent/lost_knight)
 	owner.remove_status_effect(/datum/status_effect/buff/squire_prox)
 	if(knight && knight.mind)
 		knight.mind.squire = null
@@ -179,8 +260,14 @@ Now, the knight's.
 
 /datum/status_effect/buff/knight_prox/on_remove()
 	owner.mind.squire = null
-	owner.add_stress(/datum/stressevent/lost_squire)
+	if(owner.mind?.suppress_next_squire_bond_loss_stress)
+		owner.mind.suppress_next_squire_bond_loss_stress = FALSE
+	else
+		owner.add_stress(/datum/stressevent/lost_squire)
 	owner.remove_status_effect(/datum/status_effect/buff/knight_prox)
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.verbs |= /mob/living/carbon/human/proc/take_squire
 	if(squire && squire.mind)
 		squire.mind.knight = null
 		squire.remove_status_effect(/datum/status_effect/buff/squire_prox)

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -37,6 +37,10 @@
 	id = /obj/item/scomstone/bad/garrison
 	job_bitflag = BITFLAG_GARRISON		//Move this role to garrison section later. Shouldn't be under youngroles for transparancy they are garrison.
 
+/datum/outfit/job/roguetown/squire/pre_equip(mob/living/carbon/human/H)
+	. = ..()
+	H.verbs |= /mob/living/carbon/human/proc/end_squire_connection
+
 /datum/job/roguetown/squire/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -41,6 +41,7 @@
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, squire_gameplay_preference_setup)), 60)
 
 /datum/advclass/squire/lancer
 	name = "Lancer Squire"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -872,6 +872,14 @@
 	if(length(status_examines))
 		msg += status_examines
 
+	var/user_can_view_squire_preference = check_rights_for(user?.client, R_ADMIN)
+	if(!user_can_view_squire_preference && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		user_can_view_squire_preference = H.mind?.assigned_role == "Knight" || H.mind?.assigned_role == "Knight Captain"
+	if(user != src && user_can_view_squire_preference && src.mind?.assigned_role == "Squire")
+		var/squire_preference = src.mind?.squire_gameplay_preference || "No Preference"
+		msg += span_slime("<small>Squire Preference: [squire_preference]</small>")
+
 	//Disgusting behemoth of stun absorption
 	if(islist(stun_absorption))
 		for(var/i in stun_absorption)

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -1,5 +1,5 @@
 #ifndef TESTING
-//    #define FASTLOAD
+    #define FASTLOAD
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -1,5 +1,5 @@
 #ifndef TESTING
-    #define FASTLOAD
+//    #define FASTLOAD
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif

--- a/modular/code/modules/mob/living/carbon/examine_hooks.dm
+++ b/modular/code/modules/mob/living/carbon/examine_hooks.dm
@@ -50,7 +50,7 @@
 	if(!user_can_view_squire_preference && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		user_can_view_squire_preference = H.mind?.assigned_role == "Knight" || H.mind?.assigned_role == "Knight Captain"
-	if(user_can_view_squire_preference && src.mind?.assigned_role == "Squire")
+	if(user != src && user_can_view_squire_preference && src.mind?.assigned_role == "Squire")
 		var/squire_preference = src.mind?.squire_gameplay_preference || "No Preference"
 		lines += span_notice("Squire preference: [squire_preference].")
 

--- a/modular/code/modules/mob/living/carbon/examine_hooks.dm
+++ b/modular/code/modules/mob/living/carbon/examine_hooks.dm
@@ -50,9 +50,6 @@
 	if(!user_can_view_squire_preference && ishuman(user))
 		var/mob/living/carbon/human/H = user
 		user_can_view_squire_preference = H.mind?.assigned_role == "Knight" || H.mind?.assigned_role == "Knight Captain"
-	if(user != src && user_can_view_squire_preference && src.mind?.assigned_role == "Squire")
-		var/squire_preference = src.mind?.squire_gameplay_preference || "No Preference"
-		lines += span_notice("Squire preference: [squire_preference].")
 
 	return lines
 

--- a/modular/code/modules/mob/living/carbon/examine_hooks.dm
+++ b/modular/code/modules/mob/living/carbon/examine_hooks.dm
@@ -46,6 +46,14 @@
 		else if(perception_level >= 15)
 			lines += span_aiprivradio("[m1] wearing a chastity device under [m2] clothes.")
 
+	var/user_can_view_squire_preference = check_rights_for(user?.client, R_ADMIN)
+	if(!user_can_view_squire_preference && ishuman(user))
+		var/mob/living/carbon/human/H = user
+		user_can_view_squire_preference = H.mind?.assigned_role == "Knight" || H.mind?.assigned_role == "Knight Captain"
+	if(user_can_view_squire_preference && src.mind?.assigned_role == "Squire")
+		var/squire_preference = src.mind?.squire_gameplay_preference || "No Preference"
+		lines += span_notice("Squire preference: [squire_preference].")
+
 	return lines
 
 /mob/living/carbon/human/proc/human_modular_chastity_toy_examine_line(mob/user, m2, m3)


### PR DESCRIPTION
## About The Pull Request

Adds a small option to select your 'Preferred Experience' as a Squire upon joining, (RP, Combat, Role Training/I'm New or No Preference). 

_(Training added at request, not in images but it's in there!)_

This is visible as a small piece of text in the examine window for Squires but ONLY Knights and the KC can see this. 

Also lets Squires Or Knights choose to voluntarily end their service. This will release both from their oath, and the Knight will have a short (five minute) cooldown before being able to take on a new Squire.

## Testing Evidence

<img width="433" height="378" alt="image" src="https://github.com/user-attachments/assets/39c0e25d-a70e-44c0-94f3-bb9f763886d9" />
<img width="600" height="487" alt="image" src="https://github.com/user-attachments/assets/35b59344-f631-440b-bbfd-d6d94b2c47eb" />
<img width="267" height="84" alt="image" src="https://github.com/user-attachments/assets/46f53624-520d-4854-b324-14e5d6fdeef3" />
<img width="256" height="195" alt="image" src="https://github.com/user-attachments/assets/21181c49-e977-4c0a-bfed-45277dcc5712" />
<img width="262" height="34" alt="image" src="https://github.com/user-attachments/assets/01c96dab-7a6b-42ff-a25b-89add363fb8b" />
<img width="389" height="44" alt="image" src="https://github.com/user-attachments/assets/736e997e-f783-4ad3-81a3-7ad493f0f959" />
<img width="273" height="37" alt="image" src="https://github.com/user-attachments/assets/034c16a4-a80d-4a16-9514-93a28b07629b" />
<img width="420" height="25" alt="image" src="https://github.com/user-attachments/assets/40304e91-6b0c-465c-9c43-b6c697d2c7d9" />

## Why It's Good For The Game

Fairly small change, most squires tend to either lean toward being interested primarily in combat or more toward RP. I've spoken to several squire players (and been one myself many times), and it can be a bit stressful and an unusual mix of IC/OOC to try and 'match' squires to knights. This small indicator should make it a little easier for knights to find a squire that they are likely to fit will with. Being allowed to change who is bound to who should also reduce issues which happen later in a round where a squire/knight pairing is not really working.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Small choice for squires to display their preferred style of play, viewable only by knights
add: Ability for knights or squires to end their service, knights can then take another after a short cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
