### PR TITLE
Re-Adds Amazonian Adventurers

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -569,7 +569,7 @@
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			H.set_blindness(0)
 			H.change_stat("speed", 3)
-			H.change_stat("endurance", 1)
+			H.change_stat("willpower", 1)
 			H.change_stat("strength", 1)
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/bikini
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/shorts
@@ -622,7 +622,7 @@
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			H.set_blindness(0)
 			H.change_stat("speed", 3)
-			H.change_stat("endurance", 1)
+			H.change_stat("willpower", 1)
 			H.change_stat("strength", 1)
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/bikini
 			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/shorts
@@ -674,7 +674,7 @@
 			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
 			H.set_blindness(0)
 			H.change_stat("speed", 2)
-			H.change_stat("endurance", 1)
+			H.change_stat("willpower", 1)
 			H.change_stat("strength", 2)
 			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/bikini
 			pants = /obj/item/clothing/under/roguetown/tights/black
@@ -723,7 +723,7 @@
 			ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
 			H.set_blindness(0)
 			H.change_stat("strength", 2)
-			H.change_stat("endurance", 2)
+			H.change_stat("willpower", 2)
 			H.change_stat("constitution", 1)
 			armor = /obj/item/clothing/suit/roguetown/armor/plate/bikini
 			pants = /obj/item/clothing/under/roguetown/trou/leather

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -798,3 +798,4 @@
 					r_hand = /obj/item/rogueweapon/shield/tower
 					l_hand = /obj/item/rogueweapon/shield/tower
 					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+					

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -537,3 +537,264 @@
 		H.adjust_skillrank(/datum/skill/combat/polearms, 1, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/staves, 1, TRUE)
 	//Old people get the option to become glass cannons. Expert Knives + Expert in their chosen weapon, but a permenant -I STR, -I PER, -2 SPD and -2 CON debuff.
+/datum/advclass/sfighter/amazon
+	name = "Amazon"
+	tutorial = "Fierce warrior women from distant lands, Amazons choose their armor based on their preferred fighting style - from light and agile to heavily protected."
+	outfit = /datum/outfit/job/adventurer/amazon
+	traits_applied = list(TRAIT_STEELHEARTED)
+	subclass_stats = list()
+	subclass_social_rank = SOCIAL_RANK_DIRT
+
+/datum/outfit/job/adventurer/amazon/pre_equip(mob/living/carbon/human/H, visualsOnly)
+
+	var/armor_styles = list("Leather Kini","Hide Armor Kini","Studded Leather Kini","Half Plate Kini","Plate Kini")
+	var/armor_choice = input(H, "Choose your armor style", "Available armor styles") as anything in armor_styles
+
+	switch(armor_choice)
+
+		if("Leather Kini")
+			to_chat(H, span_warning("You are a swift and agile warrior who relies on speed and evasion. Your light leather armor allows for maximum mobility."))
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/sewing, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			H.set_blindness(0)
+			H.change_stat("speed", 3)
+			H.change_stat("endurance", 1)
+			H.change_stat("strength", 1)
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/bikini
+			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/shorts
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			shoes = /obj/item/clothing/shoes/roguetown/boots/furlinedboots
+			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+			backl = /obj/item/storage/backpack/rogue/satchel
+			belt = /obj/item/storage/belt/rogue/leather
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1)
+			var/weapons = list("Steel Knuckles","Axe","Sword","Whip","Spear","MY BARE HANDS!!!")
+			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if ("Steel Knuckles")
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/knuckles
+				if("Axe")
+					H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/stoneaxe/boneaxe
+				if("Sword")
+					H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/sword/short
+					beltr = /obj/item/rogueweapon/scabbard/sword
+				if("Whip")
+					H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/whip
+				if("Spear")
+					H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/spear/bonespear
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+				if ("MY BARE HANDS!!!")
+					H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+
+		if("Hide Armor Kini")
+			to_chat(H, span_warning("You are a swift and agile warrior who relies on speed and evasion. Your light leather armor allows for maximum mobility."))
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/sewing, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/craft/tanning, 2, TRUE)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			H.set_blindness(0)
+			H.change_stat("speed", 3)
+			H.change_stat("endurance", 1)
+			H.change_stat("strength", 1)
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/hide/bikini
+			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/shorts
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			shoes = /obj/item/clothing/shoes/roguetown/boots/furlinedboots
+			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+			backl = /obj/item/storage/backpack/rogue/satchel
+			belt = /obj/item/storage/belt/rogue/leather
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1)
+			var/weapons = list("Steel Knuckles","Axe","Sword","Whip","Spear","MY BARE HANDS!!!")
+			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if ("Steel Knuckles")
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/knuckles
+				if("Axe")
+					H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/stoneaxe/boneaxe
+				if("Sword")
+					H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/sword/short
+					beltr = /obj/item/rogueweapon/scabbard/sword
+				if("Whip")
+					H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/whip
+				if("Spear")
+					H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/spear/bonespear
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+				if ("MY BARE HANDS!!!")
+					H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+
+
+		if("Studded Leather Kini")
+			to_chat(H, span_warning("You are a refined warrior who combines light protection with precision striking weapons."))
+			H.adjust_skillrank(/datum/skill/combat/knives, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/whipsflails, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 2, TRUE)
+			ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC)
+			H.set_blindness(0)
+			H.change_stat("speed", 2)
+			H.change_stat("endurance", 1)
+			H.change_stat("strength", 2)
+			armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/bikini
+			pants = /obj/item/clothing/under/roguetown/tights/black
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+			backl = /obj/item/storage/backpack/rogue/satchel
+			belt = /obj/item/storage/belt/rogue/leather
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife/idagger/steel = 1)
+			var/weapons = list("Katar","Rapier","Whip","Billhook","MY BARE HANDS!!!")
+			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if ("Katar")
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/katar
+				if("Rapier")
+					H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/sword/rapier
+				if("Whip")
+					H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/whip
+				if("Billhook")
+					H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/spear/billhook
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+				if ("MY BARE HANDS!!!")
+					H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+
+		if("Half Plate Kini")
+			to_chat(H, span_warning("You are a balanced warrior who wears medium armor and wields powerful weapons for devastating strikes."))
+			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/maces, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)			
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_NOPAIN, TRAIT_GENERIC)
+			H.set_blindness(0)
+			H.change_stat("strength", 2)
+			H.change_stat("endurance", 2)
+			H.change_stat("constitution", 1)
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/bikini
+			pants = /obj/item/clothing/under/roguetown/trou/leather
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			gloves = /obj/item/clothing/gloves/roguetown/angle
+			backl = /obj/item/storage/backpack/rogue/satchel
+			belt = /obj/item/storage/belt/rogue/leather
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			var/weapons = list("Great Sword","Eagle's Beak","Battle Axe","MY BARE HANDS!!!")
+			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if("Great Sword")
+					H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/greatsword
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+				if("Eagle's Beak")
+					H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/eaglebeak
+					backr = /obj/item/rogueweapon/scabbard/gwstrap
+				if("Battle Axe")
+					H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					beltr = /obj/item/rogueweapon/stoneaxe/battle
+				if ("MY BARE HANDS!!!")
+					H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
+			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+
+		if("Plate Kini")
+			to_chat(H, span_warning("You are a heavily armored juggernaut who can withstand tremendous punishment behind your shield."))
+			H.adjust_skillrank(/datum/skill/combat/polearms, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/axes, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/swords, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)	//Funny nerf because I can in fact stop you. No double shield meta for you.		
+			H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/athletics, 2, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
+			H.adjust_skillrank(/datum/skill/misc/reading, 1, TRUE)
+			ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
+			H.set_blindness(0)
+			H.change_stat("strength", 3)
+			H.change_stat("constitution", 3)
+			H.change_stat("speed", -1)
+			armor = /obj/item/clothing/suit/roguetown/armor/plate/full/bikini
+			pants = /obj/item/clothing/under/roguetown/trou/leather
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+			shoes = /obj/item/clothing/shoes/roguetown/boots
+			gloves = /obj/item/clothing/gloves/roguetown/angle
+			backl = /obj/item/storage/backpack/rogue/satchel
+			belt = /obj/item/storage/belt/rogue/leather
+			neck = /obj/item/storage/belt/rogue/pouch/coins/poor
+			backpack_contents = list(/obj/item/flashlight/flare/torch = 1, /obj/item/rogueweapon/huntingknife = 1, /obj/item/recipe_book/survival = 1)
+			var/weapons = list("Sword and Tower Shield","Mace and Tower Shield","TWO TOWER SHIELDS!!!")
+			var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+			switch(weapon_choice)
+				if("Sword and Tower Shield")
+					H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+					r_hand = /obj/item/rogueweapon/sword/short
+					backr = /obj/item/rogueweapon/shield/tower
+					beltr = /obj/item/rogueweapon/scabbard/sword
+				if("Mace and Tower Shield")
+					H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
+					beltr = /obj/item/rogueweapon/mace
+					backr = /obj/item/rogueweapon/shield/tower
+				if ("TWO TOWER SHIELDS!!!")
+					H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, SKILL_LEVEL_EXPERT, TRUE)
+					H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_EXPERT, TRUE)
+					r_hand = /obj/item/rogueweapon/shield/tower
+					l_hand = /obj/item/rogueweapon/shield/tower
+					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)


### PR DESCRIPTION
## About The Pull Request

Apparently, during a parity update, we lost the Amazon class from the Warrior adventurers. This PR re-ports them from Scarlet Reach's github.

With two small alterations: the "secret buff" to the two shield option has been removed. You now only get Journeyman Shields instead of Expert. Mainly because while I didn't touch most other comments, I didn't want to publish a PR with a comment that said "secret funny buff because no one can stop me." 

And the weapons that require great weapon straps now spawn with a great weapon strap. Because Scarlet Reach didn't need them, but we do.

## Testing Evidence

It compiles. It loads. It can be chosen. You spawn with stuff.
<img width="392" height="441" alt="90eb1c598d204bee52dc36d5774513c7" src="https://github.com/user-attachments/assets/683b825d-4806-48aa-870b-8d1ee9755c59" />
<img width="292" height="217" alt="7f6d8f319c7aa76d72236e36018f0a3e" src="https://github.com/user-attachments/assets/66cb6e97-3a2e-4292-8da9-6eb97ca6b657" />


## Why It's Good For The Game

Re-adds a class lost from a parity update. Bikini Armor my beloved.

## Changelog

:cl:Skye
add: Amazonian Warriors that were deterred due to changing weather paterns have re-found their way to the Vale. Bikini lovers rejoice!
/:cl: