### PR TITLE
Expert Knives for Vaquero

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/vaquero.dm
@@ -19,7 +19,7 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request
Right now the Vaquero class cannot use their unique parrying dagger (the sail dagger) to... parry. Having a core part of their identity hang off as redundant is pretty shoddy for the class. Due to how parrying works in Roguecode, the Vaquero will only parry with their rapier and not the dagger. This change allows them to use the parrying dagger to parry. Yay!

## Testing Evidence

<img width="368" height="284" alt="itjustworks" src="https://github.com/user-attachments/assets/db6f4fe4-6768-4be6-9ec8-54d7eecb71d2" />


## Why It's Good For The Game
The Vaquero has a unique sword and dagger combo which is, in theory, the core of their class identity. Being unable to effectively use the sail dagger is a direct contradiction to the intended flashy, sword-and-dagger style of the class. Now they will be able to finally live out the Alatriste fantasy.
<img width="550" height="366" alt="46d8d98e6003f17e36faff3c0464e427" src="https://github.com/user-attachments/assets/2c946708-8608-43af-acc2-f2637fca3862" />

## Changelog
:cl:
add: Vaquero now gets Expert knife skill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
