### PR TITLE
Adds tailjob/tailpegging to lamia

### DIFF
--- a/code/datums/sexcon/sex_actions/deviant/tailjob.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailjob.dm
@@ -8,7 +8,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_PENIS))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -19,7 +19,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_PENIS))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailjob.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailjob.dm
@@ -8,7 +8,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_PENIS))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -19,7 +19,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_PENIS))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
@@ -7,7 +7,7 @@
 /datum/sex_action/tailpegging_anal/shows_on_menu(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user == target)
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -16,7 +16,7 @@
 		return FALSE
 	if(!check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN, TRUE))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
@@ -7,7 +7,7 @@
 /datum/sex_action/tailpegging_anal/shows_on_menu(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user == target)
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -16,7 +16,7 @@
 		return FALSE
 	if(!check_location_accessible(user, target, BODY_ZONE_PRECISE_GROIN, TRUE))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
@@ -9,7 +9,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_VAGINA))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -20,7 +20,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_VAGINA))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) && !islamia(user))
 		return FALSE
 	return TRUE
 

--- a/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
+++ b/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
@@ -9,7 +9,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_VAGINA))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
 		return FALSE
 	return TRUE
 
@@ -20,7 +20,7 @@
 		return FALSE
 	if(!target.getorganslot(ORGAN_SLOT_VAGINA))
 		return FALSE
-	if(!user.getorganslot(ORGAN_SLOT_TAIL))
+	if(!user.getorganslot(ORGAN_SLOT_TAIL) & !islamia(user))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/Scarlet-Reach/Scarlet-Reach/pull/1347

Lamia technically don't have a tail organ so they can't use these sexcon options. This gives it to them.

## Testing Evidence

Tested months ago in SR, the code changes are very simple and self explanatory.

## Why It's Good For The Game

It simply makes sense. Lamia are easily the species best fit to use tailpegging so it's silly that lupians can do it and they can't.

## Changelog

:cl:
add: tailjob/tailpegging to lamia
/:cl: