### PR TITLE
Ports in the SR repair rework

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1669,6 +1669,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/obj_fix(mob/user, full_repair = TRUE)
 	..()
 	update_damaged_state()
+	if (shoddy_repair) // if we've been jury-rig repaired, ensure our integrity is only restored to 60%
+		obj_integrity = max_integrity * 0.6
 
 /obj/item/obj_destruction(damage_flag)
 	if (damage_flag == "acid")

--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -1,3 +1,35 @@
+// These are all constants used for tuning the balance of sewing.
+/// The chance to damage an item when entirely unskilled.
+#define BASE_FAIL_CHANCE 60
+/// The (combined) skill level at or above which repairs can't fail.
+#define SKILL_NO_FAIL SKILL_LEVEL_JOURNEYMAN
+/// Each level in tanning/sewing reduces the skill chance by this much, so that at SKILL_NO_FAIL you don't fail anymore.
+#define FAIL_REDUCTION_PER_LEVEL BASE_FAIL_CHANCE / SKILL_NO_FAIL
+/// The damage done to an item when sewing fails while entirely unskilled.
+#define BASE_SEW_DAMAGE 30
+/// Each level in either tanning or sewing reduces the damage caused by a failure by this many points
+#define DAMAGE_REDUCTION_PER_LEVEL 5
+/// The base integrity repaired when sewing succeeds while entirely unskilled.
+#define BASE_SEW_REPAIR 10
+/// The additional integrity repaired per combined level in sewing/tanning.
+#define SEW_REPAIR_PER_LEVEL 10
+/// How many seconds does unskilled sewing take?
+#define BASE_SEW_TIME 4 SECONDS
+/// At what (combined) level do we
+#define SKILL_FASTEST_SEW SKILL_LEVEL_LEGENDARY
+/// The reduction in sewing time for each (combined) level in sewing/tanning.
+#define SEW_TIME_REDUCTION_PER_LEVEL 1 SECONDS
+/// The minimum sewing time to prevent instant sewing at max level.
+#define SEW_MIN_TIME 0.5 SECONDS
+/// The maximum sewing time for squires.
+#define SQUIRE_MAX_TIME BASE_SEW_TIME / 3 // always at least twice as fast as the base time / Apparently takes too long so dunno we will see at 2 seconds
+/// The XP granted by failure. Scaled by INT. If 0, no XP is granted on failure.
+#define XP_ON_FAIL 0.25
+/// The XP granted by success. Scaled by INT. If 0, no XP is granted on success.
+#define XP_ON_SUCCESS 0.5
+/// The minimum delay between automatic sewing attempts.
+#define AUTO_SEW_DELAY CLICK_CD_MELEE
+
 /obj/item/needle
 	name = "needle"
 	icon_state = "needle"
@@ -44,7 +76,6 @@
 		return
 	. += "[icon_state]string"
 
-
 /obj/item/needle/use(used)
 	if(infinite)
 		return TRUE
@@ -82,81 +113,81 @@
 		if(I.sewrepair && I.max_integrity)
 			if(I.obj_integrity == I.max_integrity)
 				to_chat(user, span_warning("This is not broken."))
+				to_chat(user, span_warning("I can't do anything else to fix this right now - I should see a skilled craftsman."))
 				return
 			if(!I.ontable())
 				to_chat(user, span_warning("I should put this on a table first."))
 				return
-			playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
-
-			// These are all constants used for tuning the balance of sewing.
-			/// The chance to damage an item when entirely unskilled.
-			var/const/BASE_FAIL_CHANCE = 60
-			/// The (combined) skill level at or above which repairs can't fail.
-			var/const/SKILL_NO_FAIL = SKILL_LEVEL_APPRENTICE
-			/// Each level in tanning/sewing reduces the skill chance by this much, so that at SKILL_NO_FAIL you don't fail anymore.
-			var/const/FAIL_REDUCTION_PER_LEVEL = BASE_FAIL_CHANCE / SKILL_NO_FAIL
-			/// The damage done to an item when sewing fails while entirely unskilled.
-			var/const/BASE_SEW_DAMAGE = 30
-			/// Each level in either tanning or sewing reduces the damage caused by a failure by this many points
-			var/const/DAMAGE_REDUCTION_PER_LEVEL = 5
-			/// The base integrity repaired when sewing succeeds while entirely unskilled.
-			var/const/BASE_SEW_REPAIR = 10
-			/// The additional integrity repaired per combined level in sewing/tanning.
-			var/const/SEW_REPAIR_PER_LEVEL = 10
-			/// How many seconds does unskilled sewing take?
-			var/const/BASE_SEW_TIME = 6 SECONDS
-			/// At what (combined) level do we
-			var/const/SKILL_FASTEST_SEW = SKILL_LEVEL_LEGENDARY
-			/// The reduction in sewing time for each (combined) level in sewing/tanning.
-			var/const/SEW_TIME_REDUCTION_PER_LEVEL = 1 SECONDS
-			/// The minimum sewing time to prevent instant sewing at max level.
-			var/const/SEW_MIN_TIME = 0.5 SECONDS
-			/// The maximum sewing time for squires.
-			var/const/SQUIRE_MAX_TIME = BASE_SEW_TIME / 3 // always at least twice as fast as the base time / Apparently takes too long so dunno we will see at 2 seconds
-			/// The XP granted by failure. Scaled by INT. If 0, no XP is granted on failure.
-			var/const/XP_ON_FAIL = 0.5
-			/// The XP granted by success. Scaled by INT. If 0, no XP is granted on success.
-			var/const/XP_ON_SUCCESS = 1
-			/// The minimum delay between automatic sewing attempts.
-			var/const/AUTO_SEW_DELAY = CLICK_CD_MELEE
-
-			// This is the actual code that applies those constants.
-			// If you want to adjust the balance please try just tweaking the above constants first!
-			var/skill = user.get_skill_level(/datum/skill/craft/sewing) + user.get_skill_level(/datum/skill/craft/tanning)
-			// The more knowlegeable we are the less chance we damage the object
+			// basic principles: instead of failing and doing nothing, we instead do something but much less.
+			// if the item is broken and we fix it at low skill, we cap the quality of our repair to 60% total integrity
+			// only skilled craftsmen can fix things at 100% integrity.
+			
+			var/skill = max(user.get_skill_level(/datum/skill/craft/sewing), user.get_skill_level(/datum/skill/craft/tanning))
 			var/failed = prob(BASE_FAIL_CHANCE - (skill * FAIL_REDUCTION_PER_LEVEL))
 			var/sewtime = max(SEW_MIN_TIME, BASE_SEW_TIME - (SEW_TIME_REDUCTION_PER_LEVEL * skill))
