### PR TITLE
Draft: Councillor Minister system

### DIFF
--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -338,6 +338,10 @@
 /obj/item/inhand_tester,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"mO" = (
+/obj/structure/roguemachine/minister_archive,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors)
 "mW" = (
 /obj/structure/curtain/red,
 /turf/open/floor/rogue/concrete,
@@ -2938,7 +2942,7 @@ zo
 wQ
 yK
 vq
-vq
+mO
 vq
 vq
 eg

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -68,3 +68,413 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/newkeep/councillor
 		cloak = null
 		mask = null
+
+// ===== MINISTER SYSTEM =====
+// Councillors draft a writ at the ministerial archive. They bring it to a
+// faction leader, who finalizes it. The councillor then returns the finalized
+// writ to the archive to be sworn in, gaining an income boost, signet ring,
+// keys, and archive benefits (skills and traits that match their position). 
+// The patron receives a seal to contact their minister, 2-way private comms.
+
+/datum/ministry
+	var/name = "Ministry"
+	var/display_title = "Minister"
+	var/income_bonus = 20
+	var/list/ministry_keys = list()
+	var/list/archive_traits = list()
+	var/list/archive_skills = list()
+	var/ring_type = null
+	var/seal_type = null
+	var/mob/living/carbon/human/councillor = null
+	var/mob/living/carbon/human/partner = null
+	var/active = FALSE
+
+/datum/ministry/proc/archive_bonus(mob/living/carbon/human/H)
+	return
+
+/datum/ministry/guild
+	name = "Guild Ministry"
+	display_title = "Minister of Crafts"
+	ministry_keys = list(/obj/item/roguekey/crafterguild)
+	archive_traits = list(TRAIT_SEEPRICES, TRAIT_SMITHING_EXPERT)
+	archive_skills = list(
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/engineering = SKILL_LEVEL_NOVICE
+	)
+	ring_type = /obj/item/clothing/ring/minister/guild
+	seal_type = /obj/item/seal_of_ministry/guild
+
+/datum/ministry/church
+	name = "Church Ministry"
+	display_title = "Minister of the Faith"
+	ministry_keys = list(/obj/item/roguekey/church, /obj/item/roguekey/graveyard)
+	archive_traits = list(TRAIT_RITUALIST, TRAIT_VOTARY)
+	archive_skills = list(/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE)
+	ring_type = /obj/item/clothing/ring/minister/church
+	seal_type = /obj/item/seal_of_ministry/church
+
+/datum/ministry/church/archive_bonus(mob/living/carbon/human/H)
+	H.put_in_hands(new /obj/item/ritechalk(get_turf(H)))
+	if(istype(H.patron, /datum/patron/godless))
+		to_chat(H, span_warning("You hold no faith. Odd."))
+		return
+	if(H.devotion)
+		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
+		to_chat(H, span_notice("The archive deepens your existing devotion to [H.patron.name]."))
+		return
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
+	to_chat(H, span_notice("The archive stirs your faith. You feel the first whispers of [H.patron.name]'s gifts."))
+
+/datum/ministry/night
+	name = "Night Ministry"
+	display_title = "Minister of Vice"
+	ministry_keys = list(/obj/item/roguekey/nightmaiden)
+	archive_traits = list(TRAIT_CICERONE, TRAIT_GOODLOVER)
+	archive_skills = list(
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE
+	)
+	ring_type = /obj/item/clothing/ring/minister/night
+	seal_type = /obj/item/seal_of_ministry/night
+
+/datum/ministry/inquisition
+	name = "Inquisition Ministry"
+	display_title = "Minister of Orthodoxy"
+	ministry_keys = list(/obj/item/roguekey/inquisition)
+	archive_traits = list(TRAIT_STEELHEARTED)
+	archive_skills = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT
+	)
+	ring_type = /obj/item/clothing/ring/minister/inquisition
+	seal_type = /obj/item/seal_of_ministry/inquisition
+
+/datum/ministry/inquisition/archive_bonus(mob/living/carbon/human/H)
+	if(H.devotion)
+		if(!istype(H.patron, /datum/patron/old_god))
+			to_chat(H, span_warning("You are already bound to a credo more alive than PSYDON's. The Old God will not share."))
+			return
+		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
+		to_chat(H, span_notice("The archive reaffirms your covenant. ENDVRE."))
+		return
+	var/datum/devotion/C = new /datum/devotion(H, GLOB.patronlist[/datum/patron/old_god])
+	C.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
+	to_chat(H, span_notice("The dusty notes in the back of the archive remind you of the Old God's covenant. ENDVRE."))
+
+/datum/ministry/mage
+	name = "Arcane Ministry"
+	display_title = "Minister of Magic"
+	ministry_keys = list(/obj/item/roguekey/tower)
+	archive_traits = list(TRAIT_ALCHEMY_EXPERT)
+	archive_skills = list(
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
+	)
+	ring_type = /obj/item/clothing/ring/minister/mage
+	seal_type = /obj/item/seal_of_ministry/mage
+
+/datum/ministry/mage/archive_bonus(mob/living/carbon/human/H)
+	if(!H.mind)
+		return
+	if(!H.mind.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
+	H.mind.adjust_spellpoints(9)
+	to_chat(H, span_notice("The archive imparts the arcyne secrets of the previous Minister. You feel a thrum of latent power."))
+
+/datum/ministry/physician
+	name = "Physician Ministry"
+	display_title = "Minister of Health"
+	ministry_keys = list(/obj/item/roguekey/physician, /obj/item/roguekey/courtphysician)
+	archive_traits = list(TRAIT_EMPATH, TRAIT_MEDICINE_EXPERT)
+	archive_skills = list(/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT)
+	ring_type = /obj/item/clothing/ring/minister/physician
+	seal_type = /obj/item/seal_of_ministry/physician
+
+/datum/ministry/physician/archive_bonus(mob/living/carbon/human/H)
+	H.put_in_hands(new /obj/item/storage/belt/rogue/surgery_bag/full/physician(get_turf(H)))
+	to_chat(H, span_notice("The previous Minister's surgeon kit is collecting dust in the back of the archive. Following their notes, you might make use of it."))
+
+/datum/ministry/innkeeper
+	name = "Tavern Ministry"
+	display_title = "Minister of Commons"
+	ministry_keys = list(/obj/item/roguekey/tavern)
+	archive_traits = list(TRAIT_CICERONE, TRAIT_EMPATH, TRAIT_TAVERN_FIGHTER)
+	archive_skills = list(/datum/skill/craft/cooking = SKILL_LEVEL_JOURNEYMAN)
+	ring_type = /obj/item/clothing/ring/minister/innkeeper
+	seal_type = /obj/item/seal_of_ministry/innkeeper
+
+/datum/ministry/merchant
+	name = "Trade Ministry"
+	display_title = "Minister of Trade"
+	ministry_keys = list(/obj/item/roguekey/shop)
+	archive_traits = list(TRAIT_SEEPRICES, TRAIT_CICERONE)
+	archive_skills = list(/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN)
+	ring_type = /obj/item/clothing/ring/minister/merchant
+	seal_type = /obj/item/seal_of_ministry/merchant
+
+/proc/get_ministry_for_job(job_title)
+	switch(job_title)
+		if("Guildmaster")
+			return /datum/ministry/guild
+		if("Bishop")
+			return /datum/ministry/church
+		if("Bathmaster")
+			return /datum/ministry/night
+		if("Inquisitor")
+			return /datum/ministry/inquisition
+		if("Court Magician")
+			return /datum/ministry/mage
+		if("Head Physician")
+			return /datum/ministry/physician
+		if("Innkeeper")
+			return /datum/ministry/innkeeper
+		if("Merchant")
+			return /datum/ministry/merchant
+	return null
+
+/proc/establish_ministry(mob/living/carbon/human/councillor, mob/living/carbon/human/partner, datum/ministry/M, atom/archive)
+	M.councillor = councillor
+	M.partner = partner
+	M.active = TRUE
+	councillor.ministry_active = M
+	partner.ministry_partner = M
+
+	SStreasury.noble_incomes[councillor] += M.income_bonus
+
+	var/obj/item/clothing/ring/minister/ring = new M.ring_type(get_turf(councillor))
+	var/obj/item/seal_of_ministry/seal = new M.seal_type(get_turf(partner))
+	ring.paired_seal = seal
+	seal.paired_ring = ring
+
+	councillor.put_in_hands(ring)
+	councillor.put_in_hands(seal)
+
+	var/turf/key_turf = archive ? get_turf(archive) : get_turf(councillor)
+	for(var/key_type in M.ministry_keys)
+		new key_type(key_turf)
+
+/mob/living/carbon/human
+	var/datum/ministry/ministry_active = null
+	var/datum/ministry/ministry_partner = null
+	var/ministry_archive_consulted = FALSE
+
+
+// ===== MINISTRY WRIT =====
+// Writs prompt the faction heads whether they want to opt in to having a minister.
+
+/obj/item/ministry_writ
+	name = "draft writ of ministry"
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "contractunsigned"
+	w_class = WEIGHT_CLASS_SMALL
+	var/ministry_type = null
+	var/mob/living/carbon/human/author = null
+	var/mob/living/carbon/human/signatory = null
+
+/obj/item/ministry_writ/Initialize(mapload)
+	. = ..()
+	update_writ()
+
+/obj/item/ministry_writ/proc/update_writ()
+	if(ministry_type)
+		var/datum/ministry/proto = new ministry_type()
+		name = "[proto.name] writ"
+		icon_state = "contractsigned"
+		desc = "A finalized writ of the [proto.name], bearing the seal of the appropriate faction head. Return it to the ministerial archive to be sworn in."
+		qdel(proto)
+	else
+		name = "draft writ of ministry"
+		icon_state = "contractunsigned"
+		desc = "A draft writ of ministry, as yet unsigned. Present it to a faction head — Guildmaster, Bishop, Bathmaster, Inquisitor, Court Magician, Head Physician, Innkeeper, or Merchant — and ask them to finalize it."
+
+/obj/item/ministry_writ/examine(mob/user)
+	. = ..()
+	. += span_notice("Councillor: [author ? author.real_name : "Unknown"]")
+	. += span_notice("Sponsored By: [signatory ? signatory.real_name : "—"]")
+
+/obj/item/ministry_writ/attack_self(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(ministry_type)
+		to_chat(H, span_warning("This writ has already been finalized."))
+		return
+	if(!H.mind || !H.mind.assigned_role)
+		return
+	var/new_type = get_ministry_for_job(H.mind.assigned_role)
+	if(!new_type)
+		to_chat(H, span_warning("Your office holds no ministerial charter to grant."))
+		return
+	if(H.ministry_partner)
+		to_chat(H, span_warning("You have already appointed a minister."))
+		return
+	if(alert(H, "Finalize this writ and appoint a minister to your domain? They will gain keys and knowledge of your trade.", "Ministry Writ", "Finalize", "Cancel") != "Finalize")
+		return
+	ministry_type = new_type
+	signatory = H
+	update_writ()
+	H.visible_message(
+		span_notice("[H.real_name] signs [H.p_their()] name to the paper, finalizing the [name]."),
+		span_notice("You finalize the [name]. Return it to the councillor, that they might archive it to complete the appointment.")
+	)
+
+// ===== MINISTER SIGNET RING =====
+// Right-click to speak privately to the paired seal.
+
+/obj/item/clothing/ring/minister
+	name = "minister's signet"
+	desc = "A signet ring bearing the seal of a ministerial office. Press it to your lips to speak with your appointed patron."
+	icon = 'icons/roguetown/clothing/rings.dmi'
+	icon_state = "signet"
+	sellprice = 100
+	slot_flags = ITEM_SLOT_RING
+	var/obj/item/seal_of_ministry/paired_seal = null
+	var/ministry_cooldown = 0
+	var/ministry_cooldown_time = 600 // 1 minute
+
+/obj/item/clothing/ring/minister/attack_self(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(world.time < ministry_cooldown)
+		to_chat(H, span_warning("The ring's gem is still warm from its last use."))
+		return
+	if(!paired_seal || QDELETED(paired_seal))
+		to_chat(H, span_warning("The ring has no paired seal — the ministry bond is broken."))
+		return
+	if(!ismob(paired_seal.loc))
+		to_chat(H, span_warning("The seal is not being carried. Your words find no one."))
+		return
+	var/msg = input(H, "Speak into the ring.", "Ministry Channel") as null|text
+	if(!msg)
+		return
+	ministry_cooldown = world.time + ministry_cooldown_time
+	H.visible_message(span_notice("[H.real_name] presses their ring to their lips and murmurs quietly."))
+	paired_seal.receive_ministry_message(msg, H.real_name, "Minister")
+
+/obj/item/clothing/ring/minister/proc/receive_ministry_message(msg, speaker_name, speaker_role)
+	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
+	send_speech("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>", 1, src)
+
+/obj/item/clothing/ring/minister/guild
+	name = "guild minister's signet"
+	desc = "A well-worn signet ring, yet smoke-stained from the fires of the Guild."
+	icon_state = "signet"
+
+/obj/item/clothing/ring/minister/church
+	name = "church minister's signet"
+	desc = "A holy ring befitting a priest of the Divine Pantheon, now besmirched by court politick."
+	icon_state = "signet_silver"
+
+/obj/item/clothing/ring/minister/night
+	name = "night minister's signet"
+	desc = "An unassuming, sleek ring. Careful that it does not sink to the bottom of the baths."
+	icon_state = "signet"
+
+/obj/item/clothing/ring/minister/inquisition
+	name = "inquisition minister's signet"
+	desc = "A signet ring bearing the Inquisition's mark. An ENDVRING fashion choice, if outdated."
+	icon_state = "signet_silver"
+
+/obj/item/clothing/ring/minister/mage
+	name = "arcane minister's signet"
+	desc = "A ring faintly warm to the touch, marked with an arcyne glyph."
+	icon_state = "signet"
+
+/obj/item/clothing/ring/minister/physician
+	name = "physician minister's signet"
+	desc = "A ring bearing the Pestran tendrils of the court physician's office."
+	icon_state = "signet"
+
+/obj/item/clothing/ring/minister/innkeeper
+	name = "tavern minister's signet"
+	desc = "A ring bearing the inn's tap-mark. Its sheen is scratched by knife and cutting board."
+	icon_state = "signet"
+
+/obj/item/clothing/ring/minister/merchant
+	name = "trade minister's signet"
+	desc = "A ring bearing the mammon-hoarding marque of the Merchant's Guild."
+	icon_state = "signet"
+
+// ===== SEAL OF MINISTRY =====
+// Held or carried by the faction head partner.
+// Right-click to speak privately to the paired ring.
+
+/obj/item/seal_of_ministry
+	name = "seal of ministry"
+	desc = "A sealed dispatch bearing a ministerial mark. The wax is soft and dark."
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scroll_closed"
+	w_class = WEIGHT_CLASS_TINY
+	var/obj/item/clothing/ring/minister/paired_ring = null
+	var/ministry_cooldown = 0
+	var/ministry_cooldown_time = 600 // 1 minute
+
+/obj/item/seal_of_ministry/attack_self(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(world.time < ministry_cooldown)
+		to_chat(H, span_warning("The seal is still reforming from its last break. Try again in a minute."))
+		return
+	if(!paired_ring || QDELETED(paired_ring))
+		to_chat(H, span_warning("The seal has no paired ring — the ministry bond is broken."))
+		return
+	if(!ismob(paired_ring.loc))
+		to_chat(H, span_warning("Your minister is not carrying the ring. Your words find no one."))
+		return
+	var/msg = input(H, "Send word to your minister.", "Ministry Channel") as null|text
+	if(!msg)
+		return
+	ministry_cooldown = world.time + ministry_cooldown_time
+	H.visible_message(span_notice("[H.real_name] breaks the seal on the token and murmurs quietly into it."))
+	paired_ring.receive_ministry_message(msg, H.real_name, "Patron")
+
+/obj/item/seal_of_ministry/proc/receive_ministry_message(msg, speaker_name, speaker_role)
+	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
+	send_speech("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>", 1, src)
+
+
+
+/obj/item/seal_of_ministry/guild
+	name = "guild seal of ministry"
+	desc = "A rolled dispatch sealed with the crossed-hammer mark of the Guildmaster. The wax feels warm when held."
+
+/obj/item/seal_of_ministry/church
+	name = "church seal of ministry"
+	desc = "A scroll bound shut with the Pantheon cross in pale wax. It carries the faint smell of flower petals."
+
+/obj/item/seal_of_ministry/night
+	name = "night seal of ministry"
+	desc = "A plain roll of parchment, sealed with unmarked black wax. Nothing about it invites curiosity."
+
+/obj/item/seal_of_ministry/inquisition
+	name = "inquisition seal of ministry"
+	desc = "A tightly rolled writ sealed with the Archbishop's silver stamp. The edges are sharp and precise."
+
+/obj/item/seal_of_ministry/mage
+	name = "arcane seal of ministry"
+	desc = "A scroll whose wax seal faintly glows with a glyph that shifts when you aren't looking directly at it."
+
+/obj/item/seal_of_ministry/physician
+	name = "physician seal of ministry"
+	desc = "A clinical roll of parchment sealed with the caduceus in dark red wax. Smells faintly of camphor."
+
+/obj/item/seal_of_ministry/innkeeper
+	name = "tavern seal of ministry"
+	desc = "A short scroll sealed with the inn's tap-mark pressed into amber wax. It smells vaguely of ale."
+
+/obj/item/seal_of_ministry/merchant
+	name = "trade seal of ministry"
+	desc = "A folded dispatch sealed with the merchant's mark in green wax, the edges worn from handling."

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -189,6 +189,10 @@
 				. += span_notice("A fellow noble.")
 			else
 				. += span_notice("A noble!")
+		if(ministry_active?.active)
+			var/t_he = p_they(TRUE)
+			. += span_notice("[t_he] bears the office of [ministry_active.display_title].")
+			
 		// Leashed pet status effect message
 		if(has_status_effect(/datum/status_effect/leash_pet))
 			. += span_warning("A leash is hooked to their collar. They are being led like a pet.")

--- a/code/modules/roguetown/roguemachine/minister_archive.dm
+++ b/code/modules/roguetown/roguemachine/minister_archive.dm
@@ -1,0 +1,124 @@
+// Minister Archive — placed in the Councillor's office.
+// Click to pull a draft writ. Return a finalized writ to be sworn in as minister.
+// Submitting a valid writ triggers a 10-second study, then grants swearing-in and archive benefits together.
+
+/obj/structure/roguemachine/minister_archive
+	name = "ministerial archive"
+	desc = "A cabinet of sealed correspondence and official records, organized by faction. A councillor may draft a writ of ministry here, or submit a finalized one to be sworn in."
+	icon = 'icons/roguetown/misc/structure.dmi'
+	icon_state = "closetlord"
+	density = TRUE
+	anchored = TRUE
+	max_integrity = 300
+	destroy_sound = 'sound/combat/hits/onwood/destroyfurniture.ogg'
+	attacked_sound = "woodimpact"
+	/// Tracks when each councillor may pull their next writ. Keyed by mob, value is world.time they're free.
+	var/list/writ_cooldowns = list()
+	/// All currently active ministry datums. Keyed by ministry type path, value is datum/ministry.
+	var/list/active_ministries = list()
+
+/obj/structure/roguemachine/minister_archive/examine(mob/user)
+	. = ..()
+	if(!length(active_ministries))
+		. += span_notice("No ministries are currently in session.")
+		return
+	. += span_notice("The following ministries are in session:")
+	for(var/mtype in active_ministries)
+		var/datum/ministry/M = active_ministries[mtype]
+		var/cname = M.councillor ? M.councillor.real_name : "Unknown"
+		var/pname = M.partner ? M.partner.real_name : "Unknown"
+		. += span_notice("  [M.display_title] — [cname], appointed by [pname].")
+
+/obj/structure/roguemachine/minister_archive/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(!istype(user))
+		return
+	if(!user.mind || user.mind.assigned_role != "Councillor")
+		to_chat(user, span_warning("This archive is reserved for the council chamber's use."))
+		return
+	if(user.ministry_active)
+		to_chat(user, span_warning("You are already sworn to a ministry."))
+		return
+
+	// No active ministry — gate on cooldown and existing writ
+	if(writ_cooldowns[user] && world.time < writ_cooldowns[user])
+		var/remaining = round((writ_cooldowns[user] - world.time) / 600)
+		to_chat(user, span_warning("The archive will not issue another writ for [remaining] minute\s."))
+		return
+
+	for(var/obj/item/ministry_writ/W in user.contents)
+		to_chat(user, span_warning("You already carry a draft writ. Have it finalized by the appropriate faction head."))
+		return
+
+	writ_cooldowns[user] = world.time + 30 MINUTES
+	var/obj/item/ministry_writ/writ = new(get_turf(user))
+	writ.author = user
+	user.put_in_hands(writ)
+	to_chat(user, span_info("You pull a blank writ from the archive. Bring it to a faction head to have it finalized, then return it here."))
+	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
+
+// Called when the councillor returns a finalized writ (attackby)
+/obj/structure/roguemachine/minister_archive/attackby(obj/item/I, mob/living/carbon/human/user, params)
+	if(!istype(I, /obj/item/ministry_writ))
+		return ..()
+	var/obj/item/ministry_writ/writ = I
+	if(!istype(user))
+		return
+	if(!user.mind || user.mind.assigned_role != "Councillor")
+		to_chat(user, span_warning("This archive is not yours to submit to."))
+		return
+	if(user.ministry_active)
+		to_chat(user, span_warning("You are already bound to a ministry."))
+		return
+	if(!writ.ministry_type)
+		to_chat(user, span_warning("This writ has not been finalized. Bring it to the appropriate faction head first."))
+		return
+	if(!writ.author || writ.author != user)
+		to_chat(user, span_warning("This writ was not drafted for you."))
+		return
+	if(!writ.signatory || writ.signatory.stat == DEAD)
+		to_chat(user, span_warning("The faction head who sealed this writ is no longer available."))
+		return
+	if(writ.signatory.ministry_partner)
+		to_chat(user, span_warning("The faction head who sealed this writ has already taken another minister."))
+		return
+	if(active_ministries[writ.ministry_type])
+		to_chat(user, span_warning("A ministry of that charter already exists. The archive will not recognize a second appointment."))
+		qdel(writ)
+		return
+
+	to_chat(user, span_notice("You open the archive and begin the rite of appointment. Hold still..."))
+	var/ministry_type_to_create = writ.ministry_type
+	var/mob/living/carbon/human/signatory_ref = writ.signatory
+
+	if(!do_after(user, 10 SECONDS, target = src))
+		to_chat(user, span_warning("You step away before the rite is complete."))
+		return
+
+	// Re-validate after the wait
+	if(user.ministry_active)
+		to_chat(user, span_warning("Something has changed — you are already bound to a ministry."))
+		return
+	if(active_ministries[ministry_type_to_create])
+		to_chat(user, span_warning("A ministry of that charter was established while you studied. The archive cannot recognize a second."))
+		qdel(writ)
+		return
+	if(!signatory_ref || signatory_ref.stat == DEAD || signatory_ref?.ministry_partner)
+		to_chat(user, span_warning("Your patron's seal is no longer valid."))
+		qdel(writ)
+		return
+
+	var/datum/ministry/M = new ministry_type_to_create()
+	active_ministries[ministry_type_to_create] = M
+	establish_ministry(user, signatory_ref, M, src)
+
+	user.ministry_archive_consulted = TRUE
+	for(var/trait in M.archive_traits)
+		ADD_TRAIT(user, trait, "ministry_archive")
+	for(var/skill_type in M.archive_skills)
+		user.adjust_skillrank_up_to(skill_type, M.archive_skills[skill_type], TRUE)
+	M.archive_bonus(user)
+
+	to_chat(user, span_notice("You complete the rite. The knowledge of the [M.name] is now yours to draw upon."))
+	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
+	qdel(writ)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2551,6 +2551,7 @@
 #include "code\modules\roguetown\roguemachine\hoardmaster.dm"
 #include "code\modules\roguetown\roguemachine\lottery.dm"
 #include "code\modules\roguetown\roguemachine\mail.dm"
+#include "code\modules\roguetown\roguemachine\minister_archive.dm"
 #include "code\modules\roguetown\roguemachine\money.dm"
 #include "code\modules\roguetown\roguemachine\potionseller.dm"
 #include "code\modules\roguetown\roguemachine\submission.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

I faced the question, "What do councillors do?" They can get assigned to special tasks, but are quite mediocre at them. I also noticed some conversation about a "Keep Chaplain" role, but how that would disenfranchise the Church itself, et cetera. I thought, what if these councillors could go out and ingratiate themselves to the power roles of the town, be given a snippet of that role's abilities, in exchange for being a "voice inside the keep" for their purposes? That seemed like an interesting dynamic to encourage Councillors to get out and move and shake.

There is an old archive cabinet in the councillor's meeting chambers that only the councillor job can use to spawn a default "writ". They can go out to the following jobs; Guildmaster, Bishop, Innkeeper, Bathmaster, Inquisitor, Court Mage, Court Physician, and Merchant, and try to earn the patronage of that role to establish a ministry. The faction head uses the writ, which finalizes it. 

The councillor brings the writ back to the archive cabinet and submits it: this gives them some bonuses to skills apparent to that role, an appropriate key, some spells in the case of the Mage and a surgery bag in case of the Physician, as well as some devotion and miracle mechanics for the Church and Inquisition.

This also spawns a paired signet ring / seal combination (sprites pending, maybe). The councillor will give the seal to the faction head and this allows a direct, two-way communication between the faction head and the minister. I haven't put any sort of reclaim or respawn code in, but that is certainly possible to add to the cabinet if wanted. 

Councillors with a valid ministry will show up as "Minister of X" in their examine string. The councillor gets a bonus to their noble estate income to incentivize their minister position.

## Testing Evidence

Testing writ use and ring / seal / keys spawning and skills + special bonuses.

https://github.com/user-attachments/assets/84dc947f-63f4-4320-926d-923e77e795f7


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

Councillor is very much the "newbie noble" role. They are one of the few "free-form" roles left in the game, someone said. I wanted to incentivize the councillor to go out and be a "go-between" with a faction head and the keep - not only just for newbie nobles to learn the role, but also so that experienced players have enough meat on the bone to make something happen. This also handles the question of, "Do we have X but keep-oriented?" in the case of Court Chaplain, etc. In order to not step on the power role's toes, this ministry creation is completely voluntary and (ideally!) mutually beneficial for both parties. The councillor gets utility in skills and abilities; the power role gets a direct line to the keep. This in-round decision would hopefully let councillors do a benefit analysis of what roles are present, whom to be the middle-man for; as opposed to locking in at round start like subclasses would accomplish.

N.B. llm assisted code, hence draft.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Councillors can now establish Ministries with heads of town factions, gaining some of their appropriate skills.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
