### PR TITLE
Adds temporary flavortext [Bounty]

### DIFF
--- a/code/datums/keybinding/human.dm
+++ b/code/datums/keybinding/human.dm
@@ -102,3 +102,17 @@
 	var/mob/living/carbon/human/H = user.mob
 	H.toggle_eye_intent(H)
 	return TRUE
+
+/datum/keybinding/human/set_temp_ft
+	hotkey_keys = list("Unbound")
+	name = "set_pose"
+	full_name = "Set Temporary Flavortext"
+	description = "Changes the temporary flavortext."
+
+/datum/keybinding/human/set_temp_ft/down(client/user)
+	. = ..()
+	if(!.)
+		return FALSE
+	var/mob/living/carbon/human/H = user.mob
+	H.temp_flavor()
+	return TRUE

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -1157,6 +1157,13 @@
 	if(!isnull(trait_exam))
 		. += trait_exam
 
+	if(temporary_flavortext) //should be kept at the bottom always if possible, since someone could change the spans to trick people if it's on other places
+		var/max_temp_ft_length = 100 //Proably a good idea to fine-tune this later
+		if(length_char(temporary_flavortext) > max_temp_ft_length) 
+			. += " <span class='info' style='color: #eaeaea'> ø ------------ ø\n [copytext_char(temporary_flavortext, 1, max_temp_ft_length + 1)]</span>" + "<a href='?src=[REF(src)];task=show_temp_ft;'>...</a>"
+		else 
+			. += " <span class='info' style='color: #eaeaea'> ø ------------ ø\n [temporary_flavortext]</span>"
+
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!

--- a/code/modules/mob/living/carbon/human/temporary_flavortext.dm
+++ b/code/modules/mob/living/carbon/human/temporary_flavortext.dm
@@ -3,7 +3,7 @@
 
 /mob/living/carbon/human/verb/temp_flavor()
 	set name = "Set temporary flavortext"
-	set category = "IC"
+	set category = "Memory"
 
 	var/new_temp_flavortext = input(usr, "Choose a new flavortext (Empty will remove any active ones)", "Temporary flavortext") as null|text
 	if(isnull(new_temp_flavortext))

--- a/code/modules/mob/living/carbon/human/temporary_flavortext.dm
+++ b/code/modules/mob/living/carbon/human/temporary_flavortext.dm
@@ -1,0 +1,23 @@
+/mob/living/carbon/human
+	var/temporary_flavortext = null
+
+/mob/living/carbon/human/verb/temp_flavor()
+	set name = "Set temporary flavortext"
+	set category = "IC"
+
+	var/new_temp_flavortext = input(usr, "Choose a new flavortext (Empty will remove any active ones)", "Temporary flavortext") as null|text
+	if(isnull(new_temp_flavortext))
+		return
+	if(new_temp_flavortext == "")
+		temporary_flavortext = null
+		return
+	else
+		temporary_flavortext = new_temp_flavortext
+
+/mob/living/carbon/human/Topic(href, href_list)
+	. = ..()
+	if(href_list["task"] == "show_temp_ft")
+		var/output = "<span class='info' style='color: #eaeaea'>[temporary_flavortext]</span>"
+		if(!usr.client.prefs.no_examine_blocks)
+			output = examine_block(output)
+		to_chat(usr, output)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2181,6 +2181,7 @@
 #include "code\modules\mob\living\carbon\human\species.dm"
 #include "code\modules\mob\living\carbon\human\stats.dm"
 #include "code\modules\mob\living\carbon\human\status_procs.dm"
+#include "code\modules\mob\living\carbon\human\temporary_flavortext.dm"
 #include "code\modules\mob\living\carbon\human\update_icons.dm"
 #include "code\modules\mob\living\carbon\human\voicepack.dm"
 #include "code\modules\mob\living\carbon\human\npc\_npc.dm"


### PR DESCRIPTION
## About The Pull Request

As the title says! Adds a way of adding temporary flavortext, specifically, a white text that'll be shown below your descriptors, separated by a line so it doesn't get confused for anything else. If someone tries to set something longer than 100 characters, it cuts off and adds a "..." button to inspect the entire thing.

There's a new button on the IC tab called "set temporary flavortext" that lets you do this, empty deletes the flavortext, and you can also use things like `<b> </b>` or `<i> </i>` to add things like italics or bold to the flavortext.

(I *have* been informed of the potential to use this as a way to trick people by doing things like messing with the spans and putting alerts in there, BUT! The line clearly separating the flavortext from the rest of the inspection should make this way lesser, and also easier to report people obviously trying to abuse this)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="608" height="347" alt="image" src="https://github.com/user-attachments/assets/1b6bd598-939e-4672-b32f-965b3e023112" />
<img width="602" height="370" alt="image" src="https://github.com/user-attachments/assets/202f6e34-93c2-46dc-aca6-838f7e09c3b5" />
<img width="600" height="410" alt="image" src="https://github.com/user-attachments/assets/f886b587-cfad-4af6-bd62-5ce67ef6cff5" />
<img width="598" height="340" alt="image" src="https://github.com/user-attachments/assets/7c9e381a-a939-4c3d-a678-516e6ef3670f" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Adds more ways for customization! Roleplay, and other things. If you want to look like you're pissed off without putting it onto your permanent FT or constantly emoting things like groaning, frowning, sighing, etc. Now youc can.


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Temporary flavortext, now observable at the bottom of examine panels, separated by a line.
add: Set temporary flavortext button, can be found on the Memory tab at the top right.
add: Set temporary flavortext can now be bound to a keybind on the Game Preferences menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
