### PR TITLE
Salt-mine tweak: adds time-served multiplier and sentence manager

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2071,6 +2071,7 @@
 /area/rogue/dietroyt)
 "rk" = (
 /obj/effect/landmark/start/dungeoneer,
+/obj/structure/roguemachine/ticket_manager,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/dietroyt)
 "rl" = (

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1131,7 +1131,8 @@
 		/obj/item/reagent_containers/glass/bowl/carved,
 		/obj/item/reagent_containers/glass/bucket/pot/carved,
 		/obj/item/clothing/mask/rogue/facemask/carved,
-		/obj/item/cooking/platter/carved
+		/obj/item/cooking/platter/carved,
+		/obj/item/detroyt_toll
 	)
 
 /obj/structure/fluff/statue/evil/attackby(obj/item/W, mob/user, params)

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -6,6 +6,7 @@
 #define TAB_LOG 6
 #define TAB_STATISTICS 7
 #define TAB_PAYDAY 8
+#define TAB_SALTMINE 9
 
 /obj/structure/roguemachine/steward
 	name = "nerve master"
@@ -372,6 +373,7 @@
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_PAYDAY]'>\[Daily Payments\]</a><BR>"
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_LOG]'>\[Log\]</a><BR>"
 			contents += "<a href='?src=\ref[src];switchtab=[TAB_STATISTICS]'>\[Statistics\]</a><BR>"
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_SALTMINE]'>\[Salt Mine Report\]</a><BR>"
 			contents += "</center>"
 		if(TAB_BANK)
 			var/total_deposit = 0
@@ -540,6 +542,27 @@
 					contents += " <a href='?src=\ref[src];removedailypay=[job_name]'>\[Remove\]</a><BR>"
 			else
 				contents += "<center>No daily payments configured.</center><BR>"
+		if(TAB_SALTMINE)
+			var/obj/structure/roguemachine/stockpile_saltcamp/stockpile = null
+			stockpile = locate(/obj/structure/roguemachine/stockpile_saltcamp) in GLOB.saltminestockpilemachines // we're assuming there is only ever one of these machines in the world
+			contents += "<a href='?src=\ref[src];switchtab=[TAB_MAIN]'>\[Return\]</a><BR>"
+			if(!isnull(stockpile))
+				var/gambled_salt = round(stockpile.salt_spent_on_gambling, 1)
+				var/total_accounts = length(stockpile.salt_accounts)
+				contents += "<center>Die Troyt Salt Mine Report:<BR>"
+				contents += "Total Salt Gambled: [gambled_salt] piles of salt</center><BR>"
+				if(total_accounts > 0)
+					contents += "--------------<BR>"
+					contents += "<table><tr><th>Prisoner Name</th><th>Salt Mined</th><th>Interest Rate</th></tr>"
+					for(var/i = 1; i <= total_accounts; i++)
+						var/name = stockpile.salt_accounts[i]
+						var/salt = stockpile.salt_accounts[name]
+						var/salt_max = stockpile.salt_accounts_max[name]
+						var/interest = stockpile.salt_accounts_interest_max[name] * 100
+						if(salt == 0 && stockpile.salt_ticket_win[name] > 0) // don't show ticket winners who have left the mines
+							continue
+						contents += "<tr><td>[name]</td><td>[salt] salt / [salt_max] max</td><td>[interest]%</a></td>"
+					contents += "</table>"
 
 	if(!canread)
 		contents = stars(contents)
@@ -569,3 +592,4 @@
 #undef TAB_LOG
 #undef TAB_STATISTICS
 #undef TAB_PAYDAY
+#undef TAB_SALTMINE

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -86,26 +86,6 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
-/obj/structure/roguemachine/stockpile_saltcamp/proc/set_salt_interest(mob/user, amt = 0)
-	if(!user || !ishuman(user))
-		return 0
-	var/mob/living/carbon/human/H = user
-
-	var/target_name = H.real_name
-	for(var/X in salt_accounts) // already got an account
-		if(X == target_name)
-			salt_accounts_interest_max[target_name] = amt
-			return
-
-	salt_accounts += target_name // make account
-	salt_accounts[target_name] = 0
-	salt_accounts_timestamp += target_name
-	salt_accounts_timestamp[target_name] = world.time
-	salt_accounts_interest_max += target_name
-	salt_accounts_interest_max[target_name] = amt
-	salt_accounts_max += target_name
-	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
-
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_salt_balance(mob/user)
 	if(!user || !ishuman(user))
 		return 0
@@ -395,10 +375,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			if(new_max > SALT_CHANCE_MAX)
 				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_MAX]!"))
 				return
-			for(var/X in stockpile.salt_accounts)
-				if(X == name)
-					stockpile.salt_accounts_max[name] = new_max
-					break
+			stockpile.salt_accounts_max[name] = new_max
 		if("set_interest")
 			var/name = href_list["name"]
 			var/new_max = input(usr, "Set the maximum interest rate percentage (1 hour for max interest)", src, stockpile.salt_accounts_interest_max[name] * 100) as null
@@ -411,19 +388,13 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			if(new_max > SALT_CHANCE_INTEREST_MAX * 100)
 				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_INTEREST_MAX * 100]%!"))
 				return
-			for(var/X in stockpile.salt_accounts)
-				if(X == name)
-					stockpile.salt_accounts_interest_max[name] = new_max / 100
-					break
+			stockpile.salt_accounts_interest_max[name] = new_max / 100
 		if("reset_interest")
 			var/name = href_list["name"]
 			var/answer = tgui_alert(usr, "Reset [name]'s interest progression to 0%?", "Please answer in [DisplayTimeText(100)]", list("Yes", "Cancel"), 100)
 			if(!answer || answer != "Yes")
 				return
-			for(var/X in stockpile.salt_accounts)
-				if(X == name)
-					stockpile.salt_accounts_timestamp[name] = world.time
-					break
+			stockpile.salt_accounts_timestamp[name] = world.time
 	return attack_hand(usr)
 
 /obj/structure/roguemachine/ticket_manager/attack_hand(mob/living/user, menu_name)
@@ -459,10 +430,16 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	contents += "</center>"
 	if(total_accounts > 0)
 		contents += "----------<BR>"
-		contents += "NAME  -   COLLECTED SALT<BR>"
+		contents += "NAME   -   COLLECTED SALT<BR>"
 		for(var/i = 1; i <= total_accounts; i++)
 			var/name = stockpile.salt_accounts[i]
-			contents += "[name]: [stockpile.salt_accounts[name]] salt / <a href='?src=[REF(src)];task=set_salt;name=[name]'>[stockpile.salt_accounts_max[name]] maximum</a> (interest rate: <a href='?src=[REF(src)];task=set_interest;name=[name]'>[stockpile.salt_accounts_interest_max[name] * 100]%</a> - <a href='?src=[REF(src)];task=reset_interest;name=[name]'>reset progress</a>)<BR>"
+			var/salt = stockpile.salt_accounts[name]
+			var/salt_max = stockpile.salt_accounts_max[name]
+			var/interest = stockpile.salt_accounts_interest_max[name] * 100
+			contents += "[name]: "
+			contents += "[salt] salt / <a href='?src=[REF(src)];task=set_salt;name=[name]'>[salt_max] max</a> "
+			contents += "(interest rate: <a href='?src=[REF(src)];task=set_interest;name=[name]'>[interest]%</a> "
+			contents += "- <a href='?src=[REF(src)];task=reset_interest;name=[name]'>reset progress</a>)<BR>"
 
 	var/datum/browser/popup = new(user, "saltmanager", "", 800, 500)
 	popup.set_content(contents)

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -1,5 +1,7 @@
 #define SALT_CHANCE_MAX 200
 #define SALT_CHANCE_PERCENT (100/SALT_CHANCE_MAX)
+#define SALT_CHANCE_INTEREST_RATE (60 MINUTES) // time to reach max interest
+#define SALT_CHANCE_INTEREST_MAX (5) // max interest mul factor
 
 GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
@@ -14,11 +16,13 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	obj_flags = INDESTRUCTIBLE
 
 	var/list/salt_accounts = list()
+	var/list/salt_accounts_timestamp = list()
 	var/salt_spent_on_gambling = 0
 	var/gambling_active = FALSE
 
 /obj/structure/roguemachine/stockpile_saltcamp/Destroy()
 	salt_accounts = null
+	salt_accounts_timestamp = null
 	return ..()
 
 /obj/structure/roguemachine/stockpile_saltcamp/examine(mob/user)
@@ -28,6 +32,23 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	else
 		. += span_info("Right click to deposit all the salt in front of the machine.")
 
+/obj/structure/roguemachine/stockpile_saltcamp/proc/get_salt_interest(mob/user)
+	if(!user || !ishuman(user))
+		return 0
+	var/mob/living/carbon/human/H = user
+
+	var/target_name = H.real_name
+	for(var/X in salt_accounts) // already got an account
+		if(X == target_name)
+			return CLAMP(world.time - salt_accounts_timestamp[X], 1, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * SALT_CHANCE_INTEREST_MAX
+
+	salt_accounts += target_name // make account
+	salt_accounts[target_name] = 0
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
+
+	return 0
+
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_salt_balance(mob/user)
 	if(!user || !ishuman(user))
 		return 0
@@ -36,10 +57,14 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	var/target_name = H.real_name
 	for(var/X in salt_accounts) // already got an account
 		if(X == target_name)
-			return salt_accounts[X]
+			var/balance = salt_accounts[X]
+			var/interest = CLAMP(world.time - salt_accounts_timestamp[X], 0, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * SALT_CHANCE_INTEREST_MAX
+			return balance * (1 + interest)
 
 	salt_accounts += target_name // make account
 	salt_accounts[target_name] = 0
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
 
 	return salt_accounts[target_name]
 
@@ -58,6 +83,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 	salt_accounts += target_name // make account
 	salt_accounts[target_name] = amt
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/set_salt_balance(mob/user, amt = 0)
 	if(!user || !ishuman(user))
@@ -72,6 +99,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 	salt_accounts += target_name // make account
 	salt_accounts[target_name] = amt
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_odds_of_winning(mob/user)
 	var/balance = get_salt_balance(user)
@@ -79,6 +108,29 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		return 100
 	balance *= SALT_CHANCE_PERCENT
 	return balance
+
+/obj/structure/roguemachine/stockpile_saltcamp/proc/get_interest_string(mob/user)
+	var/interest = get_salt_interest(user)
+	if(interest <= 0)
+		return "<font color='#f54646'>0%</font>"
+	interest = round(interest/1,0.01)*100
+	var/string
+	if(interest < 10)
+		string = "<font color='#f54646'>"
+	else if(interest < 20)
+		string = "<font color='#f36c6c'>"	
+	else if(interest < 40)
+		string = "<font color='#f5b546'>"
+	else if(interest < 60)
+		string = "<font color='#cff546'>"
+	else if(interest < 80)
+		string = "<font color='#acf546'>"
+	else if(interest < 100)
+		string = "<font color='#4ff546'>"
+	else
+		string = "<font color='#4ff546'>"
+	string += "[interest]%</font>"
+	return string
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_odds_of_winning_string(mob/user)
 	var/balance = get_odds_of_winning(user)
@@ -99,7 +151,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		string = "<font color='#4ff546'>"
 	else
 		return "<font color='#4ff546'>[pick("WHY ARE YOU STILL HERE?!", "YOU ARE A SHAMEFUL FOOL!", "ARE YOU COMPENSATING?", "PLEASE, GO OUTSIDE!", "DID THEY FORGET YOU!?")]</font>"
-	string += "[balance]%</font>"
+	string += "[round(balance,0.5)]%</font>"
 	return string
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/roll_for_ticket(mob/user)
@@ -111,7 +163,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	animate(pixel_x = oldx, time = 1)
 	sleep(50)
 	var/prob_of_winning = get_odds_of_winning(user)
-	if(prob_of_winning == 100 || prob(prob_of_winning)) // we won!
+	if(prob_of_winning >= 100 || prob(prob_of_winning)) // we won!
 		playsound(src, 'sound/misc/machinetalk.ogg', 100, FALSE, -1)
 		gambling_active = FALSE
 		return TRUE
@@ -160,6 +212,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	var/contents = "<center>FEED THE MACHINE - WIN YOUR <font color='#ab8000'>FREEDOM</font><BR>"
 	contents += "----------<BR>"
 	contents += "DEPOSIT SALT TO INCREASE LUCK<BR>"
+	contents += "CURRENT INTEREST RATE: [get_interest_string(user)]<BR>"
 	contents += "CURRENT ODDS: [get_odds_of_winning_string(user)]<BR>"
 	contents += "----------<BR>"
 	contents += "<a href='?src=[REF(src)];task=roll'>(ROLL FOR FREEDOM)</a><BR>"
@@ -177,7 +230,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	if(sound == TRUE)
 		playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)
 	if(message == TRUE)
-		say("Salt has been deposited. Your chances are now [get_odds_of_winning(H)]% of winning.")
+		say("Salt has been deposited. Your chances are now [round(get_odds_of_winning(H),0.5)]% of winning.")
 	return TRUE
 
 /obj/structure/roguemachine/stockpile_saltcamp/attackby(obj/item/P, mob/user, params)
@@ -197,7 +250,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		for(var/obj/I in get_turf(src))
 			found_salt |= attemptsell(I, user, FALSE, FALSE)
 		if(found_salt)
-			say("Salt has been deposited. Your chances are now [get_odds_of_winning(user)]% of winnings.")
+			say("Salt has been deposited. Your chances are now [round(get_odds_of_winning(user),0.5)]% of winnings.")
 		playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)
 		playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
 
@@ -275,3 +328,5 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 #undef SALT_CHANCE_MAX
 #undef SALT_CHANCE_PERCENT
+#undef SALT_CHANCE_INTEREST_RATE
+#undef SALT_CHANCE_INTEREST_MAX

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -339,6 +339,13 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	var/out_of_service = FALSE
 	var/datum/weakref/stockpile_ref = null
 
+/obj/structure/roguemachine/ticket_manager/proc/does_name_exist(obj/structure/roguemachine/stockpile_saltcamp/stockpile, name_to_check)
+	var/total_accounts = length(stockpile.salt_accounts)
+	for(var/i = 1; i <= total_accounts; i++)
+		if(stockpile.salt_accounts[i] == name_to_check)
+			return TRUE
+	return FALSE
+
 /obj/structure/roguemachine/ticket_manager/Topic(href, href_list)
 	if(!usr.canUseTopic(src, BE_CLOSE))
 		return
@@ -365,6 +372,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 				stockpile.salt_spent_on_gambling = 0
 		if("set_salt")
 			var/name = href_list["name"]
+			if(!does_name_exist(stockpile, name)) // sanity check name argument
+				return
 			var/new_max = input(usr, "Set the maximum salt needed to assure a 100% win", src, stockpile.salt_accounts_max[name]) as null
 			if(!isnum(new_max))
 				return
@@ -378,6 +387,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			stockpile.salt_accounts_max[name] = new_max
 		if("set_interest")
 			var/name = href_list["name"]
+			if(!does_name_exist(stockpile, name)) // sanity check name argument
+				return
 			var/new_max = input(usr, "Set the maximum interest rate percentage (1 hour for max interest)", src, stockpile.salt_accounts_interest_max[name] * 100) as null
 			if(!isnum(new_max))
 				return
@@ -391,6 +402,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			stockpile.salt_accounts_interest_max[name] = new_max / 100
 		if("reset_interest")
 			var/name = href_list["name"]
+			if(!does_name_exist(stockpile, name)) // sanity check name argument
+				return
 			var/answer = tgui_alert(usr, "Reset [name]'s interest progression to 0%?", "Please answer in [DisplayTimeText(100)]", list("Yes", "Cancel"), 100)
 			if(!answer || answer != "Yes")
 				return

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -60,6 +60,24 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 	return 0
 
+/obj/structure/roguemachine/stockpile_saltcamp/proc/reset_salt_interest(mob/user)
+	if(!user || !ishuman(user))
+		return 0
+	var/mob/living/carbon/human/H = user
+
+	var/target_name = H.real_name
+	for(var/X in salt_accounts) // already got an account
+		if(X == target_name)
+			salt_accounts_timestamp[target_name] = world.time
+			return
+
+	salt_accounts += target_name // make account
+	salt_accounts[target_name] = 0
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_salt_balance(mob/user)
 	if(!user || !ishuman(user))
 		return 0
@@ -69,7 +87,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	for(var/X in salt_accounts) // already got an account
 		if(X == target_name)
 			var/balance = salt_accounts[X]
-			var/interest = CLAMP(world.time - salt_accounts_timestamp[X], 0, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * SALT_CHANCE_INTEREST_MAX
+			var/interest = CLAMP(world.time - salt_accounts_timestamp[X], 1, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * SALT_CHANCE_INTEREST_MAX
 			return balance * (1 + interest)
 
 	salt_accounts += target_name // make account
@@ -227,6 +245,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 				src.say(pick("Better luck next tyme, criminal.", "You've lost! May your tears aid your rock culling.", "Such folly, better luck next tyme!", "Ha-ha! You salt drinker, never had a chance to win!"))
 				return
 			set_salt_balance(usr, 0)
+			reset_salt_interest(usr)
 			src.say("Oh lookie here, we have ourselves a winner!!")
 			playsound(src, 'sound/misc/triumph_win_twnn.ogg', 100, FALSE, -1)
 			var/obj/item/detroyt_toll/ive_got_a_golden_ticket = new /obj/item/detroyt_toll(get_turf(src))

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -22,9 +22,13 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	var/list/salt_accounts_timestamp = list()
 	var/list/salt_accounts_interest_max = list()
 	var/list/salt_accounts_max = list()
+	var/list/salt_ticket_win = list()
 
 	var/salt_spent_on_gambling = 0
 	var/gambling_active = FALSE
+
+	var/salt_chance_default = SALT_CHANCE_DEFAULT_TOTAL
+	var/interest_rate_default = SALT_CHANCE_INTEREST_DEFAULT
 
 /obj/structure/roguemachine/stockpile_saltcamp/Initialize(mapload)
 	. = ..()
@@ -36,6 +40,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_timestamp = null
 	salt_accounts_interest_max = null
 	salt_accounts_max = null
+	salt_ticket_win = null
 	return ..()
 
 /obj/structure/roguemachine/stockpile_saltcamp/examine(mob/user)
@@ -60,13 +65,15 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
 	salt_accounts_interest_max += target_name
-	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
+	salt_accounts_interest_max[target_name] = interest_rate_default
 	salt_accounts_max += target_name
-	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+	salt_accounts_max[target_name] = salt_chance_default
+	salt_ticket_win += target_name
+	salt_ticket_win[target_name] = 0
 
 	return 0
 
-/obj/structure/roguemachine/stockpile_saltcamp/proc/reset_salt_timestamp(mob/user)
+/obj/structure/roguemachine/stockpile_saltcamp/proc/reset_salt_timestamp(mob/user, didwewinaticket = FALSE)
 	if(!user || !ishuman(user))
 		return 0
 	var/mob/living/carbon/human/H = user
@@ -75,6 +82,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	for(var/X in salt_accounts) // already got an account
 		if(X == target_name)
 			salt_accounts_timestamp[target_name] = world.time
+			if(didwewinaticket)
+				salt_ticket_win[target_name] += 1
 			return
 
 	salt_accounts += target_name // make account
@@ -85,6 +94,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+	salt_ticket_win += target_name
+	salt_ticket_win[target_name] = 0
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_salt_balance(mob/user)
 	if(!user || !ishuman(user))
@@ -103,9 +114,11 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
 	salt_accounts_interest_max += target_name
-	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
+	salt_accounts_interest_max[target_name] = interest_rate_default
 	salt_accounts_max += target_name
-	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+	salt_accounts_max[target_name] = salt_chance_default
+	salt_ticket_win += target_name
+	salt_ticket_win[target_name] = 0
 
 	return salt_accounts[target_name]
 
@@ -124,9 +137,11 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
 	salt_accounts_interest_max += target_name
-	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
+	salt_accounts_interest_max[target_name] = interest_rate_default
 	salt_accounts_max += target_name
-	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+	salt_accounts_max[target_name] = salt_chance_default
+	salt_ticket_win += target_name
+	salt_ticket_win[target_name] = 0
 
 	return salt_accounts_max[target_name]
 
@@ -148,9 +163,11 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
 	salt_accounts_interest_max += target_name
-	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
+	salt_accounts_interest_max[target_name] = interest_rate_default
 	salt_accounts_max += target_name
-	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+	salt_accounts_max[target_name] = salt_chance_default
+	salt_ticket_win += target_name
+	salt_ticket_win[target_name] = 0
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/set_salt_balance(mob/user, amt = 0)
 	if(!user || !ishuman(user))
@@ -168,9 +185,11 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
 	salt_accounts_interest_max += target_name
-	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
+	salt_accounts_interest_max[target_name] = interest_rate_default
 	salt_accounts_max += target_name
-	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+	salt_accounts_max[target_name] = salt_chance_default
+	salt_ticket_win += target_name
+	salt_ticket_win[target_name] = 0
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_odds_of_winning(mob/user)
 	var/balance = get_salt_balance(user)
@@ -262,13 +281,13 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 				src.say(pick("Better luck next tyme, criminal.", "You've lost! May your tears aid your rock culling.", "Such folly, better luck next tyme!", "Ha-ha! You salt drinker, never had a chance to win!"))
 				return
 			set_salt_balance(usr, 0)
-			reset_salt_timestamp(usr)
 			src.say("Oh lookie here, we have ourselves a winner!!")
 			playsound(src, 'sound/misc/triumph_win_twnn.ogg', 100, FALSE, -1)
 			var/obj/item/detroyt_toll/ive_got_a_golden_ticket = new /obj/item/detroyt_toll(get_turf(src))
 			if(!ive_got_a_golden_ticket) // something something went very very wrong... refund player
 				set_salt_balance(usr, current_balance)
 				return
+			reset_salt_timestamp(usr, TRUE) // reset their interest progress
 			ive_got_a_golden_ticket.sellprice = round(rand(current_balance, current_balance*3), 1) // set the value between salt spent on gambling for ticket, and three times
 			if(!usr.put_in_hands(ive_got_a_golden_ticket))
 				ive_got_a_golden_ticket.forceMove(get_turf(src))
@@ -390,6 +409,18 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_MAX]!"))
 				return
 			stockpile.salt_accounts_max[name] = new_max
+		if("set_salt_default")
+			var/new_max = input(usr, "Set the maximum salt needed to assure a 100% win", src, stockpile.salt_chance_default) as null
+			if(!isnum(new_max))
+				return
+			new_max = round(new_max, 1)
+			if(new_max < 10)
+				to_chat(usr, span_danger("You cannot set to a value lower than 10!"))
+				return
+			if(new_max > SALT_CHANCE_MAX)
+				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_MAX]!"))
+				return
+			stockpile.salt_chance_default = new_max
 		if("set_interest")
 			var/name = href_list["name"]
 			if(!does_name_exist(stockpile, name)) // sanity check name argument
@@ -405,6 +436,18 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_INTEREST_MAX * 100]%!"))
 				return
 			stockpile.salt_accounts_interest_max[name] = new_max / 100
+		if("set_interest_default")
+			var/new_max = input(usr, "Set the maximum interest rate percentage (1 hour for max interest)", src, stockpile.interest_rate_default * 100) as null
+			if(!isnum(new_max))
+				return
+			new_max = round(new_max, 1)
+			if(new_max < 0)
+				to_chat(usr, span_danger("You cannot set to a value lower than 0%!"))
+				return
+			if(new_max > SALT_CHANCE_INTEREST_MAX * 100)
+				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_INTEREST_MAX * 100]%!"))
+				return
+			stockpile.interest_rate_default = new_max / 100
 		if("reset_interest")
 			var/name = href_list["name"]
 			if(!does_name_exist(stockpile, name)) // sanity check name argument
@@ -445,6 +488,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	contents += "SALT GAMBLED AWAY: [gambled_salt]<BR>"
 	if(gambled_salt > 0)
 		contents += "<a href='?src=[REF(src)];task=withdraw'>(WITHDRAW GAMBLED SALT AS COINS)</a><BR>"
+	contents += "Salt Mined Max Default: <a href='?src=[REF(src)];task=set_salt_default;'>[stockpile.salt_chance_default]</a> | Interest Rate Default: <a href='?src=[REF(src)];task=set_interest_default;'>[stockpile.interest_rate_default * 100]%</a><BR>"
 	contents += "</center>"
 	if(total_accounts > 0)
 		contents += "<hr><BR>"
@@ -454,6 +498,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			var/salt = stockpile.salt_accounts[name]
 			var/salt_max = stockpile.salt_accounts_max[name]
 			var/interest = stockpile.salt_accounts_interest_max[name] * 100
+			if(salt == 0 && stockpile.salt_ticket_win[name] > 0) // don't show ticket winners who have left the mines
+				continue
 			contents += "<tr><td>[name]</td>"
 			contents += "<td>[salt] salt / <a href='?src=[REF(src)];task=set_salt;name=[name]'>[salt_max] max</a></td>"
 			contents += "<td><a href='?src=[REF(src)];task=set_interest;name=[name]'>[interest]%</a> "

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -2,7 +2,8 @@
 #define SALT_CHANCE_DEFAULT_TOTAL 200
 #define SALT_CHANCE_PERCENT(max_salt) (100/max_salt)
 #define SALT_CHANCE_INTEREST_RATE (60 MINUTES) // time to reach max interest
-#define SALT_CHANCE_INTEREST_MAX (5) // max interest mul factor
+#define SALT_CHANCE_INTEREST_DEFAULT (5)
+#define SALT_CHANCE_INTEREST_MAX (10) // max interest mul factor
 
 GLOBAL_LIST_EMPTY(saltminestockpilemachines)
 GLOBAL_LIST_EMPTY(saltmineticketmachines)
@@ -19,7 +20,9 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 	var/list/salt_accounts = list()
 	var/list/salt_accounts_timestamp = list()
+	var/list/salt_accounts_interest_max = list()
 	var/list/salt_accounts_max = list()
+
 	var/salt_spent_on_gambling = 0
 	var/gambling_active = FALSE
 
@@ -31,6 +34,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	GLOB.saltminestockpilemachines -= src
 	salt_accounts = null
 	salt_accounts_timestamp = null
+	salt_accounts_interest_max = null
 	salt_accounts_max = null
 	return ..()
 
@@ -49,18 +53,20 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	var/target_name = H.real_name
 	for(var/X in salt_accounts) // already got an account
 		if(X == target_name)
-			return CLAMP(world.time - salt_accounts_timestamp[X], 1, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * SALT_CHANCE_INTEREST_MAX
+			return CLAMP(world.time - salt_accounts_timestamp[X], 1, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * salt_accounts_interest_max[target_name]
 
 	salt_accounts += target_name // make account
 	salt_accounts[target_name] = 0
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
 	return 0
 
-/obj/structure/roguemachine/stockpile_saltcamp/proc/reset_salt_interest(mob/user)
+/obj/structure/roguemachine/stockpile_saltcamp/proc/reset_salt_timestamp(mob/user)
 	if(!user || !ishuman(user))
 		return 0
 	var/mob/living/carbon/human/H = user
@@ -75,6 +81,28 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = 0
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+
+/obj/structure/roguemachine/stockpile_saltcamp/proc/set_salt_interest(mob/user, amt = 0)
+	if(!user || !ishuman(user))
+		return 0
+	var/mob/living/carbon/human/H = user
+
+	var/target_name = H.real_name
+	for(var/X in salt_accounts) // already got an account
+		if(X == target_name)
+			salt_accounts_interest_max[target_name] = amt
+			return
+
+	salt_accounts += target_name // make account
+	salt_accounts[target_name] = 0
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = amt
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
@@ -87,13 +115,15 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	for(var/X in salt_accounts) // already got an account
 		if(X == target_name)
 			var/balance = salt_accounts[X]
-			var/interest = CLAMP(world.time - salt_accounts_timestamp[X], 1, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * SALT_CHANCE_INTEREST_MAX
+			var/interest = CLAMP(world.time - salt_accounts_timestamp[X], 1, SALT_CHANCE_INTEREST_RATE) / SALT_CHANCE_INTEREST_RATE * salt_accounts_interest_max[target_name]
 			return balance * (1 + interest)
 
 	salt_accounts += target_name // make account
 	salt_accounts[target_name] = 0
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
@@ -113,6 +143,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = 0
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
@@ -135,6 +167,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = amt
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
@@ -153,6 +187,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = amt
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_interest_max += target_name
+	salt_accounts_interest_max[target_name] = SALT_CHANCE_INTEREST_DEFAULT
 	salt_accounts_max += target_name
 	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
@@ -245,7 +281,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 				src.say(pick("Better luck next tyme, criminal.", "You've lost! May your tears aid your rock culling.", "Such folly, better luck next tyme!", "Ha-ha! You salt drinker, never had a chance to win!"))
 				return
 			set_salt_balance(usr, 0)
-			reset_salt_interest(usr)
+			reset_salt_timestamp(usr)
 			src.say("Oh lookie here, we have ourselves a winner!!")
 			playsound(src, 'sound/misc/triumph_win_twnn.ogg', 100, FALSE, -1)
 			var/obj/item/detroyt_toll/ive_got_a_golden_ticket = new /obj/item/detroyt_toll(get_turf(src))
@@ -347,9 +383,11 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			if(amount > 0)
 				budget2change(amount, usr)
 				stockpile.salt_spent_on_gambling = 0
-		if("set_max")
+		if("set_salt")
 			var/name = href_list["name"]
-			var/new_max = input(usr, "Set the maximum salt needed to assure a 100% win", src, stockpile.salt_accounts_max[name]) as null|num
+			var/new_max = input(usr, "Set the maximum salt needed to assure a 100% win", src, stockpile.salt_accounts_max[name]) as null
+			if(!isnum(new_max))
+				return
 			new_max = round(new_max, 1)
 			if(new_max < 10)
 				to_chat(usr, span_danger("You cannot set to a value lower than 10!"))
@@ -360,6 +398,31 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			for(var/X in stockpile.salt_accounts)
 				if(X == name)
 					stockpile.salt_accounts_max[name] = new_max
+					break
+		if("set_interest")
+			var/name = href_list["name"]
+			var/new_max = input(usr, "Set the maximum interest rate percentage (1 hour for max interest)", src, stockpile.salt_accounts_interest_max[name] * 100) as null
+			if(!isnum(new_max))
+				return
+			new_max = round(new_max, 1)
+			if(new_max < 0)
+				to_chat(usr, span_danger("You cannot set to a value lower than 0%!"))
+				return
+			if(new_max > SALT_CHANCE_INTEREST_MAX * 100)
+				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_INTEREST_MAX * 100]%!"))
+				return
+			for(var/X in stockpile.salt_accounts)
+				if(X == name)
+					stockpile.salt_accounts_interest_max[name] = new_max / 100
+					break
+		if("reset_interest")
+			var/name = href_list["name"]
+			var/answer = tgui_alert(usr, "Reset [name]'s interest progression to 0%?", "Please answer in [DisplayTimeText(100)]", list("Yes", "Cancel"), 100)
+			if(!answer || answer != "Yes")
+				return
+			for(var/X in stockpile.salt_accounts)
+				if(X == name)
+					stockpile.salt_accounts_timestamp[name] = world.time
 					break
 	return attack_hand(usr)
 
@@ -399,9 +462,9 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		contents += "NAME  -   COLLECTED SALT<BR>"
 		for(var/i = 1; i <= total_accounts; i++)
 			var/name = stockpile.salt_accounts[i]
-			contents += "[name]: Mined [stockpile.salt_accounts[name]] salt / <a href='?src=[REF(src)];task=set_max;name=[name]'>[stockpile.salt_accounts_max[name]] maximum</a><BR>"
+			contents += "[name]: [stockpile.salt_accounts[name]] salt / <a href='?src=[REF(src)];task=set_salt;name=[name]'>[stockpile.salt_accounts_max[name]] maximum</a> (interest rate: <a href='?src=[REF(src)];task=set_interest;name=[name]'>[stockpile.salt_accounts_interest_max[name] * 100]%</a> - <a href='?src=[REF(src)];task=reset_interest;name=[name]'>reset progress</a>)<BR>"
 
-	var/datum/browser/popup = new(user, "saltmanager", "", 500, 500)
+	var/datum/browser/popup = new(user, "saltmanager", "", 800, 500)
 	popup.set_content(contents)
 	popup.open()
 
@@ -481,4 +544,5 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 #undef SALT_CHANCE_DEFAULT_TOTAL
 #undef SALT_CHANCE_PERCENT
 #undef SALT_CHANCE_INTEREST_RATE
+#undef SALT_CHANCE_INTEREST_DEFAULT
 #undef SALT_CHANCE_INTEREST_MAX

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -250,13 +250,14 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		return
 	switch(href_list["task"])
 		if("roll")
-			if(!get_salt_balance(usr))
+			var/current_balance = get_salt_balance(usr)
+			if(current_balance <= 0)
 				src.say(pick("Eager fool; you need salt to gamble for freedom.", "You are missing your salt.", "A criminal without salt is no criminal at all.", "To play the game, you must first salt the ground."))
 				return
 			close_ui(usr)
 			src.say("Bow to Xylix and shall luck bless you.")
 			if(!roll_for_ticket(usr)) // if we lost the game (like you just did lol), add to spent counter and reset account back to zero
-				salt_spent_on_gambling += get_salt_balance(usr)
+				salt_spent_on_gambling += current_balance
 				set_salt_balance(usr, 0)
 				src.say(pick("Better luck next tyme, criminal.", "You've lost! May your tears aid your rock culling.", "Such folly, better luck next tyme!", "Ha-ha! You salt drinker, never had a chance to win!"))
 				return
@@ -265,6 +266,10 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 			src.say("Oh lookie here, we have ourselves a winner!!")
 			playsound(src, 'sound/misc/triumph_win_twnn.ogg', 100, FALSE, -1)
 			var/obj/item/detroyt_toll/ive_got_a_golden_ticket = new /obj/item/detroyt_toll(get_turf(src))
+			if(!ive_got_a_golden_ticket) // something something went very very wrong... refund player
+				set_salt_balance(usr, current_balance)
+				return
+			ive_got_a_golden_ticket.sellprice = round(rand(current_balance, current_balance*3), 1) // set the value between salt spent on gambling for ticket, and three times
 			if(!usr.put_in_hands(ive_got_a_golden_ticket))
 				ive_got_a_golden_ticket.forceMove(get_turf(src))
 

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -1,8 +1,10 @@
-#define SALT_CHANCE_MAX 200
-#define SALT_CHANCE_PERCENT (100/SALT_CHANCE_MAX)
+#define SALT_CHANCE_MAX 300
+#define SALT_CHANCE_DEFAULT_TOTAL 200
+#define SALT_CHANCE_PERCENT(max_salt) (100/max_salt)
 #define SALT_CHANCE_INTEREST_RATE (60 MINUTES) // time to reach max interest
 #define SALT_CHANCE_INTEREST_MAX (5) // max interest mul factor
 
+GLOBAL_LIST_EMPTY(saltminestockpilemachines)
 GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 /obj/structure/roguemachine/stockpile_saltcamp
@@ -17,12 +19,19 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 
 	var/list/salt_accounts = list()
 	var/list/salt_accounts_timestamp = list()
+	var/list/salt_accounts_max = list()
 	var/salt_spent_on_gambling = 0
 	var/gambling_active = FALSE
 
+/obj/structure/roguemachine/stockpile_saltcamp/Initialize(mapload)
+	. = ..()
+	GLOB.saltminestockpilemachines += src
+
 /obj/structure/roguemachine/stockpile_saltcamp/Destroy()
+	GLOB.saltminestockpilemachines -= src
 	salt_accounts = null
 	salt_accounts_timestamp = null
+	salt_accounts_max = null
 	return ..()
 
 /obj/structure/roguemachine/stockpile_saltcamp/examine(mob/user)
@@ -46,6 +55,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = 0
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
 	return 0
 
@@ -65,8 +76,29 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = 0
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
 	return salt_accounts[target_name]
+
+/obj/structure/roguemachine/stockpile_saltcamp/proc/get_salt_max(mob/user)
+	if(!user || !ishuman(user))
+		return 0
+	var/mob/living/carbon/human/H = user
+
+	var/target_name = H.real_name
+	for(var/X in salt_accounts) // already got an account
+		if(X == target_name)
+			return salt_accounts_max[target_name]
+
+	salt_accounts += target_name // make account
+	salt_accounts[target_name] = 0
+	salt_accounts_timestamp += target_name
+	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
+
+	return salt_accounts_max[target_name]
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/add_salt_balance(mob/user, amt = 0)
 	if(!user || !ishuman(user))
@@ -85,6 +117,8 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = amt
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/set_salt_balance(mob/user, amt = 0)
 	if(!user || !ishuman(user))
@@ -101,12 +135,16 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	salt_accounts[target_name] = amt
 	salt_accounts_timestamp += target_name
 	salt_accounts_timestamp[target_name] = world.time
+	salt_accounts_max += target_name
+	salt_accounts_max[target_name] = SALT_CHANCE_DEFAULT_TOTAL
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_odds_of_winning(mob/user)
 	var/balance = get_salt_balance(user)
-	if(balance >= SALT_CHANCE_MAX)
+	var/max_salt = get_salt_max(user)
+	if(balance >= max_salt)
 		return 100
-	balance *= SALT_CHANCE_PERCENT
+	
+	balance *= SALT_CHANCE_PERCENT(max_salt)
 	return balance
 
 /obj/structure/roguemachine/stockpile_saltcamp/proc/get_interest_string(mob/user)
@@ -254,6 +292,100 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		playsound(loc, 'sound/misc/hiss.ogg', 100, FALSE, -1)
 		playsound(loc, 'sound/misc/disposalflush.ogg', 100, FALSE, -1)
 
+/obj/structure/roguemachine/ticket_manager
+	name = "Ticket Manager Deluxe"
+	desc = "This machine controls the punishment for victims of the salt mines."
+	icon = 'icons/roguetown/misc/machines.dmi'
+	icon_state = "submit"
+	density = FALSE
+	blade_dulling = DULLING_BASH
+	pixel_y = 32
+	obj_flags = INDESTRUCTIBLE
+	var/out_of_service = FALSE
+	var/datum/weakref/stockpile_ref = null
+
+/obj/structure/roguemachine/ticket_manager/Topic(href, href_list)
+	if(!usr.canUseTopic(src, BE_CLOSE))
+		return
+	var/obj/structure/roguemachine/stockpile_saltcamp/stockpile = null
+	if(!out_of_service)
+		if(stockpile_ref)
+			stockpile = stockpile_ref.resolve()
+			if(QDELETED(stockpile) || !istype(stockpile)) // machine doesn't exist
+				out_of_service = TRUE
+		else
+			stockpile = locate(/obj/structure/roguemachine/stockpile_saltcamp) in GLOB.saltminestockpilemachines // we're assuming there is only ever one of these machines in the world
+			if(stockpile)
+				stockpile_ref = WEAKREF(stockpile)
+			else
+				out_of_service = TRUE
+	if(out_of_service || !stockpile) // aka there isn't any other machine in this world
+		say("Sorry, machine out of service!")
+		return
+	switch(href_list["task"])
+		if("withdraw")
+			var/amount = round(stockpile.salt_spent_on_gambling, 1)
+			if(amount > 0)
+				budget2change(amount, usr)
+				stockpile.salt_spent_on_gambling = 0
+		if("set_max")
+			var/name = href_list["name"]
+			var/new_max = input(usr, "Set the maximum salt needed to assure a 100% win", src, stockpile.salt_accounts_max[name]) as null|num
+			new_max = round(new_max, 1)
+			if(new_max < 10)
+				to_chat(usr, span_danger("You cannot set to a value lower than 10!"))
+				return
+			if(new_max > SALT_CHANCE_MAX)
+				to_chat(usr, span_danger("You cannot set to a value higher than [SALT_CHANCE_MAX]!"))
+				return
+			for(var/X in stockpile.salt_accounts)
+				if(X == name)
+					stockpile.salt_accounts_max[name] = new_max
+					break
+	return attack_hand(usr)
+
+/obj/structure/roguemachine/ticket_manager/attack_hand(mob/living/user, menu_name)
+	. = ..()
+	if(.)
+		return
+	var/obj/structure/roguemachine/stockpile_saltcamp/stockpile = null
+	if(!out_of_service)
+		if(stockpile_ref)
+			stockpile = stockpile_ref.resolve()
+			if(QDELETED(stockpile) || !istype(stockpile)) // machine doesn't exist
+				out_of_service = TRUE
+		else
+			stockpile = locate(/obj/structure/roguemachine/stockpile_saltcamp) in GLOB.saltminestockpilemachines // we're assuming there is only ever one of these machines in the world
+			if(stockpile)
+				stockpile_ref = WEAKREF(stockpile)
+			else
+				out_of_service = TRUE
+	if(out_of_service) // aka there isn't any other machine in this world
+		say("Sorry, machine out of service!")
+		return
+	user.changeNext_move(CLICK_CD_INTENTCAP)
+	playsound(loc, 'sound/misc/keyboard_enter.ogg', 100, FALSE, -1)
+
+	var/gambled_salt = round(stockpile.salt_spent_on_gambling, 1)
+	var/total_accounts = length(stockpile.salt_accounts)
+	var/contents = "<center>SALT MANAGER DELUXE<BR>"
+	contents += "Where tears become fears<BR>"
+	contents += "----------<BR>"
+	contents += "SALT GAMBLED AWAY: [gambled_salt]<BR>"
+	if(gambled_salt > 0)
+		contents += "<a href='?src=[REF(src)];task=withdraw'>(WITHDRAW GAMBLED SALT AS COINS)</a><BR>"
+	contents += "</center>"
+	if(total_accounts > 0)
+		contents += "----------<BR>"
+		contents += "NAME  -   COLLECTED SALT<BR>"
+		for(var/i = 1; i <= total_accounts; i++)
+			var/name = stockpile.salt_accounts[i]
+			contents += "[name]: Mined [stockpile.salt_accounts[name]] salt / <a href='?src=[REF(src)];task=set_max;name=[name]'>[stockpile.salt_accounts_max[name]] maximum</a><BR>"
+
+	var/datum/browser/popup = new(user, "saltmanager", "", 500, 500)
+	popup.set_content(contents)
+	popup.open()
+
 /obj/structure/roguemachine/ticket_master
 	name = "Ticket Slide"
 	desc = "Only ticket winners may get to ride the sorrid slide to freedom. Looks like it will strip whoever passes through."
@@ -327,6 +459,7 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 	. = ..()
 
 #undef SALT_CHANCE_MAX
+#undef SALT_CHANCE_DEFAULT_TOTAL
 #undef SALT_CHANCE_PERCENT
 #undef SALT_CHANCE_INTEREST_RATE
 #undef SALT_CHANCE_INTEREST_MAX

--- a/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
+++ b/code/modules/roguetown/roguemachine/stockpile/stockpile_saltcamp.dm
@@ -442,17 +442,18 @@ GLOBAL_LIST_EMPTY(saltmineticketmachines)
 		contents += "<a href='?src=[REF(src)];task=withdraw'>(WITHDRAW GAMBLED SALT AS COINS)</a><BR>"
 	contents += "</center>"
 	if(total_accounts > 0)
-		contents += "----------<BR>"
-		contents += "NAME   -   COLLECTED SALT<BR>"
+		contents += "<hr><BR>"
+		contents += "<table><tr><th>Prisoner Name</th><th>Salt Mined</th><th>Interest Rate</th></tr>"
 		for(var/i = 1; i <= total_accounts; i++)
 			var/name = stockpile.salt_accounts[i]
 			var/salt = stockpile.salt_accounts[name]
 			var/salt_max = stockpile.salt_accounts_max[name]
 			var/interest = stockpile.salt_accounts_interest_max[name] * 100
-			contents += "[name]: "
-			contents += "[salt] salt / <a href='?src=[REF(src)];task=set_salt;name=[name]'>[salt_max] max</a> "
-			contents += "(interest rate: <a href='?src=[REF(src)];task=set_interest;name=[name]'>[interest]%</a> "
-			contents += "- <a href='?src=[REF(src)];task=reset_interest;name=[name]'>reset progress</a>)<BR>"
+			contents += "<tr><td>[name]</td>"
+			contents += "<td>[salt] salt / <a href='?src=[REF(src)];task=set_salt;name=[name]'>[salt_max] max</a></td>"
+			contents += "<td><a href='?src=[REF(src)];task=set_interest;name=[name]'>[interest]%</a> "
+			contents += "(<a href='?src=[REF(src)];task=reset_interest;name=[name]'>reset progress</a>)</td></tr>"
+		contents += "</table>"
 
 	var/datum/browser/popup = new(user, "saltmanager", "", 800, 500)
 	popup.set_content(contents)


### PR DESCRIPTION
## About The Pull Request

There will now be a time served multiplier that increases, maxxing out at 5x at the 1 hour mark.
<img width="502" height="546" alt="image" src="https://github.com/user-attachments/assets/0421b7c5-aeab-4ccf-bd01-8f449ccea243" />

In addition, this PR adds a management machine the dungeoneer can use to customize the quota for each prisoner.
<img width="502" height="546" alt="image" src="https://github.com/user-attachments/assets/e78fb447-9c13-4b03-a50c-ec0a210ff3fc" />

It also ensures return prisoners have the multiplier for their sentence reset.

And finally full variable control is now available on a separate machine.
<img width="802" height="546" alt="image" src="https://github.com/user-attachments/assets/7a38b05c-c987-4d77-93bc-13e3c8cceaac" />




## Why It's Good For The Game

This solves a few issues wrapped up into one package. If you're not actively mining salt, then you're not progressing towards your sentence. Which means doing anything else actively halts the prisoner's momentum and forces them to single-mindedly whack rocks if they'd like to eventually meet the quota. It now serves as both a timed prison sentence and a labour one wrapped into the same package, while also allowing the dungeoneer to customize the quota/sentence length and return prisoners have their sentencing reset after successful serving.

## Changelog

:cl:
add: New machine for managing prisoner sentencing/quota/variables
code: Added a multiplier to the saltmine tracking machine that increases over time
add: Nervemaster now gets reports on prisoners in the mine
/:cl:
