### PR TITLE
I am the Knight Captain's SCOM now!

### DIFF
--- a/_maps/map_files/deserttown/deserttown.dmm
+++ b/_maps/map_files/deserttown/deserttown.dmm
@@ -21141,7 +21141,7 @@
 /area/rogue/indoors/town/shop/desert)
 "itp" = (
 /obj/structure/roguemachine/scomm/r{
-	scom_tag = "Manor - Kitchen Captain's Quarters"
+	scom_tag = "Manor - Knight Captain's Quarters"
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor/desert)


### PR DESCRIPTION
## About The Pull Request

Renames the SCOM from KC's office. From Kitchen Captain to Knight Captain.

## Testing Evidence

<img width="458" height="175" alt="image" src="https://github.com/user-attachments/assets/3ddac6ed-68b1-4436-96d2-a28ab004e16d" />

## Why It's Good For The Game

KITCHEN CAPTAIN????

## Changelog

:cl:
map: KC SCOM now labelled correctly DT + Rockhill [No more Kitchen Captain :( ]
/:cl:

