### PR TITLE
Removes Circuitus from Learnable Spells.

### DIFF
--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -60,6 +60,5 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 		/obj/effect/proc_holder/spell/invoked/silence,
 		/obj/effect/proc_holder/spell/self/recall,
 		/obj/effect/proc_holder/spell/self/findfamiliar,
-		/obj/effect/proc_holder/spell/invoked/incantation,
 		)
 ))


### PR DESCRIPTION
## About The Pull Request

Removes circuitus from learnable spell list.

Apologies for pushing this in the first place, you guys warned me it would cause issues and you were right!
I've learned my lesson.

## Testing Evidence

It compiled!

## Why It's Good For The Game

Requested en masse in feedback, the feature is too imbalanced and doesn't fit the game.

## Changelog

:cl:
balance: Removes circuitus from learnable spells.
/:cl: