### PR TITLE
Parcel Quest Fix

### DIFF
--- a/code/datums/components/connect/connect_range.dm
+++ b/code/datums/components/connect/connect_range.dm
@@ -25,6 +25,7 @@
 	if(!isatom(tracked) || isarea(tracked) || range < 0)
 		return COMPONENT_INCOMPATIBLE
 	src.connections = connections
+	src.range = range
 	set_tracked(tracked)
 	src.works_in_containers = works_in_containers
 

--- a/code/modules/roguetown/roguemachine/questing/items/parcel.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/parcel.dm
@@ -26,9 +26,6 @@
 	proximity_monitor = new(src, 7)
 
 /obj/item/parcel/HasProximity(mob/nearby)
-	if(!istype(nearby))
-		return
-
 	var/datum/component/quest_object/quest_component = GetComponent(/datum/component/quest_object)
 	if(!istype(quest_component))
 		return
@@ -37,7 +34,8 @@
 	if(!istype(quest))
 		return
 
-	if(get_dist(get_turf(src), get_turf(quest.quest_scroll_ref?.resolve())) > 7)
+	var/obj/item/paper/scroll/quest/scroll = quest.quest_scroll_ref?.resolve()
+	if(!scroll || get_turf(scroll) != get_turf(nearby))
 		return
 
 	var/image/I = image(icon = 'icons/effects/effects.dmi', loc = get_turf(src), icon_state = "hidden", layer = 18)

--- a/code/modules/roguetown/roguemachine/questing/items/parcel.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/parcel.dm
@@ -26,6 +26,9 @@
 	proximity_monitor = new(src, 7)
 
 /obj/item/parcel/HasProximity(mob/nearby)
+	if(!istype(nearby))
+		return
+
 	var/datum/component/quest_object/quest_component = GetComponent(/datum/component/quest_object)
 	if(!istype(quest_component))
 		return


### PR DESCRIPTION
## About The Pull Request

Despite being only a couple of lines, this took a couple of hours to figure out.

Anyways, Parity PR broke proximity checks for quests. This fixes it. It's also required for the Kill Contracts Proximity Spawner, otherwise, it will not work.

## Testing Evidence

<img width="488" height="470" alt="ex1" src="https://github.com/user-attachments/assets/41777d7c-48a1-47f5-8aee-cd944ea8a381" />
<img width="649" height="500" alt="ex2" src="https://github.com/user-attachments/assets/458c21ba-2496-4a5f-9f7a-895d8f8021b0" />
<img width="757" height="647" alt="ex3" src="https://github.com/user-attachments/assets/1a9afc4f-c8d0-47dd-a034-84831b722926" />

The parcel does not spawn in if I do not have the scroll.

If I ghost out, you can see that the parcel is supposed to spawn in there.

Unfortunately, my screen glitched out when I took the last screenshot. However, you can see my player mob is there, and the parcel is visible.

## Why It's Good For The Game

This ties parcel spawn to whoever holds the scroll, and it also allows players to actually find the parcel dead drop without having to stand on top of it. Prior, you would have to find the exact tile.

## Changelog


:cl:
fix: Fixes parcel dead drop, so it spawns at range, not just when you're on the same tile. Additionally, parcel spawn is tied to the scroll holder.
/:cl:
