### PR TITLE
[AP Port] Kill Contract Proximity Spawners

### DIFF
--- a/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
@@ -1,0 +1,55 @@
+/obj/effect/quest_spawn
+	name = "quest spawner"
+	icon = 'icons/effects/landmarks_static.dmi'
+	icon_state = "x"
+	anchored = TRUE
+	layer = MID_LANDMARK_LAYER
+	invisibility = INVISIBILITY_OBSERVER
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+	var/atom/movable/contained_atom
+	var/datum/proximity_monitor/proximity_monitor
+
+/obj/effect/quest_spawn/Initialize(mapload)
+	. = ..()
+	proximity_monitor = new(src, 7)
+
+/obj/effect/quest_spawn/Destroy(force)
+	. = ..()
+	QDEL_NULL(contained_atom)
+	proximity_monitor = null
+
+/obj/effect/quest_spawn/HasProximity(mob/nearby)
+	if(!contained_atom)
+		return
+
+	if(!istype(nearby))
+		return
+
+	var/datum/component/quest_object/quest_component = GetComponent(/datum/component/quest_object)
+	if(!istype(quest_component))
+		return
+
+	var/datum/quest/quest = quest_component.quest_ref?.resolve()
+	if(!istype(quest))
+		return
+
+	if(get_dist(get_turf(src), get_turf(quest.quest_scroll_ref?.resolve())) > 7)
+		return
+
+	var/image/I = image(icon = 'icons/effects/effects.dmi', loc = get_turf(src), icon_state = "mobwarning", layer = 18)
+	I.layer = 18
+	I.plane = 18
+	I.alpha = 125
+	I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	flick_overlay_view(I, 5 SECONDS)
+
+	contained_atom.forceMove(get_turf(src))
+	contained_atom = null
+
+	playsound(loc, "plantcross", 100, FALSE, 3)
+
+	qdel(src)
+
+/obj/effect/quest_spawn/ex_act()
+	return

--- a/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
@@ -17,16 +17,16 @@
 /obj/effect/quest_spawn/Destroy(force)
 	. = ..()
 	QDEL_NULL(contained_atom)
-	proximity_monitor = null
+	QDEL_NULL(proximity_monitor)
 
 /obj/effect/quest_spawn/HasProximity(mob/nearby)
 	if(!contained_atom)
 		return
 
-	if(!istype(nearby))
+	if(!istype(nearby, /mob/living) || !nearby.ckey)
 		return
 
-	var/datum/component/quest_object/quest_component = GetComponent(/datum/component/quest_object)
+	var/datum/component/quest_object/quest_component = contained_atom.GetComponent(/datum/component/quest_object)
 	if(!istype(quest_component))
 		return
 
@@ -34,7 +34,8 @@
 	if(!istype(quest))
 		return
 
-	if(get_dist(get_turf(src), get_turf(quest.quest_scroll_ref?.resolve())) > 7)
+	var/atom/scroll = quest.quest_scroll_ref?.resolve()
+	if(!scroll || get_dist(get_turf(src), get_turf(scroll)) > 7)
 		return
 
 	var/image/I = image(icon = 'icons/effects/effects.dmi', loc = get_turf(src), icon_state = "mobwarning", layer = 18)

--- a/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/spawn_effect.dm
@@ -23,7 +23,7 @@
 	if(!contained_atom)
 		return
 
-	if(!istype(nearby, /mob/living) || !nearby.ckey)
+	if(!isliving(nearby) || !nearby.ckey)
 		return
 
 	var/datum/component/quest_object/quest_component = contained_atom.GetComponent(/datum/component/quest_object)

--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -203,8 +203,6 @@ GLOBAL_LIST_EMPTY(quest_components)
 	no_outline = TRUE
 
 /datum/component/quest_object/mob_spawner/on_quest_deleted(datum/source)
-	SIGNAL_HANDLER
-
 	if(QDELETED(parent))
 		return
 

--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -3,27 +3,30 @@ GLOBAL_LIST_EMPTY(quest_components)
 /datum/component/quest_object
 	var/datum/weakref/quest_ref
 	var/is_mob = FALSE
+	var/no_outline = FALSE
+	var/override_compatibility = FALSE
 	var/outline_filter_id = "quest_item_outline"
 
 /datum/component/quest_object/Initialize(datum/quest/target_quest)
-	if(!isitem(parent) && !ismob(parent))
+	if(!override_compatibility && !isitem(parent) && !ismob(parent))
 		return COMPONENT_INCOMPATIBLE
 	
 	quest_ref = WEAKREF(target_quest)
 	is_mob = ismob(parent)
 	
-	if(is_mob)
-		var/mob/M = parent
-		M.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#ff0000", "size" = 0.5))
-		RegisterSignal(parent, COMSIG_MOB_DEATH, PROC_REF(on_target_death))
-		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_mob_examine))
-	else
-		var/obj/item/I = parent
-		I.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#008cff", "size" = 0.5))
-		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
-		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_item_dropped))
-		RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_item_dropped))
-	
+	if(!no_outline)
+		if(is_mob)
+			var/mob/M = parent
+			M.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#ff0000", "size" = 0.5))
+			RegisterSignal(parent, COMSIG_MOB_DEATH, PROC_REF(on_target_death))
+			RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_mob_examine))
+		else
+			var/obj/item/I = parent
+			I.add_filter(outline_filter_id, 2, list("type" = "outline", "color" = "#008cff", "size" = 0.5))
+			RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
+			RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_item_dropped))
+			RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_item_dropped))
+
 	RegisterSignal(target_quest, COMSIG_PARENT_QDELETING, PROC_REF(on_quest_deleted))
 	GLOB.quest_components += src
 
@@ -193,3 +196,20 @@ GLOBAL_LIST_EMPTY(quest_components)
 		Q.progress_current++
 		Q.on_progress_update()
 		return
+
+/// Component for kill quest spawners
+/datum/component/quest_object/mob_spawner
+	override_compatibility = TRUE
+	no_outline = TRUE
+
+/datum/component/quest_object/mob_spawner/Initialize(datum/quest/target_quest)
+	. = ..()
+	if(. == COMPONENT_INCOMPATIBLE)
+		return
+
+/datum/component/quest_object/mob_spawner/on_quest_deleted(datum/source)
+	if(QDELETED(parent))
+		return
+
+	qdel(parent)
+	qdel(src)

--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -202,12 +202,9 @@ GLOBAL_LIST_EMPTY(quest_components)
 	override_compatibility = TRUE
 	no_outline = TRUE
 
-/datum/component/quest_object/mob_spawner/Initialize(datum/quest/target_quest)
-	. = ..()
-	if(. == COMPONENT_INCOMPATIBLE)
-		return
-
 /datum/component/quest_object/mob_spawner/on_quest_deleted(datum/source)
+	SIGNAL_HANDLER
+
 	if(QDELETED(parent))
 		return
 

--- a/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
@@ -17,7 +17,8 @@
 
 		var/obj/effect/quest_spawn/spawn_effect = new /obj/effect/quest_spawn(spawn_turf)
 		var/mob/living/new_mob = new target_mob_type(spawn_effect)
-		
+		spawn_effect.contained_atom = new_mob
+
 		new_mob.faction |= "quest"
 		new_mob.AddComponent(/datum/component/quest_object/kill, src)
 		add_tracked_atom(new_mob)

--- a/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
+++ b/code/modules/roguetown/roguemachine/questing/types/kill/__quest_kill_base.dm
@@ -15,7 +15,9 @@
 		if(!spawn_turf)
 			continue
 
-		var/mob/living/new_mob = new target_mob_type(spawn_turf)
+		var/obj/effect/quest_spawn/spawn_effect = new /obj/effect/quest_spawn(spawn_turf)
+		var/mob/living/new_mob = new target_mob_type(spawn_effect)
+		
 		new_mob.faction |= "quest"
 		new_mob.AddComponent(/datum/component/quest_object/kill, src)
 		add_tracked_atom(new_mob)

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2595,6 +2595,7 @@
 #include "code\modules\roguetown\roguemachine\questing\questing_landmarks.dm"
 #include "code\modules\roguetown\roguemachine\questing\items\parcel.dm"
 #include "code\modules\roguetown\roguemachine\questing\items\quest_scroll.dm"
+#include "code\modules\roguetown\roguemachine\questing\items\spawn_effect.dm"
 #include "code\modules\roguetown\roguemachine\questing\types\__quest.dm"
 #include "code\modules\roguetown\roguemachine\questing\types\__quest_list.dm"
 #include "code\modules\roguetown\roguemachine\questing\types\quest_courier.dm"


### PR DESCRIPTION
## About The Pull Request

Ports [Kill Contract Proximity Spawners](https://github.com/Azure-Peak/Azure-Peak/pull/4647)

**From original PR Description:**

"Kill contracts, such as Kill, Outlaw, Raid, and so forth, now use proximity monitors to spawn the mobs in. This means, upon taking a contract, the mob won't be on the playing field until the contract itself is brought close to it."

#1417 fixes the issue with the proximity handler.

## Testing Evidence

<img width="1094" height="914" alt="test1" src="https://github.com/user-attachments/assets/60a9e2cd-7326-4ab1-8a7a-55285b6b1eab" />
<img width="612" height="648" alt="test2" src="https://github.com/user-attachments/assets/7b53a0ce-9c61-49c9-9b5c-6ac24fbdb1fd" />



- Compiles without issue. 
- Quest spawner present as it should be. 
- Player Mob with the quest triggers quest mob as anticipated.
- Player Mob without the quest does not trigger quest mob as anticipated. 

## Why It's Good For The Game

No more easy mammons. This ensures that if you want your reward, you need to kill them yourselves, not wait for someone else to do it for you.

## Changelog

:cl:
add: Ports from AP: Kill contracts, such as Kill, Outlaw, Raid, and so forth, now use proximity monitors to spawn the mobs in. This means, upon taking a contract, the mob won't be on the playing field until the contract itself is brought close to it.
/:cl:
