### PR TITLE
Blocks /image from being Destroyed

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -218,7 +218,7 @@
 	..()
 	if(hud)
 		cut_overlay(hud.object_overlay)
-		QDEL_NULL(hud.object_overlay)
+		hud.object_overlay = null
 
 /atom/movable/screen/inventory/update_icon_state()
 	if(!icon_empty)

--- a/code/datums/image.dm
+++ b/code/datums/image.dm
@@ -1,0 +1,6 @@
+/image/Destroy(force)
+	if(force)
+		return ..()
+
+	. = QDEL_HINT_LETMELIVE
+	CRASH("Something tried to qdel a [type], which shouldn't happen! (icon: [icon] - icon_state: [icon_state] [loc ? "loc: [loc] ([loc.x],[loc.y],[loc.z])" : ""])")

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -65,12 +65,12 @@
 
 	animate(bar, alpha = 0, time = PROGRESSBAR_ANIMATION_TIME)
 	addtimer(CALLBACK(src, PROC_REF(remove_from_client)), PROGRESSBAR_ANIMATION_TIME, TIMER_CLIENT_TIME)
-	QDEL_IN(bar, PROGRESSBAR_ANIMATION_TIME * 2) //for garbage collection safety
-	. = ..()
+	return ..()
 
 /datum/progressbar/proc/remove_from_client()
 	for(var/client/C in tracked_clients)
 		C.images -= bar
+	bar = null
 	tracked_clients = null
 
 #undef PROGRESSBAR_ANIMATION_TIME

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -474,6 +474,7 @@
 #include "code\datums\heritage.dm"
 #include "code\datums\http_request.dm"
 #include "code\datums\hud.dm"
+#include "code\datums\image.dm"
 #include "code\datums\map_adjustment.dm"
 #include "code\datums\map_adjustment_include.dm"
 #include "code\datums\map_config.dm"


### PR DESCRIPTION
## About The Pull Request
Images harddel when you try to destroy them, so this makes it block it instead.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Fixed 2 runtimes I found when launching a local (there's probably a lot more I can't test everything)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Harddel bad
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Prevents images from being destroyed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
