### PR TITLE
Adds new bomb and slurbow recipes 

### DIFF
--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -126,6 +126,14 @@
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 3
 
+/datum/crafting_recipe/roguetown/engineering/slurbow
+	name = "Slurbow"
+	result = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow/slurbow
+	reqs = list(/obj/item/ingot/steel = 2, /obj/item/natural/fibers = 1, /obj/item/natural/wood/plank = 4)
+	structurecraft = /obj/machinery/artificer_table
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 5
+
 /datum/crafting_recipe/roguetown/engineering/twentybolts
 	name = "Crossbow Bolts 20x"
 	reqs = list(/obj/item/natural/wood/plank = 3, /obj/item/ingot/iron)
@@ -377,6 +385,25 @@
 
 // ----------- Explosive grenades and gas belchers -----------
 // Mostly here to avoid having to use spark-generating 6 step recipes around impact grenades and other instant explosives
+
+/datum/crafting_recipe/roguetown/engineering/tntbomb
+	name = "blastsand sticks"
+	category = "Explosives"
+	result = /obj/item/tntstick
+	reqs = list(/obj/item/paper = 2, /obj/item/alch/coaldust = 2, /obj/item/compost = 1, /obj/item/natural/fibers = 1)
+	structurecraft = /obj/machinery/artificer_table
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4
+
+
+/datum/crafting_recipe/roguetown/engineering/satchelbomb
+	name = "blastsand satchel"
+	category = "Explosives"
+	result = /obj/item/satchel_bomb
+	reqs = list(/obj/item/storage/backpack/rogue/satchel  = 1, /obj/item/tntstick = 3, /obj/item/alch/firedust = 1, /obj/item/natural/fibers = 1)
+	structurecraft = /obj/machinery/artificer_table
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4
 
 /datum/crafting_recipe/roguetown/engineering/impactexplosive
 	name = "impact grenades (x3)"


### PR DESCRIPTION
## About The Pull Request

Ports AP Blastsand satchel and blastsand stick recipes

Adds slurbow engineering recipe to compliment the crossbow recipe

A relatively simple change

## Testing Evidence

Compiles

## Why It's Good For The Game

Hopefully will make TNT sticks less rare so miners can use them, also will be useful for demolition purposes for the satchel charge

Slurbows are rare, this probably won't change that but players who truly wish to use one can have an avenue of getting one without having to steal it by going through your local artificer or architect giving them more interactions and the guild line experience

Slurbow recipe should remain hopefully balanced to keep its rarity intact
## Changelog

:cl:
Add: Slurbow recipe to the engineering table
Add: Blastsand Satchel and Stick recipes to the engineering table
/:cl:
