### PR TITLE
Support Beams for Mines Pathfinding Fix

### DIFF
--- a/code/game/objects/structures/barricades.dm
+++ b/code/game/objects/structures/barricades.dm
@@ -99,9 +99,7 @@
 	icon_state = "woodenbarricade_mineshaft"
 	bar_material = WOOD
 	pass_flags = LETPASSTHROW
-
-/obj/structure/barricade/mineshaft/CanPass(atom/movable/mover, turf/target)
-	return TRUE
+	density = FALSE
 
 #undef SINGLE
 #undef VERTICAL


### PR DESCRIPTION
## About The Pull Request

There was a bug with the support beams being considered impassable walls for AI. This fixes that.

## Changelog

:cl:
fix: fixed mob path find bug related to mineshaft support beams
/:cl:
