### PR TITLE
HOTFIX - Instruments Not Playing Music

### DIFF
--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -87,6 +87,16 @@ SUBSYSTEM_DEF(soundloopers)
 			continue
 
 		if(mob && loop_parent == mob) //the sound's coming from inside the house!
+			// Skip distance-based attenuation for your own instrument, but still
+			// clear MUTESTATUS if it got stuck TRUE (e.g. playsound() missed the
+			// musician during a z-level transition and muted them in play()).
+			var/list/self_loop = played_loops[loop]
+			if(self_loop && self_loop["MUTESTATUS"])
+				self_loop["MUTESTATUS"] = FALSE
+				self_loop["VOL"] = loop.volume
+				var/sound/self_sound = self_loop["SOUND"]
+				if(self_sound)
+					mob.unmute_sound(self_sound)
 			continue
 
 		var/max_distance = world.view + loop.extra_range
@@ -147,6 +157,14 @@ SUBSYSTEM_DEF(soundloopers)
 
 			new_volume = new_volume * (prefs.mastervol * 0.01) //Modify it at the end by the player's volume setting
 
+			// Always clear MUTESTATUS when in range, regardless of whether volume changed.
+			// Previously this was inside if(old_volume != new_volume), meaning a sound that
+			// was muted and came back in range at an equal volume would stay permanently muted
+			// (e.g. after a z-level transition where volume calculations produce the same value).
+			if(loop.persistent_loop && found_loop["MUTESTATUS"] == TRUE)
+				found_loop["MUTESTATUS"] = FALSE
+				mob.unmute_sound(found_sound)
+
 			if(old_volume != new_volume)
 				var/turf/T = get_turf(mob)
 				var/dx = source_turf.x - T.x
@@ -162,9 +180,6 @@ SUBSYSTEM_DEF(soundloopers)
 //				var/dy = source_turf.z - T.z
 //				found_sound.y = dy
 
-				if(loop.persistent_loop && found_loop["MUTESTATUS"] == TRUE) //It was out of range and now back in range, reset it
-					found_loop["MUTESTATUS"] = FALSE
-					mob.unmute_sound(found_sound)
 				found_loop["VOL"] = new_volume
 				mob.update_sound_volume(played_loops[loop]["SOUND"], new_volume)
 

--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -80,15 +80,6 @@ SUBSYSTEM_DEF(soundloopers)
 		
 		var/atom/loop_parent = loop.parent?.resolve()
 		if(!loop_parent)
-			// Parent is gone — clean up the stale entry. Without this,
-			// the stored sound object's channel may be reused by another
-			// datum and volume-update packets from this client would
-			// corrupt the new owner's audio.
-			var/list/stale = played_loops[loop]
-			var/sound/stale_sound = stale?["SOUND"]
-			if(stale_sound)
-				mob.stop_sound_channel(stale_sound.channel)
-			played_loops -= loop
 			continue
 
 		if(mob && loop_parent == mob) //the sound's coming from inside the house!

--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -60,7 +60,7 @@ SUBSYSTEM_DEF(soundloopers)
 		if(get_dist(get_turf(mob),parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
 			continue
 
-		if(mob_turf.z - parent_turf.z > 2 || mob_turf.z - parent_turf.z < 2) //for some reason get_dist not checking this properly
+		if(mob_turf.z - parent_turf.z > 2 || mob_turf.z - parent_turf.z < -2) //for some reason get_dist not checking this properly
 			continue
 
 		//otherwise add it to the client loops and off we go from there
@@ -80,6 +80,10 @@ SUBSYSTEM_DEF(soundloopers)
 		
 		var/atom/loop_parent = loop.parent?.resolve()
 		if(!loop_parent)
+			// Parent is gone — stale entry. Remove it so its old channel number
+			// can't corrupt volume-update packets sent to a recycled channel.
+			// Do NOT stop the channel: it may have been reused by another datum.
+			played_loops -= loop
 			continue
 
 		if(mob && loop_parent == mob) //the sound's coming from inside the house!

--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -80,6 +80,15 @@ SUBSYSTEM_DEF(soundloopers)
 		
 		var/atom/loop_parent = loop.parent?.resolve()
 		if(!loop_parent)
+			// Parent is gone — clean up the stale entry. Without this,
+			// the stored sound object's channel may be reused by another
+			// datum and volume-update packets from this client would
+			// corrupt the new owner's audio.
+			var/list/stale = played_loops[loop]
+			var/sound/stale_sound = stale?["SOUND"]
+			if(stale_sound)
+				mob.stop_sound_channel(stale_sound.channel)
+			played_loops -= loop
 			continue
 
 		if(mob && loop_parent == mob) //the sound's coming from inside the house!

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -228,6 +228,12 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	if(!L)
 		return
 
+	if(!L["MUTESTATUS"])
+		// Already playing — do not re-send. The sound/S object passed through
+		// playsound() is shared and its x/z reflect the last processed listener's
+		// position. Re-sending here would repan the sound to the wrong tile.
+		return
+
 	L["MUTESTATUS"] = FALSE
 	L["VOL"] = volume
 

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -3,12 +3,29 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	var/list/reserved_channels = list()
 	var/channel_count = 1
 	var/last_iter = 1
+	/// If non-null, channels are managed as a checkout/return pool rather than
+	/// round-robined. Populated by subtypes that need exclusive per-user channels.
+	var/list/pool_channels
 
 /datum/sound_group/New()
 	. = ..()
 	reserved_channels = list()
 	for(var/channel = 1 to channel_count)
 		reserved_channels += SSsounds.reserve_sound_channel(src)
+
+/// Checks out one channel from the pool. Returns null if the pool is empty.
+/datum/sound_group/proc/checkout_channel()
+	if(!pool_channels?.len)
+		return null
+	var/ch = pool_channels[pool_channels.len]
+	pool_channels.len--
+	return ch
+
+/// Returns a channel to the pool. Silently ignores if already present.
+/datum/sound_group/proc/return_channel(channel)
+	if(!pool_channels || (channel in pool_channels))
+		return
+	pool_channels += channel
 
 /datum/sound_group/torches
 	channel_count = 150
@@ -17,7 +34,13 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	channel_count = 150
 
 /datum/sound_group/instruments
-	channel_count = 32 //probably more than enough
+	channel_count = 32
+
+/datum/sound_group/instruments/New()
+	. = ..()
+	// Instruments use pool semantics so idle instruments hold no channel;
+	// channels are only checked out while a song is actively playing.
+	pool_channels = reserved_channels.Copy()
 
 /*
 	parent	(the source of the sound)			The source the sound comes from

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -146,6 +146,7 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 
 /// Returns the singleton instruments sound group, cached after first lookup.
 /datum/looping_sound/instrument/proc/_get_sound_group()
+	RETURN_TYPE(/datum/sound_group/instruments)
 	var/static/datum/sound_group/instruments/cached
 	if(!cached)
 		for(var/datum/sound_group/g in GLOB.created_sound_groups)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -155,6 +155,16 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 				break
 	return cached
 
+// attach_loop_to_all_clients() sends a vol=0 sound to every client before the
+// song has actually started, pre-populating their played_loops with a stale entry.
+// When the real play() fires, playsound_local finds them already in thingshearing
+// and only issues a volume update on the finished silent sound instead of
+// sending it fresh — so clients never hear it. Skip this entirely for instruments;
+// the initial playsound() in play() covers in-range clients, and the update_sounds()
+// rescan in SSsoundloopers covers late-joiners via GLOB.persistent_sound_loops.
+/datum/looping_sound/instrument/attach_loop_to_all_clients()
+	return
+
 /datum/looping_sound/instrument/New(_parent, start_immediately=FALSE, _direct=FALSE, _channel = 0)
 	. = ..(_parent, FALSE, _direct, _channel)
 	// Parent assigned a channel via round-robin; return it to the pool since

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -4,7 +4,9 @@
 	extra_range = 10	// Increase sound range.
 	persistent_loop = TRUE
 	var/stress2give = /datum/stressevent/music
-	sound_group = null
+	sound_group = /datum/sound_group/instruments
+	/// Channel held in reserve while not playing, so it doesn't block looping_sound internals.
+	var/parked_channel
 
 GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 
@@ -146,9 +148,11 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 
 /datum/looping_sound/instrument/New(_parent, start_immediately=FALSE, _direct=FALSE, _channel = 0)
 	. = ..(_parent, FALSE, _direct, _channel)
-	// Instruments can be widespread on the map. Reserve channels only while actively playing.
+	// The sound group assigns a channel in the parent New(). Park it so the
+	// instrument doesn't hold an active channel while idle, but we keep the
+	// group-allocated channel so start() never needs reserve_sound_channel.
 	if(channel)
-		SSsounds.free_datum_channels(src)
+		parked_channel = channel
 		channel = null
 	if(start_immediately)
 		start()
@@ -157,11 +161,13 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 	if(sync_anchor)
 		starttime = sync_anchor
 	if(!channel)
-		channel = SSsounds.reserve_sound_channel(src)
-		if(!channel)
+		if(!parked_channel)
+			// Fallback: group pool exhausted (>all simultaneous instruments).
 			var/atom/resolved_parent = parent?.resolve()
-			log_game("INSTRUMENT: Failed to reserve sound channel for [resolved_parent] - channels may be exhausted (reserve_high=[SSsounds.channel_reserve_high], random_min=[SSsounds.random_channels_min])")
+			log_game("INSTRUMENT: No parked channel available for [resolved_parent] - all instrument group channels in use simultaneously.")
 			return FALSE
+		channel = parked_channel
+		parked_channel = null
 	..()
 	return TRUE
 
@@ -185,7 +191,9 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 				SEND_SOUND(C, sound(null, repeat = 0, wait = 0, channel = stop_channel))
 			C.played_loops -= src
 		thingshearing = list()  // Clear AFTER parent and client loop are done.
-		SSsounds.free_datum_channels(src)
+		// Return the channel to the parked state — don't free it via SSsounds
+		// since it belongs to the sound group, not the datum's own reservation.
+		parked_channel = channel
 		channel = null
 	else
 		. = ..(null_parent)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -5,8 +5,6 @@
 	persistent_loop = TRUE
 	var/stress2give = /datum/stressevent/music
 	sound_group = /datum/sound_group/instruments
-	/// Channel held in reserve while not playing, so it doesn't block looping_sound internals.
-	var/parked_channel
 
 GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 
@@ -146,28 +144,43 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 			if(instrument.not_held)
 				holder.remove_status_effect(/datum/status_effect/buff/harpy_sing)
 
+/// Returns the singleton instruments sound group, cached after first lookup.
+/datum/looping_sound/instrument/proc/_get_sound_group()
+	var/static/datum/sound_group/instruments/cached
+	if(!cached)
+		for(var/datum/sound_group/g in GLOB.created_sound_groups)
+			if(istype(g, /datum/sound_group/instruments))
+				cached = g
+				break
+	return cached
+
 /datum/looping_sound/instrument/New(_parent, start_immediately=FALSE, _direct=FALSE, _channel = 0)
 	. = ..(_parent, FALSE, _direct, _channel)
-	// The sound group assigns a channel in the parent New(). Park it so the
-	// instrument doesn't hold an active channel while idle, but we keep the
-	// group-allocated channel so start() never needs reserve_sound_channel.
+	// Parent assigned a channel via round-robin; return it to the pool since
+	// channels are only held while actively playing, not while idle.
 	if(channel)
-		parked_channel = channel
+		_get_sound_group()?.return_channel(channel)
 		channel = null
 	if(start_immediately)
 		start()
+
+/datum/looping_sound/instrument/Destroy()
+	// If destroyed while actively playing, return the channel to the instruments
+	// pool rather than letting the base Destroy() leak it to SSsounds' general pool.
+	if(channel)
+		_get_sound_group()?.return_channel(channel)
+		channel = null
+	return ..()
 
 /datum/looping_sound/instrument/start(atom/on_behalf_of, sync_anchor)
 	if(sync_anchor)
 		starttime = sync_anchor
 	if(!channel)
-		if(!parked_channel)
-			// Fallback: group pool exhausted (>all simultaneous instruments).
+		channel = _get_sound_group()?.checkout_channel()
+		if(!channel)
 			var/atom/resolved_parent = parent?.resolve()
-			log_game("INSTRUMENT: No parked channel available for [resolved_parent] - all instrument group channels in use simultaneously.")
+			log_game("INSTRUMENT: All [/datum/sound_group/instruments::channel_count] instrument channels in use simultaneously - [resolved_parent]")
 			return FALSE
-		channel = parked_channel
-		parked_channel = null
 	..()
 	return TRUE
 
@@ -191,9 +204,8 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 				SEND_SOUND(C, sound(null, repeat = 0, wait = 0, channel = stop_channel))
 			C.played_loops -= src
 		thingshearing = list()  // Clear AFTER parent and client loop are done.
-		// Return the channel to the parked state — don't free it via SSsounds
-		// since it belongs to the sound group, not the datum's own reservation.
-		parked_channel = channel
+		// Return the channel to the group pool so other instruments can use it.
+		_get_sound_group()?.return_channel(channel)
 		channel = null
 	else
 		. = ..(null_parent)


### PR DESCRIPTION
## [TM FIRST!]

## About The Pull Request
Potentially once more fixes music not being able to be played from: https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1140

The problem was that on a busy server like here, the sound slots were still being used up. All audio including ambient ones were taking up the channels and making it so music couldn't grab any. Oopsie.

It's changed so that instruments now use a dedicated reserved pool of hypothetical 32 slots (the actual number is pulled out of my ass somewhere based under assumption) that gets claimed at server startup before anything else can take them. That way, no other sound effects steal them before players can make use of them. When an instrument isn't being played it sends its channel back to the dedicated pool of channels. When a player starts playing, it grabs one again. When they stop, it goes back. The 32 number can be adjusted higher or lower depending on need, but 32 was the original I believe. The game itself uses around 900ish sound channels for everything I think. And those get populated very quickly.

TL:DR - It kinda works like a hotel dedicated to songs. Music checks in a room, then checks out when the instrument no longer plays.

## Testing Evidence
It ran. Hard to test locally without 100+ players consuming audio resources.
<img width="686" height="731" alt="musictest" src="https://github.com/user-attachments/assets/cfe8255b-e889-4fe8-b3f8-82d30cc5ca08" />

## Why It's Good For The Game
I want my music back, but I also want it to work gooderer.

## Changelog
:cl:
fix: Potentially fixes music again.
/:cl: