### PR TITLE
Small masochist vice buff

### DIFF
--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -536,8 +536,8 @@
 			else
 				target.add_stress(/datum/stressevent/unseemly_made_love)
 			user.add_stress(/datum/stressevent/cummax)
-	if(!oral && force >= SEX_FORCE_HIGH && user.has_flaw(/datum/charflaw/addiction/sadist)) // force pain emote if top is a sadist
-		target.emote("paincrit", forced = TRUE)
+	if(!oral && force >= SEX_FORCE_HIGH && (user.has_flaw(/datum/charflaw/addiction/sadist) || target.has_flaw(/datum/charflaw/addiction/masochist)))
+		target.emote("paincrit", forced = TRUE) // this satiates the sadomasochists in range
 
 /datum/sex_controller/proc/just_ejaculated()
 	return (last_ejaculation_time + 2 SECONDS >= world.time)


### PR DESCRIPTION
## About The Pull Request
Makes masochists always satisfied (making the pain scream) as the bottoms in bed, when the top finishes (during penetrative sex) on ROUGH or BRUTAL. This patch makes it apply even when the top isn't specifically a sadist.

To be clear, the code now additionally checks for whether the bottom is a Masochist when deciding to produce the painscream. A top with Sadist vice would also make the bottom produce the painscream, *regardless* of whether or not that bottom is masochistic.

Without this PR, only a Sadist top could force the painscream, which both does and doesn't make sense. I think masochists should be able to entertain themselves if the top is otherwise roleplaying being that mean.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It's a one-line change that is very self-explanatory. I don't need to test.

<img width="460" height="295" alt="image" src="https://github.com/user-attachments/assets/76b63b94-8d53-4bbf-ad97-e1a24c3549bf" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Muh immersions. I'd rather not have to punch myself 100 times after a scene with someone who's normal, thanks.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Masochists will always make the paincrit scream if the top finishes while penetrating with ROUGH or BRUTAL force, thus sating the vice. This patch was to make it trigger independently of whether or not the top is a Sadist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
