### PR TITLE
Fix void dragon not dropping the spell scrolls

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/voiddragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/voiddragon.dm
@@ -652,9 +652,9 @@ It will also call down lightning strikes from the sky, and fling people with it'
 	new /obj/item/clothing/ring/dragon_ring(deathspot)
 	new /obj/item/clothing/ring/dragon_ring(deathspot)
 	new /obj/item/clothing/ring/dragon_ring(deathspot)
-	new /obj/item/book/granter/spell_points/voiddragon
-	new /obj/item/book/granter/spell_points/voiddragon
-	new /obj/item/book/granter/spell_points/voiddragon
+	new /obj/item/book/granter/spell_points/voiddragon(deathspot)
+	new /obj/item/book/granter/spell_points/voiddragon(deathspot)
+	new /obj/item/book/granter/spell_points/voiddragon(deathspot)
 	update_icon()
 	spill_embedded_objects()
 


### PR DESCRIPTION
## About The Pull Request
Bugfix.
It's supposed to drop 3 spell scrolls but it has no location so it's being created in nowhere
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Why It's Good For The Game
Bugfix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix void dragon not dropping the spell points scrolls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