-			if(HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_DWARF_REPAIR))
-				failed = FALSE // Make sure they can't fail but let them suffer sewtime
+			var/unskilled = skill < SKILL_NO_FAIL
+			var/obj/item/clothing/cloth = I
+			var/integrity_percentage = (cloth.obj_integrity / cloth.max_integrity) * 100
+			if (!istype(cloth, /obj/item/clothing))
+				to_chat(user, span_warning("I can't repair that with a needle."))
+				return
+
+			if (HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR)) // squires are always considered skilled w/o other bonuses for the purposes of repair
+				unskilled = FALSE
+
+			// if we're stupid and the object isn't broken and it's had a field repair, we can't fix it any further for the moment
+			if (unskilled && !cloth.obj_broken && cloth.shoddy_repair && integrity_percentage >= 60)
+				to_chat(user, span_warning("I can't do anything else to fix this right now - I should see a skilled craftsman."))
+				return
+
 			if(!do_after(user, sewtime, target = I))
 				return
-			if(failed)
-				// We do DAMAGE_REDUCTION_PER_LEVEL less damage per level.
-				// You could write this as I.obj_integrity - BASE_SEW_DAMAGE + (skill * DAMAGE_REDUCTION_PER_LEVEL)
-				// but that's less obvious and makes it look like it could repair it if your skill was high enough (false).
-				I.obj_integrity = max(0, I.obj_integrity - (BASE_SEW_DAMAGE - (skill * DAMAGE_REDUCTION_PER_LEVEL)))
-				user.visible_message(span_info("[user] damages [I] due to a lack of skill!"))
-				playsound(src, 'sound/foley/cloth_rip.ogg', 50, TRUE)
-				if(XP_ON_FAIL > 0)
-					user.mind.add_sleep_experience(/datum/skill/craft/sewing, user.STAINT * XP_ON_FAIL)
-				if(do_after(user, AUTO_SEW_DELAY, target = I))
-					attack_obj(I, user)
-				return
-			else
-				playsound(loc, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
-				user.visible_message(span_info("[user] repairs [I]!"))
-				if(I.body_parts_covered != I.body_parts_covered_dynamic)
-					user.visible_message(span_info("[user] repairs [I]'s coverage!"))
-					I.repair_coverage()
-				if(XP_ON_SUCCESS > 0)
-					user.mind.add_sleep_experience(/datum/skill/craft/sewing, user.STAINT * XP_ON_SUCCESS)
-				I.obj_integrity = min(I.obj_integrity + BASE_SEW_REPAIR + skill * SEW_REPAIR_PER_LEVEL, I.max_integrity)
-				if(I.obj_broken && istype(I, /obj/item/clothing) && I.obj_integrity >= I.max_integrity)
-					var/obj/item/clothing/cloth = I
+
+			var/total_repair = BASE_SEW_REPAIR + skill * SEW_REPAIR_PER_LEVEL
+			var/repair_line = "[user] repairs [cloth]!"
+			var/total_XP = failed ? XP_ON_FAIL : XP_ON_SUCCESS
+		
+			if (failed)
+				total_repair = total_repair * 0.5 // 50% reduction on failed repairs, but we still repair!
+				repair_line = "[user] makes a little progress towards repairing [cloth]..."
+
+			if(cloth.body_parts_covered != cloth.body_parts_covered_dynamic)
+				user.visible_message(span_info("[user] repairs [cloth]'s coverage!"))
+				cloth.repair_coverage()
+
+			if(total_XP)
+				user.mind.add_sleep_experience(/datum/skill/craft/sewing, user.STAINT * total_XP)
+
+			cloth.obj_integrity = min(cloth.obj_integrity + total_repair, cloth.max_integrity)
+			integrity_percentage = (cloth.obj_integrity / cloth.max_integrity) * 100
+
+			playsound(loc, 'sound/foley/sewflesh.ogg', 50, TRUE, -2)
+			user.visible_message(span_info(repair_line))
+	
+			if(cloth.obj_broken)
+				var/do_fix = FALSE
+				if(unskilled && integrity_percentage >= 60)
+					user.visible_message(span_info("[user] finishes field-repairing [I]."))
+					to_chat(user, span_warning("I should get this properly fixed by a skilled craftsman later."))
+					cloth.shoddy_repair = TRUE
+					do_fix = TRUE
+				else if (!unskilled && integrity_percentage >= 100)
+					user.visible_message(span_info("[user] fully repairs [I]."))
+					if (cloth.shoddy_repair)
+						to_chat(user, span_notice("My skilled hand has fully repaired this item."))
+						cloth.shoddy_repair = FALSE
+					do_fix = TRUE
+
+				if(do_fix)
 					cloth.obj_fix()
+					stringamt -= 1
 					return
-				if(do_after(user, AUTO_SEW_DELAY, target = I))
-					attack_obj(I, user)
+			else if (!cloth.obj_broken && !unskilled && cloth.shoddy_repair && integrity_percentage >= 100)
+				cloth.shoddy_repair = FALSE
+				to_chat(user, span_notice("My skilled hand has fully repaired this item."))
+			
+			if(do_after(user, AUTO_SEW_DELAY, target = I))
+				attack_obj(I, user)
 		return
 	return ..()
 
@@ -164,13 +195,12 @@
 	if(!istype(user))
 		return FALSE
 	var/mob/living/doctor = user
-	var/mob/living/patient = target
+	var/mob/living/carbon/human/patient = target
 	if(stringamt < 1)
 		to_chat(user, span_warning("The needle has no thread left!"))
 		return
 	var/list/sewable
 	var/obj/item/bodypart/affecting
-	var/is_simple_animal = !iscarbon(patient)
 	if(iscarbon(patient))
 		affecting = patient.get_bodypart(check_zone(doctor.zone_selected))
 		if(!affecting)
@@ -190,37 +220,19 @@
 	var/skill_used = target.construct ? /datum/skill/craft/engineering : /datum/skill/misc/medicine
 	var/doctor_skill = doctor.get_skill_level(skill_used)
 	var/informed = FALSE
-	moveup = (doctor_skill+1) * 4
-	if(doctor_skill > SKILL_LEVEL_EXPERT)
-		if(doctor_skill == SKILL_LEVEL_MASTER)
-			moveup = doctor_skill * 6
-		else if(doctor_skill == SKILL_LEVEL_LEGENDARY)
-			moveup = doctor_skill * 7
+	moveup = (doctor_skill+1) * 5
 	while(!QDELETED(target_wound) && !QDELETED(src) && \
 		!QDELETED(user) && (target_wound.sew_progress < target_wound.sew_threshold) && \
 		stringamt >= 1)
-		var/sewing_start_delay = 2 SECONDS
-		if(doctor_skill > SKILL_LEVEL_EXPERT)
-			if(doctor_skill == SKILL_LEVEL_MASTER)
-				sewing_start_delay = 1.5 SECONDS
-			else if(doctor_skill == SKILL_LEVEL_LEGENDARY)
-				sewing_start_delay = 1 SECONDS
-		if(!do_after(doctor, sewing_start_delay, target = patient))
+		if(!do_after(doctor, 2 SECONDS, target = patient))
 			break
 		playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 		target_wound.sew_progress = min(target_wound.sew_progress + moveup, target_wound.sew_threshold)
-		var/bleedreduction = max((0.5 * doctor_skill), 0.5)
-		if(doctor_skill > SKILL_LEVEL_EXPERT)
-			if(doctor_skill == SKILL_LEVEL_MASTER)
-				bleedreduction = 3
-			else if(doctor_skill == SKILL_LEVEL_LEGENDARY)
-				bleedreduction = 4
+
+		var/bleedreduction = max((doctor_skill / 2), 1)	//Half of medicine skill, or 1, whichever is higher.
 		target_wound.set_bleed_rate(max( (target_wound.bleed_rate - bleedreduction), 0))
 		if(target_wound.bleed_rate == 0 && !informed)
-			if(is_simple_animal)
-				patient.visible_message(span_smallgreen("One last drop of blood trickles from the [(target_wound?.name)] on [patient] before it closes."), span_smallgreen("The throbbing warmth coming out of [target_wound] soothes and stops. It no longer bleeds."))
-			else
-				patient.visible_message(span_smallgreen("One last drop of blood trickles from the [(target_wound?.name)] on [patient]'s [affecting.name] before it closes."), span_smallgreen("The throbbing warmth coming out of [target_wound] soothes and stops. It no longer bleeds."))
+			patient.visible_message(span_smallgreen("One last drop of blood trickles from the [(target_wound.name)] on [patient]'s [affecting.name] before it closes."), span_smallgreen("The throbbing warmth coming out of [target_wound] soothes and stops. It no longer bleeds."))
 			informed = TRUE
 		if(istype(target_wound, /datum/wound/dynamic))
 			var/datum/wound/dynamic/dynwound = target_wound
@@ -232,19 +244,13 @@
 			continue
 		if(doctor.mind)
 			doctor.mind.add_sleep_experience(skill_used, doctor.STAINT * 2.5)
-		if(!target.construct)
-			use(1)
+		use(1)
 		target_wound.sew_wound()
 		if(patient == doctor)
-			if(is_simple_animal)
-				doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [doctor.p_them()]self."), span_notice("I stitch \a [target_wound.name] on myself."))
-			else
-				doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [doctor.p_them()]self."), span_notice("I stitch \a [target_wound.name] on my [affecting]."))
+			doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [doctor.p_them()]self."), span_notice("I stitch \a [target_wound.name] on my [affecting]."))
 		else
-			if(is_simple_animal)
-				doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [patient]."), span_notice("I stitch \a [target_wound.name] on [patient]."))
-			else if(affecting)
-				doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [patient]'s [affecting]."), span_notice("I stitch \a [target_wound.name] on [patient]'s [affecting]."))
+			if(affecting)
+				doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [patient]'s [affecting.name]."), span_notice("I stitch \a [target_wound.name] on [patient]'s [affecting.name]."))
 			else
 				doctor.visible_message(span_notice("[doctor] sews \a [target_wound.name] on [patient]."), span_notice("I stitch \a [target_wound.name] on [patient]."))
 		log_combat(doctor, patient, "sew", "needle")
@@ -270,3 +276,19 @@
 	desc = "This decrepit old needle doesn't seem helpful for much."
 	stringamt = 5
 	maxstring = 5
+
+#undef BASE_FAIL_CHANCE
+#undef SKILL_NO_FAIL
+#undef FAIL_REDUCTION_PER_LEVEL
+#undef BASE_SEW_DAMAGE
+#undef DAMAGE_REDUCTION_PER_LEVEL
+#undef BASE_SEW_REPAIR
+#undef SEW_REPAIR_PER_LEVEL
+#undef BASE_SEW_TIME
+#undef SKILL_FASTEST_SEW
+#undef SEW_TIME_REDUCTION_PER_LEVEL
+#undef SEW_MIN_TIME
+#undef SQUIRE_MAX_TIME
+#undef XP_ON_FAIL
+#undef XP_ON_SUCCESS
+#undef AUTO_SEW_DELAY

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -74,6 +74,7 @@
 	var/ducal_primary = FALSE // Uses duchy primary color for base color
 	var/ducal_detail = FALSE // Uses duchy secondary color for detail_color
 	var/ducal_altdetail = FALSE // Uses duchy secondary color for altdetail_color
+	var/shoddy_repair = FALSE // if we've been field repaired by an unskilled person, set this to true
 
 /obj/item/clothing/New()
 	..()

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -105,6 +105,8 @@
 			. += span_info("It's been thoroughly brushed.")
 		if(4)
 			. += span_green("It's been nicely polished.")
+	if(shoddy_repair)
+		. += span_warning("This item has been field-repaired and needs to be fixed by a proper craftsman.")
 
 /obj/item/polishing_cream
 	icon = 'icons/roguetown/items/misc.dmi'

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -100,6 +100,16 @@
 /obj/item/rogueweapon/hammer/proc/repair_item(obj/item/attacked_item, mob/living/user)
 	if(!attacked_item.anvilrepair || (attacked_item.obj_integrity >= attacked_item.max_integrity) || !isturf(attacked_item.loc))
 		return
+		// basic principles: everybody repairs now at old squire level
+		// however, if we're below journeyman, we can only field repair BROKEN objects to 60% integrity
+		// skilled craftsmen can repair to 100% as usual
+		var/obj/item/attacked_item = attacked_object
+		var/repair_skill = blacksmith.get_skill_level(attacked_item.anvilrepair)
+		var/unskilled = repair_skill < SKILL_LEVEL_JOURNEYMAN
+		var/integrity_percentage = (attacked_item.obj_integrity / attacked_item.max_integrity) * 100
+
+		if (HAS_TRAIT(blacksmith, TRAIT_SQUIRE_REPAIR)) // squires are always considered skilled w/o other bonuses for the purposes of repair
+			unskilled = FALSE
 
 	if(!attacked_item.ontable())
 		to_chat(user, span_warning("I should put this on a table or an anvil first."))
@@ -107,17 +117,17 @@
 
 	do
 		var/repair_percent = get_repair_percent(attacked_item)
-		if(user.get_skill_level(attacked_item.anvilrepair) <= 0)
-			if(HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_DWARF_REPAIR))
-				if(locate(/obj/machinery/anvil) in attacked_item.loc)
-					repair_percent = 0.035
-				//Squires can repair on tables, but less efficiently
-				else if(attacked_item.ontable())
-					repair_percent = 0.015
-			else if(prob(30))
-				repair_percent = 0.01
+		if (unskilled && !attacked_item.obj_broken && attacked_item.shoddy_repair && integrity_percentage >= 60)
+			to_chat(user, span_warning("I can't do anything else to fix this right now - I should see a skilled craftsman."))
+			return
+
+		if(repair_skill <= 0)
+			if(locate(/obj/machinery/anvil) in attacked_object.loc)
+				repair_percent = 0.035
+			else if(attacked_item.ontable())
+				repair_percent = 0.015
 			else
-				repair_percent = 0
+				repair_percent = 0.01
 		else
 			repair_percent *= user.get_skill_level(attacked_item.anvilrepair)
 
@@ -126,6 +136,7 @@
 			repair_percent *= attacked_item.max_integrity
 			var/exp_gained = min(attacked_item.obj_integrity + repair_percent, attacked_item.max_integrity) - attacked_item.obj_integrity
 			attacked_item.obj_integrity = min(attacked_item.obj_integrity + repair_percent, attacked_item.max_integrity)
+			integrity_percentage = (attacked_item.obj_integrity / attacked_item.max_integrity) * 100
 			if(repair_percent == 0.01) // If an inexperienced repair attempt has been successful
 				to_chat(user, span_warning("You fumble your way into slightly repairing [attacked_item]."))
 			else
@@ -133,8 +144,24 @@
 				if(attacked_item.body_parts_covered != attacked_item.body_parts_covered_dynamic)
 					user.visible_message(span_info("[user] repairs [attacked_item]'s coverage!"))
 					attacked_item.repair_coverage()
-			if(attacked_item.obj_broken && attacked_item.obj_integrity == attacked_item.max_integrity)
-				attacked_item.obj_fix()
+			if(attacked_item.obj_broken)
+				var/do_fix = FALSE
+				if (unskilled && integrity_percentage >= 60)
+					attacked_item.shoddy_repair = TRUE
+					blacksmith.visible_message(span_info("[blacksmith] finishes field-repairing [attacked_item]."))
+					to_chat(user, span_warning("I should get this properly fixed by a skilled craftsman later."))
+					do_fix = TRUE
+				else if (!unskilled && integrity_percentage >= 100)
+					if (attacked_item.shoddy_repair)
+						attacked_item.shoddy_repair = FALSE
+						to_chat(user, span_notice("My skilled hand has fully repaired this item."))
+					do_fix = TRUE
+				if (do_fix)
+					attacked_item.obj_fix()
+					return
+			else if (!attacked_item.obj_broken && !unskilled && attacked_item.shoddy_repair && integrity_percentage >= 100)
+				attacked_item.shoddy_repair = FALSE
+				to_chat(user, span_notice("My skilled hand has fully repaired this item."))
 			user.mind.add_sleep_experience(attacked_item.anvilrepair, exp_gained/2) //We gain as much exp as we fix divided by 2
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_item]!"))

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -35,50 +35,35 @@
 		return
 	. = ..()
 
+
 /obj/item/rogueweapon/hammer/attack_obj(obj/attacked_object, mob/living/user)
 	if(!isliving(user) || !user.mind)
 		return
+	var/mob/living/blacksmith = user
+	var/repair_percent = 0.025 // 2.5% Repairing per hammer smack
+	/// Repairing is MUCH better with an anvil!
+	if(locate(/obj/machinery/anvil) in attacked_object.loc)
+		repair_percent *= 2 // Double the repair amount if we're using an anvil
+	var/exp_gained = 0
 
 	if(isbodypart(attacked_object) && !user.cmode)
-		repair_bodypart(attacked_object, user)
-		return
-
-	if(isitem(attacked_object) && !user.cmode)
-		repair_item(attacked_object, user)
-		return
-
-	if(isstructure(attacked_object) && !user.cmode)
-		repair_structure(attacked_object, user)
-		return
-
-	. = ..()
-
-/obj/item/rogueweapon/hammer/proc/get_repair_percent(obj/attacked_object)
-	. = 0.025 // 2.5% Repairing per hammer smack
-	if(locate(/obj/machinery/anvil) in attacked_object.loc)
-		. *= 2 // Double the repair amount if we're using an anvil
-
-/obj/item/rogueweapon/hammer/proc/repair_bodypart(obj/item/bodypart/attacked_prosthetic, mob/living/user)
-	if(!attacked_prosthetic.anvilrepair) //No hammering flesh limbs
-		return
-	if(attacked_prosthetic.obj_integrity >= attacked_prosthetic.max_integrity && attacked_prosthetic.brute_dam == 0 && attacked_prosthetic.burn_dam == 0 && attacked_prosthetic.wounds == null && attacked_prosthetic.disabled == BODYPART_NOT_DISABLED)
-		to_chat(user, span_warning("There is nothing to further repair on [attacked_prosthetic]."))
-		return
-
-	do
-		var/repair_percent = get_repair_percent(attacked_prosthetic)
-		if(user.get_skill_level(attacked_prosthetic.anvilrepair) <= 0)
+		var/obj/item/bodypart/attacked_prosthetic = attacked_object
+		if(!attacked_prosthetic.anvilrepair) //No hammering flesh limbs
+			return
+		if(attacked_prosthetic.obj_integrity >= attacked_prosthetic.max_integrity && attacked_prosthetic.brute_dam == 0 && attacked_prosthetic.burn_dam == 0 && attacked_prosthetic.wounds == null && attacked_prosthetic.disabled == BODYPART_NOT_DISABLED) //A mouthful
+			to_chat(user, span_warning("There is nothing to further repair on [attacked_prosthetic]."))
+			return
+		if(blacksmith.get_skill_level(attacked_prosthetic.anvilrepair) <= 0)
 			if(prob(30))
 				repair_percent = 0.01
 			else
 				repair_percent = 0
 		else
-			repair_percent *= user.get_skill_level(attacked_prosthetic.anvilrepair)
-
+			repair_percent *= blacksmith.get_skill_level(attacked_prosthetic.anvilrepair)
 		playsound(src,'sound/items/bsmith3.ogg', 100, FALSE)
 		if(repair_percent)
 			repair_percent *= attacked_prosthetic.max_integrity
-			var/exp_gained = min(attacked_prosthetic.obj_integrity + repair_percent, attacked_prosthetic.max_integrity) - attacked_prosthetic.obj_integrity
+			exp_gained = min(attacked_prosthetic.obj_integrity + repair_percent, attacked_prosthetic.max_integrity) - attacked_prosthetic.obj_integrity
 			attacked_prosthetic.obj_integrity = min(attacked_prosthetic.obj_integrity + repair_percent, attacked_prosthetic.max_integrity)
 			attacked_prosthetic.brute_dam = max(attacked_prosthetic.brute_dam - 10, 0)
 			attacked_prosthetic.burn_dam = max(attacked_prosthetic.burn_dam - 10, 0)
@@ -88,18 +73,18 @@
 				to_chat(user, span_warning("You fumble your way into slightly repairing [attacked_prosthetic]."))
 			else
 				user.visible_message(span_info("[user] repairs [attacked_prosthetic]!"))
-			user.mind.add_sleep_experience(attacked_prosthetic.anvilrepair, exp_gained/2) //We gain as much exp as we fix divided by 2
+			blacksmith.mind.add_sleep_experience(attacked_prosthetic.anvilrepair, exp_gained/2) //We gain as much exp as we fix divided by 2
+			if(do_after(user, CLICK_CD_MELEE, target = attacked_object))
+				attack_obj(attacked_object, user)
+			return
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_prosthetic]!"))
+			if(do_after(user, CLICK_CD_MELEE, target = attacked_object))
+				attack_obj(attacked_object, user)
+			return
 
-		if(attacked_prosthetic.obj_integrity >= attacked_prosthetic.max_integrity && attacked_prosthetic.brute_dam == 0 && attacked_prosthetic.burn_dam == 0 && attacked_prosthetic.wounds == null && attacked_prosthetic.disabled == BODYPART_NOT_DISABLED)
-			break
 
-	while(do_after(user, CLICK_CD_MELEE, target = attacked_prosthetic))
-
-/obj/item/rogueweapon/hammer/proc/repair_item(obj/item/attacked_item, mob/living/user)
-	if(!attacked_item.anvilrepair || (attacked_item.obj_integrity >= attacked_item.max_integrity) || !isturf(attacked_item.loc))
-		return
+	if(isitem(attacked_object) && !user.cmode)
 		// basic principles: everybody repairs now at old squire level
 		// however, if we're below journeyman, we can only field repair BROKEN objects to 60% integrity
 		// skilled craftsmen can repair to 100% as usual
@@ -111,12 +96,13 @@
 		if (HAS_TRAIT(blacksmith, TRAIT_SQUIRE_REPAIR)) // squires are always considered skilled w/o other bonuses for the purposes of repair
 			unskilled = FALSE
 
-	if(!attacked_item.ontable())
-		to_chat(user, span_warning("I should put this on a table or an anvil first."))
-		return
+		if(!attacked_item.anvilrepair || (attacked_item.obj_integrity >= attacked_item.max_integrity) || !isturf(attacked_item.loc))
+			return
 
-	do
-		var/repair_percent = get_repair_percent(attacked_item)
+		if(!attacked_item.ontable())
+			to_chat(user, span_warning("I should put this on a table or an anvil first."))
+			return
+
 		if (unskilled && !attacked_item.obj_broken && attacked_item.shoddy_repair && integrity_percentage >= 60)
 			to_chat(user, span_warning("I can't do anything else to fix this right now - I should see a skilled craftsman."))
 			return
@@ -129,12 +115,12 @@
 			else
 				repair_percent = 0.01
 		else
-			repair_percent *= user.get_skill_level(attacked_item.anvilrepair)
+			repair_percent *= blacksmith.get_skill_level(attacked_item.anvilrepair)
 
 		playsound(src,'sound/items/bsmithfail.ogg', 40, FALSE)
 		if(repair_percent)
 			repair_percent *= attacked_item.max_integrity
-			var/exp_gained = min(attacked_item.obj_integrity + repair_percent, attacked_item.max_integrity) - attacked_item.obj_integrity
+			exp_gained = min(attacked_item.obj_integrity + repair_percent, attacked_item.max_integrity) - attacked_item.obj_integrity
 			attacked_item.obj_integrity = min(attacked_item.obj_integrity + repair_percent, attacked_item.max_integrity)
 			integrity_percentage = (attacked_item.obj_integrity / attacked_item.max_integrity) * 100
 			if(repair_percent == 0.01) // If an inexperienced repair attempt has been successful
@@ -162,35 +148,41 @@
 			else if (!attacked_item.obj_broken && !unskilled && attacked_item.shoddy_repair && integrity_percentage >= 100)
 				attacked_item.shoddy_repair = FALSE
 				to_chat(user, span_notice("My skilled hand has fully repaired this item."))
-			user.mind.add_sleep_experience(attacked_item.anvilrepair, exp_gained/2) //We gain as much exp as we fix divided by 2
+			blacksmith.mind.add_sleep_experience(attacked_item.anvilrepair, exp_gained/2) //We gain as much exp as we fix divided by 2
+			if(do_after(user, CLICK_CD_MELEE, target = attacked_object))
+				attack_obj(attacked_object, user)
+			return
 		else
 			user.visible_message(span_warning("[user] fumbles trying to repair [attacked_item]!"))
+			if(do_after(user, CLICK_CD_MELEE, target = attacked_object))
+				attack_obj(attacked_object, user)
+			return
 
-		if(attacked_item.obj_integrity >= attacked_item.max_integrity)
-			break
-
-	while(do_after(user, CLICK_CD_MELEE, target = attacked_item))
-
-/obj/item/rogueweapon/hammer/proc/repair_structure(obj/structure/attacked_structure, mob/living/user)
-	if(!attacked_structure.hammer_repair || !attacked_structure.max_integrity)
-		return
-	if(user.get_skill_level(attacked_structure.hammer_repair) <= 0)
-		to_chat(user, span_warning("I don't know how to repair this.."))
-		return
-
-	do
-		var/repair_percent = get_repair_percent(attacked_structure)
-		repair_percent *= user.get_skill_level(attacked_structure.hammer_repair) * attacked_structure.max_integrity
-		var/exp_gained = min(attacked_structure.obj_integrity + repair_percent, attacked_structure.max_integrity) - attacked_structure.obj_integrity
+	if(isstructure(attacked_object) && !user.cmode)
+		var/obj/structure/attacked_structure = attacked_object
+		if(!attacked_structure.hammer_repair || !attacked_structure.max_integrity)
+			return
+		if(blacksmith.get_skill_level(attacked_structure.hammer_repair) <= 0)
+			to_chat(user, span_warning("I don't know how to repair this.."))
+			return
+		repair_percent *= blacksmith.get_skill_level(attacked_structure.hammer_repair) * attacked_structure.max_integrity
+		exp_gained = min(attacked_structure.obj_integrity + repair_percent, attacked_structure.max_integrity) - attacked_structure.obj_integrity
 		attacked_structure.obj_integrity = min(attacked_structure.obj_integrity + repair_percent, attacked_structure.max_integrity)
-		user.mind.add_sleep_experience(attacked_structure.hammer_repair, exp_gained) //We gain as much exp as we fix
+		blacksmith.mind.add_sleep_experience(attacked_structure.hammer_repair, exp_gained) //We gain as much exp as we fix
 		playsound(src,'sound/items/bsmithfail.ogg', 100, FALSE)
 		user.visible_message(span_info("[user] repairs [attacked_structure]!"))
+		if(attacked_object.obj_integrity <= attacked_object.max_integrity && do_after(user, CLICK_CD_MELEE, target = attacked_object))
+			attack_obj(attacked_object, user)
+		return
 
-		if(attacked_structure.obj_integrity >= attacked_structure.max_integrity)
-			break
+	. = ..()
 
-	while(do_after(user, CLICK_CD_MELEE, target = attacked_structure))
+/obj/item/rogueweapon/hammer/attack_hand(mob/living/user)
+	if(HAS_TRAIT(user, TRAIT_CURSE_MALUM))
+		to_chat(user, span_warning("Your cursed hands burn at the touch of the hammer!"))
+		user.freak_out()
+		return
+	. = ..()
 
 /obj/item/rogueweapon/hammer/attack(mob/living/M, mob/user)
 	testing("attack")
@@ -213,50 +205,40 @@
 		var/obj/item/bodypart/affecting = H.get_bodypart(check_zone(user.zone_selected))
 		if(!affecting)
 			return
-		var/used_time = 7 SECONDS
-		var/skill_used = /datum/skill/craft/engineering // used for adding experience.
-		var/mob/living/artificer = user
-		var/artificer_skill = artificer.get_skill_level(skill_used)
-		if(M == artificer)
-			to_chat(artificer, span_warning("Repairing myself is difficult..."))
-			used_time += 3 SECONDS //repairing yourself as a construct is logistically going to be a lot more difficult than someone else doing it for you
-		if(artificer.mind)
-			used_time -= (artificer_skill * 1 SECONDS)
-		if(!(H.mobility_flags & MOBILITY_STAND)) // lil construct is lying down.
-			used_time -= 3 SECONDS
-		
-		used_time = max(0.5 SECONDS, used_time)
 
-		playsound(loc, 'sound/items/bsmith1.ogg', 100, FALSE)
-		while(do_after(artificer, used_time, target = M, same_direction = TRUE, no_interrupt = FALSE) && (affecting.get_damage() != 0 || length(affecting.wounds)))
-			if(get_dist(artificer, M) >= 2)
-				to_chat(artificer, span_warning("I need to be closer to them to repair them!"))
+		while(affecting.get_damage() != 0 || length(affecting.wounds))
+			var/used_time = 70
+			if(M == user)
+				to_chat(user, span_warning("Repairing myself is difficult..."))
+				used_time += 30 //repairing yourself as a golem is logistically going to be a lot more difficult than someone else doing it for you
+			if(user.mind)
+				used_time -= (user.get_skill_level(/datum/skill/craft/engineering) * 10)
+			playsound(loc, 'sound/items/bsmith1.ogg', 100, FALSE)
+			if(!do_mob(user, M, used_time))
 				return
-			var/brute_heal = (affecting.brute_dam / 2) + 5 // Heals ONE limb at a time.
-			var/burn_heal = (affecting.burn_dam / 2) + 5
+			playsound(loc, 'sound/items/bsmith4.ogg', 100, FALSE)
+
+			var/brute_heal = (affecting.brute_dam / 2)+5 //scale golem healing based on how much damage the limb has so we're not hammering a super damaged golem for years but also not fully healing them in 7 seconds
+			var/burn_heal = (affecting.burn_dam / 2)+5 //also keep in mind that this is healing one body part's damage, rather than the entire body's damage at once
 			affecting.heal_damage(brute_heal, burn_heal)
 
 			if(affecting.brute_dam == 0 && affecting.burn_dam == 0)
 				affecting.heal_wounds(20)//heal wounds twice as fast if there's no other damage to patch up
 			else
 				affecting.heal_wounds(10) // Other heal are far more powerful and can heal skullcrack in 15 hits instead of 75
+
 			H.update_damage_overlays()
 
-			if(M == artificer)
-				artificer.visible_message(span_notice("[artificer] hammers [artificer.p_their()] [affecting]."), span_notice("I hammer my [affecting]."))
+			if(M == user)
+				user.visible_message(span_notice("[user] hammers [user.p_their()] [affecting.name]."), span_notice("I hammer my [affecting.name]."))
 			else
-				artificer.visible_message(span_notice("[artificer] hammers [M]'s [affecting]."), span_notice("I hammer [M]'s [affecting]."))
-			playsound(loc, 'sound/items/bsmith4.ogg', 100, FALSE)
-
-			if(artificer.mind)
-				artificer.mind.add_sleep_experience(skill_used, artificer.STAINT) // a lil smidge of XP for the repairing individual :3
-
-			if(affecting.get_damage() == 0 && !length(affecting.wounds))//if the bodypart has no damage nor wounds on it...
-				if(M == artificer)
-					to_chat(artificer, span_warning("My [affecting.name] is undamaged."))
-				else
-					to_chat(artificer, span_warning("[M]'s [affecting.name] is undamaged."))
-				return
+				user.visible_message(span_notice("[user] hammers [M]'s [affecting.name]."), span_notice("I hammer [M]'s [affecting.name]."))
+		if(affecting.get_damage() == 0 && !length(affecting.wounds))//if the bodypart has no damage nor wounds on it...
+			if(M == user)
+				to_chat(user, span_warning("My [affecting.name] is undamaged."))
+			else
+				to_chat(user, span_warning("[M]'s [affecting.name] is undamaged."))
+			return
 	else //Non-construct.
 		to_chat(user, span_warning("I can't tinker on living flesh!"))
 
@@ -265,7 +247,6 @@
 	desc = "A wooden mallet is an artificers second best friend! But it may also come in handy to a smith..."
 	icon_state = "hammer_w"
 	force = 16
-	metalizer_result = /obj/item/rogueweapon/hammer/iron
 
 /obj/item/rogueweapon/hammer/stone	// stone hammer
 	name = "stone hammer"
@@ -276,14 +257,11 @@
 
 /obj/item/rogueweapon/hammer/aalloy
 	name = "decrepit hammer"
-	desc = "A hammer of wrought bronze. It has pounded out the beginning of a thousand legacies; of humble adventurers, of noble legionnaires, and of foolish heroes."
+	desc = "A decrepit old hammer."
 	icon_state = "ahammer"
 	force = 12
 	max_integrity = 10
-	smeltresult = /obj/item/ingot/aaslag
-	color = "#bb9696"
-	sellprice = 15
-
+	smeltresult = /obj/item/ingot/aalloy
 
 
 /obj/item/rogueweapon/hammer/copper
@@ -305,23 +283,6 @@
 	icon_state = "hammer_s"
 	smeltresult = /obj/item/ingot/steel
 
-/*
-/obj/item/rogueweapon/hammer/steel/attack_turf(turf/T, mob/living/user)
-	if(!user.cmode)
-		if(T.hammer_repair && T.max_integrity && !T.obj_broken)
-			var/repair_percent = 0.05
-			if(user.mind)
-				if(user.get_skill_level(I.hammer_repair) <= 0)
-					to_chat(user, span_warning("I don't know how to repair this.."))
-					return
-				repair_percent = max(user.get_skill_level(I.hammer_repair) * 0.05, 0.05)
-			repair_percent = repair_percent * I.max_integrity
-			I.obj_integrity = min(obj_integrity+repair_percent, I.max_integrity)
-			playsound(src,'sound/items/bsmithfail.ogg', 100, FALSE)
-			user.visible_message(span_info("[user] repairs [I]!"))
-			return
-	..()
-*/
 /obj/item/rogueweapon/hammer/blacksteel
 	force = 25
 	name = "blacksteel hammer"
@@ -343,21 +304,67 @@
 			if("onbelt")
 				return list("shrink" = 0.5,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
+/*
+/obj/item/rogueweapon/hammer/steel/attack_turf(turf/T, mob/living/user)
+	if(!user.cmode)
+		if(T.hammer_repair && T.max_integrity && !T.obj_broken)
+			var/repair_percent = 0.05
+			if(user.mind)
+				if(user.get_skill_level(I.hammer_repair) <= 0)
+					to_chat(user, span_warning("I don't know how to repair this.."))
+					return
+				repair_percent = max(user.get_skill_level(I.hammer_repair) * 0.05, 0.05)
+			repair_percent = repair_percent * I.max_integrity
+			I.obj_integrity = min(obj_integrity+repair_percent, I.max_integrity)
+			playsound(src,'sound/items/bsmithfail.ogg', 100, FALSE)
+			user.visible_message(span_info("[user] repairs [I]!"))
+			return
+	..()
+*/
+
+/obj/item/rogueweapon/hammer/getonmobprop(tag)
+	. = ..()
+	if(tag)
+		switch(tag)
+			if("gen")
+				return list("shrink" = 0.6,
+"sx" = -15,
+"sy" = -12,
+"nx" = 9,
+"ny" = -11,
+"wx" = -11,
+"wy" = -11,
+"ex" = 1,
+"ey" = -12,
+"northabove" = 0,
+"southabove" = 1,
+"eastabove" = 1,
+"westabove" = 0,
+"nturn" = 90,
+"sturn" = -90,
+"wturn" = -90,
+"eturn" = 90,
+"nflip" = 0,
+"sflip" = 8,
+"wflip" = 8,
+"eflip" = 0)
+			if("onbelt")
+				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/tongs
 	force = 10
 	possible_item_intents = list(/datum/intent/mace/strike)
 	name = "tongs"
-	desc = "A pair of blacksteel tongs that'll hold onto Psydonia's hottest metal without ever warping. 'Tis a symbol of prestige."
+	desc = "A pair of iron jaws used to carry hot ingots."
 	icon_state = "tongs"
 	icon = 'icons/roguetown/weapons/tools.dmi'
 	sharpness = IS_BLUNT
 	//dropshrink = 0.8
-	wlength = WLENGTH_SHORT
+	wlength = 10
 	slot_flags = ITEM_SLOT_HIP
 	tool_behaviour = TOOL_IMPROVISED_HEMOSTAT
-	associated_skill = /datum/skill/craft/blacksmithing	//Tongs don't do a lot of damage and have 3 defense. This associated skill should be alright.
-	var/obj/item/hingot = null
+	associated_skill = null
+	var/obj/item/ingot/hingot = null
 	var/hott = FALSE
 	smeltresult = /obj/item/ingot/iron
 	grid_width = 32
@@ -392,7 +399,6 @@
 /obj/item/rogueweapon/tongs/proc/make_unhot(input)
 	if(hott == input)
 		hott = FALSE
-		update_icon()
 
 /obj/item/rogueweapon/tongs/attack_self(mob/user)
 	if(hingot)
@@ -401,26 +407,6 @@
 			hingot = null
 			hott = FALSE
 			update_icon()
-
-/obj/item/rogueweapon/tongs/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/natural/glass/heated))
-		var/obj/item/natural/glass/heated/G = I
-		if (loc in user.contents)
-			to_chat(user, span_warning("I can't take out the heated glass from inside."))
-			return
-		if(!hingot)
-			if(!user.transferItemToLoc(G, src) && G.loc != src)
-				G.forceMove(src)
-			hingot = G
-			hott = world.time  // Mark as hot
-			addtimer(CALLBACK(src, PROC_REF(make_unhot), world.time), 10 SECONDS)
-			update_icon()
-			to_chat(user, span_notice("I carefully grasp the heated glass with the tongs."))
-			return TRUE
-		else
-			to_chat(user, span_warning("The tongs are already holding something!"))
-			return TRUE
-	return ..()
 
 /obj/item/rogueweapon/tongs/dropped()
 	. = ..()
@@ -435,11 +421,29 @@
 	if(tag)
 		switch(tag)
 			if("gen")
-				return list("shrink" = 0.6,"sx" = -11,"sy" = -8,"nx" = 12,"ny" = -8,"wx" = -5,"wy" = -8,"ex" = 6,"ey" = -8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 90,"sturn" = -90,"wturn" = -90,"eturn" = 90,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
-			if("wielded")
-				return list("shrink" = 0.7,"sx" = 5,"sy" = -4,"nx" = -5,"ny" = -4,"wx" = -5,"wy" = -3,"ex" = 7,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -45,"sturn" = 45,"wturn" = -45,"eturn" = 45,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
+				return list("shrink" = 0.6,
+"sx" = -15,
+"sy" = -12,
+"nx" = 9,
+"ny" = -11,
+"wx" = -11,
+"wy" = -11,
+"ex" = 1,
+"ey" = -12,
+"northabove" = 0,
+"southabove" = 1,
+"eastabove" = 1,
+"westabove" = 0,
+"nturn" = 90,
+"sturn" = -90,
+"wturn" = -90,
+"eturn" = 90,
+"nflip" = 0,
+"sflip" = 8,
+"wflip" = 8,
+"eflip" = 0)
 			if("onbelt")
-				return list("shrink" = 0.5,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/tongs/stone
 	name = "stone tongs"
@@ -460,13 +464,10 @@
 
 /obj/item/rogueweapon/tongs/aalloy
 	name = "decrepit tongs"
-	desc = "Wrought bronze pincers the molten alloy, putting it before the anvil and hammer. Soon, it will fashion a new legacy; one unmarred by this dogmatic millennia."
 	icon_state = "atongs"
 	force = 5
 	smeltresult = null
 	max_integrity = 10
-	color = "#bb9696"
-	sellprice = 5
 
 /obj/item/rogueweapon/tongs/aalloy/update_icon()
 	. = ..()

--- a/code/modules/roguetown/roguejobs/blacksmith/tools.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/tools.dm
@@ -207,10 +207,10 @@
 			return
 
 		while(affecting.get_damage() != 0 || length(affecting.wounds))
-			var/used_time = 70
+			var/used_time = 7 SECONDS
 			if(M == user)
 				to_chat(user, span_warning("Repairing myself is difficult..."))
-				used_time += 30 //repairing yourself as a golem is logistically going to be a lot more difficult than someone else doing it for you
+				used_time += 3 SECONDS //repairing yourself as a golem is logistically going to be a lot more difficult than someone else doing it for you
 			if(user.mind)
 				used_time -= (user.get_skill_level(/datum/skill/craft/engineering) * 10)
 			playsound(loc, 'sound/items/bsmith1.ogg', 100, FALSE)
@@ -327,29 +327,11 @@
 	if(tag)
 		switch(tag)
 			if("gen")
-				return list("shrink" = 0.6,
-"sx" = -15,
-"sy" = -12,
-"nx" = 9,
-"ny" = -11,
-"wx" = -11,
-"wy" = -11,
-"ex" = 1,
-"ey" = -12,
-"northabove" = 0,
-"southabove" = 1,
-"eastabove" = 1,
-"westabove" = 0,
-"nturn" = 90,
-"sturn" = -90,
-"wturn" = -90,
-"eturn" = 90,
-"nflip" = 0,
-"sflip" = 8,
-"wflip" = 8,
-"eflip" = 0)
+				return list("shrink" = 0.6,"sx" = -11,"sy" = -8,"nx" = 12,"ny" = -8,"wx" = -5,"wy" = -8,"ex" = 6,"ey" = -8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 90,"sturn" = -90,"wturn" = -90,"eturn" = 90,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+			if("wielded")
+				return list("shrink" = 0.7,"sx" = 5,"sy" = -4,"nx" = -5,"ny" = -4,"wx" = -5,"wy" = -3,"ex" = 7,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -45,"sturn" = 45,"wturn" = -45,"eturn" = 45,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
 			if("onbelt")
-				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+				return list("shrink" = 0.5,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/tongs
 	force = 10
@@ -421,29 +403,11 @@
 	if(tag)
 		switch(tag)
 			if("gen")
-				return list("shrink" = 0.6,
-"sx" = -15,
-"sy" = -12,
-"nx" = 9,
-"ny" = -11,
-"wx" = -11,
-"wy" = -11,
-"ex" = 1,
-"ey" = -12,
-"northabove" = 0,
-"southabove" = 1,
-"eastabove" = 1,
-"westabove" = 0,
-"nturn" = 90,
-"sturn" = -90,
-"wturn" = -90,
-"eturn" = 90,
-"nflip" = 0,
-"sflip" = 8,
-"wflip" = 8,
-"eflip" = 0)
+				return list("shrink" = 0.6,"sx" = -11,"sy" = -8,"nx" = 12,"ny" = -8,"wx" = -5,"wy" = -8,"ex" = 6,"ey" = -8,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = 90,"sturn" = -90,"wturn" = -90,"eturn" = 90,"nflip" = 0,"sflip" = 8,"wflip" = 8,"eflip" = 0)
+			if("wielded")
+				return list("shrink" = 0.7,"sx" = 5,"sy" = -4,"nx" = -5,"ny" = -4,"wx" = -5,"wy" = -3,"ex" = 7,"ey" = -4,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0,"nturn" = -45,"sturn" = 45,"wturn" = -45,"eturn" = 45,"nflip" = 8,"sflip" = 0,"wflip" = 8,"eflip" = 0)
 			if("onbelt")
-				return list("shrink" = 0.3,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
+				return list("shrink" = 0.5,"sx" = -2,"sy" = -5,"nx" = 4,"ny" = -5,"wx" = 0,"wy" = -5,"ex" = 2,"ey" = -5,"nturn" = 0,"sturn" = 0,"wturn" = 0,"eturn" = 0,"nflip" = 0,"sflip" = 0,"wflip" = 0,"eflip" = 0,"northabove" = 0,"southabove" = 1,"eastabove" = 1,"westabove" = 0)
 
 /obj/item/rogueweapon/tongs/stone
 	name = "stone tongs"

--- a/code/modules/spells/spell_types/wizard/utility/mending.dm
+++ b/code/modules/spells/spell_types/wizard/utility/mending.dm
@@ -59,6 +59,9 @@
 	if(I.obj_integrity >= I.max_integrity)
 		if(I.obj_broken)
 			I.obj_fix()
+		if (I.shoddy_repair && user.get_skill_level(/datum/skill/magic/arcane) >= SKILL_LEVEL_JOURNEYMAN)
+			I.shoddy_repair = FALSE
+			user.visible_message(span_info("[I] glows gently, arcyne magic amending the damage wrought by hasty repairs."))
 		if(I.body_parts_covered_dynamic != I.body_parts_covered)
 			I.repair_coverage()
 			to_chat(user, span_info("[I]'s shorn layers mend together."))

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -91,7 +91,7 @@
 					recipient.forceMove(spawn_loc)
 					to_chat(recipient, span_notice("As a resident of the vale, you find yourself in the local tavern."))
 
-/datum/virtue/utility/failed_squire
+/*/datum/virtue/utility/failed_squire
 	name = "Failed Squire"
 	desc = "I was once a squire in training, but failed to achieve knighthood. Though my dreams of glory were dashed, I retained my knowledge of equipment maintenance and repair, including how to polish arms and armor."
 	added_traits = list(TRAIT_SQUIRE_REPAIR)
@@ -103,7 +103,7 @@
 
 /datum/virtue/utility/failed_squire/apply_to_human(mob/living/carbon/human/recipient)
 	to_chat(recipient, span_notice("Though you failed to become a knight, your training in equipment maintenance and repair remains useful."))
-	to_chat(recipient, span_notice("You can retrieve your hammer and polishing tools from a tree, statue, or clock."))
+	to_chat(recipient, span_notice("You can retrieve your hammer and polishing tools from a tree, statue, or clock."))*/
 
 /datum/virtue/utility/linguist
 	name = "Intellectual"

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -91,7 +91,7 @@
 					recipient.forceMove(spawn_loc)
 					to_chat(recipient, span_notice("As a resident of the vale, you find yourself in the local tavern."))
 
-/*/datum/virtue/utility/failed_squire
+/datum/virtue/utility/failed_squire
 	name = "Failed Squire"
 	desc = "I was once a squire in training, but failed to achieve knighthood. Though my dreams of glory were dashed, I retained my knowledge of equipment maintenance and repair, including how to polish arms and armor."
 	added_traits = list(TRAIT_SQUIRE_REPAIR)
@@ -103,7 +103,7 @@
 
 /datum/virtue/utility/failed_squire/apply_to_human(mob/living/carbon/human/recipient)
 	to_chat(recipient, span_notice("Though you failed to become a knight, your training in equipment maintenance and repair remains useful."))
-	to_chat(recipient, span_notice("You can retrieve your hammer and polishing tools from a tree, statue, or clock."))*/
+	to_chat(recipient, span_notice("You can retrieve your hammer and polishing tools from a tree, statue, or clock."))
 
 /datum/virtue/utility/linguist
 	name = "Intellectual"


### PR DESCRIPTION
## About The Pull Request

Ports in https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1758
An unskilled person can now repair things much quicker, but they can only repair broken items to a maximum of around 60%. Anyone with Jman or above repair skill or the squire repair trait or a mage with mending and jman or above arcana can repair once-broken items all the way to their maximum of 100%.
The rest of the changes are in the linked PR

## Testing Evidence

<img width="417" height="423" alt="image" src="https://github.com/user-attachments/assets/981c386a-29ca-4ad3-a382-6b679cc9336c" />
<img width="457" height="749" alt="image" src="https://github.com/user-attachments/assets/a958a5de-da0e-4bd8-8086-603324549e2d" />
<img width="385" height="604" alt="image" src="https://github.com/user-attachments/assets/728a24b4-697b-4eca-af79-e043bc383011" />
<img width="378" height="559" alt="image" src="https://github.com/user-attachments/assets/dec1f50c-abf5-4849-8bcb-b89a1101d6e7" />
And when repairing as an expert...
<img width="354" height="78" alt="image" src="https://github.com/user-attachments/assets/b4d631b2-844a-461e-a833-65be0e4be040" />
<img width="346" height="77" alt="image" src="https://github.com/user-attachments/assets/f0f60ab5-b41a-4b26-ac86-aa641e23128a" />

## Why It's Good For The Game

 Instead of being encouraged to sit around auto-hammering for 10 minutes for the still-worth-it mechanical reward of a full repair, you hammer for a minute or so in exchange for the more reasonable reward of ~60%. If you want something repaired all the way to 100, seeks a proper expert (Jman or above). This makes repair a lot less tedious, while also keeping it balanced and keeping incentives to visit real craftsmen.

## Changelog

:cl:
balance: implements the SR repair rework, meaning an untrained person can only repair a broken item up to 60% of its max integrity, but in exchange can repair up to 60% much more quickly.
/:cl: