### PR TITLE
Cursed Collar QoL

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -377,7 +377,7 @@
 
 /obj/item/clothing/neck/roguetown/gorget/cursed_collar // minor flavor swap so people know it's a scam shitty knockoff.
 	name = "lesser cursed collar"
-	desc = "A metal collar that seems to radiate an ominous aura. A pale imitation of it's artificed counterpart."
+	desc = "A metal collar that seems to radiate an ominous aura. A pale imitation of it's artificed counterpart. \nLooks like you'd need someone else's help to take it off."
 	icon_state = "cursed_collar"
 	item_state = "cursed_collar"
 	armor = ARMOR_CLOTHING
@@ -393,7 +393,6 @@
 
 /obj/item/clothing/neck/roguetown/gorget/cursed_collar/Initialize(mapload)
 	. = ..()
-	name = "cursed collar"
 	ADD_TRAIT(src, TRAIT_NO_SELF_UNEQUIP, CURSED_ITEM_TRAIT)
 /*
 /obj/item/clothing/neck/roguetown/gorget/cursed_collar/dropped(mob/living/carbon/human/user)

--- a/modular/code/modules/slave_collar/cursed_collar.dm
+++ b/modular/code/modules/slave_collar/cursed_collar.dm
@@ -1,7 +1,7 @@
 /obj/item/clothing/neck/roguetown/cursed_collar
 	name = "cursed collar"
 	always_show_examine_link = TRUE
-	desc = "A sinister looking collar with ruby studs. It seems to radiate a dark energy."
+	desc = "A sinister looking collar with ruby studs. It seems to radiate a dark energy. \nLooks like you'd need someone else's help to take it off."
 	// Credit regarding sprites to Necbro
 	// https://github.com/StoneHedgeSS13/StoneHedge/commit/9ddc09d4cb91903beff6d523c91aef75312d5163
 	icon = 'modular_stonehedge/icons/clothing/armor/neck.dmi'


### PR DESCRIPTION
## About The Pull Request

- Makes Lesser Cursed Collar actually called that in-game. (There was a name override in the cursed item initialization)
- Adds descriptive hint to both versions of the cursed collar to let you know that you'll need someone else to remove it.

## Testing Evidence

<img width="1437" height="860" alt="image" src="https://github.com/user-attachments/assets/7a89cc8d-fc31-4cda-9ce6-2f40c44454fd" />

## Why It's Good For The Game

Shows the difference between the two more in the name, and informs players so that they know they'll need help. (So we don't keep getting 100 mhelps about it on desert town, only 50)

## Changelog

:cl:
fix: Lesser Cursed Collar is now named properly.
qol: Cursed Collars' descriptions now tell you that you'll need someone else to remove them.
/:cl: