### PR TITLE
fixes lockpicking sound spreading over multi-z

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -361,7 +361,7 @@
 				break
 			if(prob(pickchance))
 				lockprogress += moveup
-				playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE)
+				playsound(src.loc, pick('sound/items/pickgood1.ogg','sound/items/pickgood2.ogg'), 5, TRUE, 2, ignore_walls = FALSE)
 				to_chat(user, "<span class='warning'>Click...</span>")
 				if(L.mind)
 					add_sleep_experience(L, /datum/skill/misc/lockpicking, L.STAINT/2)
@@ -375,7 +375,7 @@
 				else
 					continue
 			else
-				playsound(loc, 'sound/items/pickbad.ogg', 40, TRUE)
+				playsound(loc, 'sound/items/pickbad.ogg', 40, TRUE, 2, ignore_walls = FALSE)
 				I.take_damage(1, BRUTE, "blunt")
 				to_chat(user, "<span class='warning'>Clack.</span>")
 				add_sleep_experience(L, /datum/skill/misc/lockpicking, L.STAINT/4)


### PR DESCRIPTION
## About The Pull Request

lockpicks no longer escape z-level they're on

## Testing Evidence

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/18b4fd02-7d1e-4dd7-bc54-885d1603e99a" />


## Why It's Good For The Game

fixes old ass bug that was pending for a year straight

## Changelog

:cl:
fix: Lockpicks no longer escape z-level they're on
/:cl:
