### PR TITLE
Added APAB (All Paladins are Bastards) by Burialgoods to selectable combat music

### DIFF
--- a/code/datums/combat_music.dm
+++ b/code/datums/combat_music.dm
@@ -453,6 +453,13 @@ GLOBAL_LIST_EMPTY(cmode_tracks_by_name)
 	credits = "T-87 SULFURHEAD - ABedofMoss (https://www.youtube.com/@T87-Sulfurhead)"
 	musicpath = list('sound/music/cmode/nobility/combat_spymaster.ogg')
 
+/datum/combat_music/sorcerer
+    name = "Sorcerer (Evil)"
+    desc = "Defund the retinue."
+    shortname = "Sorcerer"
+    credits = "burialgoods - APAB (All Paladins Are Bastards) (https://www.youtube.com/watch?v=CMyvIDLAub8)"
+    musicpath = list('sound/music/cmode/antag/combat_sorcerer.ogg')
+
 /datum/combat_music/squire
 	name = "Squire"
 	desc = ""


### PR DESCRIPTION
## About The Pull Request

Adds the song APAB (All Paladins are Bastards) by Burialgoods to selectable combat music themes under the title, "Sorcerer (Evil)". I felt not having this track was a loss from this server and it perfectly suits your average hyperwar Lich or something similar.

## Testing Evidence

Example of the track in game.

https://github.com/user-attachments/assets/40f3f6f6-2e37-47de-bff0-724e6dacc1f8

## Why It's Good For The Game

We should have this as a selectable combat track in the game because it adds more diversity to the combat themes. It is a unique song among the others while still feeling like it fits in with the theme of the game.

## Changelog

:cl: Mr. Pickle Willy
add: Added "APAB (All Paladins Are Bastards)" by Burialgoods as a selectable combat track, under the name "Sorcerer (Evil)".
/:cl:
