### PR TITLE
fixes rookie clothing on rockhill

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/rookie.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/rookie.dm
@@ -82,6 +82,8 @@
 	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
 	backr = /obj/item/storage/backpack/rogue/satchel
+	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
+	head = /obj/item/clothing/head/roguetown/helmet/kettle/
 	if(SSmapping.config.map_name == "Rockhill")
 		cloak = /obj/item/clothing/cloak/citywatch
 		head = /obj/item/clothing/head/roguetown/helmet/kettle/citywatch
@@ -90,9 +92,6 @@
 		head = /obj/item/clothing/head/roguetown/helmet/janissaryhelm
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/zyb
-	else
-		cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
-		head = /obj/item/clothing/head/roguetown/helmet/kettle/
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger,
 		/obj/item/storage/belt/rogue/pouch,

--- a/code/modules/jobs/job_types/roguetown/garrison/rookie.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/rookie.dm
@@ -154,6 +154,8 @@
 	backr = /obj/item/storage/backpack/rogue/satchel
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
 	beltl = /obj/item/rogueweapon/mace/cudgel
+	cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
+	head = /obj/item/clothing/head/roguetown/helmet/kettle
 	if(SSmapping.config.map_name == "Rockhill")
 		cloak = /obj/item/clothing/cloak/citywatch
 		head = /obj/item/clothing/head/roguetown/helmet/kettle/citywatch
@@ -162,9 +164,6 @@
 		head = /obj/item/clothing/head/roguetown/helmet/janissaryhelm
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/zyb
-	else
-		cloak = /obj/item/clothing/cloak/stabard/surcoat/guard
-		head = /obj/item/clothing/head/roguetown/helmet/kettle/
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger,
 		/obj/item/storage/belt/rogue/pouch,

--- a/code/modules/jobs/job_types/roguetown/peasants/cook.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/cook.dm
@@ -68,6 +68,10 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt/random
 	else if(should_wear_femme_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
+	if(SSmapping.config.map_name == "Desert Town")
+		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/thawb/random
+		pants = /obj/item/clothing/under/roguetown/sirwal/plainrandom
+		shoes = /obj/item/clothing/shoes/roguetown/sandals
 	backpack_contents = list(
 		/obj/item/recipe_book/survival,
 	)

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -89,3 +89,8 @@
 		pants = /obj/item/clothing/under/roguetown/tights/random
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest
 		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/random
+	if(SSmapping.config.map_name == "Desert Town")
+		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/thawb/random
+		pants = /obj/item/clothing/under/roguetown/sirwal/plainrandom
+		shoes = /obj/item/clothing/shoes/roguetown/sandals
+		head = /obj/item/clothing/head/roguetown/roguehood/shalal/nomad

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -91,6 +91,9 @@
 	beltl = /obj/item/storage/keyring/archivist
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	mask = /obj/item/clothing/mask/rogue/spectacles
+	if(SSmapping.config.map_name == "Desert Town")
+		head = /obj/item/clothing/head/roguetown/tagelmust
+		shoes = /obj/item/clothing/shoes/roguetown/sandals
 	id = /obj/item/scomstone/bad
 	backpack_contents = list(
 		/obj/item/recipe_book/alchemy,

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -93,7 +93,7 @@
 	mask = /obj/item/clothing/mask/rogue/spectacles
 	if(SSmapping.config.map_name == "Desert Town")
 		head = /obj/item/clothing/head/roguetown/tagelmust
-		shoes = /obj/item/clothing/shoes/roguetown/sandals
+		shoes = /obj/item/clothing/shoes/roguetown/gladiator
 	id = /obj/item/scomstone/bad
 	backpack_contents = list(
 		/obj/item/recipe_book/alchemy,

--- a/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
@@ -76,6 +76,10 @@
 	else if(should_wear_masc_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/shortshirt
 		armor = /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor
+	if(SSmapping.config.map_name == "Desert Town")
+		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/thawb/random
+		pants = /obj/item/clothing/under/roguetown/sirwal/plainrandom
+		shoes = /obj/item/clothing/shoes/roguetown/gladiator
 	backpack_contents = list(
 		/obj/item/recipe_book/survival,
 		/obj/item/bottle_kit

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
@@ -96,6 +96,10 @@
 		beltl = /obj/item/storage/belt/rogue/pouch/coins/poor
 		beltr = /obj/item/roguekey/crafterguild
 		cloak = /obj/item/clothing/cloak/apron/blacksmith
+	if(SSmapping.config.map_name == "Desert Town")
+		pants = /obj/item/clothing/under/roguetown/sirwal/plainrandom
+		head = /obj/item/clothing/head/roguetown/turban/random
+		shoes = /obj/item/clothing/shoes/roguetown/sandals
 
 /datum/advclass/guildsman/artificer
 	name = "Artificer"
@@ -158,6 +162,8 @@
 						/obj/item/clothing/mask/rogue/spectacles/golden = 1, //putting them in the bag because bad eye sight virtue strips these
 						/obj/item/contraption/linker = 1,
 						)
+	if(SSmapping.config.map_name == "Desert Town")
+		shoes = /obj/item/clothing/shoes/roguetown/sandals
 	// Not a real mage, no free spell point. Take Arcyne Potential if you want it.
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
@@ -227,5 +233,9 @@
 						/obj/item/roguekey/crafterguild = 1,
 						/obj/item/rogueweapon/blowrod = 1
 						)
+	if(SSmapping.config.map_name == "Desert Town")
+		pants = /obj/item/clothing/under/roguetown/sirwal/plainrandom
+		head = /obj/item/clothing/head/roguetown/turban/random
+		shoes = /obj/item/clothing/shoes/roguetown/sandals
 	ADD_TRAIT(H, TRAIT_MASTER_CARPENTER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_MASTER_MASON, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/tailor.dm
@@ -68,6 +68,11 @@
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/silkdress
 	else if(should_wear_masc_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/shirt/tunic/random
+	if(SSmapping.config.map_name == "Desert Town")
+		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/thawb/gold
+		armor = /obj/item/clothing/suit/roguetown/shirt/robe/bisht/purple
+		head = /obj/item/clothing/head/roguetown/turban/fancypurple
+		shoes = /obj/item/clothing/shoes/roguetown/gladiator
 	if(H.mind)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fittedclothing)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/takeapprentice)


### PR DESCRIPTION
## About The Pull Request

Due to a code mistake made when I added janissary cloaks to desert town, rookies on rockhill were spawning with the wrong equipment. This fixes that.

It also adds some more desert-specific equipment to some roles I missed, like the soilson, cook and archivist

## Testing Evidence

<img width="1325" height="315" alt="image" src="https://github.com/user-attachments/assets/008a519a-9a05-483b-bf08-a9f9b9425e7d" />

## Why It's Good For The Game

Bugfix

## Changelog
🆑
fix: rookies now spawn with the correct equipment based on map
/:cl:
