### PR TITLE
Whitevein Renovation Project (And Rogue's Den Touchhup)

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -123,16 +123,6 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
-"aby" = (
-/obj/structure/table/church/m,
-/obj/machinery/light/rogue/hearth{
-	pixel_y = 10
-	},
-/obj/item/natural/bundle/stick{
-	pixel_x = 14
-	},
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/bath)
 "abA" = (
 /obj/structure/fluff/walldeco/stone,
 /turf/closed/mineral/random/rogue,
@@ -141,10 +131,8 @@
 /turf/closed/mineral/rogue,
 /area/rogue/outdoors/town/roofs)
 "abF" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/concrete,
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "abI" = (
 /obj/machinery/light/rogue/candle/blue/r,
@@ -238,7 +226,7 @@
 	dir = 5
 	},
 /obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "acB" = (
 /obj/structure/bed/rogue,
@@ -762,14 +750,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/rhgoblinencampment)
-"ajr" = (
-/obj/structure/mineral_door/wood/red{
-	locked = "1";
-	lockid = "steam";
-	name = "Steaming Room"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
 "ajs" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/chair/wood/rogue{
@@ -961,13 +941,6 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
-"alL" = (
-/obj/structure/fluff/statue/small{
-	pass_flags = 1;
-	pixel_y = -32
-	},
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/indoors/town/bath)
 "alM" = (
 /obj/effect/spawner/roguemap/hauntpile,
 /turf/open/floor/rogue/dirt/road,
@@ -1035,15 +1008,11 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
 "amt" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
 /obj/structure/fluff/walldeco/maidendrape{
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "amx" = (
 /obj/structure/chair/wood/rogue/chair3{
@@ -1101,18 +1070,6 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/manor/rockhill)
-"anz" = (
-/obj/structure/fluff/statue/small{
-	pass_flags = 1;
-	pixel_x = 32
-	},
-/obj/machinery/light/rogue/candle/blue/r{
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "anF" = (
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/woodsrat/safe)
@@ -1213,17 +1170,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/bograt/north)
 "aoT" = (
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_x = -1;
-	pixel_y = -9
-	},
-/obj/structure/fluff/statue/small{
-	pass_flags = 1;
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "aoW" = (
 /obj/effect/landmark/start/martyr,
 /turf/open/floor/rogue/churchbrick,
@@ -1593,10 +1541,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
 "aum" = (
-/obj/structure/roguemachine/scomm/l{
-	scom_tag = "Bath House - Mess Hall"
-	},
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/water/cleanshallow,
 /area/rogue/indoors/town/bath)
 "auq" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -1665,16 +1610,10 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/sewer)
 "avb" = (
-/obj/structure/stairs/stone,
 /obj/structure/fluff/railing/border{
-	dir = 10
+	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "avc" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab/cabbit{
@@ -2131,12 +2070,6 @@
 	},
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bograt/north)
-"aAG" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	dir = 1;
-	icon_state = "iron_corner"
-	},
-/area/rogue/indoors/town/bath)
 "aAI" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -2582,13 +2515,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
 "aFT" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = -12;
-	pixel_y = -8
-	},
-/obj/structure/flora/roguegrass/herb/salvia,
-/turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/turf/closed/wall/mineral/rogue/decostone/long,
+/area/rogue/under/cave)
 "aFV" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -2984,14 +2912,6 @@
 /obj/structure/flora/roguegrass/herb/rosa,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church)
-"aKu" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -9
-	},
-/obj/structure/shisha/hookah,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "aKx" = (
 /obj/effect/decal/cleanable/debris/stony,
 /obj/item/natural/stoneblock{
@@ -3371,7 +3291,7 @@
 /obj/structure/fluff/walldeco/rpainting/crown{
 	pixel_x = -32
 	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "aPr" = (
 /turf/closed/mineral/rogue,
@@ -3456,17 +3376,15 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
 "aQx" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
+/obj/machinery/light/rogue/hearth{
+	pixel_y = 10
 	},
-/obj/structure/chair/bench/couch,
-/obj/effect/landmark/start/nightmaiden,
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_y = 32
+/obj/machinery/light/rogue/oven/south,
+/obj/item/cooking/pan{
+	pixel_x = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "aQB" = (
 /obj/structure/fluff/railing/fence{
@@ -3678,13 +3596,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/garrison)
 "aTg" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/fluff/pillow/magenta{
+	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "aTh" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -3862,18 +3777,13 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/beach/harbor)
-"aVb" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "aVs" = (
-/obj/structure/chair/bench/coucha/r{
-	pixel_y = 2
+/obj/effect/decal/carpet{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = 0
 	},
-/obj/structure/shisha/hookah,
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "aVv" = (
 /obj/item/natural/rock,
@@ -3979,15 +3889,9 @@
 /turf/open/floor/rogue/snowrough,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "aWD" = (
-/obj/structure/roguemachine/mail{
-	mailtag = "Whitevein"
-	},
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "aWF" = (
 /obj/machinery/light/rogue/firebowl,
 /obj/structure/lever/wall{
@@ -4507,10 +4411,6 @@
 /obj/effect/wisp/prestidigitation,
 /turf/closed/mineral/random/rogue,
 /area/rogue/under/cavewet)
-"bdd" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/bath/fakepond,
-/area/rogue/indoors/town/bath)
 "bdg" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass,
@@ -4636,7 +4536,7 @@
 	redstone_id = "rd_escape"
 	},
 /turf/open/floor/rogue/greenstone,
-/area/rogue/under/town/sewer)
+/area/rogue/indoors/town/bath)
 "bfe" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 4
@@ -5175,13 +5075,8 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor/rockhill)
 "bmu" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/closed/wall/mineral/rogue/decostone/end{
-	dir = 1
-	},
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "bmy" = (
 /obj/structure/fluff/railing/border/east,
@@ -5219,8 +5114,8 @@
 	name = "Mage's Tower"
 	})
 "bna" = (
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/tile/harem1,
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bnb" = (
 /obj/structure/fluff/railing/border{
@@ -5238,16 +5133,21 @@
 /turf/open/floor/rogue/dirt/nospawn,
 /area/rogue/outdoors/bogsafe)
 "bnf" = (
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 4
-	},
-/obj/structure/fluff/wallclock,
+/obj/machinery/light/rogue/candle/red/l,
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "bng" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 8
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Office"
 	},
+/obj/structure/curtain/magenta,
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "bnj" = (
 /obj/structure/fermentation_keg,
@@ -5586,10 +5486,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue)
 "bsp" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
+/obj/structure/shisha/hookah,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bst" = (
 /obj/structure/fluff/railing/border{
@@ -5648,13 +5546,10 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "bsY" = (
-/obj/machinery/light/rogue/candle/floorcandle{
-	icon_state = "floorcandlee1";
-	pixel_x = -4;
-	pixel_y = -16
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/town/sewer)
+/obj/structure/table/wood,
+/obj/structure/bars/shop,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "bsZ" = (
 /obj/effect/decal/remains/saiga,
 /turf/open/floor/rogue/grassred,
@@ -5795,8 +5690,12 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "buy" = (
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/bell_common{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/town/sewer)
 "buE" = (
 /obj/structure/fluff/railing/border{
@@ -9171,13 +9070,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woodsrat/north)
 "cjQ" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1";
+	redstone_id = "tourneytop"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/curtain/magenta,
+/obj/structure/stairs,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "cjY" = (
 /obj/structure/table/wood,
@@ -10368,8 +10268,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "cAc" = (
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/churchrough,
-/area/rogue/under/town/sewer)
+/area/rogue/indoors/town/bath)
 "cAg" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_y = 32
@@ -12009,10 +11910,16 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/under/cavewet/wizarddungeon)
 "cRt" = (
-/turf/open/water/bath{
-	layer = 1.9
+/obj/structure/table/church/m,
+/obj/machinery/light/rogue/hearth{
+	pixel_y = 10
 	},
-/area/rogue/indoors/town/bath)
+/obj/item/natural/bundle/stick{
+	pixel_x = 14
+	},
+/obj/item/flint,
+/turf/open/floor/rogue/church,
+/area/rogue/under/cavewet)
 "cRu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -12206,37 +12113,17 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "cUC" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -5
+/obj/structure/bars/grille{
+	dir = 4;
+	layer = 1.9
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "cUF" = (
-/obj/structure/fluff/walldeco/maidensigil{
-	pixel_y = -32
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
 	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Leashes";
-	pixel_x = -4
-	},
-/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
-/obj/item/leash/leather,
-/obj/item/leash/chain,
-/obj/item/leash/chain,
-/obj/item/leash/leather,
-/obj/item/leash/chain,
-/obj/item/leash/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "cUK" = (
 /obj/structure/table/wood/poor,
@@ -12741,12 +12628,9 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach/harbor)
 "dbq" = (
-/obj/machinery/light/rogue/candle/blue/r{
-	pixel_y = 5
-	},
-/obj/structure/stairs/stone{
-	dir = 1
-	},
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/obj/structure/fluff/statue/small,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
 "dbr" = (
@@ -12868,16 +12752,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor/rockhill)
-"dcg" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "dck" = (
 /turf/open/water/ocean/deep/thermalwater,
 /area/rogue/outdoors/woodsrat/safe)
@@ -13071,15 +12945,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "deO" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/table/wood/fancy/purple,
+/obj/item/candle/eora/lit,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "deT" = (
 /obj/structure/fluff/railing/border,
@@ -13237,9 +13105,6 @@
 	},
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/beach/harbor)
-"dgC" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
-/area/rogue/indoors/town/bath)
 "dgM" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/tile,
@@ -13328,15 +13193,15 @@
 	},
 /area/rogue/outdoors/bograt/above)
 "dhO" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/machinery/light/rogue/oven/south,
+/obj/machinery/light/rogue/hearth{
+	pixel_y = 10
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
+/obj/item/reagent_containers/glass/bucket/pot{
+	pixel_x = -2;
+	pixel_y = 5
 	},
-/turf/open/floor/rogue/tile/harem,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "dhP" = (
 /turf/open/floor/rogue/tile/harem,
@@ -13763,7 +13628,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
 "dnb" = (
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/fluff/statue/femalestatue1{
+	pixel_y = 0
+	},
+/turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "dne" = (
 /mob/living/simple_animal/hostile/retaliate/goose,
@@ -13779,12 +13649,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town)
-"dnv" = (
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/under/town/sewer)
 "dnw" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -13985,9 +13849,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
 "dpJ" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "dpP" = (
@@ -14531,7 +14394,7 @@
 	pixel_x = 16;
 	pixel_y = -2
 	},
-/obj/machinery/light/rogue/candle/l,
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dwz" = (
@@ -14584,10 +14447,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
 "dwQ" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/machinery/light/rogue/candle/blue,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "dwV" = (
 /obj/structure/flora/roguegrass,
@@ -14673,7 +14534,9 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue)
 "dzn" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/obj/item/roguebin/trash,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dzq" = (
 /turf/open/floor/rogue/cobble/mossy,
@@ -15458,15 +15321,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "dId" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/railing/border{
-	dir = 10
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner"
 	},
-/obj/structure/chair/bench/coucha{
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "dIe" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -15530,13 +15388,6 @@
 	},
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/warden)
-"dIY" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/chair/bench/coucha{
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "dJa" = (
 /obj/structure/bars/pipe{
 	dir = 9;
@@ -15766,15 +15617,6 @@
 /obj/item/rope,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors)
-"dLJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
 "dLM" = (
 /obj/structure/flora/hotspring_rocks/grassy,
 /turf/open/floor/rogue/grass,
@@ -15834,14 +15676,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/dwarfin/rockhill)
-"dMF" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "dMI" = (
 /obj/structure/bars/steel,
 /obj/structure/table/wood/poor,
@@ -16619,13 +16453,6 @@
 /obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
-"dWp" = (
-/obj/structure/chair/smallbench,
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "dWq" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -16770,24 +16597,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/inq/basement)
 "dYM" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/structure/lever{
-	name = "Front Desk Shutters";
-	pixel_y = 4;
-	redstone_id = "whitevein_desk"
-	},
-/obj/machinery/light/rogue/candle/blue/r,
-/obj/machinery/light/rogue/candle/floorcandle/pink,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/walldeco/flower,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/under/town/sewer)
 "dYP" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -17017,10 +16829,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woodsrat/south)
-"ebt" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
 "ebu" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grasscold,
@@ -17627,17 +17435,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin/rockhill)
-"eim" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/obj/machinery/light/rogue/candle/blue/l{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "eis" = (
 /obj/structure/fluff/railing/border/west{
 	dir = 9
@@ -17750,9 +17547,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
 "ejY" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "ekg" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /obj/item/storage/roguebag,
@@ -18154,13 +17951,16 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
 "epj" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Office"
 	},
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/floor/rogue/tile/harem1,
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "epm" = (
 /obj/structure/table/wood,
@@ -18228,20 +18028,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "eqj" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	pixel_y = -3
-	},
-/obj/structure/bell_common,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/obj/structure/bars/passage/shutter{
-	name = "Toy Shop";
-	redstone_id = "gambleaccess"
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/roguemachine/vendor/bathhouse,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/bath)
 "eqn" = (
 /obj/structure/fluff/railing/fence{
@@ -18492,12 +18280,37 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/wizarddungeon)
 "euh" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Special Toys";
+	pixel_x = 4
 	},
-/turf/closed/wall/mineral/rogue/decostone/end,
-/area/rogue/indoors/town/bath)
+/obj/item/dildo/wood{
+	pixel_y = -4
+	},
+/obj/item/dildo/iron{
+	pixel_x = 5
+	},
+/obj/item/dildo/wood{
+	pixel_x = 10;
+	pixel_y = -4
+	},
+/obj/item/dildo/iron{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/berrypoison,
+/obj/item/rogueweapon/whip,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/lockpickring/mundane,
+/obj/machinery/light/rogue/candle/blue{
+	pixel_y = -32
+	},
+/obj/machinery/light/rogue/candle/blue/r,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "eui" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8;
@@ -19313,11 +19126,8 @@
 /turf/open/water/swamp,
 /area/rogue/under/underdarker/rockhill)
 "eDw" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "eDA" = (
 /obj/structure/fluff/railing/wood{
@@ -19715,7 +19525,7 @@
 /area/rogue/under/town/basement/keep)
 "eHR" = (
 /obj/structure/table/church,
-/turf/open/floor/carpet/stellar,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/Academy)
 "eIa" = (
 /obj/structure/spider/stickyweb,
@@ -20179,10 +19989,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
 "eOx" = (
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 8
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "eOB" = (
 /obj/structure/mineral_door/wood/red{
@@ -20365,7 +20176,7 @@
 	dir = 1
 	},
 /obj/structure/curtain/magenta,
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "eQK" = (
 /turf/open/floor/rogue/blocks,
@@ -20797,10 +20608,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/grove)
 "eVY" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/chair/stool/rogue,
+/obj/effect/decal/carpet/square/black{
+	dir = 8;
+	pixel_x = 2
 	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "eVZ" = (
 /obj/structure/fluff/railing/border{
@@ -21401,7 +21214,7 @@
 	},
 /obj/structure/mirror,
 /obj/item/azure_lipstick/black,
-/obj/machinery/light/rogue/candle/l,
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "fdM" = (
@@ -21466,8 +21279,63 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
 "feE" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
-/area/rogue/under/town/sewer)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/kitchen/spoon/iron{
+	pixel_x = -5
+	},
+/obj/item/kitchen/spoon/iron{
+	pixel_x = -5
+	},
+/obj/item/kitchen/spoon/iron{
+	pixel_x = -5
+	},
+/obj/item/kitchen/spoon/iron{
+	pixel_x = -5
+	},
+/obj/item/kitchen/fork/iron{
+	pixel_x = 5
+	},
+/obj/item/kitchen/fork/iron{
+	pixel_x = 5
+	},
+/obj/item/kitchen/fork/iron{
+	pixel_x = 5
+	},
+/obj/item/kitchen/fork/iron{
+	pixel_x = 5
+	},
+/obj/item/kitchen/fork/iron{
+	pixel_x = 5
+	},
+/obj/item/kitchen/fork/iron{
+	pixel_x = 5
+	},
+/obj/item/kitchen/spoon/iron{
+	pixel_x = -5
+	},
+/obj/item/kitchen/spoon/iron{
+	pixel_x = -5
+	},
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/cooking/platter/pewter,
+/obj/item/reagent_containers/glass/bowl/tin,
+/obj/item/reagent_containers/glass/bowl/tin,
+/obj/item/reagent_containers/glass/bowl/tin,
+/obj/item/reagent_containers/glass/bowl/tin,
+/obj/item/reagent_containers/glass/bowl/tin,
+/obj/item/reagent_containers/glass/bowl/tin,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/obj/item/reagent_containers/glass/cup,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "feF" = (
 /obj/structure/table/wood/long_table/right,
 /obj/effect/spawner/lootdrop/valuable_candle_spawner,
@@ -21778,18 +21646,15 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/rhgoblinencampment)
 "fit" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Special Toys";
+	pixel_x = 4
 	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fiD" = (
 /obj/structure/bookcase/random/archive,
@@ -22055,14 +21920,12 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/outdoors/town/roofs)
 "flB" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/roguemachine/withdraw{
+	pixel_y = 0;
+	pixel_x = -32
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/under/town/sewer)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "flH" = (
 /obj/structure/flora/newtree,
 /turf/open/water/swamp/deep,
@@ -22750,11 +22613,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog)
 "fuU" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/closed/wall/mineral/rogue/decostone,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/machinery/light/rogue/candle/red/l,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fuW" = (
 /obj/structure/stairs/stone{
@@ -22860,10 +22721,16 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdark/rockhill/west)
 "fwH" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Employees Only"
 	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/curtain/magenta,
+/obj/structure/stairs{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "fwQ" = (
 /obj/structure/rack/rogue{
@@ -23042,9 +22909,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "fzf" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 1
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -2;
+	pixel_y = -2
 	},
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "fzh" = (
 /obj/structure/bed/rogue/bedroll,
@@ -24042,15 +23912,14 @@
 	},
 /area/rogue/indoors/town/bath)
 "fLZ" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	layer = 2
+/obj/structure/lever/wall{
+	dir = 8;
+	name = "Toy Shop Shutters";
+	pixel_y = 4;
+	redstone_id = "gambleaccess"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "fMe" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/twig,
@@ -24876,12 +24745,8 @@
 /turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/manor/rockhill)
 "fUP" = (
-/obj/effect/decal/carpet/kover_darkred{
-	dir = 8;
-	pixel_x = 15;
-	pixel_y = 17
-	},
-/turf/open/floor/carpet/inn,
+/obj/structure/chair/wood/rogue/chair5,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fUQ" = (
 /obj/effect/wisp/prestidigitation{
@@ -24969,16 +24834,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church/chapel)
 "fVn" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 8;
-	pixel_x = -7;
-	pixel_y = -8
-	},
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "fVv" = (
 /obj/structure/bars/passage/shutter{
 	redstone_id = "heartbeast_shutter"
@@ -25131,15 +24988,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield/rockhill)
-"fXp" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "fXu" = (
 /obj/structure/roguewindow/stained/silver,
 /obj/structure/vine,
@@ -25715,17 +25563,10 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/under/town/sewer)
 "ggb" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/obj/structure/closet/crate/chest/crate{
-	locked = 1;
-	lockid = "nightmaiden";
-	pixel_y = 14
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ggk" = (
 /obj/structure/stairs{
@@ -26444,14 +26285,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/basement)
 "gps" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 1;
+	icon_state = "iron_corner"
 	},
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "gpw" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -27208,7 +27046,8 @@
 	name = "Massage Table"
 	},
 /obj/structure/mirror,
-/obj/machinery/light/rogue/candle/r,
+/obj/machinery/light/rogue/candle/floorcandle/pink,
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "gzD" = (
@@ -27367,17 +27206,6 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield/rockhill)
-"gBZ" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/chair/bench/coucha/r{
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "gCe" = (
 /obj/structure/fluff/alch,
 /turf/open/floor/rogue/concrete,
@@ -27583,12 +27411,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/rockhill)
 "gEP" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4;
-	locked = 1;
-	name = "Bathroom"
-	},
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "gES" = (
 /obj/structure/rack/rogue,
@@ -27701,18 +27525,17 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
 "gGL" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
+/obj/structure/roguemachine/atm{
+	location_tag = "Bathhouse Lobby";
+	mammonsiphoned = 250;
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/obj/structure/chair/stool/rogue{
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -2;
 	pixel_y = -2
 	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	layer = 1;
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "gGN" = (
 /obj/machinery/light/rogue/candle/green,
@@ -28055,12 +27878,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
-"gKX" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/turf/open/water/bath/fakepond,
-/area/rogue/indoors/town/bath)
 "gKZ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -28076,13 +27893,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet)
 "gLm" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = 44
-	},
-/turf/open/floor/carpet/inn,
+/obj/machinery/light/rogue/candle/red/l,
+/obj/structure/closet/crate/chest/wicker,
+/obj/structure/fluff/wallclock,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "gLo" = (
 /turf/open/floor/rogue/blocks,
@@ -28216,7 +28030,7 @@
 	icon_state = "borderfall";
 	pixel_x = -8
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "gNu" = (
 /obj/machinery/light/rogue/lanternpost,
@@ -28279,10 +28093,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/rhgoblinencampment)
 "gNW" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/obj/structure/glowshroom,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "gNX" = (
 /obj/structure/table/wood/poor,
 /obj/item/clothing/mask/cigarette/pipe{
@@ -28318,11 +28131,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor/rockhill)
 "gOi" = (
-/obj/structure/bars/grille{
-	dir = 8
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
 	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "gOo" = (
 /obj/structure/plasticflaps,
 /obj/structure/spider/stickyweb,
@@ -28361,11 +28173,12 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield/rockhill/above)
 "gPd" = (
-/obj/structure/fluff/walldeco/church/line{
+/obj/effect/decal/carpet/kover_purple{
 	dir = 4;
-	pixel_x = 2
+	pixel_x = 20;
+	pixel_y = -15
 	},
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "gPj" = (
 /obj/structure/bed/rogue/inn{
@@ -28400,15 +28213,11 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor/rockhill)
 "gPP" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/water/sewer,
+/area/rogue/under/town/sewer)
 "gPV" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/bars/grille,
@@ -29116,12 +28925,12 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/under/town/sewer)
 "gYH" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/obj/structure/table/vtable,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "gYJ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -29197,13 +29006,9 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cavewet/wizarddungeon)
 "gZt" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/churchrough,
+/obj/structure/bars/shop,
+/obj/structure/table/wood,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "gZA" = (
 /turf/open/water/swamp/deep,
@@ -29541,15 +29346,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/dungeon1)
-"hcW" = (
-/obj/structure/bars/grille{
-	dir = 1
-	},
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
 "hcX" = (
 /obj/machinery/light/rogue/candle,
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -29934,11 +29730,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors)
 "hiw" = (
-/obj/structure/chair/bench/couchablack,
-/obj/structure/fluff/walldeco/painting/seraphina{
-	pixel_y = 32
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
 	},
-/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "hiz" = (
 /obj/structure/roguewindow/openclose/reinforced{
@@ -30346,10 +30142,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "hnr" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -30462,9 +30255,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"hoS" = (
-/turf/closed/mineral/random/rogue,
-/area/rogue/indoors/town/bath)
 "hoT" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/ruinedwood/turned,
@@ -31512,15 +31302,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave)
 "hCX" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "hDc" = (
 /obj/structure/fluff/walldeco/customflag/rockhill,
 /turf/closed/wall/mineral/rogue/stone,
@@ -31581,15 +31367,6 @@
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
-"hDM" = (
-/obj/structure/table/church/m{
-	icon_state = "churchtable_mid_alt"
-	},
-/obj/item/toy/cards/deck/syndicate{
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/bath)
 "hDN" = (
 /obj/structure/chair/wood/rogue/fancy,
 /turf/open/floor/rogue/tile/masonic,
@@ -31657,12 +31434,22 @@
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/shop)
 "hED" = (
-/obj/structure/roguemachine/lottery_roguetown{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/carpet,
+/obj/structure/closet/crate/chest/crate{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "hEF" = (
 /obj/structure/table/wood/poor,
@@ -31885,22 +31672,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
 "hGX" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = 4;
+	pixel_y = 41
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = 4;
+	pixel_y = 41
 	},
-/obj/structure/roguemachine/scomm{
-	scom_tag = "Bath House - Entrance"
-	},
-/obj/machinery/light/rogue/candle/blue/l,
-/obj/effect/landmark/start/grabber,
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "hHb" = (
 /obj/structure/mineral_door/wood/donjon/stone{
@@ -32764,13 +32545,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "hSv" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/bars/grille{
+	dir = 4;
+	layer = 1.9
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "hSw" = (
 /obj/structure/rack/rogue,
@@ -33369,15 +33151,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
 "hZk" = (
-/obj/structure/chair/bench/couchablack/r,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
+/obj/structure/bars/grille{
+	dir = 8
 	},
-/obj/structure/shisha/hookah,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "hZr" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -33781,18 +33559,19 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "iey" = (
-/obj/structure/table/church{
-	icon_state = "churchtable_alt"
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 4
 	},
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = 8
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 8
 	},
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = -6;
-	pixel_y = 5
+/obj/structure/fluff/walldeco/maidendrape{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "ieK" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/chair/wood/rogue,
@@ -33817,9 +33596,13 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains)
 "ieR" = (
-/obj/structure/fluff/walldeco/stone,
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/table/vtable/v2,
+/obj/structure/roguemachine/mail{
+	mailtag = "Whitevein Office"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "ieU" = (
 /obj/structure/table/wood{
 	icon_state = "map4"
@@ -34109,14 +33892,31 @@
 	name = "Mage's Tower"
 	})
 "iia" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/fluff/walldeco/maidensigil{
+	pixel_y = -32
 	},
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/machinery/light/rogue/candle/blue{
+	pixel_y = -32
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Leashes";
+	pixel_x = -4
+	},
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/leash/leather,
+/obj/item/leash/chain,
+/obj/item/leash/chain,
+/obj/item/leash/leather,
+/obj/item/leash/chain,
+/obj/item/leash/leather,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "iiD" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/woodturned,
@@ -34569,10 +34369,12 @@
 	},
 /area/rogue/outdoors/town/rockhill)
 "ipI" = (
-/obj/structure/fluff/statue/small{
-	pass_flags = 1
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall"
 	},
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
 /area/rogue/indoors/town/bath)
 "ipQ" = (
 /turf/open/floor/rogue/naturalstone,
@@ -35331,8 +35133,12 @@
 /obj/structure/chair/stool/rogue{
 	pixel_y = -2
 	},
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/candle/red/l,
+/obj/effect/decal/carpet/square/black{
+	pixel_x = 16;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "iBJ" = (
 /obj/machinery/light/rogue/candle/off,
@@ -35983,8 +35789,13 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/skeletoncrypt)
 "iJF" = (
-/obj/structure/fluff/walldeco/rpainting/forest,
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/structure/fermentation_keg/beer,
+/obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = 37
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "iJP" = (
 /obj/structure/roguemachine/scomm{
@@ -37357,12 +37168,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/rhgoblinencampment)
 "jbC" = (
-/obj/structure/chair/bench/couchablack/r,
-/obj/machinery/light/rogue/candle/blue,
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Bath House - Stage"
-	},
-/turf/open/floor/carpet/inn,
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/bath)
 "jbF" = (
 /obj/structure/fluff/railing/fence{
@@ -37527,7 +37335,7 @@
 /turf/open/floor/rogue/tile/bath{
 	icon_state = "bathtileratwood"
 	},
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "jdr" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
@@ -38379,24 +38187,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/basement)
 "jnW" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 4
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_y = -11
 	},
-/obj/structure/table/wood{
-	icon_state = "largetable";
-	pixel_y = -3
-	},
-/obj/item/perfume/random{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/perfume/random{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "jol" = (
 /turf/closed/wall/mineral/rogue/roofwall/innercorner/dir8,
@@ -39123,8 +38917,14 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet)
 "jxW" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "jyd" = (
 /obj/item/cushion/desert1{
@@ -39292,8 +39092,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "jAu" = (
-/obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/carpet/inn,
+/obj/structure/roguewindow/harem1{
+	opacity = 1
+	},
+/obj/structure/drape/zybantine,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "jAx" = (
 /obj/structure/ladder,
@@ -40064,16 +39867,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "jJq" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/table/wood/long_table,
+/obj/item/millstone{
+	pixel_y = 10
 	},
-/obj/effect/decal/carpet/kover_darkred{
-	dir = 8;
-	pixel_x = 15;
-	pixel_y = 17
+/obj/structure/rack/rogue/shelf{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/under/town/sewer)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "jJu" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -40391,17 +40193,6 @@
 /obj/structure/rack/rogue/shelf/big,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/bog)
-"jNn" = (
-/obj/structure/bars/pipe{
-	dir = 9;
-	layer = 2;
-	pixel_x = 10;
-	pixel_y = -15
-	},
-/turf/open/water/bath{
-	layer = 1.9
-	},
-/area/rogue/indoors/town/bath)
 "jNp" = (
 /obj/structure/shisha/hookah,
 /turf/open/floor/rogue/tile/bath,
@@ -40605,13 +40396,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
-"jPH" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "jPI" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/bath)
@@ -40774,8 +40558,8 @@
 	lockid = "nightmaiden";
 	name = "Storeroom"
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/town/sewer)
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/bath)
 "jSF" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/bars/grille,
@@ -40839,16 +40623,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
 "jTy" = (
-/obj/effect/decal/cobbleedge{
+/obj/structure/table/wood/fancy/purple,
+/obj/effect/decal/carpet/square/black{
 	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
+	pixel_x = 2
 	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "jTA" = (
 /obj/structure/bars/grille{
@@ -41393,6 +41173,9 @@
 /area/rogue/indoors/shelter/mountains)
 "kaO" = (
 /obj/structure/mineral_door/wood/bath/courtesan,
+/obj/structure/curtain/magenta{
+	alpha = 200
+	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "kaP" = (
@@ -43014,16 +42797,10 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue)
 "kto" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/obj/structure/fluff/walldeco/painting{
-	pixel_x = -32
+/obj/structure/curtain/magenta{
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
 	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
@@ -43979,14 +43756,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors)
 "kGM" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 4;
+	icon_state = "iron_line"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "kGQ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -44908,12 +44682,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
 "kSf" = (
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = 31
-	},
 /obj/structure/fluff/pillow/magenta{
 	dir = 1
 	},
+/obj/machinery/light/rogue/candle/red/r,
+/obj/structure/shisha/hookah,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kSl" = (
@@ -45272,20 +45045,10 @@
 	pixel_x = 10;
 	pixel_y = 22
 	},
-/obj/structure/flora/ausbushes/reedbush{
-	layer = 2;
-	pixel_x = 12;
-	pixel_y = -4
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	layer = 2;
-	pixel_x = -8;
-	pixel_y = 2
-	},
 /obj/structure/hotspring{
 	icon_state = "lilypetals2"
 	},
-/turf/open/water/bath/fakepond,
+/turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "kXq" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -45621,11 +45384,9 @@
 	name = "Mage's Tower"
 	})
 "lct" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/turned,
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "lcD" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -46344,14 +46105,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "lme" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/harem1,
+/obj/machinery/light/rogue/candle/red/l,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "lmf" = (
 /obj/structure/stairs/stone,
@@ -46429,9 +46184,6 @@
 /area/rogue/indoors/town/church)
 "lnq" = (
 /obj/structure/flora/ausbushes/reedbush,
-/obj/structure/fluff/walldeco/stone{
-	pixel_x = -32
-	},
 /obj/structure/flora/roguegrass/herb/salvia,
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
@@ -46835,13 +46587,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/harbor)
 "lsQ" = (
-/obj/structure/bars/grille{
-	dir = 8
-	},
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
-	},
-/turf/open/water/bath,
+/turf/closed,
 /area/rogue/indoors/town/bath)
 "lsS" = (
 /obj/structure/mannequin/male/female{
@@ -47233,8 +46979,9 @@
 /area/rogue/indoors/town/cell)
 "lys" = (
 /obj/structure/fluff/railing/border{
-	dir = 10
+	dir = 5
 	},
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "lyt" = (
@@ -48170,17 +47917,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/underdarker/rockhill)
-"lKN" = (
-/obj/structure/bars/pipe{
-	dir = 6;
-	layer = 2;
-	pixel_x = -15;
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "lKO" = (
 /obj/structure/chair/stool/rogue{
 	pixel_x = -3;
@@ -48224,6 +47960,7 @@
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 15
 	},
+/obj/structure/flora/ausbushes/reedbush,
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "lLo" = (
@@ -48340,14 +48077,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
 "lMC" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Employees Only"
-	},
-/obj/structure/curtain/magenta,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/under/cave)
 "lME" = (
 /obj/item/paper/scroll,
 /obj/structure/table/wood/long_table,
@@ -48508,10 +48239,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield/rockhill)
 "lOH" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/effect/decal/cleanable/food/egg_smudge,
+/turf/open/floor/rogue/tile{
+	icon_state = "bfloorz"
 	},
-/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "lON" = (
 /obj/structure/stairs/stone,
@@ -48952,11 +48683,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "lUL" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/stairs{
+	dir = 1
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cavewet)
 "lUW" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors)
@@ -49173,12 +48904,6 @@
 /obj/structure/flora/hotspring_rocks/grassy,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/bograt/sunken)
-"lXA" = (
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "lXB" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/wood,
@@ -49410,12 +49135,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
 "lZO" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/turf/open/floor/carpet/inn,
+/obj/structure/chair/wood/rogue/chair5,
+/obj/machinery/light/rogue/candle/red/l,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "lZP" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -49730,12 +49452,8 @@
 	name = "Mage's Tower"
 	})
 "mcL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/shisha/hookah,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cavewet)
 "mcN" = (
 /turf/closed/wall/mineral/rogue/roofwall/innercorner/dir1,
 /area/rogue/indoors/town)
@@ -49878,7 +49596,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/town/sewer)
 "meZ" = (
 /obj/structure/spider/stickyweb,
@@ -50699,11 +50417,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
 "mom" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Special Toys";
+	pixel_x = 4
 	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "mon" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
@@ -51626,12 +51347,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"myZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
 "mzd" = (
 /obj/structure/curtain/magenta{
 	alpha = 200
@@ -52342,14 +52057,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/warden)
-"mIy" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "mIz" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -52508,14 +52215,14 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
 "mKf" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/bars/grille{
+	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
 	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "mKg" = (
 /obj/structure/stairs{
 	dir = 4
@@ -52675,7 +52382,7 @@
 	name = "Dressing Room"
 	},
 /obj/structure/curtain/magenta,
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "mLV" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
@@ -52970,11 +52677,9 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "mQe" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/curtain/red,
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/fermentation_keg/distiller,
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "mQj" = (
 /obj/structure/table/wood,
@@ -53289,17 +52994,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
 "mVl" = (
-/obj/structure/rogue/trophy/deer,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_x = 13;
-	pixel_y = 5
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "mVp" = (
 /obj/structure/bed/rogue/shit,
@@ -53496,13 +53193,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church)
 "mYd" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/turf/open/floor/rogue/tile{
+	icon_state = "bfloorz"
 	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "mYj" = (
 /obj/machinery/light/rogue/candle{
@@ -54197,18 +53890,45 @@
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
 "nfQ" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Tools";
+	pixel_x = 3
 	},
-/obj/effect/landmark/start/grabber,
-/obj/structure/roguemachine/drugmachine{
-	density = 0;
-	pixel_y = 32
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
+	pixel_x = -10;
+	pixel_y = 13
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
+	pixel_x = -10;
+	pixel_y = 13
+	},
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "ngc" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -54741,10 +54461,6 @@
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/rockhill)
-"nnl" = (
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "nnJ" = (
 /obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
@@ -55435,12 +55151,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "nvM" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 8
 	},
-/obj/structure/curtain/red,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "nvQ" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -55568,7 +55283,7 @@
 /obj/structure/chair/stool/rogue{
 	pixel_y = -2
 	},
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "nxH" = (
 /obj/effect/decal/cobbleedge{
@@ -56005,12 +55720,13 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/physician)
 "nDe" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -9
+/obj/structure/mineral_door/wood/red{
+	locked = "1";
+	lockid = "steam";
+	name = "Steaming Room"
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cavewet)
 "nDh" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -56336,10 +56052,10 @@
 /area/rogue/outdoors/woodsrat/above)
 "nIe" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
-/area/rogue/under/town/sewer)
+/area/rogue/indoors/town/bath)
 "nIo" = (
 /obj/item/roguebin/water,
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "nIw" = (
 /obj/structure/rack/rogue/shelf/big{
@@ -56651,17 +56367,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin/rockhill)
-"nMr" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/item/roguebin/trash{
-	pixel_x = -3;
-	pixel_y = 9
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "nMt" = (
 /obj/effect/particle_effect/smoke{
 	lifetime = 14400
@@ -56834,12 +56539,16 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/harbor)
 "nPb" = (
-/obj/structure/table/wood/poker,
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/rogue/churchrough,
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1";
+	redstone_id = "tourneytop"
+	},
+/obj/structure/curtain/magenta,
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "nPi" = (
 /obj/structure/chair/stool/rogue,
@@ -57216,22 +56925,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
-"nSY" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable";
-	pixel_y = -3
-	},
-/obj/structure/bars/passage/shutter{
-	name = "Toy Shop";
-	redstone_id = "gambleaccess"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "nTb" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/town/roofs)
@@ -57542,17 +57235,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield/rockhill)
 "nWH" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_x = -1;
-	pixel_y = -13
-	},
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/carpet/inn,
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/bath)
 "nWJ" = (
 /obj/structure/table/wood{
@@ -57626,13 +57311,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "nXp" = (
-/obj/structure/chair/bench/couchablack,
-/obj/machinery/light/rogue/candle/blue,
 /obj/structure/fluff/walldeco/maidendrape{
 	pixel_x = -32;
 	pixel_y = 0
 	},
-/turf/open/floor/carpet/inn,
+/turf/closed/wall/mineral/rogue/decostone/long{
+	dir = 1;
+	max_integrity = 100
+	},
 /area/rogue/indoors/town/bath)
 "nXs" = (
 /obj/structure/table/wood/long_table,
@@ -57759,14 +57445,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield/rockhill/above)
 "nYX" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/lever/wall{
-	dir = 8;
-	name = "Toy Shop Shutters";
-	pixel_y = 4;
-	redstone_id = "gambleaccess"
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/roguemachine/drugmachine,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/bath)
 "nZh" = (
 /obj/structure/stairs/stone,
@@ -58381,7 +58061,7 @@
 	icon_state = "borderfall";
 	pixel_x = 8
 	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "ogP" = (
 /obj/structure/stairs,
@@ -59295,13 +58975,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
 "osw" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = 0;
-	pixel_y = -2
-	},
-/obj/machinery/light/rogue/candle/blue/l,
-/obj/structure/curtain/magenta,
-/turf/open/floor/rogue/churchbrick,
+/obj/machinery/light/rogue/candle/floorcandle/pink,
+/obj/structure/fluff/wallclock,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "osx" = (
 /obj/structure/hotspring,
@@ -59679,10 +59355,10 @@
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
 	lockid = "nightmaiden";
-	name = "Employees Only"
+	name = "Employee Lounge"
 	},
 /obj/structure/curtain/magenta,
-/turf/closed,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "oxd" = (
 /obj/structure/closet/crate/roguecloset{
@@ -59735,20 +59411,6 @@
 /obj/machinery/light/rogue/candle/red,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
-"oxB" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/maidendrape{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "oxC" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobblerock,
@@ -59767,9 +59429,6 @@
 /obj/item/rogueweapon/stoneaxe/woodcut,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
-"oxV" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/indoors/town/bath)
 "oxY" = (
 /obj/machinery/light/rogue/torchholder/hotspring,
 /turf/open/floor/rogue/grass,
@@ -61318,10 +60977,6 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement/tavern)
 "oTd" = (
-/obj/structure/bars/passage/shutter{
-	name = "Whitevein Lounge";
-	redstone_id = "whitevein_desk"
-	},
 /obj/structure/table/wood,
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -61786,32 +61441,21 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
 "oXT" = (
-/obj/machinery/light/rogue/candle/blue/r,
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Favours";
-	pixel_x = 3
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	pixel_y = -3
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/spice,
-/obj/item/reagent_containers/powder/spice,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
+/obj/structure/bell_common,
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/obj/structure/bars/passage/shutter{
+	name = "Toy Shop";
+	redstone_id = "gambleaccess"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/under/cave)
 "oXU" = (
 /obj/structure/plasticflaps,
 /turf/open/water/river{
@@ -63959,7 +63603,7 @@
 /area/rogue/indoors/town/dwarfin/rockhill)
 "pzk" = (
 /obj/structure/chair/bench/couchamagenta/r,
-/obj/machinery/light/rogue/candle/r,
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "pzl" = (
@@ -64206,16 +63850,16 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/bograt/above)
 "pCp" = (
-/obj/structure/table/church/m,
-/obj/machinery/light/rogue/hearth{
-	pixel_y = 10
+/obj/structure/bars/pipe{
+	dir = 6;
+	layer = 2;
+	pixel_x = -15;
+	pixel_y = 9
 	},
-/obj/item/natural/bundle/stick{
-	pixel_x = 14
+/turf/open/floor/rogue/tile/bath{
+	icon_state = "bathtileratwood"
 	},
-/obj/item/flint,
-/turf/open/floor/rogue/church,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "pCr" = (
 /obj/machinery/light/rogue/candle/green,
 /turf/open/floor/rogue/naturalstone,
@@ -64567,16 +64211,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church)
 "pGs" = (
-/obj/structure/fluff/statue/femalestatue{
-	desc = "Wow, she is beautiful.";
-	icon_state = "5";
-	name = "Lady of the Lake";
-	pixel_x = -28;
-	pixel_y = -28
+/obj/structure/fluff/railing/border{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "pGw" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -64728,10 +64367,13 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cave/rhgoblinencampment)
 "pHV" = (
-/obj/effect/particle_effect/smoke{
-	color = "#7f788a";
-	lifetime = 14400
+/obj/structure/bars/pipe{
+	dir = 8;
+	layer = 2.05;
+	pixel_x = 10;
+	pixel_y = -20
 	},
+/obj/structure/bars,
 /turf/open/water/river{
 	icon_state = "rockwd"
 	},
@@ -64971,15 +64613,6 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
-"pLC" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
-	},
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "pLG" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -65882,10 +65515,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "pXB" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
@@ -66252,10 +65882,12 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "qcG" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Whitevein Downstairs"
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "qcL" = (
 /obj/machinery/light/rogue/campfire{
@@ -67137,44 +66769,13 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
 "qoJ" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Tools";
-	pixel_x = 3
+/obj/structure/table/wood/fancy/purple,
+/obj/item/candle/eora/lit{
+	pixel_x = -5;
+	pixel_y = 18
 	},
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/clothing/mask/cigarette/pipe,
-/turf/open/floor/rogue/churchbrick,
+/obj/item/alch/rosa,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "qoM" = (
 /obj/item/paper,
@@ -67638,8 +67239,9 @@
 /area/rogue/under/town/sewer)
 "qut" = (
 /obj/structure/table/wood,
-/obj/structure/bars/shop,
-/obj/structure/bars/passage/shutter,
+/obj/structure/mineral_door/wood/deadbolt/shutter{
+	dir = 2
+	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "qux" = (
@@ -68409,14 +68011,6 @@
 /obj/item/roguestatue/gold,
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
-"qDT" = (
-/obj/structure/roguemachine/vendor/bathhouse{
-	keycontrol = "nightmaiden"
-	},
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 4
-	},
-/area/rogue/indoors/town/bath)
 "qDV" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/floor/rogue/grasscold,
@@ -68936,8 +68530,8 @@
 	icon_state = "longtable";
 	name = "Massage Table"
 	},
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "qKU" = (
 /obj/structure/bars/steel,
@@ -68947,7 +68541,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "qLc" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -68962,81 +68556,12 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/cell)
 "qLo" = (
-/obj/structure/fluff/wallclock{
-	pixel_x = -32;
-	pixel_y = 0
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -21
 	},
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/nightmaiden,
-/obj/item/storage/keyring,
-/obj/item/storage/keyring,
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux1";
-	name = "room I key"
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux1";
-	name = "room I key"
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux2";
-	name = "room II key";
-	pixel_x = 9;
-	pixel_y = -11
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux2";
-	name = "room II key";
-	pixel_x = 9;
-	pixel_y = -11
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux3";
-	name = "room III key";
-	pixel_y = 7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux3";
-	name = "room III key";
-	pixel_y = 7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux4";
-	name = "room IV key";
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux4";
-	name = "room IV key";
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "steam";
-	name = "steam room key"
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "steam";
-	name = "steam room key"
-	},
-/obj/item/roguekey/nightmaiden{
-	icon_state = "spikekey";
-	lockid = "punishroom";
-	name = "punishment room key";
-	pixel_y = 4;
-	pixel_x = 10
-	},
-/obj/item/roguekey/nightmaiden{
-	icon_state = "spikekey";
-	lockid = "punishroom";
-	name = "punishment room key";
-	pixel_y = 4;
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/machinery/light/rogue/candle/red/l,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "qLp" = (
 /obj/structure/rack/rogue,
@@ -69160,14 +68685,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "qMQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/walldeco/flower,
-/obj/structure/bell_common{
-	dir = 4;
-	pixel_x = -10;
-	pixel_y = -8
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -2;
+	pixel_y = -2
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/town/sewer)
@@ -69673,10 +69193,13 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/shelter/bog)
 "qUr" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/structure/table/wood/fancy/purple,
+/obj/item/candle/eora/lit{
+	pixel_x = -5;
+	pixel_y = 18
 	},
-/turf/open/floor/rogue/churchrough,
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "qUs" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
@@ -69910,16 +69433,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
-"qYl" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "qYw" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -70211,20 +69724,10 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/rockhill)
 "rct" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone/long{
+	dir = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/stairs,
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "rcz" = (
 /turf/closed/mineral/rogue/bedrock,
@@ -70467,12 +69970,8 @@
 /turf/open/floor/rogue/grassgrey,
 /area/rogue/under/cavewet/wizarddungeon)
 "rfY" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Front Office"
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/rack/rogue/shelf/biggest,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "rgc" = (
 /obj/structure/roguemachine/scomm{
@@ -70876,11 +70375,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/grove)
 "rmv" = (
-/obj/structure/stairs/stone{
-	dir = 4
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/turf/closed,
+/area/rogue/under/cavewet)
 "rmz" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -71144,9 +70640,6 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/rockhill)
 "rpV" = (
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = -32
-	},
 /obj/structure/fluff/pillow/magenta{
 	dir = 1
 	},
@@ -71154,6 +70647,8 @@
 	pixel_x = 16;
 	pixel_y = -2
 	},
+/obj/machinery/light/rogue/candle/red/l,
+/obj/structure/shisha/hookah,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "rqa" = (
@@ -71564,11 +71059,7 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bogsafe)
 "ruk" = (
-/obj/structure/roguewindow/harem2,
-/obj/structure/fluff/statue/small{
-	pass_flags = 1;
-	pixel_y = -2
-	},
+/obj/structure/roguewindow/harem1,
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/bath)
 "rup" = (
@@ -73336,10 +72827,16 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/rhgoblinencampment)
 "rRk" = (
-/obj/structure/stairs{
-	dir = 1
+/obj/structure/bars/pipe{
+	dir = 1;
+	layer = 2;
+	pixel_x = -10;
+	pixel_y = -10
 	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
+	},
+/turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "rRm" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -73480,10 +72977,9 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/bog)
 "rUg" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/item/roguebin/water,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "rUh" = (
 /obj/structure/handcart,
@@ -73694,14 +73190,14 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "rWD" = (
-/obj/structure/bars/pipe{
-	dir = 9;
-	layer = 2.05;
-	pixel_x = 10;
-	pixel_y = 22
+/obj/structure/bars/grille{
+	dir = 1
 	},
-/turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/indoors/town/bath)
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
+	},
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "rWK" = (
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
@@ -73959,17 +73455,9 @@
 /turf/open/floor/rogue/volcanic,
 /area/rogue/outdoors/bograt/above)
 "sak" = (
-/obj/structure/bondage/gloryhole{
-	color = "#97999c"
-	},
-/obj/structure/curtain/magenta{
-	color = "#a1254a";
-	icon_state = "curtain-closed";
-	opacity = 1;
-	open = 0
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/under/town/sewer)
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "san" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
@@ -74036,10 +73524,16 @@
 /turf/open/water/river/muddy,
 /area/rogue/outdoors/bograt/north)
 "sbj" = (
-/obj/machinery/light/rogue/candle/blue,
-/obj/item/roguebin/water,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/under/town/sewer)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 4
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "sbn" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -74292,15 +73786,63 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/shelter/mountains)
 "sey" = (
-/obj/structure/table/church{
-	dir = 1;
-	icon_state = "churchtable_end_alt"
+/obj/structure/rack/rogue/shelf/big,
+/obj/structure/rack/rogue/shelf/big,
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = -8;
+	pixel_y = 15
 	},
-/obj/item/paper/scroll{
-	pixel_y = 5
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = -8;
+	pixel_y = 15
 	},
-/obj/item/natural/feather,
-/turf/open/floor/rogue/carpet,
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/cup/tin/small{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = 8;
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/claybottle{
+	pixel_x = 7;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/glass/bottle/claybottle{
+	pixel_x = 7;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/glass/bottle/claybottle{
+	pixel_x = 7;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/glass/bottle/claybottle{
+	pixel_x = 7;
+	pixel_y = 18
+	},
+/turf/open/floor/rogue/tile{
+	icon_state = "bfloorz"
+	},
 /area/rogue/indoors/town/bath)
 "seF" = (
 /obj/structure/flora/roguegrass,
@@ -74670,13 +74212,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog)
 "siB" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
+/obj/structure/chair/smallbench,
+/obj/machinery/light/rogue/candle/blue,
+/turf/open/floor/rogue/tile/bath{
+	icon_state = "bathtileratwood"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "siJ" = (
 /obj/structure/bed/rogue/shit,
 /mob/living/carbon/human/species/human/northern/highwayman,
@@ -75003,9 +74544,13 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
 "sno" = (
-/obj/structure/chair/bench/couchablack/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/obj/structure/roguemachine/vendor/bathhouse{
+	keycontrol = "nightmaiden"
+	},
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
+	dir = 4
+	},
+/area/rogue/under/cave)
 "snp" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -75207,9 +74752,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
 "spx" = (
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = 32
-	},
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "spz" = (
@@ -75808,11 +75351,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/inq/basement)
 "sxH" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner";
+	dir = 1
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "sxL" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -75830,12 +75373,6 @@
 /obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
-"sxQ" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/chair/bench/couchablack,
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "sxT" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/grass,
@@ -75893,15 +75430,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cavewet)
-"szf" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "szh" = (
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/herringbone,
@@ -76223,18 +75751,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
-"sDQ" = (
-/obj/structure/bars/pipe{
-	dir = 5;
-	layer = 2;
-	pixel_x = -15;
-	pixel_y = -8
-	},
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
 "sDW" = (
 /obj/structure/flora/roguetree{
 	pixel_x = 0
@@ -77089,22 +76605,6 @@
 /obj/structure/chair/smallbench,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/rtfield/rockhill)
-"sNv" = (
-/obj/structure/bars/pipe{
-	dir = 1;
-	layer = 2;
-	pixel_x = 25;
-	pixel_y = -10
-	},
-/obj/structure/bars/grille{
-	dir = 1;
-	layer = 1.9
-	},
-/turf/open/water/river{
-	dir = 8;
-	icon_state = "rockwd"
-	},
-/area/rogue/indoors/town/bath)
 "sND" = (
 /turf/open/water/river/muddy{
 	dir = 4
@@ -77234,11 +76734,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor/rockhill)
 "sPx" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4;
+	pixel_x = 2
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/cave)
 "sPA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/roguegrass/herb/salvia,
@@ -77583,14 +77084,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/eora)
 "sUG" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fermentation_keg/whitewine{
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/churchrough,
+/obj/structure/curtain/magenta,
+/obj/structure/stairs,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "sUO" = (
 /obj/machinery/tanningrack,
@@ -78056,10 +77552,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
 "tag" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/fluff/wallclock{
+	pixel_x = 32;
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/carpet,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "taj" = (
 /obj/structure/roguemachine/mail{
@@ -78304,11 +77801,21 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "tcZ" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/bars{
+	icon_state = "barsbent";
+	layer = 2.81
+	},
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable";
+	pixel_y = -3
+	},
+/obj/structure/bars/passage/shutter{
+	name = "Toy Shop";
+	redstone_id = "gambleaccess"
 	},
 /turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cave)
 "tdk" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -78662,10 +78169,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "thM" = (
-/turf/closed/wall/mineral/rogue/decostone/long{
-	dir = 1
-	},
-/area/rogue/under/town/sewer)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "thQ" = (
 /obj/structure/fluff/psycross/crafted,
 /turf/open/floor/rogue/churchmarble,
@@ -78823,16 +78329,16 @@
 /area/rogue/outdoors/beach/harbor)
 "tjy" = (
 /obj/structure/bars/pipe{
-	dir = 8;
-	layer = 2.05;
+	dir = 1;
+	layer = 2;
 	pixel_x = 10;
-	pixel_y = -20
+	pixel_y = -10
 	},
-/obj/structure/bars,
-/turf/open/water/river{
-	icon_state = "rockwd"
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
 	},
-/area/rogue/indoors/town/bath)
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "tjA" = (
 /obj/structure/glowshroom{
 	icon_state = "glowshroom2"
@@ -78894,16 +78400,19 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/church)
 "tjT" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = 6
 	},
-/obj/structure/chair/bench/couch/r,
-/obj/effect/landmark/start/nightmaiden,
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/structure/fluff/statue/femalestatue{
+	pixel_y = 0
+	},
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "tjW" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -79318,6 +78827,12 @@
 	name = "Massage Table"
 	},
 /obj/structure/mirror,
+/obj/item/candle/eora/lit{
+	pixel_x = -5;
+	pixel_y = 18;
+	icon_x_offset = 5
+	},
+/obj/item/hair_dye_cream,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "tpx" = (
@@ -80804,13 +80319,8 @@
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/town/sewer)
 "tIz" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/roguewindow/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "tIG" = (
 /obj/structure/bed/rogue/inn{
@@ -80848,17 +80358,6 @@
 /obj/effect/decal/cobble/mossy,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/grove)
-"tJc" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Bath House - Public Bath"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "tJk" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -81139,12 +80638,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/warden)
-"tMU" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "tNa" = (
 /obj/structure/fluff/railing/border/east,
 /turf/open/transparent/openspace,
@@ -81252,12 +80745,8 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bograt/sunken)
 "tOu" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4;
-	locked = 1;
-	name = "Confessional"
-	},
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
 /area/rogue/indoors/town/bath)
 "tOx" = (
 /obj/structure/stairs/stone{
@@ -81982,11 +81471,9 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/bograt/above)
 "tWl" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Whitevein";
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/rogue/decostone/long,
+/obj/structure/table/wood,
+/obj/structure/bars/shop,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "tWp" = (
 /obj/structure/rack/rogue,
@@ -82169,10 +81656,82 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/town/sewer)
 "tYx" = (
-/turf/closed/wall/mineral/rogue/decostone/end{
-	dir = 4
+/obj/structure/fluff/wallclock{
+	pixel_x = -32;
+	pixel_y = 0
 	},
-/area/rogue/indoors/town/bath)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/nightmaiden,
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux1";
+	name = "room I key"
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux1";
+	name = "room I key"
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux2";
+	name = "room II key";
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux2";
+	name = "room II key";
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux3";
+	name = "room III key";
+	pixel_y = 7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux3";
+	name = "room III key";
+	pixel_y = 7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux4";
+	name = "room IV key";
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux4";
+	name = "room IV key";
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "steam";
+	name = "steam room key"
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "steam";
+	name = "steam room key"
+	},
+/obj/item/roguekey/nightmaiden{
+	icon_state = "spikekey";
+	lockid = "punishroom";
+	name = "punishment room key";
+	pixel_y = 4;
+	pixel_x = 10
+	},
+/obj/item/roguekey/nightmaiden{
+	icon_state = "spikekey";
+	lockid = "punishroom";
+	name = "punishment room key";
+	pixel_y = 4;
+	pixel_x = 10
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cave)
 "tYC" = (
 /obj/item/flashlight/flare/torch/metal,
 /obj/structure/closet/crate/chest{
@@ -82621,8 +82180,8 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/cave)
 "ufg" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless,
@@ -82685,13 +82244,10 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
 "ufJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
 	},
-/obj/structure/fluff/pillow/purple,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ufN" = (
 /obj/structure/toilet,
@@ -83584,14 +83140,11 @@
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors)
 "uqT" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
+/obj/structure/table/wood/long_table/right,
+/obj/structure/rack/rogue/shelf{
+	pixel_y = -32
 	},
-/obj/machinery/light/roguestreet/orange/walllamp{
-	dir = 1
-	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "urb" = (
 /turf/open/transparent/openspace,
@@ -83946,17 +83499,6 @@
 	dir = 8
 	},
 /area/rogue/outdoors/beach/harbor)
-"uvH" = (
-/obj/structure/fluff/statue/pillar{
-	pixel_x = 15;
-	pixel_y = 20
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
 "uvL" = (
 /obj/structure/table/vtable,
 /obj/structure/broadcast_horn/loudmouth{
@@ -84056,18 +83598,14 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue,
 /area/rogue/indoors/town/church/chapel)
 "uwW" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4
+/obj/structure/fermentation_keg/whitewine,
+/obj/machinery/light/rogue/candle/blue/l,
+/obj/structure/rack/rogue/shelf,
+/obj/item/storage/roguebag{
+	pixel_x = -8;
+	pixel_y = 38
 	},
-/obj/effect/landmark/start/nightman,
-/obj/effect/landmark/start/nightman,
-/obj/effect/landmark/start/nightman,
-/obj/effect/landmark/start/nightman,
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "uwX" = (
 /turf/open/floor/rogue/concrete,
@@ -84648,36 +84186,13 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern)
 "uFw" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Special Toys";
-	pixel_x = 4
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/obj/item/dildo/wood{
-	pixel_y = -4
-	},
-/obj/item/dildo/iron{
-	pixel_x = 5
-	},
-/obj/item/dildo/wood{
-	pixel_x = 10;
-	pixel_y = -4
-	},
-/obj/item/dildo/iron{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/berrypoison,
-/obj/item/rogueweapon/whip,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/lockpickring/mundane,
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/rogue/churchbrick,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "uFz" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/saiga/tame,
@@ -85465,8 +84980,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
 "uQa" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/under/town/sewer)
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = 0;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "uQm" = (
 /obj/structure/fluff/walldeco/customflag/rockhill,
 /turf/closed/wall/mineral/rogue/stone,
@@ -85744,12 +85263,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "uSL" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
+/obj/structure/bars/pipe{
+	dir = 9;
+	layer = 2.05;
+	pixel_x = 10;
+	pixel_y = 22
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/closed/wall/mineral/rogue/pipe,
+/area/rogue/under/cavewet)
 "uSR" = (
 /obj/structure/stairs{
 	dir = 4
@@ -86094,18 +85615,40 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "uXF" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
+/obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Favours";
+	pixel_x = 3
 	},
-/obj/structure/bell_common{
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/spice,
+/obj/item/reagent_containers/powder/spice,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
+/obj/item/perfume/random{
 	pixel_x = 5;
-	pixel_y = 19
+	pixel_y = 0
 	},
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/obj/item/perfume/random{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "uXG" = (
 /obj/structure/fluff/customsign{
 	icon_state = "signwrote";
@@ -86709,12 +86252,11 @@
 	tavern_area = 1
 	})
 "vfx" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = 0;
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -2;
 	pixel_y = -2
 	},
-/obj/structure/curtain/magenta,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vfC" = (
 /obj/structure/fluff/railing/wood{
@@ -86937,12 +86479,17 @@
 	},
 /area/rogue/indoors/town/church/chapel)
 "vjo" = (
-/obj/structure/mineral_door/wood/deadbolt{
+/obj/structure/fluff/walldeco/church/line{
 	dir = 1;
-	name = "Confessional"
+	pixel_x = 0;
+	pixel_y = 4
 	},
-/turf/closed,
-/area/rogue/under/town/sewer)
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/cave)
 "vjp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -87247,15 +86794,11 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church)
 "vnK" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/chair/wood/rogue/chair4{
+	dir = 1
 	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	icon_state = "floorcandlee1";
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/machinery/light/rogue/candle/red/l,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "vnU" = (
 /obj/structure/stairs{
@@ -87855,22 +87398,16 @@
 	},
 /area/rogue/indoors/shelter/bog)
 "vuU" = (
-/obj/effect/decal/carpet{
-	pixel_x = 15;
-	pixel_y = 12
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Front Office"
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cave)
 "vuV" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = 6
-	},
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/under/cave)
 "vvb" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/cobble,
@@ -87919,11 +87456,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "vvx" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner";
+	dir = 4
 	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "vvH" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
@@ -87999,7 +87536,11 @@
 /area/rogue/outdoors/mountains/decap/rockhill)
 "vwA" = (
 /obj/structure/chair/wood/rogue/chair5,
-/turf/open/floor/rogue/tile/harem2,
+/obj/effect/decal/carpet/square/black{
+	pixel_x = 16;
+	pixel_y = -4
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "vwB" = (
 /turf/open/floor/rogue/woodturned,
@@ -88091,15 +87632,6 @@
 	layer = 1.9
 	},
 /area/rogue/outdoors/woodsrat/north)
-"vxJ" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
 "vxK" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /turf/open/floor/rogue/grassred,
@@ -88252,7 +87784,7 @@
 	icon_state = "longtable";
 	name = "Massage Table"
 	},
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "vzO" = (
 /obj/structure/fluff/wallclock{
@@ -88311,10 +87843,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/warden)
 "vAm" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/chair/bench/couchamagenta,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -21
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vAB" = (
 /obj/structure/fluff/railing/border{
@@ -88722,7 +88256,7 @@
 	dir = 4;
 	pixel_x = 2
 	},
-/turf/open/floor/carpet/inn,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "vGj" = (
 /obj/structure/fluff/statue/abyssor,
@@ -89482,11 +89016,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement/tavern)
 "vQT" = (
-/obj/structure/fluff/statue/pillar{
-	pixel_x = -2;
-	pixel_y = 11
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/hexstone,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "vQZ" = (
 /obj/structure/bed/rogue/inn/wool,
@@ -89738,7 +89271,7 @@
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "vUh" = (
 /obj/structure/fluff/railing/border{
@@ -89756,13 +89289,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
 "vUl" = (
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/obj/structure/fluff/walldeco/church/line{
+/obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/churchmarble,
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "vUp" = (
 /obj/structure/glowshroom,
@@ -89841,11 +89372,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
 "vVo" = (
-/obj/structure/chair/bench/coucha{
-	pixel_y = 2
-	},
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/carpet/inn,
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone/long,
 /area/rogue/indoors/town/bath)
 "vVv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/troll/cave,
@@ -90302,24 +89830,13 @@
 /obj/item/book/rogue/bibble,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"wbn" = (
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = 42
-	},
-/obj/structure/chair/bench/couchablack,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "wbo" = (
-/obj/structure/stairs/stone,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
+/obj/structure/roguemachine/atm{
+	location_tag = "Whitevein";
+	pixel_y = 0
 	},
-/area/rogue/indoors/town/bath)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/under/cave)
 "wbq" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -91442,12 +90959,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bograt/sunken)
 "wqF" = (
-/obj/structure/fluff/statue/small{
-	pass_flags = 1;
-	pixel_y = -2
+/obj/structure/fermentation_keg/redwine,
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = 37
 	},
-/obj/structure/roguewindow/harem2,
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "wqH" = (
 /obj/structure/table/wood{
@@ -91531,22 +91048,9 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/warden)
-"wrB" = (
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = 42
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "wrE" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = 0;
-	pixel_y = -2
-	},
-/obj/structure/curtain/magenta,
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "wrG" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -91918,12 +91422,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/warden)
 "wwF" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/floor/rogue/ruinedwood/turned,
-/area/rogue/under/town/sewer)
+/obj/structure/fermentation_keg/distiller,
+/obj/machinery/light/rogue/candle/blue/r,
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/bath)
 "wwL" = (
 /obj/structure/closet/dirthole/closed,
 /turf/open/floor/rogue/grass,
@@ -92521,17 +92023,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/woodsrat/south)
-"wDQ" = (
-/obj/structure/bars/pipe{
-	dir = 5;
-	layer = 2;
-	pixel_x = -10;
-	pixel_y = -15
-	},
-/turf/open/water/bath{
-	layer = 1.9
-	},
-/area/rogue/indoors/town/bath)
 "wEb" = (
 /obj/structure/roguemachine/scomm/l{
 	scom_tag = "Inquisition Manor - Basement"
@@ -92660,21 +92151,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
-"wFm" = (
-/obj/structure/chair/stool/rogue{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -5
-	},
-/obj/item/natural/cloth{
-	pixel_x = -5
-	},
-/obj/item/soap/bath,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/indoors/town/bath)
 "wFn" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/closed/wall/mineral/rogue/stone,
@@ -93082,13 +92558,8 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "wJD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/tile/harem2,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/bath)
 "wJF" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
@@ -93133,13 +92604,13 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/church)
 "wKd" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/mineral_door/wood/donjon{
+	name = "Office";
+	lockid = "nightmaiden";
+	locked = 1
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/stairs,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "wKe" = (
 /obj/structure/table/wood/poor,
@@ -93658,9 +93129,6 @@
 /obj/item/natural/bundle/fibers/full,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
-"wQG" = (
-/turf/open/water/bath/fakepond,
-/area/rogue/indoors/town/bath)
 "wQL" = (
 /obj/effect/wisp/prestidigitation{
 	color = "#ff2448";
@@ -93867,10 +93335,8 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor/rockhill)
 "wTy" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "wTH" = (
 /obj/structure/flora/roguegrass/herb/random,
@@ -93912,9 +93378,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town/rockhill)
-"wTZ" = (
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "wUl" = (
 /turf/closed/mineral/random/rogue,
 /area/rogue/outdoors/bograt/north)
@@ -94142,13 +93605,8 @@
 /turf/open/floor/rogue/snowrough,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "wXq" = (
-/obj/structure/flora/ausbushes/reedbush{
-	layer = 2;
-	pixel_x = -8;
-	pixel_y = 2
-	},
 /obj/machinery/light/rogue/candle,
-/turf/open/water/bath/fakepond,
+/turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "wXu" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
@@ -94243,7 +93701,7 @@
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_y = 32
 	},
-/obj/item/roguebin/water,
+/obj/machinery/gear_painter,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "wYS" = (
@@ -94582,10 +94040,10 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/Academy)
 "xdC" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/fluff/statue/small,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "xdD" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -94778,10 +94236,9 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/cavewet)
 "xgi" = (
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/hexstone,
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xgo" = (
 /obj/structure/flora/newtree,
@@ -95371,6 +94828,7 @@
 	lockid = "nightmaiden";
 	name = "Kitchen"
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "xoc" = (
@@ -95618,16 +95076,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
 "xrr" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/carpet,
+/area/rogue/under/cave)
 "xrx" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -95666,7 +95116,7 @@
 	pixel_x = 16;
 	pixel_y = -21
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xsa" = (
 /obj/structure/flora/rogueshroom{
@@ -95802,8 +95252,17 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "xtR" = (
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
+/obj/structure/bars/pipe{
+	dir = 5;
+	layer = 2;
+	pixel_x = -15;
+	pixel_y = -8
+	},
+/obj/structure/hotspring{
+	icon_state = "lilypetals2"
+	},
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "xtV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -95841,12 +95300,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "xuA" = (
-/obj/machinery/light/rogue/candle/blue/l{
-	pixel_y = 10
-	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
+/obj/structure/chair/bench/couchamagenta,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xuJ" = (
 /obj/item/roguebin/water{
@@ -96332,10 +95787,24 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "xAO" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Whitevein Downstairs"
+/obj/structure/closet/crate/roguecloset{
+	keylock = 1;
+	lockid = "manor"
 	},
-/turf/closed/wall/mineral/rogue/craftstone,
+/obj/item/bottle_kit,
+/obj/item/reagent_containers/peppermill,
+/obj/item/rogueweapon/huntingknife/chefknife{
+	pixel_x = 5;
+	pixel_y = 1
+	},
+/obj/item/rogueweapon/huntingknife/cleaver{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/kitchen/rollingpin,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "xAT" = (
 /obj/effect/landmark/start/guardsman,
@@ -96918,9 +96387,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
 "xHB" = (
-/obj/effect/landmark/start/nightmaiden,
-/turf/open/floor/rogue/hexstone,
-/area/rogue/indoors/town/bath)
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "xHD" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -96978,14 +96449,6 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet)
 "xII" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
@@ -97615,9 +97078,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
 "xQB" = (
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/bars/steel,
+/obj/structure/bars/steel,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "xQH" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/rooftop/green/corner1,
@@ -98895,21 +98359,20 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/sewer)
 "yho" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/glowshroom,
+/turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
 "yhp" = (
-/obj/structure/fluff/walldeco/church/line,
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/table/church/m,
+/obj/machinery/light/rogue/hearth{
+	pixel_y = 10
 	},
-/obj/structure/chair/bench/coucha/r{
-	pixel_y = 2
+/obj/item/natural/bundle/stick{
+	pixel_x = 14
 	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/church,
+/area/rogue/under/cavewet)
 "yht" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town/rockhill)
@@ -156774,10 +156237,10 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
+sxH
+gOi
+gOi
+dId
 whb
 whb
 whb
@@ -157205,12 +156668,12 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+gps
+tRJ
+yhp
+cRt
+tRJ
+dId
 whb
 whb
 whb
@@ -157637,12 +157100,12 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+kGM
+pCp
+mKf
+hZk
+xtR
+kGM
 whb
 whb
 whb
@@ -158069,12 +157532,12 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+kGM
+jdl
+fVn
+rWD
+hZk
+kGM
 whb
 whb
 whb
@@ -158501,12 +157964,12 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+tRJ
+siB
+hCX
+hZk
+tjy
+kGM
 whb
 whb
 whb
@@ -158933,12 +158396,12 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+nDe
+lUL
+mcL
+mcL
+uSL
+vvx
 whb
 whb
 whb
@@ -159365,11 +158828,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+rmv
+tRJ
+gOi
+gOi
+tRJ
 whb
 whb
 whb
@@ -160220,12 +159683,12 @@ yeY
 vuC
 rTJ
 xCt
-hoS
-isM
-gns
-gns
-cgV
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
 whb
 whb
 whb
@@ -160652,12 +160115,12 @@ otP
 vXL
 taK
 xCt
-aAG
-bjz
-aby
-pCp
-bjz
-cgV
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -161084,12 +160547,12 @@ bKu
 oNk
 oxg
 xCt
-gtj
-lKN
 lsQ
-gOi
-sDQ
-gtj
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -161516,12 +160979,12 @@ xCt
 xCt
 soz
 xCt
-gtj
-jdl
-wpu
-hcW
-gOi
-gtj
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -161939,21 +161402,21 @@ xrC
 eFJ
 eFJ
 sIL
-alL
+eFJ
 soz
 uAi
 uAi
-soz
-eZt
-dgC
-eZt
+gns
 ipI
 bjz
-dWp
-ecV
-gOi
-cZt
-gtj
+gns
+ipI
+ipI
+bjz
+cgV
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -162364,28 +161827,28 @@ gfr
 yee
 yee
 yee
-aoT
-qff
-gLm
+scK
+sIR
+cNQ
 acp
-vvx
+cNQ
 aPk
 ogI
 vGg
-jPH
-aKu
-scK
-soz
-fVn
-eGq
-eGq
+sIR
+sIR
+cro
 xuA
-ajr
+kdw
 rRk
-xtR
-xtR
-rWD
-iGo
+nWH
+xuA
+kdw
+rRk
+gtj
+lsQ
+lsQ
+lsQ
 whb
 whb
 sGa
@@ -162797,27 +162260,27 @@ fPE
 yee
 yee
 scK
-scK
-nvM
+sIR
+dyT
 soz
 eFJ
 mSL
 rqF
-kAa
-goe
-qYl
-eim
-vxJ
-eGq
-wFm
-wpu
-guE
-otv
-bjz
-gns
-gns
-bjz
-hoS
+pXx
+sIR
+sIR
+lwr
+bOT
+kdw
+ecV
+nWH
+bOT
+kdw
+ecV
+gtj
+lsQ
+lsQ
+lsQ
 whb
 whb
 iad
@@ -163229,25 +162692,25 @@ eFJ
 scK
 vdR
 scK
-vVo
-vuU
+sIR
+sIR
 xrC
 rvT
 sIR
 hbl
 sIR
 sIR
-dIY
-wTZ
+sIR
+lwr
 xgi
-eGq
-wpu
-wpu
-wpu
-wDQ
-bjz
-scK
-whb
+kdw
+ecV
+nWH
+xgi
+kdw
+ecV
+gtj
+wQS
 whb
 whb
 whb
@@ -163658,29 +163121,29 @@ vXL
 sWm
 vaX
 qgT
-wTZ
-sAY
-scK
-aVs
 sIR
-xAO
+sIR
+sIR
+sIR
+sIR
+xrC
 rvT
 sIR
 hbl
 sIR
 sIR
-yhp
-sxH
-tIz
-mIy
-rmv
-ecV
-wpu
-wpu
+sIR
 otv
-scK
-bjz
-whb
+tIz
+ufJ
+tIz
+eZt
+tIz
+ufJ
+tIz
+rCz
+ipI
+tRJ
 whb
 whb
 whb
@@ -164090,28 +163553,28 @@ xrC
 scK
 scK
 kJN
-nnl
-sAY
-eFJ
-scK
-mQe
+sIR
+sIR
+sIR
+sIR
+cNQ
 soz
 eFJ
 gGR
 lqS
 qKV
 sIR
-lys
-dLJ
-uvH
-gps
-eGq
-wpu
-wpu
-ecV
-wpu
+sIR
+hSv
+cUC
+cUC
+cUC
+cUC
+cUC
+cUC
+cUC
+cUC
 ivA
-tjy
 pHV
 vTW
 vTW
@@ -164522,28 +163985,28 @@ bjz
 dKR
 vPH
 soz
-wrB
-sAY
-lmJ
-nfP
-eVY
+sIR
+sIR
+sIR
+sIR
+dyT
 hnp
-eVY
+dyT
 gNl
 gNl
 pXx
 sIR
-hON
+sIR
 hSv
 cUC
-gps
-eGq
-wpu
-wpu
-wpu
-wpu
+cUC
+cUC
+cUC
+cUC
+cUC
+cUC
+cUC
 ivA
-tjy
 pHV
 vTW
 vTW
@@ -164954,29 +164417,29 @@ qcz
 jfX
 jfX
 cGQ
-wTZ
-sAY
-lmJ
-eFJ
-iey
-hDM
-sey
-eFJ
-qcG
-qUr
 sIR
-dId
-mcL
-kGM
-ufJ
-guE
-wpu
-ecV
-wpu
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
 otv
-scK
-bjz
-whb
+tIz
+ufJ
+tIz
+otv
+tIz
+ufJ
+tIz
+isM
+ipI
+tRJ
 whb
 whb
 whb
@@ -165386,28 +164849,28 @@ twA
 bFa
 jfX
 yjd
-lUL
-sAY
-lmJ
-oxV
-tag
-tag
-tag
-oxV
-nfP
-gPP
 sIR
-gBZ
-wTZ
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+lwr
 xgi
-eGq
-wpu
-wpu
-wpu
-jNn
-bjz
-scK
-whb
+kdw
+ecV
+lwr
+xgi
+kdw
+ecV
+gtj
+wQS
 whb
 whb
 whb
@@ -165818,27 +165281,27 @@ ady
 vLn
 wpu
 soz
-pLC
-sAY
-lmJ
-oxV
-oxV
-oxV
-oxV
-oxV
-nfP
-jAu
-ebt
-vvx
-ogI
-mKf
-eGq
-wFm
-cRt
-rmv
-otv
-scK
-whb
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+lwr
+xuA
+kdw
+ecV
+lwr
+xuA
+kdw
+ecV
+kGM
 whb
 whb
 whb
@@ -166250,27 +165713,27 @@ scK
 dlu
 dlu
 scK
-wbn
-sAY
-tYx
-hED
-oxV
-hED
-oxV
-hED
-tYx
-sxQ
-ebt
-nDe
-scK
-soz
-dMF
-lXA
-sNv
-anz
-scK
-whb
-whb
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+cro
+bOT
+kdw
+cZt
+lwr
+bOT
+kdw
+tjy
+kGM
 whb
 whb
 whb
@@ -166682,27 +166145,27 @@ vEr
 sLa
 bqs
 eFJ
-hZk
-vUl
-fuU
-bmu
-gPd
-fuU
-gPd
-euh
-fuU
-gNW
-ebt
-tMU
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
 soz
-bjz
 gns
 gns
 bjz
-soz
-scK
-scK
-scK
+gns
+ipI
+ipI
+bjz
+iGo
 scK
 whb
 whb
@@ -167114,18 +166577,18 @@ qYX
 yjj
 yjj
 dbS
-aVb
-hCX
-uSL
-uSL
-uSL
-uSL
-uSL
-uSL
-uSL
-uSL
-siB
-wTZ
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
 tVH
 dpu
 vTh
@@ -167546,18 +167009,18 @@ uUV
 pLA
 bKC
 eFJ
-dcg
-ogI
-ogI
-lUL
-vvx
-ogI
-tJc
-ogI
-szf
-fXp
-ogI
-nWH
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
 qff
 bnO
 aIy
@@ -169701,8 +169164,8 @@ scK
 soz
 scK
 scK
-gKX
-wQG
+mHZ
+wpu
 eGq
 pji
 akg
@@ -170134,7 +169597,7 @@ whb
 whb
 bjz
 kXo
-wQG
+wpu
 bOa
 iGg
 utv
@@ -170565,8 +170028,8 @@ whb
 whb
 whb
 nvH
-bdd
-wQG
+wpu
+wpu
 soz
 nvH
 gbe
@@ -242284,12 +241747,12 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+lMC
+aFT
+aFT
+vuU
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -242716,12 +242179,12 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+wbo
+fLZ
+ejY
+aoT
+tYx
+iia
 cjc
 cjc
 cjc
@@ -243148,12 +242611,12 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+oXT
+aWD
+uQa
+ufe
+ufe
+sbj
 cjc
 cjc
 cjc
@@ -243580,12 +243043,12 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+tcZ
+aoT
+uQa
+xrr
+xrr
+vjo
 cjc
 cjc
 cjc
@@ -244012,12 +243475,12 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+sno
+gYH
+uQa
+sPx
+sPx
+iey
 cjc
 cjc
 cjc
@@ -244444,12 +243907,12 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+vuV
+ieR
+nvM
+uXF
+nfQ
+euh
 cjc
 cjc
 cjc
@@ -267766,26 +267229,26 @@ pdz
 eFO
 eCo
 orb
-iyZ
-rRb
+nvH
+scK
 beZ
-iyZ
-feE
-uQa
-uQa
-uQa
+nvH
+mrD
+bWA
+bWA
+bWA
 nIe
 bWA
 bWA
 bWA
 rUt
-iyZ
-iyZ
-iyZ
-iyZ
-iyZ
-iyZ
-iyZ
+nvH
+nvH
+nvH
+nvH
+nvH
+nvH
+scK
 tcx
 iyZ
 mXk
@@ -268204,20 +267667,20 @@ jOU
 uAi
 cro
 dww
-aum
+kdw
 rpV
 lwr
 vUb
 iBH
 nIo
 rhw
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-iyZ
+gLm
+flB
+hON
+avb
+lys
+bmu
+scK
 oGO
 lrs
 uEX
@@ -268641,15 +268104,15 @@ mkY
 lwr
 vzL
 nxG
-kdw
+jfX
 qut
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-iyZ
+mYd
+mYd
+scK
+dhO
+vUl
+jJq
+scK
 oGO
 lrs
 ctJ
@@ -269067,21 +268530,21 @@ kTh
 pQc
 rFB
 mrD
-rUt
+xdC
 sPd
 kdw
 eQv
-kdw
-kdw
-kdw
+jfX
+jfX
+jfX
 qut
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-iyZ
+mYd
+lOH
+scK
+aQx
+pGs
+uqT
+scK
 otg
 lrs
 ctJ
@@ -269500,20 +268963,20 @@ pQc
 rFB
 mrD
 rUt
-sPd
+osw
 kdw
 eQv
-kdw
-kdw
-kdw
-rhw
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-rRb
+jfX
+jfX
+jfX
+eFJ
+sey
+mYd
+hED
+jxW
+kAa
+xAO
+scK
 otg
 lrs
 uEX
@@ -269937,15 +269400,15 @@ dqX
 lwr
 vwA
 vUb
-kdw
+jfX
 xoa
 cAc
+pQc
+pQc
+sak
 cAc
-cAc
-cAc
-cAc
-cAc
-rRb
+feE
+bjz
 ctJ
 iyZ
 lrs
@@ -270360,24 +269823,24 @@ aZr
 gIO
 rhw
 gzz
-pQc
+tag
 pQc
 vPK
 pzk
 kdw
 kSf
 lwr
-vwA
+fUP
 qKT
 eOx
 eFJ
-rRb
+scK
 jSA
-rRb
-rRb
-rRb
-rRb
-rRb
+scK
+scK
+scK
+scK
+scK
 ctJ
 rSC
 oGO
@@ -270792,24 +270255,24 @@ xWK
 fLn
 eFJ
 eFJ
-scK
+eFJ
 mLT
 qRR
-uAi
+bWA
 owS
-uAi
-uAi
-uAi
-uAi
-uAi
-eFJ
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-rRb
+bWA
+bWA
+bWA
+bWA
+bWA
+qRR
+uwW
+idl
+idl
+mQe
+bjz
+fIL
+fIL
 hFG
 oGO
 rSC
@@ -271223,27 +270686,27 @@ csO
 ckL
 iMj
 orb
-rhw
+vPK
 bnf
+aVs
 pQc
 pQc
 pQc
 pQc
-pQc
-pQc
+aVs
 pQc
 rvT
 njY
 scK
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-rRb
+wqF
+idl
+idl
+aum
+nvH
+xHB
+gPP
+oGO
 rSC
-uEX
 lrs
 lrs
 rSC
@@ -271655,26 +271118,26 @@ mVG
 ckL
 nAB
 csO
-rhw
-aWD
-ejY
+vPK
+pQc
+pQc
+cAc
 pQc
 pQc
 pQc
-xQB
-pQc
+cAc
 pQc
 rvT
 njY
 scK
-cAc
-cAc
-cAc
-cAc
-cAc
-cAc
-rRb
-uEX
+iJF
+idl
+idl
+wwF
+nvH
+fZL
+fZL
+fZL
 jaY
 uEX
 lrs
@@ -272087,24 +271550,24 @@ xWK
 ckL
 lNS
 csO
+qRR
+bng
+bWA
+bWA
+bWA
+bWA
 eFJ
-soz
-iJF
-nvH
-xrC
-xrC
-soz
-lMC
-xrC
-xrC
-xrC
+uAi
+fwH
+uAi
+uAi
 scK
-iWT
-iWT
-iWT
-iWT
-rRb
-rRb
+scK
+scK
+scK
+scK
+scK
+iyZ
 nXf
 hJH
 uun
@@ -272519,18 +271982,18 @@ rYl
 ckL
 uSn
 orb
-soz
+mVl
 hGX
 lZO
 jTy
 vnK
-ggb
+jfX
 epj
 lme
-qUr
-pQc
+kdw
+wrE
+kdw
 jZb
-idl
 iTw
 iTw
 gNw
@@ -272951,17 +272414,17 @@ pSN
 xWK
 lVR
 orb
-rhw
-aQx
-wTZ
-mom
-uXF
-uwW
-nfP
-nfP
-fLZ
+hiw
+jfX
+jfX
+jfX
+jfX
+jfX
+vPK
+vfx
+kdw
 wJD
-scK
+jAu
 scK
 jiQ
 iTw
@@ -273383,16 +272846,16 @@ nZI
 xWK
 xHs
 lyG
-rhw
-tjT
-wTZ
+hiw
+jfX
+fit
 mom
 fit
-myZ
-vTB
+jfX
+vPK
 xrZ
-lys
-gZt
+kdw
+cWN
 njY
 soz
 bwd
@@ -273815,16 +273278,16 @@ lyG
 lyG
 lyG
 lyG
+mVl
+tnc
 eFJ
-nfQ
-wTZ
-tMU
-xrr
-avb
-vAm
+jbC
+eFJ
+tnc
+rhw
 bna
-pQc
-rvT
+kdw
+cWN
 njY
 scK
 ibs
@@ -274240,24 +273703,24 @@ vRu
 gMO
 gMO
 gMO
-soz
+nvH
 nXp
 dwQ
 amt
 kto
-dhO
+dhP
 xII
 wKd
-sPx
-wTZ
-wTZ
-cQX
-wbo
-nfP
-eFJ
+jfX
+fuU
 rfY
-eFJ
-uAi
+fuU
+jfX
+gZt
+kdw
+kdw
+wJD
+jAu
 eFJ
 cBf
 iTw
@@ -274271,7 +273734,7 @@ uEX
 fZL
 uEX
 gLf
-rSC
+gLf
 rSC
 lrs
 imq
@@ -274673,24 +274136,24 @@ gMO
 tLK
 gMO
 nvH
-sno
-qUr
-hON
-nMr
+qRR
+vVo
+vVo
+qRR
 wTy
-xHB
-cUC
-gGL
-wTZ
-wTZ
-uqT
-scK
+dhP
 tWl
-eFJ
-tnc
+jfX
+jfX
+eVY
+jfX
+jfX
+tWl
+xrZ
+kdw
 qLo
 cUF
-eFJ
+qRR
 mQj
 wbD
 rDV
@@ -275104,22 +274567,22 @@ tQZ
 uEX
 gMO
 gMO
-xrC
+nvH
 mVl
 qUr
 aTg
 rct
-mYd
+dhP
 vQT
-cUC
-cQX
-wTZ
-wTZ
-eDw
+qRR
+qRR
+bsY
+bsY
+bsY
 eqj
 nYX
-osw
-bsp
+kdw
+kdw
 bsp
 deO
 sMN
@@ -275536,23 +274999,23 @@ tQZ
 uEX
 mXk
 gMO
-xrC
+nvH
 hiw
-qUr
-lys
+vAm
+kdw
 sUG
-fwH
-xHB
-cUC
+dhP
+dhP
+dbq
 gGL
-wTZ
-wTZ
-eDw
-nSY
-jxW
+kdw
+kdw
+kdw
+kdw
+dbq
 vfx
-oxV
-oxV
+kdw
+kdw
 jnW
 scK
 iYW
@@ -275968,24 +275431,24 @@ xpI
 uun
 uEX
 gMO
-soz
-jbC
-ufe
-gYH
-xdC
-lOH
-lOH
+nvH
+hiw
+bOT
+kdw
+sUG
+dhP
+dhP
 cjQ
-tcZ
-wTZ
-fUP
+kdw
 eDw
-qDT
+kdw
+eDw
+kdw
 nPb
-wrE
+xrZ
+kdw
 gPd
-gPd
-oxB
+kdw
 scK
 iWT
 cBf
@@ -276398,24 +275861,24 @@ vRu
 vRu
 tQZ
 gMO
-gMO
-gMO
+uEX
+gNW
 nvH
-xrC
-sIR
-ebt
-dhP
+mVl
+ggb
+qcG
+rct
 spx
 dhP
 dbq
 rUg
-iia
-fXp
-dYM
+kdw
+thM
+kdw
 dzn
-eZt
+dbq
 fzf
-oXT
+aTg
 qoJ
 uFw
 scK
@@ -276830,26 +276293,26 @@ vRu
 vRu
 tQZ
 tLK
-gMO
-iyZ
-iyZ
+uEX
+uEX
 nvH
+qRR
 tOu
-soz
-eFJ
-eFJ
-eFJ
-wqF
-ieR
+tOu
+qRR
+bWA
+bWA
+qRR
+uAi
 kKd
 oTd
 ruk
-bng
-soz
-eFJ
-soz
 uAi
-eFJ
+qRR
+bWA
+bWA
+bWA
+qRR
 scK
 iWT
 iTw
@@ -277262,23 +276725,23 @@ vRu
 vRu
 tQZ
 gMO
+ocN
+uEX
+tLK
+iyZ
+iyZ
+iyZ
+iyZ
+tLK
+lct
 gMO
-wRU
-sbj
-dnb
-dnv
-dnb
-vjo
-lqt
-lqt
-wwF
 qMQ
-aQY
-xZo
-bsY
+dYM
+buy
+gMO
 lnq
-gMO
-gMO
+abF
+ckQ
 gLf
 rRb
 rRb
@@ -277694,20 +277157,20 @@ vRu
 vRu
 tQZ
 gMO
-tLK
-iyZ
-iyZ
+fIL
+uEX
+uEX
+lEn
+fIL
 gEP
 iyZ
-gEP
-rRb
 dpJ
 bJl
-lct
-vuV
-aFT
-flB
-jJq
+aQY
+aQY
+aQY
+aQY
+xZo
 meU
 wvM
 dWF
@@ -278126,19 +277589,19 @@ vRu
 vRu
 vRu
 tLK
-gMO
-gMO
-iyZ
-buy
-sak
+uEX
+uEX
+uEX
+uEX
+uEX
 yho
-thM
+iyZ
 gMO
 iHh
 lqx
-pGs
-gMO
 lqx
+tLK
+dnb
 lHb
 lqt
 spQ
@@ -278560,19 +278023,19 @@ tQZ
 tQZ
 pvK
 uEX
-iyZ
-iyZ
-iyZ
-iyZ
-rRb
-dpJ
+uEX
+fIL
+lEn
+lEn
+xQB
+gMO
 iHh
-pFg
+tjT
 lEn
 lLk
 pFg
 lHb
-abF
+bJl
 bpi
 dWF
 gMO
@@ -278994,7 +278457,7 @@ ocN
 gMO
 uEX
 uEX
-gMO
+uEX
 gMO
 maJ
 tLK
@@ -279426,7 +278889,7 @@ gMO
 uEX
 ocN
 ocN
-gMO
+uEX
 gMO
 rtV
 gMO

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -228,6 +228,9 @@
 	pixel_y = 4;
 	redstone_id = "entrancelockdown"
 	},
+/obj/structure/roguemachine/scomm/l{
+	scom_tag = "Whitevein - Front Office"
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "acB" = (
@@ -14646,8 +14649,9 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue)
 "dzn" = (
-/obj/item/roguebin/trash,
-/obj/machinery/light/rogue/candle/r,
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Whitevein - Lobby"
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dzq" = (
@@ -16048,6 +16052,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/grove)
+"dQD" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Whitevein - Kitchen"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "dQH" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -30328,6 +30338,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor/rockhill)
+"hnK" = (
+/obj/structure/roguemachine/drugmachine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/indoors/town/bath)
 "hnO" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/chair/wood/rogue/chair3{
@@ -33587,6 +33601,10 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"icN" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "icW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -37507,7 +37525,7 @@
 /area/rogue/under/underdarker/rockhill)
 "jdl" = (
 /obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/under/cavewet)
 "jdr" = (
 /obj/structure/stairs/fancy/r{
@@ -40800,10 +40818,6 @@
 /obj/effect/decal/carpet/square/black{
 	dir = 8;
 	pixel_x = 2
-	},
-/obj/structure/fluff/wallclock{
-	pixel_x = -32;
-	pixel_y = 0
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
@@ -50497,7 +50511,6 @@
 	lockid = "nightman";
 	name = "Nighmaster's Room"
 	},
-/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "mmv" = (
@@ -55573,6 +55586,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
+"nyE" = (
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	desc = "These candles produces a heady vapor, warding away the less pleasing scents of the sewer.";
+	name = "scented candles";
+	pixel_y = 4;
+	plane = -7
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "nyI" = (
 /obj/structure/stairs/stone/ccwdown{
 	dir = 4
@@ -57470,7 +57492,7 @@
 "nWH" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32;
-	scom_tag = "Whitevein - Waiting Room"
+	scom_tag = "Whitevein - Lounge"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -72190,6 +72212,15 @@
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
+"rFS" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/roguemachine/mail{
+	mailtag = "Whitevein - Office"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "rGf" = (
 /turf/closed/wall/mineral/rogue/stone/window{
 	icon_state = "stonewindow"
@@ -76562,7 +76593,11 @@
 /obj/structure/stairs/stone{
 	dir = 4
 	},
-/obj/structure/curtain/magenta,
+/obj/structure/curtain/magenta{
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "sIN" = (
@@ -78948,8 +78983,12 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor/rockhill)
 "tnc" = (
-/obj/structure/curtain/magenta,
 /obj/machinery/light/rogue/candle,
+/obj/structure/curtain/magenta{
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "tnd" = (
@@ -79863,7 +79902,6 @@
 	pixel_x = -10;
 	pixel_y = -8
 	},
-/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "tyA" = (
@@ -84089,6 +84127,38 @@
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/natural/feather,
+/obj/item/roguekey/nightmaiden{
+	icon_state = "spikekey";
+	lockid = "punishroom";
+	name = "punishment room key";
+	pixel_y = 4;
+	pixel_x = 10
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux1";
+	name = "room I key"
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux2";
+	name = "room II key";
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux3";
+	name = "room III key";
+	pixel_y = 7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux4";
+	name = "room IV key";
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "steam";
+	name = "steam room key"
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "uzr" = (
@@ -95975,7 +96045,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/underdarker/rockhill)
 "xyu" = (
-/obj/structure/curtain/magenta,
+/obj/structure/curtain/magenta{
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "xyA" = (
@@ -163557,7 +163631,7 @@ rct
 ufJ
 rct
 bjz
-kdw
+jfX
 tRJ
 tRJ
 gOi
@@ -163968,9 +164042,9 @@ eFJ
 eFJ
 eFJ
 eFJ
-qKT
+icN
 jfX
-qRR
+hnK
 lcD
 lcD
 qRR
@@ -164834,7 +164908,7 @@ kdw
 cGQ
 jfX
 mym
-hnp
+nyE
 cUC
 hnp
 jAb
@@ -166995,7 +167069,7 @@ dbS
 jfX
 kgP
 hnp
-hnp
+kfv
 hnp
 grO
 kFp
@@ -269821,7 +269895,7 @@ cAc
 pQc
 pQc
 sak
-pQc
+dQD
 feE
 bjz
 ctJ
@@ -273262,7 +273336,7 @@ xWK
 xHs
 lyG
 mVl
-oFW
+rFS
 mom
 mom
 mom
@@ -276289,7 +276363,7 @@ dbq
 rUg
 kdw
 thM
-kdw
+vfx
 dzn
 dbq
 fzf

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -222,14 +222,13 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "acp" = (
-/obj/structure/bed/rogue/inn{
-	dir = 1
+/obj/structure/lever/wall{
+	dir = 8;
+	name = "Entrance Lockdown";
+	pixel_y = 4;
+	redstone_id = "entrancelockdown"
 	},
-/obj/item/bedsheet/rogue/fabric{
-	dir = 1
-	},
-/obj/structure/curtain/magenta,
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "acB" = (
 /obj/structure/bed/rogue,
@@ -1556,8 +1555,12 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
 "aum" = (
-/obj/structure/fermentation_keg/redwine,
-/turf/open/floor/rogue/cobble,
+/obj/item/roguebin/trash{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/tile/brownbrick{
+	color = "#ffd9f2"
+	},
 /area/rogue/indoors/town/bath)
 "auq" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -1816,12 +1819,11 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/woodsrat/above)
 "axp" = (
-/obj/item/roguebin/trash{
-	pixel_y = 5
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = 27
 	},
-/turf/open/floor/rogue/tile/brownbrick{
-	color = "#ffd9f2"
-	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "axt" = (
 /obj/structure/chair/stool/rogue,
@@ -2685,12 +2687,19 @@
 	},
 /area/rogue/under/cave/rhgoblinencampment)
 "aIb" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 8
+/obj/structure/chair/wood,
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/turf/open/floor/rogue/tile/harem2,
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_y = 45
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "aIf" = (
 /obj/structure/fluff/railing/border,
@@ -2723,8 +2732,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
 "aIl" = (
-/obj/structure/fermentation_keg/distiller,
-/turf/open/floor/rogue/cobble,
+/obj/structure/toilet,
+/obj/structure/bars/grille{
+	dir = 1
+	},
+/turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/bath)
 "aIm" = (
 /turf/open/floor/rogue/ruinedwood{
@@ -2812,22 +2824,6 @@
 /obj/structure/roguemachine/noticeboard,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/south)
-"aJC" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "locker2";
-	name = "locker 2"
-	},
-/obj/structure/curtain/magenta{
-	color = "#a1254a"
-	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker3";
-	name = "locker 3 key"
-	},
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "aJE" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble/mossy,
@@ -3207,10 +3203,18 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
 "aNp" = (
-/obj/structure/bell_common{
-	dir = 4;
-	pixel_x = -10;
-	pixel_y = -8
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker6";
+	name = "locker 6"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/item/roguekey/roomi/village{
+	lockid = "locker6";
+	name = "locker 6 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -5756,6 +5760,15 @@
 /obj/structure/flora/roguetree,
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bograt/sunken)
+"bvJ" = (
+/obj/structure/mineral_door/wood/donjon{
+	dir = 4;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Arena"
+	},
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/bath)
 "bvO" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -6913,17 +6926,18 @@
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
 "bKC" = (
-/obj/structure/mineral_door/wood/donjon{
-	locked = 1;
-	lockid = "dungeon";
-	name = "Dungeons"
-	},
-/obj/structure/curtain/black{
-	open = 0;
-	opacity = 1;
-	icon_state = "curtain-closed"
-	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bKE" = (
 /obj/structure/fluff/railing/border/north,
@@ -10694,6 +10708,11 @@
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
+"cEf" = (
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/floorcandle/pink,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "cEh" = (
 /obj/structure/fluff/railing/corner,
 /obj/structure/fluff/psycross,
@@ -12850,13 +12869,17 @@
 	},
 /area/rogue/outdoors/woodsrat/north)
 "ddp" = (
-/obj/structure/lever/wall{
-	dir = 8;
-	name = "Entrance Lockdown";
-	pixel_y = 4;
-	redstone_id = "entrancelockdown"
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "dungeon";
+	name = "Dungeons"
 	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/curtain/black{
+	open = 0;
+	opacity = 1;
+	icon_state = "curtain-closed"
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "dds" = (
 /turf/open/floor/rogue/blocks,
@@ -14000,24 +14023,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bogsafe)
 "dru" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	name = "Tableware"
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/structure/curtain/magenta{
-	color = "#a1254a";
-	icon_state = "curtain-closed";
-	opacity = 1;
-	open = 0
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cavewet)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "drA" = (
 /obj/item/roguebin/water/gross,
 /obj/item/roguebin/water/gross,
@@ -15576,10 +15588,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet)
 "dKR" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/obj/structure/bars,
-/turf/open/water/swamp,
-/area/rogue/under/town/sewer)
+/obj/structure/curtain/magenta,
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/bath)
 "dLa" = (
 /obj/structure/wooden_horse/mobile,
 /turf/open/floor/rogue/cobble/mossy,
@@ -15789,19 +15800,20 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "dOe" = (
-/obj/structure/chair/wood,
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker4";
+	name = "locker 4"
 	},
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine{
-	pixel_x = -6;
-	pixel_y = 45
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
 	},
-/obj/item/reagent_containers/glass/bottle/rogue/redwine{
-	pixel_y = 45
+/obj/item/roguekey/roomi/village{
+	lockid = "locker4";
+	name = "locker 4 key"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dOj" = (
 /turf/closed/mineral/rogue,
@@ -18227,23 +18239,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "ete" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	name = "Games"
-	},
-/obj/item/toy/cards/deck,
-/obj/item/toy/cards/deck,
-/obj/item/toy/cards/deck/tarot,
-/obj/item/storage/pill_bottle/dice/farkle,
-/obj/item/storage/pill_bottle/dice/farkle,
-/obj/structure/curtain/magenta{
-	color = "#a1254a";
-	icon_state = "curtain-closed";
-	opacity = 1;
-	open = 0
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cavewet)
+/obj/structure/fluff/pillow/magenta,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "etg" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -18728,12 +18726,12 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/woodsrat/north)
 "eyL" = (
-/obj/item/hair_dye_cream,
-/obj/item/dye_brush,
-/obj/item/needle/thorn,
-/obj/item/natural/cloth,
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/blocks/paving,
+/obj/structure/fluff/walldeco/maidendrape,
+/obj/item/candle/eora/lit{
+	pixel_x = -5;
+	pixel_y = 18
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "eyO" = (
 /obj/structure/fluff/railing/border{
@@ -19133,20 +19131,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "eDb" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "locker5";
-	name = "locker 5"
-	},
-/obj/structure/curtain/magenta{
-	color = "#a1254a"
-	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker5";
-	name = "locker 5 key"
-	},
-/turf/open/floor/rogue/tile/harem2,
+/obj/structure/fermentation_keg/distiller,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "eDc" = (
 /obj/structure/rack/rogue/shelf,
@@ -20959,7 +20945,11 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town/grove)
 "eZt" = (
-/obj/structure/fermentation_keg/water,
+/obj/structure/bell_common{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = -8
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "eZx" = (
@@ -21449,12 +21439,6 @@
 "ffv" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
-"ffw" = (
-/obj/structure/fluff/walldeco/chains{
-	pixel_y = -15
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/indoors/town/bath)
 "ffz" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains/decap/rockhill)
@@ -28236,9 +28220,8 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor/rockhill)
 "gPP" = (
-/obj/structure/table/wood/poor,
-/obj/machinery/light/rogue/candle/floorcandle/pink,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fermentation_keg/redwine,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "gPV" = (
 /obj/structure/flora/roguegrass/water/reeds,
@@ -28513,14 +28496,8 @@
 	},
 /area/rogue/outdoors/beach/harbor)
 "gTt" = (
-/obj/structure/bars/pipe{
-	dir = 1;
-	layer = 2;
-	pixel_x = 10;
-	pixel_y = -10
-	},
-/turf/open/water/bath,
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "gTw" = (
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
@@ -32689,11 +32666,12 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church)
 "hTq" = (
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -2
+/obj/structure/fluff/pillow/magenta{
+	dir = 8
 	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "hTE" = (
 /obj/structure/spider/stickyweb,
@@ -33829,10 +33807,14 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "ihq" = (
-/obj/structure/fermentation_keg,
-/obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "dungeon";
+	name = "Bathhouse"
+	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/cell)
 "ihs" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/mountains/decap/rockhill)
@@ -35818,7 +35800,10 @@
 /area/rogue/under/cave/skeletoncrypt)
 "iJF" = (
 /obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/tile/harem2,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_y = 37
+	},
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "iJP" = (
 /obj/structure/roguemachine/scomm{
@@ -38924,9 +38909,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor/rockhill)
 "jxQ" = (
-/obj/structure/shisha/hookah,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/obj/structure/fermentation_keg/beer,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "jxS" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet)
@@ -40999,9 +40984,15 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church)
 "jYg" = (
-/obj/structure/fermentation_keg/beer,
-/turf/open/floor/rogue/cobble,
-/area/rogue/under/town/sewer)
+/obj/structure/bed/rogue/inn{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric{
+	dir = 1
+	},
+/obj/structure/curtain/magenta,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "jYx" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
@@ -41187,17 +41178,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter/mountains)
 "kaO" = (
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
-/obj/item/reagent_containers/glass/cup/steel,
+/obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kaP" = (
@@ -41342,12 +41323,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield/rockhill/above)
 "kdd" = (
-/obj/structure/fluff/walldeco/maidendrape,
-/obj/item/candle/eora/lit{
-	pixel_x = -5;
-	pixel_y = 18
-	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "kdh" = (
 /obj/structure/bed/rogue/shit,
@@ -43156,9 +43132,9 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/shop)
 "kxR" = (
-/obj/structure/curtain/magenta,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/under/cavewet)
 "kxU" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -44574,6 +44550,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"kQO" = (
+/obj/item/roguebin/trash{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/bath)
 "kQW" = (
 /obj/structure/roguethrone{
 	name = "throne of Rockhill"
@@ -45260,10 +45242,8 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/rockhill)
 "kZR" = (
-/obj/item/roguebin/trash{
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/cobble,
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kZS" = (
 /obj/structure/table/wood{
@@ -51296,10 +51276,12 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
 "mym" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/obj/structure/bars,
-/turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "myq" = (
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
@@ -55318,6 +55300,9 @@
 	icon_state = "longtable";
 	name = "Massage Table"
 	},
+/obj/machinery/light/rogue/candle/green{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
 "nyn" = (
@@ -56327,14 +56312,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/woodsrat/south)
-"nLu" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
 "nLx" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/outdoors/woodsrat/north)
@@ -57988,8 +57965,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/tavern)
 "ofB" = (
-/obj/structure/fluff/pillow/magenta,
-/turf/open/floor/carpet/royalblack,
+/obj/structure/fluff/walldeco/chains{
+	pixel_y = -15
+	},
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/bath)
 "ofC" = (
 /obj/structure/flora/newleaf,
@@ -59063,8 +59042,23 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "otv" = (
-/turf/open/floor/rogue/blocks/platform,
-/area/rogue/indoors/town/bath)
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	name = "Games"
+	},
+/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck/tarot,
+/obj/item/storage/pill_bottle/dice/farkle,
+/obj/item/storage/pill_bottle/dice/farkle,
+/obj/structure/curtain/magenta{
+	color = "#a1254a";
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cavewet)
 "otC" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
@@ -60071,9 +60065,6 @@
 	dir = 1;
 	icon_state = "longtable";
 	name = "Massage Table"
-	},
-/obj/machinery/light/rogue/candle/green{
-	pixel_y = -32
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/bath)
@@ -61863,6 +61854,12 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
+"pcI" = (
+/obj/item/roguebin/trash{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "pcK" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /obj/structure/flora/roguegrass,
@@ -65354,9 +65351,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woodsrat/south)
 "pUM" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/under/cavewet)
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/bars,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "pVc" = (
 /obj/structure/curtain,
 /turf/open/floor/rogue/church,
@@ -65520,13 +65518,10 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "pXx" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 4;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Arena"
+/obj/effect/decal/carpet{
+	pixel_y = 17
 	},
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "pXB" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
@@ -75536,15 +75531,15 @@
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
 	locked = 1;
-	lockid = "locker4";
-	name = "locker 4"
+	lockid = "locker1";
+	name = "locker I"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
 /obj/item/roguekey/roomi/village{
-	lockid = "locker4";
-	name = "locker 4 key"
+	lockid = "locker1";
+	name = "locker 1 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -79557,14 +79552,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "tyx" = (
-/obj/structure/mineral_door/wood/donjon{
-	dir = 1;
-	locked = 1;
-	lockid = "dungeon";
-	name = "Bathhouse"
+/obj/structure/bell_common{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = -8
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/cell)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "tyA" = (
 /obj/structure/table/wood/poor,
 /obj/machinery/light/rogue/candle/off{
@@ -84009,12 +84003,10 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "uCg" = (
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = 27
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/bars,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "uCi" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
@@ -86072,15 +86064,15 @@
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
 	locked = 1;
-	lockid = "locker6";
-	name = "locker 6"
+	lockid = "locker5";
+	name = "locker 5"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
 /obj/item/roguekey/roomi/village{
-	lockid = "locker6";
-	name = "locker 6 key"
+	lockid = "locker5";
+	name = "locker 5 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -88644,14 +88636,12 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
 "vLn" = (
-/obj/effect/decal/carpet/kover_purple{
-	dir = 4;
-	pixel_x = 20;
-	pixel_y = -15
-	},
-/obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/turf/open/floor/rogue/tile/harem2,
+/obj/item/hair_dye_cream,
+/obj/item/dye_brush,
+/obj/item/needle/thorn,
+/obj/item/natural/cloth,
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "vLo" = (
 /obj/structure/flora/roguetree/evil,
@@ -88843,11 +88833,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor/rockhill)
 "vOe" = (
-/obj/structure/toilet,
-/obj/structure/bars/grille{
-	dir = 1
-	},
-/turf/open/floor/rogue/blocks/newstone/alt,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "vOg" = (
 /obj/structure/fluff/railing/fence{
@@ -88927,15 +88914,15 @@
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
 	locked = 1;
-	lockid = "locker1";
-	name = "locker I"
+	lockid = "locker2";
+	name = "locker 2"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
 /obj/item/roguekey/roomi/village{
-	lockid = "locker1";
-	name = "locker 1 key"
+	lockid = "locker3";
+	name = "locker 3 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -90966,12 +90953,24 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bograt/sunken)
 "wqF" = (
-/obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_y = 37
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	name = "Tableware"
 	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/bath)
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/structure/curtain/magenta{
+	color = "#a1254a";
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cavewet)
 "wqH" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -94304,10 +94303,14 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "xhv" = (
-/obj/item/roguebin/trash{
-	pixel_y = 5
+/obj/effect/decal/carpet/kover_purple{
+	dir = 4;
+	pixel_x = 20;
+	pixel_y = -15
 	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xhx" = (
 /obj/item/natural/poo/cow,
@@ -95554,13 +95557,14 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy,
 /area/rogue/under/cave/skeletoncrypt)
 "xxR" = (
-/obj/structure/bell_common{
-	dir = 4;
-	pixel_x = -10;
-	pixel_y = -8
+/obj/structure/bars/pipe{
+	dir = 1;
+	layer = 2;
+	pixel_x = 10;
+	pixel_y = -10
 	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "xxY" = (
 /obj/machinery/light/rogue/firebowl/off,
 /turf/open/floor/rogue/grass,
@@ -95702,7 +95706,8 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/Academy)
 "xzL" = (
-/turf/open/floor/rogue/tile/bath,
+/obj/structure/shisha/hookah,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "xzN" = (
 /obj/structure/stairs/stone{
@@ -97113,10 +97118,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/south)
 "xQX" = (
-/obj/effect/decal/carpet{
-	pixel_y = 17
-	},
-/turf/open/floor/rogue/tile/harem,
+/obj/structure/fermentation_keg,
+/obj/machinery/light/rogue/candle/blue/r,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "xRa" = (
 /turf/open/water/river/muddy{
@@ -156660,7 +156664,7 @@ abI
 hKR
 djL
 odm
-kxR
+dKR
 bJx
 kIL
 eFJ
@@ -157104,7 +157108,7 @@ thM
 eFJ
 eFJ
 xkI
-acp
+jYg
 eFJ
 eFJ
 whb
@@ -157537,7 +157541,7 @@ eFJ
 jUB
 qcz
 qcz
-acp
+jYg
 eFJ
 whb
 whb
@@ -157956,7 +157960,7 @@ qRR
 scK
 kmW
 jfX
-hTq
+mym
 uzk
 eFJ
 eFJ
@@ -158383,7 +158387,7 @@ grO
 qRR
 hSV
 yee
-eyL
+vLn
 qRR
 fJX
 peE
@@ -160122,9 +160126,9 @@ pQc
 cWN
 idl
 tLa
-otv
+kdd
 otP
-otv
+kdd
 taK
 eFJ
 gGR
@@ -160549,7 +160553,7 @@ idl
 mVl
 cAm
 pQc
-uCg
+axp
 pQc
 cWN
 fBN
@@ -160972,9 +160976,9 @@ wPo
 tYD
 wPo
 eFJ
-vOe
+aIl
 fPJ
-vOe
+aIl
 qRR
 qRR
 idl
@@ -160984,7 +160988,7 @@ pQc
 pQc
 pQc
 cWN
-kZR
+kQO
 eFJ
 eFJ
 eFJ
@@ -161836,19 +161840,19 @@ bXZ
 xCt
 scK
 gfr
-xzL
-xzL
-xzL
+gTt
+gTt
+gTt
 vPK
-kaO
+bKC
 kdw
 kdw
 kdw
 kdw
 ccw
 jfX
-nLu
-gPP
+dru
+cEf
 cro
 nXJ
 rFo
@@ -162269,18 +162273,18 @@ xCt
 xCt
 eFJ
 fPE
-xzL
-xzL
+gTt
+gTt
 vPK
-eZt
+kaO
 kdw
 qRR
 rqF
 mSL
 qRR
 jfX
-jxQ
-ofB
+xzL
+ete
 lwr
 bOT
 kdw
@@ -162694,7 +162698,7 @@ nvH
 nvH
 xlO
 vXL
-ffw
+ofB
 wPo
 wPo
 bPA
@@ -162704,7 +162708,7 @@ eFJ
 vVo
 fSS
 qRR
-iJF
+kZR
 gps
 eFJ
 hbl
@@ -163123,7 +163127,7 @@ kYH
 kYH
 kYH
 kYH
-bKC
+ddp
 vXL
 jPI
 jPI
@@ -163144,7 +163148,7 @@ asP
 wFB
 asP
 jfX
-xhv
+pcI
 qRR
 tIz
 ufJ
@@ -163993,13 +163997,13 @@ eFJ
 eFJ
 eFJ
 eFJ
+aNp
 vdR
-eDb
-sAY
+dOe
 cro
 jfX
 jfX
-xxR
+tyx
 jfX
 jfX
 jfX
@@ -165290,8 +165294,8 @@ yjj
 wMC
 eFJ
 ady
-aJC
 vPH
+sAY
 cro
 jfX
 jfX
@@ -165714,7 +165718,7 @@ vqG
 whb
 whb
 eFJ
-kdd
+eyL
 asP
 asP
 eFJ
@@ -165744,7 +165748,7 @@ cZt
 lwr
 bOT
 kJN
-gTt
+xxR
 kGM
 whb
 whb
@@ -166123,7 +166127,7 @@ lOc
 lOc
 dHW
 iQm
-tyx
+ihq
 kYH
 kYH
 kYH
@@ -166605,7 +166609,7 @@ tVH
 dpu
 vTh
 vTh
-axp
+aum
 sRH
 cqQ
 ooc
@@ -167023,16 +167027,16 @@ iel
 eFJ
 jfX
 jfX
+vOe
+jfX
+jfX
+vOe
 jfX
 jfX
 jfX
 jfX
-jfX
-jfX
-jfX
-jfX
-jfX
-xhv
+vOe
+pcI
 qff
 bnO
 aIy
@@ -168751,7 +168755,7 @@ tHn
 hQG
 nyf
 rhw
-dOe
+aIb
 bIc
 dJa
 hCf
@@ -170479,10 +170483,10 @@ eFJ
 eFJ
 eFJ
 eFJ
-ete
+otv
 kcM
 lGk
-dru
+wqF
 eFJ
 eFJ
 fqM
@@ -170912,8 +170916,8 @@ whb
 whb
 whb
 bjD
-pUM
-pUM
+kxR
+kxR
 bjD
 whb
 rhw
@@ -270280,10 +270284,10 @@ bWA
 qRR
 uwW
 idl
-aum
+gPP
 mQe
 idl
-jYg
+jxQ
 nXf
 hFG
 oGO
@@ -270710,7 +270714,7 @@ pQc
 rvT
 njY
 scK
-wqF
+iJF
 idl
 idl
 idl
@@ -271142,9 +271146,9 @@ pQc
 rvT
 njY
 scK
-wqF
-ihq
-aIl
+iJF
+xQX
+eDb
 wwF
 idl
 gMO
@@ -271574,12 +271578,12 @@ fwH
 uAi
 uAi
 scK
-pXx
+bvJ
 scK
 scK
 scK
 scK
-mym
+uCg
 rRb
 hJH
 uun
@@ -271999,7 +272003,7 @@ hGX
 lZO
 jTy
 vnK
-ddp
+acp
 epj
 lme
 kdw
@@ -272443,7 +272447,7 @@ iTw
 iWT
 iWT
 lrs
-dKR
+pUM
 rRb
 lrs
 lrs
@@ -274153,7 +274157,7 @@ vVo
 vVo
 qRR
 wTy
-xQX
+pXx
 tWl
 jfX
 jfX
@@ -274582,7 +274586,7 @@ gMO
 nvH
 mVl
 qUr
-aIb
+hTq
 rct
 dhP
 vQT
@@ -275023,7 +275027,7 @@ gGL
 kdw
 kdw
 kdw
-aNp
+eZt
 dbq
 vfx
 kdw
@@ -275449,7 +275453,7 @@ bOT
 kdw
 sUG
 dhP
-xQX
+pXx
 cjQ
 kdw
 eDw
@@ -275459,7 +275463,7 @@ kdw
 nPb
 xrZ
 kdw
-vLn
+xhv
 kdw
 scK
 iWT

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -281,17 +281,13 @@
 "ady" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
-	locked = 1;
-	lockid = "locker3";
 	name = "locker 3"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker2";
-	name = "locker 2 key"
-	},
+/obj/machinery/light/rogue/candle/red,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "adC" = (
@@ -1482,6 +1478,12 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsafe)
+"atr" = (
+/obj/structure/stairs/stone{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "ats" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "EscapeDieTroyt1";
@@ -2219,7 +2221,8 @@
 /obj/item/bedsheet/rogue/fabric_double{
 	dir = 1
 	},
-/turf/open/floor/carpet/purple,
+/obj/effect/decal/carpet/kover_darkred,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "aCn" = (
 /obj/structure/closet/crate/roguecloset/dark{
@@ -2736,6 +2739,7 @@
 /obj/structure/bars/grille{
 	dir = 1
 	},
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/bath)
 "aIm" = (
@@ -3205,17 +3209,12 @@
 "aNp" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
-	locked = 1;
-	lockid = "locker6";
 	name = "locker 6"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker6";
-	name = "locker 6 key"
-	},
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "aNy" = (
@@ -3315,6 +3314,12 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
+"aPn" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "aPr" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/church)
@@ -3505,6 +3510,12 @@
 	water_color = "#3459a3"
 	},
 /area/rogue/under/cavewet)
+"aRM" = (
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/town/bath)
 "aRN" = (
 /obj/structure/roguewindow/stained/silver,
 /turf/open/floor/rogue/church,
@@ -3569,7 +3580,7 @@
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/wizarddungeon)
 "aSr" = (
-/obj/structure/ladder/unbreakable,
+/obj/structure/ladder,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "aSw" = (
@@ -5071,6 +5082,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town/church)
+"bmr" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "bms" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -5080,6 +5097,7 @@
 /area/rogue/indoors/town/manor/rockhill)
 "bmu" = (
 /obj/structure/fermentation_keg/water,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "bmy" = (
@@ -5137,8 +5155,8 @@
 /turf/open/floor/rogue/dirt/nospawn,
 /area/rogue/outdoors/bogsafe)
 "bnf" = (
-/obj/machinery/light/rogue/candle/red/l,
-/turf/open/floor/rogue/churchrough,
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "bng" = (
 /obj/structure/mineral_door/wood/red{
@@ -5181,7 +5199,6 @@
 /area/rogue/under/town/sewer)
 "bnO" = (
 /obj/structure/table/wood/poor,
-/obj/machinery/light/rogue/candle/floorcandle/alt,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "boa" = (
@@ -5767,7 +5784,7 @@
 	lockid = "nightmaiden";
 	name = "Arena"
 	},
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "bvO" = (
 /obj/machinery/light/rogue/candle{
@@ -6821,8 +6838,7 @@
 	icon_state = "borderfall";
 	pixel_y = -8
 	},
-/obj/structure/curtain/magenta,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bJK" = (
 /obj/structure/table/wood/poor,
@@ -7150,6 +7166,10 @@
 	color = "#d4ffcf"
 	},
 /area/rogue/under/cave/skeletoncrypt)
+"bMZ" = (
+/obj/structure/stairs/stone,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "bNh" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassyel,
@@ -7660,10 +7680,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church)
-"bSL" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/indoors/town/bath)
 "bSM" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -7728,6 +7744,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
+"bTz" = (
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink{
+	icon_state = "floorcandle1"
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "bTC" = (
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/tile{
@@ -8154,6 +8176,9 @@
 /area/rogue/indoors/town/manor/rockhill)
 "bXZ" = (
 /obj/structure/bondage/torture_table/lever,
+/obj/machinery/light/rogue/candle/green{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "bYf" = (
@@ -10214,6 +10239,10 @@
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors)
+"cyJ" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "cyM" = (
 /obj/structure/closet/crate/roguecloset{
 	keylock = 1;
@@ -10291,7 +10320,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "cAc" = (
-/obj/machinery/light/rogue/candle/red/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "cAg" = (
@@ -10334,6 +10363,20 @@
 	icon_state = "stonewindow"
 	},
 /area/rogue/outdoors/bograt/sunken)
+"cAQ" = (
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/double_pelt{
+	dir = 1
+	},
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "cAS" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/rtfield/rockhill/above)
@@ -10812,7 +10855,9 @@
 	pixel_y = -10
 	},
 /obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/decostone,
+/turf/closed/wall/mineral/rogue/decostone/long{
+	dir = 1
+	},
 /area/rogue/indoors/town/bath)
 "cFL" = (
 /obj/structure/flora/newleaf,
@@ -12150,15 +12195,18 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "cUC" = (
-/obj/structure/bars/grille{
-	dir = 4;
-	layer = 1.9
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/turf/open/water/bath,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "cUF" = (
 /obj/structure/fluff/pillow/magenta{
 	dir = 1
+	},
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -12259,13 +12307,13 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/inq/basement)
 "cWj" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_y = -32
 	},
 /obj/structure/fluff/railing/border,
+/obj/structure/chair/wood/rogue{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "cWm" = (
@@ -12668,7 +12716,9 @@
 /obj/structure/roguewindow/harem1,
 /obj/structure/drape/zybantine,
 /obj/structure/fluff/statue/small,
-/turf/open/floor/rogue/herringbone,
+/turf/closed/wall/mineral/rogue/decostone/long{
+	dir = 1
+	},
 /area/rogue/indoors/town/bath)
 "dbr" = (
 /obj/structure/fluff/railing/wood{
@@ -12871,7 +12921,7 @@
 "ddp" = (
 /obj/structure/mineral_door/wood/donjon{
 	locked = 1;
-	lockid = "dungeon";
+	lockid = "nightman";
 	name = "Dungeons"
 	},
 /obj/structure/curtain/black{
@@ -13464,6 +13514,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
+"djX" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "dkk" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/rogue/grass,
@@ -13559,8 +13615,13 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
 "dlu" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/stonebrick,
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
+	},
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dlw" = (
 /obj/structure/table/wood{
@@ -13582,6 +13643,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet)
+"dlB" = (
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/bath)
 "dlE" = (
 /obj/structure/table/wood/map/three,
 /turf/open/floor/carpet/red,
@@ -13600,6 +13667,10 @@
 /mob/living/simple_animal/hostile/rogue/deepone,
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/under/cavewet)
+"dmk" = (
+/obj/item/alch/rosa,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "dml" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/rtfield/rockhill/above)
@@ -14434,13 +14505,9 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/warden)
 "dww" = (
-/obj/structure/chair/bench/couchamagenta,
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -2
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
 	},
-/obj/machinery/light/rogue/candle/red/l,
-/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dwz" = (
 /obj/machinery/light/rogue/firebowl/standing/green,
@@ -14580,7 +14647,7 @@
 /area/rogue)
 "dzn" = (
 /obj/item/roguebin/trash,
-/obj/machinery/light/rogue/candle/red/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dzq" = (
@@ -15588,8 +15655,8 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet)
 "dKR" = (
-/obj/structure/curtain/magenta,
-/turf/open/floor/carpet/purple,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "dLa" = (
 /obj/structure/wooden_horse/mobile,
@@ -15802,16 +15869,10 @@
 "dOe" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
-	locked = 1;
-	lockid = "locker4";
 	name = "locker 4"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
-	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker4";
-	name = "locker 4 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -16120,6 +16181,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
+"dRw" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 8
+	},
+/area/rogue/indoors/town/bath)
 "dRx" = (
 /obj/structure/lever/wall{
 	dir = 4;
@@ -17140,6 +17207,15 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/town/sewer)
+"eeg" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -32
+	},
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "eeo" = (
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
@@ -19131,8 +19207,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "eDb" = (
-/obj/structure/fermentation_keg/distiller,
-/turf/open/floor/rogue/cobble,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "eDc" = (
 /obj/structure/rack/rogue/shelf,
@@ -20025,9 +20106,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
 "eOx" = (
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	pixel_x = -2;
-	pixel_y = -2
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Whitevein - Staff Lounge"
+	},
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
@@ -20292,6 +20375,12 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor/rockhill)
+"eSi" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals1"
+	},
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "eSk" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -21374,6 +21463,7 @@
 /obj/item/reagent_containers/glass/cup,
 /obj/item/reagent_containers/glass/cup,
 /obj/item/reagent_containers/glass/cup,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "feF" = (
@@ -21686,14 +21776,40 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/rhgoblinencampment)
 "fit" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Special Toys";
-	pixel_x = 4
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/machinery/light/rogue/candle/red/l,
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux1";
+	name = "room I key"
 	},
-/obj/machinery/light/rogue/candle/red/r,
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux2";
+	name = "room II key";
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux3";
+	name = "room III key";
+	pixel_y = 7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux4";
+	name = "room IV key";
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "steam";
+	name = "steam room key"
+	},
+/obj/item/roguekey/nightmaiden{
+	icon_state = "spikekey";
+	lockid = "punishroom";
+	name = "punishment room key";
+	pixel_y = 4;
+	pixel_x = 10
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fiD" = (
@@ -22648,6 +22764,7 @@
 "fuU" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/machinery/light/rogue/candle/red/l,
+/obj/item/storage/keyring/nightman,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fuW" = (
@@ -26131,7 +26248,11 @@
 	icon_state = "borderfall";
 	pixel_y = -8
 	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -8;
+	pixel_y = -20
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "gnf" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -26216,7 +26337,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "goe" = (
-/obj/structure/fluff/walldeco/church/line,
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "gor" = (
@@ -26309,6 +26433,9 @@
 /obj/effect/decal/carpet/kover_purple{
 	pixel_x = 16;
 	pixel_y = 27
+	},
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -26453,7 +26580,10 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors)
 "grO" = (
-/turf/closed/wall/mineral/rogue/pipe/line/four,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "grU" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
@@ -26506,6 +26636,12 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/chapel)
+"gsi" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "gsj" = (
 /obj/structure/closet/crate/chest{
 	lockid = "manor";
@@ -27739,11 +27875,13 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town/garrison)
 "gJb" = (
-/obj/structure/stairs/stone{
-	dir = 8
+/obj/structure/bell_common{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = -8
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "gJj" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/roguegrass/thorn_bush,
@@ -27752,6 +27890,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/grove)
+"gJk" = (
+/obj/structure/table/wood,
+/obj/structure/bars/shop,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "frontdeskshutters"
+	},
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "gJl" = (
 /obj/item/scrying,
 /obj/structure/table/wood,
@@ -27908,9 +28055,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet)
 "gLm" = (
-/obj/machinery/light/rogue/candle/red/l,
 /obj/structure/closet/crate/chest/wicker,
 /obj/structure/fluff/wallclock,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "gLo" = (
@@ -27942,6 +28089,13 @@
 	},
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave/rhgoblinencampment)
+"gLB" = (
+/obj/machinery/light/rogue/torchholder/c{
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "gLD" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -31285,11 +31439,11 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/inq)
 "hCf" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
 /obj/structure/fluff/railing/border{
 	dir = 6
+	},
+/obj/structure/chair/wood/rogue{
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
@@ -31693,6 +31847,9 @@
 	pixel_x = 4;
 	pixel_y = 41
 	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "hHb" = (
@@ -31714,7 +31871,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "hHr" = (
-/obj/structure/fluff/statue/small{
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/purple,
@@ -32187,6 +32346,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
+"hNl" = (
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/greenstone,
+/area/rogue/under/town/sewer)
 "hNo" = (
 /turf/open/floor/rogue/snowrough,
 /area/rogue/indoors/shelter/mountains)
@@ -32554,14 +32717,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave)
 "hSv" = (
-/obj/structure/bars/grille{
-	dir = 4;
-	layer = 1.9
-	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
-/turf/open/water/bath,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "hSw" = (
 /obj/structure/rack/rogue,
@@ -33798,13 +33958,21 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/church/chapel)
 "ihp" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/roguegrass/herb/salvia,
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
+/obj/structure/fluff/pillow/magenta,
+/obj/effect/decal/cobbleedge{
+	dir = 4;
+	icon_state = "borderfall";
+	pixel_x = 8;
+	layer = 3.1
 	},
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall";
+	pixel_y = 8
+	},
+/obj/structure/rack/rogue/shelf,
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "ihq" = (
 /obj/structure/mineral_door/wood/donjon{
@@ -34717,19 +34885,13 @@
 	},
 /area/rogue/under/cave/rhgoblinencampment)
 "ivA" = (
-/obj/structure/bars/pipe{
+/obj/effect/decal/carpet{
 	dir = 8;
-	layer = 2;
-	pixel_x = 10;
-	pixel_y = -20
+	pixel_x = 12;
+	pixel_y = 0
 	},
-/obj/structure/bars/grille{
-	dir = 4;
-	layer = 1.9
-	},
-/turf/open/water/bath{
-	layer = 1.9
-	},
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "ivD" = (
 /obj/structure/flora/roguetree/burnt{
@@ -35143,11 +35305,11 @@
 /obj/structure/chair/stool/rogue{
 	pixel_y = -2
 	},
-/obj/machinery/light/rogue/candle/red/l,
 /obj/effect/decal/carpet/square/black{
 	pixel_x = 16;
 	pixel_y = -4
 	},
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "iBJ" = (
@@ -35821,6 +35983,10 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
+"iJY" = (
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/bath)
 "iKe" = (
 /obj/item/candle/yellow,
 /obj/structure/closet/crate/drawer{
@@ -36739,6 +36905,10 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
+"iXl" = (
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "iXn" = (
 /obj/structure/fluff/railing/corner/south_west,
 /turf/open/floor/rogue/hexstone,
@@ -37336,6 +37506,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
 "jdl" = (
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/under/cavewet)
 "jdr" = (
@@ -37381,13 +37552,10 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bograt/west)
 "jdK" = (
-/obj/structure/table/wood/poor,
-/obj/item/natural/feather,
-/obj/structure/roguemachine/mail{
-	mailtag = "Whitevein - Nightmaster";
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "jdP" = (
 /obj/structure/fluff/statue/pillar{
@@ -39000,6 +39168,10 @@
 /obj/structure/table/wood/large_table/south_west,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/warden)
+"jzl" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "jzm" = (
 /obj/structure/fluff/railing/border{
 	pixel_x = 4
@@ -39083,6 +39255,12 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
+"jAb" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/roguegrass/herb/rosa,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/bath)
 "jAj" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -39091,9 +39269,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "jAu" = (
-/obj/structure/roguewindow/harem1{
-	opacity = 1
-	},
+/obj/structure/roguewindow/harem1,
 /obj/structure/drape/zybantine,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -39915,6 +40091,7 @@
 	pixel_x = 16;
 	pixel_y = -2
 	},
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "jJO" = (
@@ -40167,6 +40344,7 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "jNg" = (
@@ -41132,6 +41310,13 @@
 /obj/structure/roguewindow/stained/yellow,
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/church/chapel)
+"kah" = (
+/obj/machinery/light/rogue/candle/red,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "kao" = (
 /turf/open/floor/rogue/grass/nospawn,
 /area/rogue/outdoors/bograt/above)
@@ -41308,6 +41493,7 @@
 	dir = 1
 	},
 /obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet)
 "kcO" = (
@@ -41550,6 +41736,10 @@
 /obj/structure/spider/stickyweb,
 /turf/open/transparent/openspace,
 /area/rogue/under/cave)
+"kfv" = (
+/obj/machinery/light/rogue/candle/floorcandle/alt,
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "kfw" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -41687,6 +41877,12 @@
 /obj/machinery/light/rogue/oven,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors)
+"kgP" = (
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/bath)
 "kgT" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/cobble,
@@ -42286,10 +42482,12 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/obj/structure/bookcase/random{
-	pixel_x = 4
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 1
 	},
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "knh" = (
 /obj/structure/bars/passage/shutter{
@@ -42993,6 +43191,7 @@
 /area/rogue/outdoors/woodsafe)
 "kvU" = (
 /obj/structure/chair/stool/rogue,
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/bath)
 "kwc" = (
@@ -43346,6 +43545,7 @@
 	pixel_y = 32
 	},
 /obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "kAU" = (
@@ -43640,6 +43840,12 @@
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield/rockhill/above)
+"kFp" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/grass,
+/area/rogue/indoors/town/bath)
 "kFt" = (
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/outdoors/bograt/west)
@@ -43911,9 +44117,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet)
 "kIL" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed,
-/area/rogue/indoors/town/bath)
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "kIO" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/cavewet)
@@ -44043,6 +44249,7 @@
 	pixel_y = 8
 	},
 /obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kJR" = (
@@ -44554,6 +44761,9 @@
 /obj/item/roguebin/trash{
 	pixel_y = 5
 	},
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "kQW" = (
@@ -44613,6 +44823,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "kRJ" = (
@@ -45408,6 +45619,7 @@
 "lcD" = (
 /obj/structure/table/wood,
 /obj/structure/bars/shop,
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "lcH" = (
@@ -46121,8 +46333,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
 "lme" = (
-/obj/machinery/light/rogue/candle/red/l,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "lmf" = (
 /obj/structure/stairs/stone,
@@ -46576,6 +46788,10 @@
 /area/rogue/under/cave/dungeon1)
 "lsD" = (
 /obj/structure/closet/crate/roguecloset/dark,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/brownbrick{
 	color = "#ffd9f2"
 	},
@@ -46873,9 +47089,14 @@
 /turf/open/floor/rogue/hay,
 /area/rogue/outdoors/exposed/town/keep)
 "lwr" = (
-/obj/structure/roguewindow/harem1,
-/obj/structure/drape/zybantine,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32;
+	pixel_x = 0
+	},
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "lwu" = (
 /turf/open/floor/rogue/ruinedwood{
@@ -46999,7 +47220,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "lyt" = (
@@ -47331,6 +47551,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "lDK" = (
@@ -48895,6 +49116,7 @@
 "lXl" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/roguegem/violet,
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -49269,6 +49491,14 @@
 	},
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/indoors/town/manor/rockhill)
+"mar" = (
+/obj/structure/bell_common{
+	dir = 8;
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "max" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/manor{
@@ -50648,6 +50878,12 @@
 	},
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsafe)
+"mqO" = (
+/obj/structure/hotspring{
+	icon_state = "lilypetals3"
+	},
+/turf/open/water/bath,
+/area/rogue/indoors/town/bath)
 "mqQ" = (
 /obj/machinery/anvil,
 /obj/item/rogueweapon/hammer/iron{
@@ -51276,11 +51512,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
 "mym" = (
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -2
-	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "myq" = (
 /obj/item/kitchen/spoon,
@@ -52675,8 +52910,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "mQe" = (
-/obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/fermentation_keg/whitewine,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "mQj" = (
@@ -55436,10 +55671,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/inq)
 "nAc" = (
-/obj/machinery/light/rogue/candle/l{
-	light_power = 0
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "nAd" = (
 /obj/structure/table/vtable,
@@ -56709,6 +56944,10 @@
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
+/obj/machinery/light/rogue/candle/floorcandle{
+	layer = 1.5;
+	pixel_y = -14
+	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "nQT" = (
@@ -57229,9 +57468,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/rtfield/rockhill)
 "nWH" = (
-/obj/structure/roguewindow/harem1,
-/obj/structure/drape/zybantine,
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
+/obj/structure/roguemachine/scomm{
+	pixel_y = -32;
+	scom_tag = "Whitevein - Waiting Room"
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "nWJ" = (
 /obj/structure/table/wood{
@@ -57731,6 +57972,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/Academy)
+"ocS" = (
+/obj/structure/stairs/stone,
+/obj/machinery/light/rogue/candle/green/r,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "ocY" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -57766,8 +58012,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/obj/structure/curtain/magenta,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "odo" = (
 /obj/structure/table/wood{
@@ -58217,7 +58462,10 @@
 	icon_state = "borderfall";
 	pixel_y = 8
 	},
-/obj/machinery/light/rogue/candle/red,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32;
+	pixel_x = 0
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ojZ" = (
@@ -58966,8 +59214,7 @@
 /area/rogue/outdoors/town/rockhill)
 "osw" = (
 /obj/machinery/light/rogue/candle/floorcandle/pink,
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "osx" = (
 /obj/structure/hotspring,
@@ -59051,11 +59298,9 @@
 /obj/item/toy/cards/deck/tarot,
 /obj/item/storage/pill_bottle/dice/farkle,
 /obj/item/storage/pill_bottle/dice/farkle,
+/obj/machinery/light/rogue/candle/red,
 /obj/structure/curtain/magenta{
-	color = "#a1254a";
-	icon_state = "curtain-closed";
-	opacity = 1;
-	open = 0
+	color = "#a1254a"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet)
@@ -59922,6 +60167,12 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
+"oFW" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "oFY" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -61855,10 +62106,10 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
 "pcI" = (
-/obj/item/roguebin/trash{
-	pixel_y = 5
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Whitevein - Game Room"
 	},
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "pcK" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
@@ -61975,11 +62226,18 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
 "peE" = (
-/obj/structure/fluff/clock,
 /obj/structure/fluff/walldeco/bigpainting/lake{
 	pixel_x = -28
 	},
-/turf/open/floor/rogue/tile/harem2,
+/obj/structure/shisha/hookah{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "peK" = (
 /obj/structure/table/wood{
@@ -62474,6 +62732,11 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
+"pkM" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 4
+	},
+/area/rogue/indoors/town/bath)
 "pkS" = (
 /obj/structure/fluff/railing/border,
 /obj/effect/decal/cobbleedge{
@@ -62679,6 +62942,7 @@
 /obj/item/reagent_containers/glass/bottle/rogue/wine,
 /obj/item/roguecoin/gold/pile,
 /obj/item/roguecoin/silver/pile,
+/obj/item/roguekey/nightman,
 /obj/item/roguekey/nightman,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
@@ -62996,6 +63260,10 @@
 /obj/structure/stairs,
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/town)
+"pqY" = (
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "pri" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -63501,6 +63769,10 @@
 "pyh" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"pyi" = (
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/bath)
 "pyn" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/clothing/suit/roguetown/armor/chainmail/iron,
@@ -63610,9 +63882,8 @@
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "pzk" = (
-/obj/structure/chair/bench/couchamagenta/r,
-/obj/machinery/light/rogue/candle/red/r,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/transparent/openspace,
 /area/rogue/indoors/town/bath)
 "pzl" = (
 /obj/structure/mineral_door/wood/violet{
@@ -63865,6 +64136,7 @@
 	pixel_x = -1;
 	pixel_y = 7
 	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "pCr" = (
@@ -63906,6 +64178,12 @@
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/beach/harbor)
+"pCP" = (
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 8
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "pCR" = (
 /obj/structure/stairs{
 	dir = 8
@@ -64808,6 +65086,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"pNG" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "pNH" = (
 /obj/structure/stairs{
 	dir = 8
@@ -65352,7 +65634,7 @@
 /area/rogue/outdoors/woodsrat/south)
 "pUM" = (
 /obj/structure/flora/roguegrass/water/reeds,
-/obj/structure/bars,
+/obj/structure/plasticflaps,
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
 "pVc" = (
@@ -68525,12 +68807,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/town/grove)
 "qKT" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable";
-	name = "Massage Table"
-	},
-/obj/machinery/light/rogue/candle/red/r,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "qKU" = (
@@ -68556,12 +68833,10 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/cell)
 "qLo" = (
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -21
+/obj/machinery/light/rogue/candle/green{
+	pixel_y = -32
 	},
-/obj/machinery/light/rogue/candle/red/l,
-/turf/open/floor/rogue/tile/harem2,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/bath)
 "qLp" = (
 /obj/structure/rack/rogue,
@@ -68744,8 +69019,10 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsrat/above)
 "qNw" = (
-/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
-/turf/open/floor/carpet/purple,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "qNy" = (
 /obj/structure/fluff/railing/border{
@@ -69349,6 +69626,13 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
+"qWQ" = (
+/obj/structure/spider/stickyweb{
+	alpha = 90
+	},
+/obj/item/natural/bone,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "qWY" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/transparent/openspace,
@@ -70384,6 +70668,7 @@
 	pixel_y = -10
 	},
 /obj/structure/closet/crate/roguecloset/inn,
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "rmz" = (
@@ -71062,8 +71347,10 @@
 /turf/open/water/swamp/deep,
 /area/rogue/outdoors/bogsafe)
 "ruk" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/obj/structure/roguemachine/scomm/l{
+	scom_tag = "Whitevein - Public Baths"
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "rup" = (
 /obj/structure/flora/roguegrass/water,
@@ -71889,11 +72176,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/grove)
 "rFo" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 8
-	},
-/obj/structure/shisha/hookah,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/candle/green/r,
+/turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/bath)
 "rFu" = (
 /turf/closed/mineral/random/rogue/med,
@@ -72589,6 +72873,7 @@
 /obj/item/reagent_containers/glass/cup/golden{
 	pixel_x = 8
 	},
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -72972,7 +73257,7 @@
 /area/rogue/indoors/shelter/bog)
 "rUg" = (
 /obj/item/roguebin/water,
-/obj/machinery/light/rogue/candle/red/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "rUh" = (
@@ -74319,11 +74604,14 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
 "skm" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
 /obj/structure/fluff/railing/border{
 	dir = 10
+	},
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
+	},
+/obj/structure/chair/wood/rogue{
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/under/cavewet)
@@ -74681,6 +74969,7 @@
 /obj/item/roguebin/water{
 	anchored = 1
 	},
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/bath)
 "soL" = (
@@ -74739,7 +75028,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
 "spx" = (
-/obj/machinery/light/rogue/candle/red/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "spz" = (
@@ -75530,16 +75819,10 @@
 "sAY" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
-	locked = 1;
-	lockid = "locker1";
 	name = "locker I"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
-	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker1";
-	name = "locker 1 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -75772,6 +76055,12 @@
 	dir = 8
 	},
 /area/rogue/outdoors/woodsrat/above)
+"sEj" = (
+/obj/structure/spider/stickyweb{
+	alpha = 90
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "sEl" = (
 /obj/structure/stairs{
 	dir = 4
@@ -75849,6 +76138,10 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/shelter/bog)
+"sEU" = (
+/obj/item/natural/bone,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "sEV" = (
 /obj/structure/fluff/railing/border{
 	pixel_y = -8
@@ -75872,9 +76165,9 @@
 	pixel_x = -8
 	},
 /obj/structure/roguemachine/scomm/l{
-	scom_tag = "Bath House - Nitemaster's Suite"
+	scom_tag = "Whitevein - Nitemaster's Suite"
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "sFk" = (
 /obj/structure/flora/roguegrass/bush,
@@ -76684,6 +76977,13 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor/rockhill)
+"sOC" = (
+/obj/structure/curtain/magenta,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "sOF" = (
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -76977,13 +77277,14 @@
 /obj/structure/fluff/walldeco/rpainting/forest{
 	pixel_y = -32
 	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	pixel_y = -8
+	},
 /obj/structure/stairs/stone{
 	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "sTn" = (
 /obj/structure/flora/newleaf,
@@ -77590,6 +77891,9 @@
 /obj/structure/shisha/hookah{
 	pixel_x = -1;
 	pixel_y = 7
+	},
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
 	},
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
@@ -78540,6 +78844,16 @@
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bograt/sunken)
+"tmh" = (
+/obj/item/candle/eora/lit{
+	pixel_x = 13;
+	pixel_y = -2
+	},
+/obj/item/clothing/neck/roguetown/psicross/eora{
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "tmp" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -78635,6 +78949,7 @@
 /area/rogue/indoors/town/manor/rockhill)
 "tnc" = (
 /obj/structure/curtain/magenta,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "tnd" = (
@@ -79111,7 +79426,7 @@
 	icon_state = "borderfall";
 	pixel_y = -8
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ttd" = (
 /obj/structure/composter{
@@ -79323,17 +79638,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/cave)
 "tvr" = (
-/obj/structure/flora/roguegrass{
-	layer = 3.9
-	},
-/obj/structure/flora/ausbushes/brflowers{
-	layer = 4
-	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/flora/roguegrass/herb/salvia,
-/turf/open/floor/rogue/grass,
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/bath)
 "tvz" = (
 /obj/structure/bookcase/random/archive{
@@ -79557,6 +79863,7 @@
 	pixel_x = -10;
 	pixel_y = -8
 	},
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "tyA" = (
@@ -79963,6 +80270,7 @@
 /area/rogue/outdoors/bograt/west)
 "tEu" = (
 /obj/structure/bondage/x_pillory,
+/obj/machinery/light/rogue/candle/green/l,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/bath)
 "tEx" = (
@@ -80740,9 +81048,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bograt/sunken)
 "tOu" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/indoors/town/bath)
+/obj/structure/ladder,
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 5
+	},
+/area/rogue/outdoors/town/roofs/keep)
 "tOx" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -81276,6 +81586,12 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors)
+"tUd" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "tUp" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -82078,6 +82394,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
+"uek" = (
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/bath)
 "ueo" = (
 /obj/structure/fluff/railing/border{
 	pixel_y = -8
@@ -82861,8 +83181,10 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/dungeon1)
 "uob" = (
-/obj/structure/roguewindow/harem1,
-/turf/open/floor/rogue/tile/brownbrick,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/roguegrass/herb/rosa,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "uoc" = (
 /obj/structure/chair/bench/couch,
@@ -83191,6 +83513,7 @@
 	pixel_x = 3;
 	pixel_y = 8
 	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "urX" = (
@@ -83466,6 +83789,13 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
+"uvz" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/bath)
 "uvA" = (
 /obj/structure/fluff/statue/gargoyle/moss,
 /turf/open/floor/rogue/cobble/mossy,
@@ -83590,12 +83920,12 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue,
 /area/rogue/indoors/town/church/chapel)
 "uwW" = (
-/obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/rack/rogue/shelf,
 /obj/item/storage/roguebag{
 	pixel_x = -8;
 	pixel_y = 38
 	},
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "uwX" = (
@@ -83728,10 +84058,6 @@
 	},
 /area/rogue/under/town/basement/keep)
 "uzk" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -5
-	},
 /obj/item/natural/feather,
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -83746,6 +84072,23 @@
 /obj/item/roguekey/nightmaiden,
 /obj/item/roguekey/nightmaiden,
 /obj/item/roguekey/nightmaiden,
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	pixel_y = -9
+	},
+/obj/effect/decal/carpet/kover_darkred{
+	pixel_x = 16;
+	pixel_y = 10
+	},
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "uzr" = (
@@ -84816,6 +85159,12 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
+"uNX" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -32
+	},
+/turf/open/floor/rogue/tile/bath,
+/area/rogue/indoors/town/bath)
 "uOc" = (
 /obj/structure/table/wood/poor,
 /obj/item/candle/skull,
@@ -85782,6 +86131,15 @@
 "uZr" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/bogsafe)
+"uZs" = (
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "uZu" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -86063,17 +86421,12 @@
 "vdR" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
-	locked = 1;
-	lockid = "locker5";
 	name = "locker 5"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker5";
-	name = "locker 5 key"
-	},
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vdS" = (
@@ -86293,6 +86646,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/exposed/town/keep)
+"vfT" = (
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "vgn" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguegrass/bush/wall,
@@ -88641,6 +88998,8 @@
 /obj/item/needle/thorn,
 /obj/item/natural/cloth,
 /obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/red/l,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "vLo" = (
@@ -88893,6 +89252,12 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave)
+"vPh" = (
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/masonic/inverted,
+/area/rogue/indoors/town/bath)
 "vPp" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/church/chapel)
@@ -88913,16 +89278,10 @@
 "vPH" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
-	locked = 1;
-	lockid = "locker2";
 	name = "locker 2"
 	},
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
-	},
-/obj/item/roguekey/roomi/village{
-	lockid = "locker3";
-	name = "locker 3 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -89010,7 +89369,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement/tavern)
 "vQT" = (
-/obj/machinery/light/rogue/candle/red{
+/obj/machinery/light/rogue/candle{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/tile/harem,
@@ -89231,6 +89590,11 @@
 "vTB" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10;
+	pixel_x = 32;
+	pixel_y = 32
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -90963,11 +91327,11 @@
 /obj/item/reagent_containers/glass/cup/steel,
 /obj/item/reagent_containers/glass/cup/steel,
 /obj/item/reagent_containers/glass/cup/steel,
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
 /obj/structure/curtain/magenta{
-	color = "#a1254a";
-	icon_state = "curtain-closed";
-	opacity = 1;
-	open = 0
+	color = "#a1254a"
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet)
@@ -90983,6 +91347,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/harbor)
+"wqK" = (
+/obj/structure/flora/roguegrass/herb/salvia,
+/obj/structure/flora/roguegrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/rogue/dirt/road,
+/area/rogue/indoors/town/bath)
 "wqL" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -91054,8 +91424,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/warden)
 "wrE" = (
-/obj/machinery/light/rogue/candle/red/r,
-/turf/open/floor/rogue/tile/harem2,
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "wrG" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -91428,7 +91798,7 @@
 /area/rogue/indoors/town/warden)
 "wwF" = (
 /obj/machinery/light/rogue/candle/blue/r,
-/obj/structure/fermentation_keg/distiller,
+/obj/structure/fermentation_keg,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "wwL" = (
@@ -92564,8 +92934,10 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "wJD" = (
-/turf/open/floor/rogue/tile/harem2,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/obj/structure/roguemachine/scomm/l{
+	scom_tag = "Whitevein - Staff Area"
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "wJF" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
@@ -93343,7 +93715,10 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor/rockhill)
 "wTy" = (
-/obj/machinery/light/rogue/candle/red,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32;
+	pixel_x = 0
+	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "wTH" = (
@@ -93710,6 +94085,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/gear_painter,
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "wYS" = (
@@ -94048,9 +94426,9 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/Academy)
 "xdC" = (
-/obj/structure/fluff/statue/small,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 1
+	dir = 4
 	},
 /area/rogue/indoors/town/bath)
 "xdD" = (
@@ -94581,6 +94959,7 @@
 "xkI" = (
 /obj/structure/closet/crate/drawer,
 /obj/structure/mirror,
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "xkX" = (
@@ -94684,6 +95063,7 @@
 	})
 "xlO" = (
 /obj/machinery/light/rogue/candle/floorcandle,
+/obj/machinery/light/rogue/candle/green,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/bath)
 "xlP" = (
@@ -95314,6 +95694,7 @@
 /obj/item/soap/bath{
 	pixel_y = -10
 	},
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xuJ" = (
@@ -95593,6 +95974,10 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/underdarker/rockhill)
+"xyu" = (
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "xyA" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -95674,7 +96059,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xzE" = (
 /obj/structure/fluff/railing/border{
@@ -95707,6 +96092,7 @@
 /area/rogue/indoors/town/Academy)
 "xzL" = (
 /obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "xzN" = (
@@ -95848,13 +96234,17 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/rtfield/eora)
 "xBi" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
+/obj/structure/table/wood/poor,
+/obj/item/natural/feather,
+/obj/structure/roguemachine/mail{
+	mailtag = "Whitevein - Nightmaster";
+	pixel_y = -32
 	},
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/roguegrass,
-/obj/structure/flora/roguegrass/herb/salvia,
-/turf/open/floor/rogue/grass,
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	pixel_y = -9
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "xBl" = (
 /obj/structure/flora/roguegrass,
@@ -96398,8 +96788,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
 "xHB" = (
-/obj/structure/ladder/unbreakable,
-/obj/structure/ladder/unbreakable,
+/obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "xHD" = (
@@ -96547,6 +96936,11 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/shop)
+"xJG" = (
+/obj/machinery/light/rogue/torchholder/r,
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
 "xJO" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
@@ -96766,6 +97160,12 @@
 /obj/structure/bars/cemetery,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
+"xMA" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "xMB" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -97967,11 +98367,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/church/basement)
 "ycM" = (
-/obj/structure/fluff/statue/gargoyle{
-	pixel_x = 1;
-	pixel_y = -9
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
 	},
-/turf/closed/wall/mineral/rogue/stone,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ycQ" = (
 /obj/structure/closet/crate/chest/wicker,
@@ -154507,10 +154906,10 @@ whb
 whb
 whb
 eFJ
-uob
+rct
 wpu
 qiF
-uob
+rct
 eFJ
 whb
 whb
@@ -154939,10 +155338,10 @@ whb
 whb
 whb
 eFJ
-uob
-wpu
+rct
+iXl
 dHo
-uob
+rct
 eFJ
 whb
 whb
@@ -155367,9 +155766,9 @@ eFJ
 whb
 eFJ
 eFJ
-rqF
+rct
 eFJ
-rqF
+rct
 eFJ
 eFJ
 eFJ
@@ -155802,11 +156201,11 @@ bMh
 xzC
 sFi
 gne
-kIL
+rct
 eFJ
-jJJ
+cAQ
 kdw
-siB
+rct
 jJJ
 kdw
 eFJ
@@ -156227,18 +156626,18 @@ eFJ
 lXl
 xkd
 jfX
-fLW
+uZs
 eFJ
 eFJ
 eFJ
-qNw
+dKR
 aCi
 ttc
-kIL
+rct
 eFJ
 pCp
 kdw
-siB
+rct
 pCp
 kdw
 wDt
@@ -156664,15 +157063,15 @@ abI
 hKR
 djL
 odm
-dKR
+kdw
 bJx
-kIL
+rct
 eFJ
-siB
-sYr
+rct
+sOC
 eFJ
-siB
-sYr
+rct
+sOC
 eFJ
 eFJ
 eFJ
@@ -157091,12 +157490,12 @@ eFJ
 rOm
 gjr
 jfX
-fLW
+uZs
 eFJ
 wAU
 vTB
-tvr
-gJb
+tUd
+atr
 sTl
 eFJ
 eFJ
@@ -157525,16 +157924,16 @@ lNK
 pnx
 eFJ
 eFJ
-ycM
+xCt
 ojQ
 jfX
 jfX
-jfX
-qtm
+aPn
+jdK
 eFJ
 rmv
 kdw
-siB
+rct
 xuA
 kdw
 eFJ
@@ -157951,7 +158350,7 @@ bSW
 bSW
 xeg
 xeg
-grO
+qRR
 qRR
 qRR
 qRR
@@ -157960,7 +158359,7 @@ qRR
 scK
 kmW
 jfX
-mym
+jfX
 uzk
 eFJ
 eFJ
@@ -157970,7 +158369,7 @@ eFJ
 eFJ
 wBa
 eFJ
-fqM
+uvz
 fqM
 qcz
 tTb
@@ -158383,7 +158782,7 @@ bSW
 wDf
 fJP
 xeg
-grO
+qRR
 qRR
 hSV
 yee
@@ -158393,12 +158792,12 @@ fJX
 peE
 jfX
 bUS
-jdK
+xBi
 eFJ
 eFJ
 kZS
 asP
-nAc
+qcz
 qcz
 asP
 eFJ
@@ -158815,7 +159214,7 @@ ldt
 wDf
 kJh
 xeg
-grO
+qRR
 qRR
 qRR
 yee
@@ -158824,8 +159223,8 @@ qRR
 eFJ
 ihp
 jfX
-goe
-xBi
+jfX
+jfX
 eFJ
 eFJ
 qcz
@@ -159247,7 +159646,7 @@ xJX
 rpp
 fJP
 xeg
-grO
+qRR
 qRR
 hSV
 yee
@@ -159679,20 +160078,20 @@ xeg
 xeg
 lOm
 xeg
-grO
 qRR
 qRR
-yee
+qRR
+wrE
 qRR
 qRR
 idl
 sWm
+xyu
 pQc
 pQc
-pQc
-pQc
+wJD
 cWN
-idl
+dlB
 eFJ
 hUU
 yeY
@@ -160111,13 +160510,13 @@ nBT
 nBT
 xCt
 xCt
-grO
+qRR
 qRR
 hSV
 yee
 yee
 bAd
-idl
+dlB
 qRR
 nIe
 pQc
@@ -160543,9 +160942,9 @@ kTa
 fNk
 xCt
 jty
-rCz
-gns
-gns
+qRR
+qRR
+qRR
 eFJ
 qRR
 qRR
@@ -160974,7 +161373,7 @@ wPo
 wPo
 wPo
 tYD
-wPo
+qLo
 eFJ
 aIl
 fPJ
@@ -161841,25 +162240,25 @@ xCt
 scK
 gfr
 gTt
-gTt
+uNX
 gTt
 vPK
 bKC
 kdw
-kdw
+vfT
 kdw
 kdw
 ccw
-jfX
+ruk
 dru
 cEf
-cro
+vPK
 nXJ
-rFo
+hTq
 rRk
-nWH
+vPK
 nXJ
-rFo
+hTq
 rRk
 gtj
 gGR
@@ -162277,19 +162676,19 @@ gTt
 gTt
 vPK
 kaO
-kdw
+dlu
 qRR
-rqF
-mSL
+tvr
+tvr
 qRR
-jfX
+gsi
 xzL
 ete
-lwr
+vPK
 bOT
 kdw
 wpu
-nWH
+vPK
 bOT
 kdw
 wpu
@@ -162705,7 +163104,7 @@ bPA
 sWm
 eFJ
 eFJ
-vVo
+rct
 fSS
 qRR
 kZR
@@ -162717,11 +163116,11 @@ wFB
 asP
 jfX
 jfX
-lwr
+vPK
 xgi
 kdw
 ecV
-nWH
+vPK
 xgi
 kdw
 ecV
@@ -163122,19 +163521,19 @@ whb
 whb
 whb
 gQh
+kIL
 kYH
 kYH
-kYH
-kYH
-kYH
+sEj
+gJb
 ddp
 vXL
 jPI
-jPI
-jPI
+jzl
+rFo
 vXL
 vXL
-sWm
+ocS
 vaX
 qgT
 jfX
@@ -163148,15 +163547,15 @@ asP
 wFB
 asP
 jfX
-pcI
+jfX
 qRR
-tIz
+rct
 ufJ
-tIz
+rct
 qRR
-tIz
+rct
 ufJ
-tIz
+rct
 bjz
 kdw
 tRJ
@@ -163554,9 +163953,9 @@ whb
 whb
 whb
 gQh
-kYH
+sEj
 gQh
-gQh
+pNG
 gQh
 gQh
 jxS
@@ -163569,7 +163968,7 @@ eFJ
 eFJ
 eFJ
 eFJ
-jfX
+qKT
 jfX
 qRR
 lcD
@@ -163579,18 +163978,18 @@ rqF
 mSL
 qRR
 jfX
-cUC
-cUC
-hSv
-cUC
-cUC
-cUC
-cUC
-cUC
-cUC
-cUC
-cUC
-ivA
+jfX
+jfX
+goe
+jfX
+jfX
+jfX
+bnf
+jfX
+jfX
+jfX
+jfX
+jfX
 pHV
 vTW
 vTW
@@ -163988,7 +164387,7 @@ gQh
 gQh
 kYH
 gQh
-whb
+gQh
 whb
 eFJ
 eFJ
@@ -164005,24 +164404,24 @@ jfX
 jfX
 tyx
 jfX
+aPn
+eeg
+oFW
+jfX
+bnf
 jfX
 jfX
 jfX
-jfX
-jfX
-cUC
-cUC
-cUC
 hSv
-cUC
-cUC
-cUC
-cUC
-cUC
-cUC
-cUC
-cUC
-ivA
+jfX
+jfX
+jfX
+vOe
+jfX
+jfX
+jfX
+jfX
+vOe
 pHV
 vTW
 vTW
@@ -164403,6 +164802,11 @@ lOc
 whb
 whb
 gQh
+kIL
+kYH
+kYH
+kYH
+bMZ
 kYH
 kYH
 kYH
@@ -164412,12 +164816,7 @@ kYH
 kYH
 kYH
 kYH
-kYH
-kYH
-kYH
-kYH
-kYH
-kYH
+myI
 kYH
 gQh
 whb
@@ -164428,29 +164827,29 @@ pGh
 rAt
 fnf
 fnf
-bSL
+rct
 kdw
 gPd
 kdw
 cGQ
 jfX
-jfX
-jfX
+mym
 hnp
+cUC
 hnp
-hnp
-hnp
+jAb
+uob
 hnp
 hnp
 cUC
-cUC
-jfX
+wqK
+nAc
 qRR
 tIz
 ufJ
 tIz
 qRR
-tIz
+rct
 ufJ
 tIz
 isM
@@ -164836,17 +165235,17 @@ lOc
 whb
 gQh
 kYH
+kYH
+kYH
+gLB
 gQh
 gQh
 gQh
 gQh
 gQh
-gQh
-gQh
-gQh
-gQh
-gQh
-gQh
+sEj
+pqY
+xJG
 gQh
 gQh
 gQh
@@ -164860,28 +165259,28 @@ yjj
 vZw
 oLX
 lWE
-bSL
+rct
 kdw
 kdw
 kdw
 yjd
 jfX
-jfX
 lqS
 wpu
 wpu
-ecV
+wpu
+eSi
 wpu
 wpu
 ecV
 wpu
 foc
 jfX
-lwr
+vPK
 xgi
 kdw
 ecV
-lwr
+vPK
 xgi
 kdw
 ecV
@@ -165267,19 +165666,19 @@ xtk
 lOc
 whb
 gQh
+cyJ
 kYH
+sEj
+qWQ
 gQh
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+gQh
+gQh
+gQh
+gQh
+gQh
 whb
 whb
 whb
@@ -165297,23 +165696,23 @@ ady
 vPH
 sAY
 cro
-jfX
-jfX
+djX
 hnp
-ecV
 wpu
 wpu
 ecV
+tmh
+kfv
 wpu
 wpu
-wpu
+mqO
 hnp
 jfX
-lwr
+vPK
 nXJ
 kdw
 wpu
-lwr
+vPK
 nXJ
 kdw
 wpu
@@ -165700,10 +166099,10 @@ lOc
 gQh
 gQh
 kYH
+kYH
+sEU
+sEj
 gQh
-whb
-whb
-whb
 xvD
 whb
 whb
@@ -165726,26 +166125,26 @@ nQo
 uNi
 eFJ
 eFJ
-dlu
-dlu
+rct
+rct
 eFJ
-jfX
-jfX
-hnp
+eDb
+bTz
 wpu
 wpu
 wpu
-wpu
-wpu
+bTz
+dmk
 ecV
 wpu
-hnp
+wpu
+osw
 jfX
-cro
+vPK
 bOT
 kJN
 cZt
-lwr
+vPK
 bOT
 kJN
 xxR
@@ -166128,14 +166527,14 @@ lOc
 dHW
 iQm
 ihq
+mar
 kYH
 kYH
-kYH
-kYH
+pCP
 gQh
-whb
-whb
-whb
+gQh
+gQh
+gQh
 whb
 lOc
 vqG
@@ -166161,9 +166560,9 @@ vEr
 sLa
 bqs
 eFJ
-jfX
-jfX
+kah
 foc
+wpu
 wpu
 ecV
 wpu
@@ -166586,7 +166985,7 @@ ueZ
 asP
 asP
 eFJ
-yjj
+uek
 yjj
 yjj
 qYX
@@ -166594,23 +166993,23 @@ yjj
 yjj
 dbS
 jfX
-jfX
-jfX
+kgP
 hnp
 hnp
 hnp
+grO
+kFp
 hnp
+osw
 hnp
-hnp
-hnp
-jfX
+aRM
 jfX
 tVH
 dpu
 vTh
 vTh
 aum
-sRH
+rct
 cqQ
 ooc
 qdY
@@ -167025,18 +167424,18 @@ uUV
 pLA
 iel
 eFJ
+qKT
+jfX
+vOe
 jfX
 jfX
 vOe
 jfX
 jfX
-vOe
-jfX
-jfX
-jfX
+qNw
 jfX
 vOe
-pcI
+jfX
 qff
 bnO
 aIy
@@ -167450,12 +167849,12 @@ eFJ
 nQK
 yjj
 yjj
-yjj
+vPh
 soz
 scK
 scK
-dlu
-dlu
+rct
+rct
 eFJ
 tHT
 soz
@@ -167463,8 +167862,8 @@ eFJ
 jlt
 jlt
 eFJ
-dlu
-dlu
+rct
+rct
 nIe
 hfH
 qRR
@@ -167474,7 +167873,7 @@ aYO
 kdw
 gdY
 vTh
-sRH
+rct
 kdw
 dZH
 jXm
@@ -167881,7 +168280,7 @@ whb
 eFJ
 mNl
 ejG
-sIR
+iJY
 lhs
 scK
 bbL
@@ -167891,11 +168290,11 @@ vch
 qww
 vXL
 vPK
+pyi
 sIR
 sIR
-sIR
-sIR
-cro
+pyi
+vPK
 oPu
 lmJ
 nfP
@@ -167906,7 +168305,7 @@ nRw
 jdP
 urC
 lsD
-sRH
+rct
 guE
 wpu
 wpu
@@ -168327,7 +168726,7 @@ fqM
 fqM
 fqM
 fqM
-cro
+vPK
 prR
 lmJ
 ewB
@@ -168338,7 +168737,7 @@ sGL
 pLH
 gfd
 uSs
-sRH
+rct
 ecV
 ecV
 wpu
@@ -168772,7 +169171,7 @@ gns
 gns
 mQq
 wpu
-wpu
+iXl
 wpu
 eFJ
 eFJ
@@ -170051,7 +170450,7 @@ eFJ
 gbe
 gbe
 eFJ
-fqM
+pcI
 ogI
 ogI
 ogI
@@ -170493,7 +170892,7 @@ fqM
 fqM
 fqM
 eLV
-bSL
+rct
 fAH
 wpu
 wpu
@@ -266817,7 +267216,7 @@ iyZ
 nXf
 gLf
 gLf
-gLf
+hNl
 gLf
 gLf
 gLf
@@ -267681,11 +268080,11 @@ eFJ
 uAi
 jOU
 uAi
-cro
-dww
+vPK
+nXJ
 kdw
 rpV
-lwr
+vPK
 vUb
 iBH
 nIo
@@ -268117,7 +268516,7 @@ vPK
 bOT
 kdw
 mkY
-lwr
+vPK
 vzL
 nxG
 jfX
@@ -268545,7 +268944,7 @@ rhw
 kTh
 pQc
 rFB
-mrD
+pkM
 xdC
 sPd
 kdw
@@ -268977,14 +269376,14 @@ rhw
 wYJ
 pQc
 rFB
-mrD
-rUt
-osw
+dww
+dRw
+sPd
 kdw
 eQv
 jfX
 jfX
-jfX
+xMA
 eFJ
 sey
 mYd
@@ -269413,7 +269812,7 @@ vPK
 nXJ
 kdw
 dqX
-lwr
+vPK
 vwA
 vUb
 jfX
@@ -269422,7 +269821,7 @@ cAc
 pQc
 pQc
 sak
-cAc
+pQc
 feE
 bjz
 ctJ
@@ -269842,12 +270241,12 @@ gzz
 tag
 pQc
 vPK
-pzk
+bOT
 kdw
 kSf
-lwr
+vPK
 fUP
-qKT
+vzL
 eOx
 eFJ
 scK
@@ -270278,8 +270677,8 @@ bWA
 owS
 bWA
 bWA
-bWA
-bWA
+siB
+siB
 bWA
 qRR
 uwW
@@ -270703,13 +271102,13 @@ ckL
 iMj
 orb
 vPK
-bnf
-aVs
-pQc
-pQc
-pQc
 pQc
 aVs
+lme
+pQc
+pQc
+pQc
+ivA
 pQc
 rvT
 njY
@@ -271136,19 +271535,19 @@ nAB
 csO
 vPK
 pQc
-pQc
 cAc
 pQc
 pQc
 pQc
-cAc
+pQc
+pQc
 pQc
 rvT
-njY
+pzk
 scK
 iJF
 xQX
-eDb
+idl
 wwF
 idl
 gMO
@@ -272005,9 +272404,9 @@ jTy
 vnK
 acp
 epj
-lme
 kdw
-wrE
+kdw
+kdw
 kdw
 jZb
 iTw
@@ -272430,16 +272829,16 @@ pSN
 xWK
 lVR
 orb
-hiw
-jfX
+mVl
+lwr
 jfX
 jfX
 jfX
 jfX
 vPK
 vfx
-kdw
-wJD
+ycM
+qRR
 jAu
 scK
 jiQ
@@ -272862,11 +273261,11 @@ nZI
 xWK
 xHs
 lyG
-hiw
-jfX
-fit
+mVl
+oFW
 mom
-fit
+mom
+mom
 jfX
 vPK
 xrZ
@@ -273728,14 +274127,14 @@ dhP
 xII
 wKd
 jfX
-fuU
+fit
 rfY
 fuU
 jfX
 gZt
 kdw
-kdw
-wJD
+nWH
+qRR
 jAu
 eFJ
 cBf
@@ -274153,12 +274552,12 @@ tLK
 gMO
 nvH
 qRR
-vVo
-vVo
+rct
+rct
 qRR
 wTy
 pXx
-tWl
+gJk
 jfX
 jfX
 eVY
@@ -274167,7 +274566,7 @@ jfX
 tWl
 xrZ
 kdw
-qLo
+xrZ
 cUF
 qRR
 mQj
@@ -275464,7 +275863,7 @@ nPb
 xrZ
 kdw
 xhv
-kdw
+bmr
 scK
 iWT
 cBf
@@ -276313,8 +276712,8 @@ uEX
 uEX
 nvH
 qRR
-tOu
-tOu
+rct
+rct
 qRR
 bWA
 bWA
@@ -276322,7 +276721,7 @@ qRR
 uAi
 kKd
 oTd
-ruk
+rct
 uAi
 qRR
 bWA
@@ -607207,7 +607606,7 @@ naI
 kbs
 yei
 pIx
-hHW
+tOu
 geS
 mRr
 mRr

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -135,12 +135,12 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "abI" = (
-/obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
 	locked = 1;
 	lockid = "nightman"
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "abL" = (
@@ -222,20 +222,15 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "acp" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/bed/rogue/inn{
+	dir = 1
 	},
-/obj/machinery/light/rogue/candle/l{
-	pixel_x = 32
+/obj/item/bedsheet/rogue/fabric{
+	dir = 1
 	},
-/obj/structure/flora/roguegrass/bush/westleach{
-	pixel_y = 13
-	},
-/obj/item/roguebin/water{
-	anchored = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/structure/curtain/magenta,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "acB" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -285,8 +280,20 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/rockhill)
 "ady" = (
-/obj/machinery/light/rogue/candle/blue,
-/turf/closed/wall/mineral/rogue/pipe,
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker3";
+	name = "locker 3"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/item/roguekey/roomi/village{
+	lockid = "locker2";
+	name = "locker 2 key"
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "adC" = (
 /obj/structure/stairs/stone,
@@ -1549,7 +1556,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
 "aum" = (
-/turf/open/water/cleanshallow,
+/obj/structure/fermentation_keg/redwine,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "auq" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -1585,11 +1593,19 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "auL" = (
-/obj/structure/fluff/pillow/magenta{
+/obj/structure/stairs/stone{
 	dir = 1
 	},
-/turf/open/floor/carpet/purple,
-/area/rogue/under/cavewet)
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1";
+	redstone_id = "tourneytop"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town/bath)
 "auR" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -1800,13 +1816,11 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/woodsrat/above)
 "axp" = (
-/obj/machinery/light/rogue/candle/blue,
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 8;
-	name = "Bathroom"
+/obj/item/roguebin/trash{
+	pixel_y = 5
 	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
+/turf/open/floor/rogue/tile/brownbrick{
+	color = "#ffd9f2"
 	},
 /area/rogue/indoors/town/bath)
 "axt" = (
@@ -2671,12 +2685,12 @@
 	},
 /area/rogue/under/cave/rhgoblinencampment)
 "aIb" = (
-/obj/machinery/light/rogue/candle/l{
-	light_power = 0;
-	pixel_x = 0;
-	pixel_y = 32
+/obj/structure/fluff/pillow/magenta{
+	dir = 8
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "aIf" = (
 /obj/structure/fluff/railing/border,
@@ -2709,16 +2723,8 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
 "aIl" = (
-/obj/structure/toilet,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -10;
-	pixel_y = -5
-	},
-/obj/structure/bars/grille{
-	dir = 1
-	},
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/water/sewer,
+/obj/structure/fermentation_keg/distiller,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "aIm" = (
 /turf/open/floor/rogue/ruinedwood{
@@ -2806,6 +2812,22 @@
 /obj/structure/roguemachine/noticeboard,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/south)
+"aJC" = (
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker2";
+	name = "locker 2"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/item/roguekey/roomi/village{
+	lockid = "locker3";
+	name = "locker 3 key"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "aJE" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/cobble/mossy,
@@ -3185,13 +3207,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
 "aNp" = (
-/obj/item/bedsheet/rogue/wool{
-	dir = 1
+/obj/structure/bell_common{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = -8
 	},
-/obj/structure/bed/rogue/inn{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "aNy" = (
 /turf/open/floor/rogue/tile/tilerg,
@@ -3544,22 +3565,8 @@
 /turf/closed/wall/mineral/rogue/stone/blue_moss,
 /area/rogue/under/cavewet/wizarddungeon)
 "aSr" = (
-/obj/structure/closet/crate/roguecloset{
-	keylock = 1;
-	lockid = "nightman"
-	},
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/effect/decal/cleanable/dirt/cobweb{
-	dir = 1
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/storage/roguebag,
-/obj/item/storage/roguebag,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/ladder/unbreakable,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "aSw" = (
 /obj/structure/fluff/railing/border{
@@ -3833,10 +3840,6 @@
 /obj/structure/fluff/statue/small{
 	pixel_x = 32
 	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_x = 32;
-	pixel_y = 13
-	},
 /obj/structure/hotspring{
 	icon_state = "lilypetals2"
 	},
@@ -4056,7 +4059,6 @@
 	dir = 1;
 	layer = 2
 	},
-/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "aZp" = (
@@ -4314,8 +4316,10 @@
 	pixel_x = -16;
 	pixel_y = 16
 	},
-/obj/structure/flora/roguegrass/water/reeds,
-/turf/open/water/ocean,
+/obj/item/roguebin/trash{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "bbO" = (
 /obj/structure/fluff/railing/border{
@@ -4481,6 +4485,10 @@
 "bef" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
+"ben" = (
+/obj/structure/table/wood/map/six,
+/turf/open/floor/carpet/red,
+/area/rogue/under/cavewet)
 "bet" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -4831,13 +4839,8 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/bath)
 "bjD" = (
-/obj/structure/fluff/statue/spider{
-	desc = "They watch you breed from the corners of the room.";
-	name = "Broodmother";
-	color = "#998f9c"
-	},
-/turf/closed/wall/mineral/rogue/stone,
-/area/rogue/indoors/town/bath)
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/under/cavewet)
 "bjN" = (
 /obj/structure/bed/rogue/inn/wool{
 	dir = 1
@@ -5131,7 +5134,6 @@
 /area/rogue/outdoors/bogsafe)
 "bnf" = (
 /obj/machinery/light/rogue/candle/red/l,
-/obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "bng" = (
@@ -5374,9 +5376,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/town/sewer)
 "bqs" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	lockid = "nightman"
-	},
+/obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "bqw" = (
@@ -5484,6 +5484,7 @@
 /area/rogue)
 "bsp" = (
 /obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bst" = (
@@ -5545,6 +5546,9 @@
 "bsY" = (
 /obj/structure/table/wood,
 /obj/structure/bars/shop,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "frontdeskshutters"
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bsZ" = (
@@ -6097,7 +6101,7 @@
 	lockid = "nightmaiden";
 	name = "Prostitutes Quarters"
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "bAk" = (
 /obj/structure/mineral_door/wood/window{
@@ -6498,10 +6502,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
 "bFa" = (
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_y = -14
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/bath)
 "bFe" = (
 /obj/structure/fluff/railing/border{
@@ -6698,14 +6707,8 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
 "bIc" = (
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 18
-	},
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/table/wood/map/four,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "bIk" = (
 /obj/structure/chair/bench{
@@ -6805,6 +6808,7 @@
 	icon_state = "borderfall";
 	pixel_y = -8
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "bJK" = (
@@ -6882,7 +6886,7 @@
 	},
 /obj/item/dildo/iron,
 /obj/item/dildo/iron,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "bKz" = (
 /obj/structure/fluff/railing/border{
@@ -6909,10 +6913,17 @@
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
 "bKC" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
+/obj/structure/mineral_door/wood/donjon{
+	locked = 1;
+	lockid = "dungeon";
+	name = "Dungeons"
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/curtain/black{
+	open = 0;
+	opacity = 1;
+	icon_state = "curtain-closed"
+	},
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "bKE" = (
 /obj/structure/fluff/railing/border/north,
@@ -7636,9 +7647,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/church)
 "bSL" = (
-/obj/structure/roguewindow/harem3{
-	opacity = 1
-	},
+/obj/structure/roguewindow/harem1,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/bath)
 "bSM" = (
@@ -7813,7 +7822,7 @@
 /area/rogue/indoors/inq)
 "bUS" = (
 /obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "bUW" = (
 /obj/structure/spider/stickyweb,
@@ -8131,7 +8140,7 @@
 /area/rogue/indoors/town/manor/rockhill)
 "bXZ" = (
 /obj/structure/bondage/torture_table/lever,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "bYf" = (
 /obj/machinery/light/rogue/candle,
@@ -8416,12 +8425,15 @@
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/manor/rockhill)
 "ccw" = (
-/obj/structure/roguewindow/harem3{
-	opacity = 1
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Employee Quarters"
 	},
-/turf/closed/wall/mineral/rogue/decostone/long{
-	dir = 1
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
 	},
+/turf/open/floor/rogue/church,
 /area/rogue/indoors/town/bath)
 "ccz" = (
 /obj/structure/fluff/railing/border{
@@ -9070,7 +9082,7 @@
 /obj/structure/bars/passage{
 	density = 0;
 	icon_state = "passage1";
-	redstone_id = "tourneytop"
+	redstone_id = "entrancelockdown"
 	},
 /obj/structure/curtain/magenta,
 /obj/structure/stairs,
@@ -10780,6 +10792,7 @@
 	icon_state = "borderfall";
 	pixel_y = -10
 	},
+/obj/structure/roguewindow/harem1,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/bath)
 "cFL" = (
@@ -10921,7 +10934,7 @@
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "cGY" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
@@ -11869,7 +11882,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "cQX" = (
-/turf/open/floor/rogue/herringbone,
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Employee Quarters"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "cRj" = (
 /turf/open/floor/rogue/wood/herringbone,
@@ -12219,11 +12240,14 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/inq/basement)
 "cWj" = (
-/obj/structure/shisha/hookah,
-/obj/structure/chair/bench/couchablack/r{
-	pixel_y = 2
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "cWm" = (
 /obj/structure/chair/wood/rogue{
@@ -12433,9 +12457,6 @@
 	layer = 2;
 	pixel_x = 10;
 	pixel_y = -10
-	},
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
 	},
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
@@ -12829,8 +12850,13 @@
 	},
 /area/rogue/outdoors/woodsrat/north)
 "ddp" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/lever/wall{
+	dir = 8;
+	name = "Entrance Lockdown";
+	pixel_y = 4;
+	redstone_id = "entrancelockdown"
+	},
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "dds" = (
 /turf/open/floor/rogue/blocks,
@@ -13358,7 +13384,7 @@
 	redstone_id = "night_escape"
 	},
 /obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "djS" = (
 /obj/machinery/light/rogue/firebowl/stump,
@@ -13510,9 +13536,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/inq/basement)
 "dlu" = (
-/obj/structure/roguewindow/harem3{
-	opacity = 1
-	},
+/obj/structure/roguewindow/harem1,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/bath)
 "dlw" = (
@@ -13536,14 +13560,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet)
 "dlE" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
-	},
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/tile/brick,
+/obj/structure/table/wood/map/three,
+/turf/open/floor/carpet/red,
 /area/rogue/under/cavewet)
 "dlG" = (
 /obj/structure/table/wood/poor,
@@ -13982,12 +14000,24 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bogsafe)
 "dru" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	name = "Tableware"
 	},
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/bath)
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/structure/curtain/magenta{
+	color = "#a1254a";
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cavewet)
 "drA" = (
 /obj/item/roguebin/water/gross,
 /obj/item/roguebin/water/gross,
@@ -15228,11 +15258,10 @@
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "dHo" = (
-/obj/structure/fluff/statue/spider{
-	desc = "They watch you breed from the corners of the room.";
-	name = "Broodmother"
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "dHr" = (
 /obj/structure/flora/hotspring_rocks,
@@ -15392,17 +15421,8 @@
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/indoors/town/warden)
 "dJa" = (
-/obj/structure/bars/pipe{
-	dir = 9;
-	layer = 2;
-	pixel_x = 16;
-	pixel_y = -15
-	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	layer = 1.5;
-	pixel_y = -14
-	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/table/wood/map,
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "dJe" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/troll,
@@ -15556,20 +15576,10 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet)
 "dKR" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/steel{
-	pixel_y = 11
-	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/machinery/light/rogue/candle/red,
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/bars,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "dLa" = (
 /obj/structure/wooden_horse/mobile,
 /turf/open/floor/rogue/cobble/mossy,
@@ -15779,8 +15789,19 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
 "dOe" = (
-/obj/effect/decal/cleanable/vomit/old,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/chair/wood,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 45
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_y = 45
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "dOj" = (
 /turf/closed/mineral/rogue,
@@ -17680,11 +17701,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
 "emc" = (
-/obj/structure/roguewindow/harem2,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/under/cavewet)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "emd" = (
 /obj/structure/flora/rogueshroom{
 	icon_state = "mush2"
@@ -17962,6 +17983,7 @@
 /obj/structure/stairs{
 	dir = 1
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "epm" = (
@@ -18205,11 +18227,23 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "ete" = (
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/rogue/churchbrick{
-	icon_state = "concretefloor1"
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	name = "Games"
 	},
-/area/rogue/indoors/town/bath)
+/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck,
+/obj/item/toy/cards/deck/tarot,
+/obj/item/storage/pill_bottle/dice/farkle,
+/obj/item/storage/pill_bottle/dice/farkle,
+/obj/structure/curtain/magenta{
+	color = "#a1254a";
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cavewet)
 "etg" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -18694,12 +18728,13 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/woodsrat/north)
 "eyL" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 1
-	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/purple,
-/area/rogue/under/cavewet)
+/obj/item/hair_dye_cream,
+/obj/item/dye_brush,
+/obj/item/needle/thorn,
+/obj/item/natural/cloth,
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/blocks/paving,
+/area/rogue/indoors/town/bath)
 "eyO" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -19061,6 +19096,7 @@
 /obj/item/roguekey/tavern,
 /obj/item/roguekey/tavern,
 /obj/item/roguekey/tavernkeep,
+/obj/structure/shisha/hookah,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
 "eCx" = (
@@ -19097,16 +19133,21 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "eDb" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker5";
+	name = "locker 5"
 	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 11;
-	pixel_y = 1
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/item/roguekey/roomi/village{
+	lockid = "locker5";
+	name = "locker 5 key"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "eDc" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/table/wood{
@@ -19836,15 +19877,15 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
 "eLV" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_y = 13
-	},
 /obj/item/reagent_containers/glass/bucket{
 	anchored = 1
 	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall";
 	pixel_y = -10
+	},
+/obj/structure/flora/roguegrass/bush/westleach{
+	pixel_y = 13
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
@@ -20918,7 +20959,8 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/indoors/town/grove)
 "eZt" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "eZx" = (
 /obj/structure/fluff/railing/border{
@@ -20965,11 +21007,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "fac" = (
-/obj/effect/decal/carpet/square/black{
-	pixel_x = 19;
-	pixel_y = -6
+/turf/closed/wall/mineral/rogue/pipe{
+	dir = 1;
+	icon_state = "iron_corner"
 	},
-/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "faj" = (
 /obj/structure/table/wood,
@@ -21021,7 +21062,7 @@
 	icon_state = "2,0";
 	pixel_x = 32
 	},
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/bath)
 "fbi" = (
 /obj/structure/flora/newleaf,
@@ -21408,6 +21449,12 @@
 "ffv" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
+"ffw" = (
+/obj/structure/fluff/walldeco/chains{
+	pixel_y = -15
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "ffz" = (
 /turf/closed/mineral/random/rogue/high,
 /area/rogue/outdoors/mountains/decap/rockhill)
@@ -22091,17 +22138,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/inq/basement)
 "foc" = (
-/obj/structure/bed/rogue/inn{
-	dir = 1
+/obj/structure/fluff/statue/femalestatue{
+	pixel_y = 0
 	},
-/obj/item/bedsheet/rogue/wool{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cobbleedge{
-	dir = 5
-	},
-/turf/open/floor/rogue/blocks/paving,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "foe" = (
 /obj/structure/fluff/railing/wood{
@@ -23112,7 +23152,7 @@
 /obj/structure/fluff/walldeco/maidendrape{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/herringbone,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "fBR" = (
 /turf/open/floor/rogue/churchmarble,
@@ -24080,9 +24120,14 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsrat/south)
 "fNt" = (
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/cavewet)
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 5
+	},
+/obj/structure/chair/smallbench,
+/turf/open/floor/rogue/tile/bath{
+	icon_state = "bathtileratwood"
+	},
+/area/rogue/indoors/town/bath)
 "fNw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -24288,8 +24333,8 @@
 	pixel_x = 3;
 	pixel_y = 22
 	},
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/rogue/blocks/paving,
+/obj/machinery/light/rogue/candle/floorcandle/pink,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "fPG" = (
 /obj/structure/fluff/walldeco/customflag/rockhill,
@@ -24312,9 +24357,7 @@
 	opacity = 1;
 	open = 0
 	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
+/turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "fPM" = (
 /obj/structure/flora/roguegrass/pyroclasticflowers,
@@ -24609,9 +24652,8 @@
 	dir = 8;
 	name = "Bathroom"
 	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "fTc" = (
 /obj/structure/fluff/railing/wood{
@@ -25472,7 +25514,6 @@
 	})
 "gfd" = (
 /obj/structure/fluff/pillow/purple,
-/obj/machinery/light/rogue/candle/red/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "gfj" = (
@@ -25494,10 +25535,6 @@
 /obj/structure/table/wood,
 /obj/item/roguebin/water{
 	pixel_y = 12
-	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -12;
-	pixel_y = 1
 	},
 /obj/structure/mirror,
 /turf/open/floor/rogue/blocks/paving,
@@ -26196,7 +26233,7 @@
 /area/rogue/outdoors/mountains/decap/rockhill)
 "goe" = (
 /obj/structure/fluff/walldeco/church/line,
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "gor" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -26285,11 +26322,12 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/basement)
 "gps" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	dir = 1;
-	icon_state = "iron_corner"
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = 27
 	},
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "gpw" = (
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -27544,13 +27582,7 @@
 	},
 /area/rogue/under/cavewet)
 "gGR" = (
-/obj/structure/stairs/stone{
-	dir = 8
-	},
-/obj/structure/stairs/stone{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
+/turf/closed/mineral/random/rogue,
 /area/rogue/indoors/town/bath)
 "gGU" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
@@ -28204,11 +28236,10 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/manor/rockhill)
 "gPP" = (
-/obj/structure/flora/roguegrass/water/reeds,
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
-/turf/open/water/sewer,
-/area/rogue/under/town/sewer)
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/floorcandle/pink,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "gPV" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/bars/grille,
@@ -28482,9 +28513,14 @@
 	},
 /area/rogue/outdoors/beach/harbor)
 "gTt" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/bath)
+/obj/structure/bars/pipe{
+	dir = 1;
+	layer = 2;
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/turf/open/water/bath,
+/area/rogue/under/cavewet)
 "gTw" = (
 /obj/effect/landmark/observer_start,
 /turf/open/floor/rogue/cobble,
@@ -28999,6 +29035,9 @@
 "gZt" = (
 /obj/structure/bars/shop,
 /obj/structure/table/wood,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "frontdeskshutters"
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "gZA" = (
@@ -30129,7 +30168,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "hnp" = (
-/turf/open/floor/rogue/tile/bath,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "hnr" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -31268,6 +31307,15 @@
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/inq)
+"hCf" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/bath)
 "hCw" = (
 /obj/structure/table/wood{
 	icon_state = "map5"
@@ -31689,9 +31737,6 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "hHr" = (
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = 45
-	},
 /obj/structure/fluff/statue/small{
 	pixel_y = 32
 	},
@@ -32605,15 +32650,14 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/rtfield/rockhill)
 "hSV" = (
-/obj/effect/decal/cobbleedge{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/vomit/old,
 /obj/structure/bed/rogue/inn{
 	dir = 1
 	},
 /obj/item/bedsheet/rogue/wool{
 	dir = 1
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
 	},
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
@@ -32645,16 +32689,11 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church)
 "hTq" = (
-/obj/structure/stairs/stone{
-	dir = 8
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
 	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/obj/structure/curtain/magenta{
-	color = "#a1254a"
-	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "hTE" = (
 /obj/structure/spider/stickyweb,
@@ -32780,19 +32819,21 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/rhgoblinencampment)
 "hUU" = (
-/obj/structure/rack/rogue,
-/obj/item/candle/yellow{
-	pixel_x = -5
+/obj/structure/closet/crate/roguecloset{
+	keylock = 1;
+	lockid = "nightman"
 	},
-/obj/item/candle/yellow{
-	pixel_x = 5
-	},
-/obj/item/candle/yellow,
-/obj/item/soap/bath{
-	pixel_y = -10
-	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/cobble,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/storage/roguebag,
+/obj/item/storage/roguebag,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "hUX" = (
 /obj/structure/chair/wood,
@@ -33676,7 +33717,7 @@
 	pixel_x = -7;
 	pixel_y = -13
 	},
-/turf/open/floor/rogue/cobblerock,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "igw" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -33788,9 +33829,9 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "ihq" = (
-/obj/structure/stairs/stone,
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/fermentation_keg,
+/obj/machinery/light/rogue/candle/blue/r,
+/turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "ihs" = (
 /turf/open/floor/rogue/naturalstone,
@@ -35776,13 +35817,8 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cave/skeletoncrypt)
 "iJF" = (
-/obj/structure/fermentation_keg/beer,
-/obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/rack/rogue/shelf,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_y = 37
-	},
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "iJP" = (
 /obj/structure/roguemachine/scomm{
@@ -37315,13 +37351,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
 "jdl" = (
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = 5
-	},
-/obj/structure/chair/smallbench,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/under/cavewet)
 "jdr" = (
 /obj/structure/stairs/fancy/r{
@@ -37372,7 +37402,7 @@
 	mailtag = "Whitevein - Nightmaster";
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "jdP" = (
 /obj/structure/fluff/statue/pillar{
@@ -37915,7 +37945,6 @@
 /obj/structure/stairs/stone{
 	dir = 8
 	},
-/obj/machinery/light/rogue/candle/blue,
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
@@ -38809,11 +38838,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/grove)
 "jvZ" = (
-/obj/structure/flora/roguegrass/bush{
-	pixel_y = 13
-	},
 /obj/item/reagent_containers/glass/bucket{
 	anchored = 1
+	},
+/obj/structure/flora/roguegrass/bush/westleach{
+	pixel_y = 13
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
@@ -38895,10 +38924,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor/rockhill)
 "jxQ" = (
-/obj/structure/fluff/walldeco/chains{
-	pixel_y = -15
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/shisha/hookah,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "jxS" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -39893,21 +39920,18 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "jJJ" = (
-/obj/structure/bed/rogue/inn{
+/obj/structure/bed/rogue/inn/double{
 	dir = 1
 	},
-/obj/item/bedsheet/rogue/fabric{
+/obj/item/bedsheet/rogue/double_pelt{
 	dir = 1
 	},
-/obj/machinery/light/rogue/candle/l{
-	pixel_x = 0;
-	pixel_y = -32
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
 	},
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "jJO" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hay,
@@ -40155,13 +40179,11 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/bog)
 "jNf" = (
-/obj/structure/table/wood/large_table,
-/obj/item/hair_dye_cream,
-/obj/item/dye_brush,
-/obj/structure/mirror,
-/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
-/turf/open/floor/carpet/purple,
-/area/rogue/under/cavewet)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "jNg" = (
 /obj/structure/pillory/reinforced{
 	lockid = list("inquisition")
@@ -40544,7 +40566,7 @@
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
 	lockid = "nightmaiden";
-	name = "Storeroom"
+	name = "Cellar"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
@@ -40615,6 +40637,10 @@
 /obj/effect/decal/carpet/square/black{
 	dir = 8;
 	pixel_x = 2
+	},
+/obj/structure/fluff/wallclock{
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
@@ -40698,6 +40724,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave/goblinfort)
+"jUB" = (
+/obj/structure/closet/crate/roguecloset/inn/south{
+	lockid = ""
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "jUE" = (
 /obj/item/rope/chain,
 /obj/item/rope/chain,
@@ -40967,14 +40999,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church)
 "jYg" = (
-/obj/structure/bars/pipe{
-	dir = 9;
-	layer = 2;
-	pixel_x = 16;
-	pixel_y = -15
-	},
-/turf/open/water/bath,
-/area/rogue/indoors/town/bath)
+/obj/structure/fermentation_keg/beer,
+/turf/open/floor/rogue/cobble,
+/area/rogue/under/town/sewer)
 "jYx" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
@@ -41160,9 +41187,19 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter/mountains)
 "kaO" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/cavewet)
+/obj/structure/rack/rogue/shelf/biggest,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/obj/item/reagent_containers/glass/cup/steel,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "kaP" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsafe)
@@ -41178,7 +41215,7 @@
 /obj/item/reagent_containers/glass/bucket{
 	anchored = 1
 	},
-/obj/structure/flora/roguegrass/bush{
+/obj/structure/flora/roguegrass/bush/westleach{
 	pixel_y = 13
 	},
 /turf/open/floor/carpet/royalblack,
@@ -41286,11 +41323,12 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/woodsrat/above)
 "kcM" = (
-/obj/structure/stairs/stone{
-	dir = 4
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/obj/structure/shisha/hookah,
+/turf/open/floor/rogue/churchmarble,
+/area/rogue/under/cavewet)
 "kcO" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass/nospawn,
@@ -41304,8 +41342,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield/rockhill/above)
 "kdd" = (
-/obj/machinery/light/rogue/candle/red/r,
-/turf/open/water/bath,
+/obj/structure/fluff/walldeco/maidendrape,
+/obj/item/candle/eora/lit{
+	pixel_x = -5;
+	pixel_y = 18
+	},
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "kdh" = (
 /obj/structure/bed/rogue/shit,
@@ -42271,7 +42313,7 @@
 /obj/structure/bookcase/random{
 	pixel_x = 4
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "knh" = (
 /obj/structure/bars/passage/shutter{
@@ -42974,18 +43016,9 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsafe)
 "kvU" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 1
-	},
-/obj/item/bedsheet/rogue/double_pelt{
-	dir = 1
-	},
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/under/cavewet)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "kwc" = (
 /obj/item/natural/worms/leech,
 /obj/item/natural/worms/leech{
@@ -43123,13 +43156,8 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/shop)
 "kxR" = (
-/obj/item/roguebin/water{
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/woodturned,
+/obj/structure/curtain/magenta,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "kxU" = (
 /obj/structure/chair/wood{
@@ -43907,11 +43935,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet)
 "kIL" = (
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/cavewet)
+/obj/structure/roguewindow/harem1,
+/turf/closed,
+/area/rogue/indoors/town/bath)
 "kIO" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/cavewet)
@@ -44036,11 +44062,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor/rockhill)
 "kJN" = (
-/obj/structure/fluff/statue/small{
-	pass_flags = 1;
-	pixel_x = 32
+/obj/structure/fluff/pillow/magenta{
+	pixel_x = 7;
+	pixel_y = 8
 	},
-/turf/closed/wall/mineral/rogue/decostone,
+/obj/structure/shisha/hookah,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kJR" = (
 /obj/structure/fluff/railing/wood{
@@ -44072,6 +44099,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "kKd" = (
+/obj/structure/bars/passage{
+	density = 0;
+	icon_state = "passage1";
+	redstone_id = "entrancelockdown"
+	},
 /obj/structure/mineral_door/wood/donjon{
 	dir = 8;
 	lockid = "nightmaiden";
@@ -44595,9 +44627,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
 "kRu" = (
-/obj/machinery/light/rogue/candle,
+/obj/structure/chair/wood,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
 /turf/open/floor/carpet/red,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "kRJ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -45225,7 +45260,18 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/rockhill)
 "kZR" = (
-/turf/open/floor/rogue/church,
+/obj/item/roguebin/trash{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/indoors/town/bath)
+"kZS" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
+	},
+/obj/item/candle/eora/lit,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/bath)
 "kZU" = (
 /obj/structure/stairs/stone/ccwdown{
@@ -45380,8 +45426,10 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "lcD" = (
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/cavewet)
+/obj/structure/table/wood,
+/obj/structure/bars/shop,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "lcH" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -46472,10 +46520,10 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/outdoors/woodsrat/south)
 "lqS" = (
-/obj/structure/stairs/stone{
-	dir = 8
+/obj/structure/fluff/statue/femalestatue1{
+	pixel_y = 0
 	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "lqX" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -46572,7 +46620,12 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/harbor)
 "lsQ" = (
-/turf/closed,
+/obj/structure/table/wood/large_table,
+/obj/item/hair_dye_cream,
+/obj/item/dye_brush,
+/obj/structure/mirror,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "lsS" = (
 /obj/structure/mannequin/male/female{
@@ -47506,16 +47559,12 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "lGk" = (
-/obj/structure/closet/crate/roguecloset/inn,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/soap/bath{
-	pixel_y = -10
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet)
 "lGl" = (
 /obj/structure/glowshroom,
@@ -48149,7 +48198,6 @@
 /obj/item/reagent_containers/powder/moondust,
 /obj/item/reagent_containers/glass/bottle/rogue/poison,
 /obj/item/reagent_containers/glass/bottle/rogue/emberwine,
-/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -48225,9 +48273,7 @@
 /area/rogue/outdoors/rtfield/rockhill)
 "lOH" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "lON" = (
 /obj/structure/stairs/stone,
@@ -48473,7 +48519,6 @@
 /obj/item/leash/chain,
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/rogueweapon/surgery/cautery/branding/slave,
-/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -48870,7 +48915,6 @@
 "lXl" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/roguegem/violet,
-/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -50243,6 +50287,7 @@
 	lockid = "nightman";
 	name = "Nighmaster's Room"
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "mmv" = (
@@ -51251,10 +51296,10 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
 "mym" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/light/rogue/candle/red/l,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/bath)
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/bars,
+/turf/open/water/cleanshallow,
+/area/rogue/under/town/sewer)
 "myq" = (
 /obj/item/kitchen/spoon,
 /obj/item/kitchen/spoon,
@@ -52648,8 +52693,8 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors)
 "mQe" = (
-/obj/structure/fermentation_keg/distiller,
 /obj/machinery/light/rogue/candle/blue/l,
+/obj/structure/fermentation_keg/whitewine,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "mQj" = (
@@ -53152,9 +53197,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church)
 "mYd" = (
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "mYj" = (
 /obj/machinery/light/rogue/candle{
@@ -55407,6 +55450,12 @@
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/inq)
+"nAc" = (
+/obj/machinery/light/rogue/candle/l{
+	light_power = 0
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "nAd" = (
 /obj/structure/table/vtable,
 /obj/item/reagent_containers/glass/bottle/rogue,
@@ -56278,6 +56327,14 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/woodsrat/south)
+"nLu" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "nLx" = (
 /turf/closed/wall/mineral/rogue/stone/window/moss,
 /area/rogue/outdoors/woodsrat/north)
@@ -56501,7 +56558,7 @@
 /obj/structure/bars/passage{
 	density = 0;
 	icon_state = "passage1";
-	redstone_id = "tourneytop"
+	redstone_id = "entrancelockdown"
 	},
 /obj/structure/curtain/magenta,
 /obj/structure/stairs{
@@ -56628,7 +56685,9 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor/rockhill)
 "nQo" = (
-/obj/machinery/light/rogue/candle/blue,
+/obj/structure/fluff/walldeco/painting/seraphina{
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/bath)
 "nQu" = (
@@ -56670,7 +56729,6 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
 "nQS" = (
-/obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
 	},
@@ -57731,6 +57789,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "odo" = (
@@ -57929,10 +57988,8 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/tavern)
 "ofB" = (
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/floor/rogue/churchbrick{
-	icon_state = "concretefloor1"
-	},
+/obj/structure/fluff/pillow/magenta,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "ofC" = (
 /obj/structure/flora/newleaf,
@@ -58181,8 +58238,8 @@
 	icon_state = "borderfall";
 	pixel_y = 8
 	},
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/rogue/tile/harem1,
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ojZ" = (
 /obj/structure/flora/rogueshroom{
@@ -59006,7 +59063,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/tavern)
 "otv" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "otC" = (
 /obj/item/reagent_containers/food/snacks/crow{
@@ -59052,7 +59109,7 @@
 /area/rogue/outdoors/rtfield/eora)
 "otP" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "otW" = (
 /obj/structure/stairs,
@@ -59337,8 +59394,7 @@
 /obj/item/toy/cards/deck,
 /obj/item/toy/cards/deck,
 /obj/item/needle/thorn,
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/cobble,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "oxq" = (
 /turf/open/water/river/muddy{
@@ -60420,7 +60476,7 @@
 /obj/item/natural/bundle/stick,
 /obj/item/natural/bundle/stick,
 /obj/item/rogue/instrument/accord,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "oNo" = (
 /obj/machinery/light/rogue/campfire/fireplace{
@@ -60644,9 +60700,6 @@
 /obj/item/roguebin/trash{
 	pixel_y = 5
 	},
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_y = 32
-	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "oPw" = (
@@ -60692,6 +60745,10 @@
 /obj/structure/flora/roguegrass/herb/manabloom,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/cavewet)
+"oPU" = (
+/obj/structure/table/wood/map/five,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/bath)
 "oQc" = (
 /obj/structure/fluff/walldeco/psybanner{
 	pixel_y = 29
@@ -61925,7 +61982,7 @@
 /obj/structure/fluff/walldeco/bigpainting/lake{
 	pixel_x = -28
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "peK" = (
 /obj/structure/table/wood{
@@ -63804,16 +63861,15 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/bograt/above)
 "pCp" = (
-/obj/structure/bars/pipe{
-	dir = 6;
-	layer = 2;
-	pixel_x = -15;
-	pixel_y = 9
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
 	},
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
+/obj/structure/shisha/hookah{
+	pixel_x = -1;
+	pixel_y = 7
 	},
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "pCr" = (
 /obj/machinery/light/rogue/candle/green,
 /turf/open/floor/rogue/naturalstone,
@@ -65298,11 +65354,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woodsrat/south)
 "pUM" = (
-/obj/machinery/light/rogue/candle{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/indoors/town/bath)
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/under/cavewet)
 "pVc" = (
 /obj/structure/curtain,
 /turf/open/floor/rogue/church,
@@ -65466,15 +65520,14 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "pXx" = (
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	pixel_x = 1;
-	pixel_y = -7
+/obj/structure/mineral_door/wood/donjon{
+	dir = 4;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Arena"
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/under/cavewet)
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/indoors/town/bath)
 "pXB" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
 	dir = 4
@@ -65832,12 +65885,7 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "qcz" = (
-/obj/structure/bars/pipe{
-	dir = 1;
-	layer = 1
-	},
-/obj/structure/chair/bench/couchamagenta,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/bath)
 "qcG" = (
 /obj/structure/fluff/pillow/magenta{
@@ -66022,7 +66070,7 @@
 /obj/structure/fluff/statue/small{
 	pass_flags = 1
 	},
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/bath)
 "qfi" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -66237,10 +66285,14 @@
 /area/rogue/indoors/shelter/bog)
 "qiF" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "qiH" = (
 /obj/structure/closet/crate/roguecloset/lord{
 	lockid = "physician"
@@ -67974,11 +68026,16 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/cavewet)
 "qDX" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/under/cavewet)
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "qDY" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -68486,11 +68543,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/bath)
 "qKV" = (
-/obj/structure/roguewindow/harem2,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/under/cavewet)
+/obj/structure/fluff/walldeco/maidendrape{
+	pixel_y = 0
+	},
+/turf/closed/wall/mineral/rogue/decostone,
+/area/rogue/indoors/town/bath)
 "qLc" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -68685,10 +68742,6 @@
 	pass_flags = 1;
 	pixel_x = 32
 	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_x = 32;
-	pixel_y = 13
-	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "qNk" = (
@@ -68696,8 +68749,7 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsrat/above)
 "qNw" = (
-/obj/machinery/light/rogue/candle/red,
-/obj/machinery/light/rogue/candle/blue,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "qNy" = (
@@ -69918,7 +69970,12 @@
 /turf/open/floor/rogue/grassgrey,
 /area/rogue/under/cavewet/wizarddungeon)
 "rfY" = (
-/obj/structure/rack/rogue/shelf/biggest,
+/obj/structure/lever/wall{
+	dir = 8;
+	name = "Desk Shutters";
+	pixel_y = 4;
+	redstone_id = "frontdeskshutters"
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "rgc" = (
@@ -70323,8 +70380,17 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/grove)
 "rmv" = (
-/turf/closed,
-/area/rogue/under/cavewet)
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/soap/bath{
+	pixel_y = -10
+	},
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "rmz" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -70663,11 +70729,8 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/town/rockhill)
 "rqF" = (
-/obj/structure/closet/crate/roguecloset/inn/south{
-	lockid = ""
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/structure/roguewindow/harem1,
+/area/rogue/indoors/town/bath)
 "rqJ" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town/roofs/keep)
@@ -71831,13 +71894,12 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/grove)
 "rFo" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Dormitory"
+/obj/structure/fluff/pillow/magenta{
+	dir = 8
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cavewet)
+/obj/structure/shisha/hookah,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "rFu" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/underdark/rockhill)
@@ -72532,7 +72594,6 @@
 /obj/item/reagent_containers/glass/cup/golden{
 	pixel_x = 8
 	},
-/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -72675,7 +72736,7 @@
 	icon_state = "0,1";
 	pixel_x = -32
 	},
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/bath)
 "rQs" = (
 /obj/structure/closet/crate/roguecloset/dark{
@@ -72774,9 +72835,6 @@
 	layer = 2;
 	pixel_x = -10;
 	pixel_y = -10
-	},
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
 	},
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
@@ -72904,8 +72962,7 @@
 /obj/item/clothing/gloves/roguetown/harms,
 /obj/item/clothing/mask/rogue/hblinders,
 /obj/item/clothing/head/roguetown/hbit,
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "rTK" = (
 /turf/open/floor/rogue/tile/masonic{
@@ -73415,10 +73472,6 @@
 	icon_state = "borderfall";
 	pixel_y = -10
 	},
-/obj/machinery/light/rogue/candle/blue/l{
-	pixel_x = 0;
-	pixel_y = -32
-	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "saB" = (
@@ -73782,9 +73835,7 @@
 	pixel_x = 7;
 	pixel_y = 18
 	},
-/turf/open/floor/rogue/tile{
-	icon_state = "bfloorz"
-	},
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/bath)
 "seF" = (
 /obj/structure/flora/roguegrass,
@@ -74154,12 +74205,9 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog)
 "siB" = (
-/obj/structure/chair/smallbench,
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/rogue/tile/bath{
-	icon_state = "bathtileratwood"
-	},
-/area/rogue/under/cavewet)
+/obj/structure/roguewindow/harem1,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "siJ" = (
 /obj/structure/bed/rogue/shit,
 /mob/living/carbon/human/species/human/northern/highwayman,
@@ -74276,8 +74324,13 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
 "skm" = (
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/carpet/red,
 /area/rogue/under/cavewet)
 "sks" = (
 /obj/structure/closet/crate/chest{
@@ -74512,7 +74565,6 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/obj/machinery/light/rogue/candle/red/l,
 /obj/structure/table/wood{
 	dir = 4;
 	icon_state = "largetable"
@@ -74625,9 +74677,17 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/bath)
 "soD" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/cavewet)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/flora/roguegrass/bush/westleach{
+	pixel_y = 13
+	},
+/obj/item/roguebin/water{
+	anchored = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "soL" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -75006,7 +75066,6 @@
 /turf/open/floor/carpet/purple,
 /area/rogue/outdoors/rtfield/eora)
 "sur" = (
-/obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
@@ -75283,11 +75342,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/inq/basement)
 "sxH" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/area/rogue/under/cavewet)
+/obj/structure/chair/wood/rogue,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/indoors/town/bath)
 "sxL" = (
 /obj/structure/bars{
 	icon_state = "barsbent";
@@ -75473,10 +75533,20 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
 "sAY" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker4";
+	name = "locker 4"
 	},
-/turf/open/floor/rogue/churchmarble,
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/item/roguekey/roomi/village{
+	lockid = "locker4";
+	name = "locker 4 key"
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "sBf" = (
 /obj/structure/roguemachine/scomm{
@@ -75974,7 +76044,6 @@
 	dir = 1;
 	layer = 2
 	},
-/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "sGO" = (
@@ -76202,12 +76271,11 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
 "sIL" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Employee Quarters"
+/obj/structure/stairs/stone{
+	dir = 4
 	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "sIN" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -76384,9 +76452,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/manor/rockhill)
 "sLa" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	lockid = "nightman"
-	},
+/obj/structure/closet/crate/roguecloset/dark,
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
@@ -76790,9 +76856,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bograt/west)
 "sRH" = (
-/obj/structure/roguewindow/harem2,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
+/obj/structure/roguewindow/harem1,
 /turf/open/floor/rogue/tile/brownbrick{
 	color = "#ffd9f2"
 	},
@@ -77532,7 +77596,7 @@
 	pixel_x = -1;
 	pixel_y = 7
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "taV" = (
 /obj/structure/fluff/railing/border{
@@ -77557,12 +77621,15 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/mountains)
 "tbs" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32
 	},
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/bath)
 "tbu" = (
 /obj/structure/stairs/stone,
 /obj/structure/fluff/railing/border{
@@ -77931,12 +77998,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
 "tfS" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/structure/table/wood/map/two,
+/turf/open/floor/carpet/red,
+/area/rogue/indoors/town/bath)
 "tfU" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
@@ -79048,15 +79112,9 @@
 	icon_state = "borderfall";
 	pixel_y = -8
 	},
-/obj/machinery/light/rogue/candle/red{
-	pixel_y = -32
-	},
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall";
 	pixel_y = -8
-	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
 	},
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
@@ -79279,9 +79337,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
-	},
 /obj/structure/flora/roguegrass/herb/salvia,
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
@@ -79394,12 +79449,14 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
 "twA" = (
-/obj/structure/bars/pipe{
-	dir = 1;
-	layer = 1
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
 	},
-/obj/structure/chair/bench/couchamagenta/r,
-/turf/open/floor/rogue/churchbrick,
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/bath)
 "twD" = (
 /obj/structure/fluff/walldeco/chains,
@@ -79500,9 +79557,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "tyx" = (
-/obj/machinery/light/rogue/candle/l,
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "dungeon";
+	name = "Bathhouse"
+	},
 /turf/open/floor/rogue/cobble,
-/area/rogue/indoors/town/bath)
+/area/rogue/indoors/town/cell)
 "tyA" = (
 /obj/structure/table/wood/poor,
 /obj/machinery/light/rogue/candle/off{
@@ -79528,7 +79590,9 @@
 	},
 /area/rogue/outdoors/beach/harbor)
 "tyJ" = (
-/obj/structure/flora/roguegrass/bush,
+/obj/structure/flora/roguegrass/bush/westleach{
+	pixel_y = 13
+	},
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/bath)
 "tyW" = (
@@ -80418,7 +80482,7 @@
 	lockid = "nightmaiden";
 	name = "Storage Closet"
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "tLg" = (
 /obj/machinery/light/rogue/candle/blue/l,
@@ -81093,17 +81157,9 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/cave/goblinfort)
 "tTb" = (
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/soap/bath{
-	pixel_y = -10
-	},
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/carpet/purple,
-/area/rogue/under/cavewet)
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "tTi" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/sabre/stalker,
@@ -81412,6 +81468,9 @@
 "tWl" = (
 /obj/structure/table/wood,
 /obj/structure/bars/shop,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "frontdeskshutters"
+	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "tWp" = (
@@ -82638,12 +82697,12 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/exposed/town/keep)
 "umj" = (
-/obj/structure/closet/crate/roguecloset/inn/chest,
 /obj/effect/decal/carpet/kover_darkred{
 	dir = 8;
 	pixel_x = 15;
 	pixel_y = 17
 	},
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "umm" = (
@@ -82808,9 +82867,9 @@
 /turf/open/water/swamp,
 /area/rogue/under/cave/dungeon1)
 "uob" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/structure/roguewindow/harem1,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "uoc" = (
 /obj/structure/chair/bench/couch,
 /obj/machinery/light/rogue/candle/l,
@@ -83537,7 +83596,6 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue,
 /area/rogue/indoors/town/church/chapel)
 "uwW" = (
-/obj/structure/fermentation_keg/whitewine,
 /obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/rack/rogue/shelf,
 /obj/item/storage/roguebag{
@@ -83681,9 +83739,6 @@
 	pixel_y = -5
 	},
 /obj/item/natural/feather,
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
 /obj/item/paper/scroll,
@@ -83697,7 +83752,7 @@
 /obj/item/roguekey/nightmaiden,
 /obj/item/roguekey/nightmaiden,
 /obj/item/roguekey/nightmaiden,
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "uzr" = (
 /obj/structure/hotspring/border/three,
@@ -83845,11 +83900,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
 "uAG" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/structure/mirror{
+	pixel_y = -32
 	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/bath)
 "uAL" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -83954,12 +84009,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
 "uCg" = (
-/obj/structure/table/wood/poor,
-/obj/item/natural/cloth,
-/obj/item/needle/thorn,
-/obj/item/hair_dye_cream,
-/obj/item/dye_brush,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = 27
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "uCi" = (
 /obj/item/roguebin/water,
@@ -85804,10 +85858,7 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/church)
 "vaX" = (
-/obj/machinery/light/rogue/candle/l{
-	pixel_x = 32
-	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "vba" = (
 /obj/structure/fluff/railing/fence,
@@ -86018,11 +86069,20 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/outdoors/town/rockhill)
 "vdR" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 8;
-	name = "Bathroom"
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker6";
+	name = "locker 6"
 	},
-/turf/open/floor/rogue/concrete,
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/item/roguekey/roomi/village{
+	lockid = "locker6";
+	name = "locker 6 key"
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vdS" = (
 /obj/structure/stairs{
@@ -86297,7 +86357,7 @@
 /area/rogue/outdoors/town/grove)
 "vhJ" = (
 /obj/structure/roguemachine/bathvend,
-/turf/closed/wall/mineral/rogue/stonebrick,
+/turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/bath)
 "vhN" = (
 /obj/structure/closet/crate/drawer{
@@ -87316,8 +87376,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
 "vuC" = (
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/item/roguebin/water{
+	pixel_y = 6
+	},
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "vuJ" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -88190,11 +88252,11 @@
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/shelter/mountains)
 "vGg" = (
-/obj/machinery/light/rogue/candle/l{
-	light_power = 0
+/obj/structure/chair/smallbench,
+/turf/open/floor/rogue/tile/bath{
+	icon_state = "bathtileratwood"
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "vGj" = (
 /obj/structure/fluff/statue/abyssor,
 /turf/open/floor/rogue/churchmarble,
@@ -88582,13 +88644,14 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors)
 "vLn" = (
-/obj/structure/bars/pipe{
-	dir = 10;
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 13
+/obj/effect/decal/carpet/kover_purple{
+	dir = 4;
+	pixel_x = 20;
+	pixel_y = -15
 	},
-/turf/open/water/bath,
+/obj/structure/shisha/hookah,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vLo" = (
 /obj/structure/flora/roguetree/evil,
@@ -88781,12 +88844,10 @@
 /area/rogue/indoors/town/manor/rockhill)
 "vOe" = (
 /obj/structure/toilet,
-/obj/item/reagent_containers/food/snacks/smallrat,
 /obj/structure/bars/grille{
 	dir = 1
 	},
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/water/sewer,
+/turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/indoors/town/bath)
 "vOg" = (
 /obj/structure/fluff/railing/fence{
@@ -88863,9 +88924,18 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave)
 "vPH" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "locker1";
+	name = "locker I"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/obj/item/roguekey/roomi/village{
+	lockid = "locker1";
+	name = "locker 1 key"
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -89175,7 +89245,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/tile/harem1,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vTE" = (
 /obj/structure/stairs,
@@ -90823,7 +90893,7 @@
 /area/rogue/indoors/town/shop)
 "wpn" = (
 /obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "wpu" = (
 /turf/open/water/bath,
@@ -90896,7 +90966,6 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bograt/sunken)
 "wqF" = (
-/obj/structure/fermentation_keg/redwine,
 /obj/structure/rack/rogue/shelf,
 /obj/item/reagent_containers/glass/bucket{
 	pixel_y = 37
@@ -91359,8 +91428,8 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/warden)
 "wwF" = (
-/obj/structure/fermentation_keg/distiller,
 /obj/machinery/light/rogue/candle/blue/r,
+/obj/structure/fermentation_keg/distiller,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/bath)
 "wwL" = (
@@ -91436,12 +91505,16 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
 "wxx" = (
-/obj/structure/mineral_door/wood/bath/courtesan,
-/obj/structure/curtain/magenta{
-	alpha = 200
+/obj/structure/bars/pipe{
+	dir = 6;
+	layer = 2;
+	pixel_x = -15;
+	pixel_y = 9
 	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/tile/bath{
+	icon_state = "bathtileratwood"
+	},
+/area/rogue/indoors/town/bath)
 "wxy" = (
 /obj/effect/landmark/start/tailor,
 /turf/open/floor/carpet/red,
@@ -91731,13 +91804,10 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "wBa" = (
-/obj/item/bedsheet/rogue/fabric,
-/obj/structure/bed/rogue/inn,
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/cavewet)
+/obj/structure/mineral_door/wood/bath/courtesan,
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/concrete,
+/area/rogue/indoors/town/bath)
 "wBe" = (
 /obj/structure/flora/rogueshroom{
 	pixel_y = -5
@@ -91940,8 +92010,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bogsafe)
 "wDt" = (
-/turf/open/floor/carpet/purple,
-/area/rogue/under/cavewet)
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/indoors/town/bath)
 "wDz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
@@ -92108,10 +92179,10 @@
 /area/rogue/indoors/town/garrison)
 "wFB" = (
 /obj/structure/curtain/magenta{
-	alpha = 200
+	color = "#a1254a"
 	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/under/cavewet)
+/turf/open/floor/carpet/purple,
+/area/rogue/indoors/town/bath)
 "wFJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -92546,6 +92617,7 @@
 	locked = 1
 	},
 /obj/structure/stairs,
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "wKe" = (
@@ -92720,6 +92792,7 @@
 	icon_state = "longtable";
 	name = "Massage Table"
 	},
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "wMH" = (
@@ -93790,7 +93863,7 @@
 	lockid = "nightman";
 	name = "Cell Door"
 	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "xbl" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -94231,17 +94304,11 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "xhv" = (
-/obj/structure/bed/rogue/inn{
-	dir = 1
+/obj/item/roguebin/trash{
+	pixel_y = 5
 	},
-/obj/item/bedsheet/rogue/fabric{
-	dir = 1
-	},
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "xhx" = (
 /obj/item/natural/poo/cow,
 /turf/open/floor/rogue/cobble/mossy,
@@ -94509,13 +94576,10 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "xkI" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/eora/lit,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/under/cavewet)
+/obj/structure/closet/crate/drawer,
+/obj/structure/mirror,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/bath)
 "xkX" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -94616,7 +94680,6 @@
 	name = "Mage's Tower"
 	})
 "xlO" = (
-/obj/machinery/light/rogue/candle/red,
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/bath)
@@ -95239,7 +95302,15 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
 "xuA" = (
-/obj/structure/chair/bench/couchamagenta,
+/obj/structure/closet/crate/roguecloset/inn,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/soap/bath{
+	pixel_y = -10
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xuJ" = (
@@ -95483,10 +95554,12 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy,
 /area/rogue/under/cave/skeletoncrypt)
 "xxR" = (
-/obj/structure/chair/bench/couchablack{
-	pixel_y = 2
+/obj/structure/bell_common{
+	dir = 4;
+	pixel_x = -10;
+	pixel_y = -8
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "xxY" = (
 /obj/machinery/light/rogue/firebowl/off,
@@ -95594,11 +95667,9 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/obj/machinery/light/rogue/candle/red/l,
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "xzE" = (
@@ -95631,11 +95702,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/Academy)
 "xzL" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	pixel_x = -10
-	},
-/turf/open/floor/rogue/cobble/mossy,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "xzN" = (
 /obj/structure/stairs/stone{
@@ -95720,10 +95787,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woodsrat/above)
 "xAL" = (
-/obj/structure/closet/crate/drawer,
-/obj/machinery/light/rogue/candle,
+/obj/item/bedsheet/rogue/fabric,
+/obj/structure/bed/rogue/inn,
+/obj/structure/curtain/magenta,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "xAO" = (
 /obj/structure/closet/crate/roguecloset{
 	keylock = 1;
@@ -96325,10 +96393,9 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
 "xHB" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/stickyweb,
-/turf/open/water/swamp,
+/obj/structure/ladder/unbreakable,
+/obj/structure/ladder/unbreakable,
+/turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "xHD" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -97046,13 +97113,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/south)
 "xQX" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/effect/decal/carpet{
+	pixel_y = 17
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "xRa" = (
 /turf/open/water/river/muddy{
@@ -98133,7 +98197,17 @@
 /obj/item/kitchen/fork/iron,
 /obj/item/kitchen/fork/iron,
 /obj/item/kitchen/fork/iron,
-/turf/open/floor/rogue/cobble,
+/obj/item/soap/bath{
+	pixel_y = -10
+	},
+/obj/item/soap/bath{
+	pixel_y = -10
+	},
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
+/turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
 "yfk" = (
 /turf/open/floor/rogue/concrete,
@@ -98450,7 +98524,7 @@
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
 	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "yji" = (
 /obj/structure/fluff/walldeco/maidensigil,
@@ -146220,11 +146294,11 @@ whb
 whb
 whb
 whb
-jxS
-aSH
-jxS
-jxS
-jxS
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -146652,11 +146726,11 @@ whb
 whb
 whb
 whb
-emc
-fVn
-dlE
-emc
-jxS
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -147084,11 +147158,11 @@ whb
 whb
 whb
 whb
-emc
-fVn
-uAG
-emc
-jxS
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -147516,16 +147590,16 @@ whb
 whb
 whb
 whb
-jxS
-jxS
-wFB
-jxS
-jxS
-jxS
-jxS
-jxS
-jxS
-jxS
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -147948,16 +148022,16 @@ whb
 whb
 whb
 whb
-xks
-kvU
-lcD
-qKV
-kvU
-fNt
-jxS
-fVn
-fVn
-jxS
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -148380,16 +148454,16 @@ whb
 whb
 whb
 whb
-xks
-eyL
-lcD
-qKV
-auL
-lcD
-wFB
-qDX
-pXx
-jxS
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -148812,17 +148886,17 @@ whb
 whb
 whb
 whb
-xks
-qKV
-kIL
-xks
-qKV
-kIL
-aSH
-jxS
-jxS
-aSH
-jxS
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -149244,18 +149318,18 @@ whb
 whb
 whb
 whb
-xks
-jNf
-kaO
-qKV
-jNf
-kaO
-jxS
-jxS
-xAL
-xhv
-gQh
-jxS
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -149676,18 +149750,18 @@ whb
 whb
 whb
 whb
-aSH
-tTb
-lcD
-qKV
-lGk
-lcD
-jxS
-rqF
-fuF
-fuF
-jJJ
-gQh
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -150108,18 +150182,18 @@ whb
 whb
 whb
 whb
-jxS
-jxS
-wxx
-jxS
-jxS
-wxx
-jxS
-ogI
-ogI
-fuF
-soD
-aSH
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -150540,18 +150614,18 @@ whb
 whb
 whb
 whb
-jxS
-xkI
-wDt
-vGg
-fuF
-wDt
-aSH
-kRu
-ogI
-fuF
-wBa
-jxS
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -150972,18 +151046,18 @@ whb
 whb
 whb
 whb
-aSH
-skm
-fuF
-uob
-eDb
-uob
-rFo
-qiF
-acp
-tbs
-tfS
-gQh
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -153996,19 +154070,19 @@ whb
 whb
 whb
 whb
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
-rmv
-rmv
-rmv
-rmv
-rmv
-rmv
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -154428,19 +154502,19 @@ whb
 whb
 whb
 whb
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
-rmv
-rmv
-rmv
-rmv
-rmv
-rmv
+eFJ
+uob
+wpu
+qiF
+uob
+eFJ
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -154860,19 +154934,19 @@ whb
 whb
 whb
 whb
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
-rmv
-rmv
-rmv
-rmv
-rmv
-rmv
+eFJ
+uob
+wpu
+dHo
+uob
+eFJ
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -155282,29 +155356,29 @@ sFx
 sFx
 xeg
 whb
-scK
-scK
-scK
-scK
+eFJ
+eFJ
+eFJ
+eFJ
 whb
-xrC
-xrC
-soz
-scK
-fJX
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
-rmv
+eFJ
+eFJ
+rqF
+eFJ
+rqF
+eFJ
+eFJ
+eFJ
+wDt
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+whb
+whb
 whb
 whb
 whb
@@ -155713,30 +155787,30 @@ sFx
 rCO
 nvn
 xeg
-scK
-scK
+eFJ
+eFJ
 lRY
 oMw
-scK
-scK
-xrC
+eFJ
+eFJ
+eFJ
 bMh
 xzC
 sFi
 gne
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
-rmv
+kIL
+eFJ
+jJJ
+kdw
+siB
+jJJ
+kdw
+eFJ
+wpu
+wpu
+eFJ
+whb
+whb
 whb
 whb
 whb
@@ -156145,40 +156219,40 @@ sFx
 sFx
 sFx
 xeg
-scK
+eFJ
 lXl
 xkd
 jfX
-ofB
-scK
-xrC
-xrC
+fLW
+eFJ
+eFJ
+eFJ
 qNw
 aCi
 ttc
-fJX
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
-rmv
+kIL
+eFJ
+pCp
+kdw
+siB
+pCp
+kdw
+wDt
+jNf
+twA
+eFJ
 whb
 whb
 whb
 whb
 whb
 whb
-sxH
-gOi
-gOi
-dId
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -156586,32 +156660,32 @@ abI
 hKR
 djL
 odm
-asP
+kxR
 bJx
-fJX
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
+kIL
+eFJ
+siB
+sYr
+eFJ
+siB
+sYr
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
 whb
 whb
 whb
 whb
 whb
-gps
-tRJ
-yhp
-cRt
-tRJ
-dId
+whb
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -157009,41 +157083,41 @@ lwH
 haM
 xeg
 xeg
-scK
+eFJ
 rOm
 gjr
 jfX
-ete
-scK
+fLW
+eFJ
 wAU
 vTB
 tvr
 gJb
 sTl
-xrC
+eFJ
+eFJ
 lsQ
+thM
+siB
 lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
+thM
+eFJ
+eFJ
+xkI
+acp
+eFJ
+eFJ
 whb
 whb
 whb
 whb
 whb
-kGM
-pCp
-mKf
-hZk
-xtR
-kGM
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -157441,41 +157515,41 @@ xeg
 rwR
 xeg
 dXU
-scK
-scK
+eFJ
+eFJ
 lNK
 pnx
-scK
-scK
+eFJ
+eFJ
 ycM
 ojQ
-xQX
-pQc
-pQc
+jfX
+jfX
+jfX
 qtm
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
+eFJ
+rmv
+kdw
+siB
+xuA
+kdw
+eFJ
+jUB
+qcz
+qcz
+acp
+eFJ
 whb
 whb
 whb
 whb
 whb
-kGM
-jdl
-fVn
-rWD
-hZk
-kGM
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -157874,40 +157948,40 @@ bSW
 xeg
 xeg
 grO
-scK
-scK
-scK
-scK
-nvH
+qRR
+qRR
+qRR
+qRR
+qRR
 scK
 kmW
-sAY
-pQc
+jfX
+hTq
 uzk
-soz
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
+eFJ
+eFJ
+eFJ
+wBa
+eFJ
+eFJ
+wBa
+eFJ
+fqM
+fqM
+qcz
+tTb
+eFJ
 whb
 whb
 whb
 whb
 whb
-tRJ
-siB
-hCX
-hZk
-tjy
-kGM
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -158306,40 +158380,40 @@ wDf
 fJP
 xeg
 grO
-nvH
-nvH
-uCg
-wpn
-nvH
+qRR
+hSV
+yee
+eyL
+qRR
 fJX
 peE
-sAY
+jfX
 bUS
 jdK
-fJX
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
+eFJ
+eFJ
+kZS
+asP
+nAc
+qcz
+asP
+eFJ
+fqM
+fqM
+qcz
+xAL
+eFJ
 whb
 whb
 whb
 whb
 whb
-nDe
-lUL
-mcL
-mcL
-uSL
-vvx
+whb
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -158738,39 +158812,39 @@ wDf
 kJh
 xeg
 grO
-scK
-foc
-idl
-otP
-aNp
-fJX
+qRR
+qRR
+yee
+wpn
+qRR
+eFJ
 ihp
-sAY
+jfX
 goe
 xBi
-fJX
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
+eFJ
+eFJ
+qcz
+qcz
+kvU
+qDX
+qcz
+bzy
+emc
+soD
+sxH
+bFa
+eFJ
 whb
 whb
 whb
 whb
 whb
-rmv
-tRJ
-gOi
-gOi
-tRJ
+whb
+whb
+whb
+whb
+whb
 whb
 whb
 whb
@@ -159170,29 +159244,29 @@ rpp
 fJP
 xeg
 grO
-scK
-nvH
-aIb
-idl
-nvH
-nvH
-soz
-tFU
+qRR
+hSV
+yee
+yee
+hSV
+eFJ
+eFJ
+qKV
 mmt
 tFU
-soz
-xCt
+eFJ
+eFJ
 bzy
-soz
-nvH
-nvH
-xCt
-soz
-xCt
-xCt
-xCt
-xCt
-xCt
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
 whb
 whb
 whb
@@ -159602,31 +159676,31 @@ xeg
 lOm
 xeg
 grO
-nvH
-hSV
-vXL
-xzL
-nvH
-cQX
-ihq
-vXL
+qRR
+qRR
+yee
+qRR
+qRR
 idl
-vXL
-tyx
+sWm
+pQc
+pQc
+pQc
+pQc
 cWN
-cQX
-xCt
+idl
+eFJ
 hUU
 yeY
 vuC
 rTJ
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-rmv
+eFJ
+gGR
+gGR
+gGR
+gGR
+gGR
+whb
 whb
 whb
 whb
@@ -160034,31 +160108,31 @@ nBT
 xCt
 xCt
 grO
-nvH
-nvH
-scK
-vXL
+qRR
+hSV
+yee
+yee
 bAd
-cQX
-xrC
-xrC
-ddp
-dOe
 idl
+qRR
+nIe
+pQc
+pQc
+pQc
 cWN
-cQX
-tLa
 idl
+tLa
+otv
 otP
-vXL
+otv
 taK
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
+eFJ
+gGR
+gGR
+gGR
+gGR
+gGR
+gGR
 whb
 whb
 whb
@@ -160468,32 +160542,32 @@ jty
 rCz
 gns
 gns
-scK
-scK
-scK
-cQX
-xrC
-cAm
-vXL
+eFJ
+qRR
+qRR
 idl
-vXL
+mVl
+cAm
+pQc
+uCg
+pQc
 cWN
 fBN
-xCt
+eFJ
 aSr
 bKu
 oNk
 oxg
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-whb
-whb
-whb
+eFJ
+gGR
+gGR
+gGR
+gGR
+gGR
+isM
+gOi
+gOi
+dId
 whb
 whb
 whb
@@ -160896,37 +160970,37 @@ wPo
 wPo
 wPo
 tYD
-pUM
-scK
+wPo
+eFJ
 vOe
 fPJ
-aIl
-scK
-dHo
-kcM
-xrC
-cAm
-vXL
-vXL
+vOe
+qRR
+qRR
 idl
+mVl
+cAm
+pQc
+pQc
+pQc
 cWN
-cQX
-bjD
-xCt
-xCt
-xCt
-soz
-xCt
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-lsQ
-whb
-whb
-whb
-whb
+kZR
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+gGR
+gGR
+gGR
+gGR
+fac
+bjz
+yhp
+cRt
+tRJ
+dId
 whb
 whb
 whb
@@ -161329,21 +161403,21 @@ wPo
 igu
 xCt
 bKQ
-scK
-axp
-scK
+eFJ
 fSS
-scK
-scK
+eFJ
+fSS
+qRR
+qRR
 sIL
-xrC
-eFJ
-eFJ
+qRR
+nIe
 sIL
-eFJ
-soz
-uAi
-uAi
+qRR
+bWA
+bWA
+bWA
+qRR
 gns
 ipI
 bjz
@@ -161352,13 +161426,13 @@ ipI
 ipI
 bjz
 cgV
-lsQ
-lsQ
-lsQ
-whb
-whb
-whb
-whb
+gGR
+gtj
+wxx
+mKf
+hZk
+xtR
+kGM
 whb
 whb
 whb
@@ -161762,35 +161836,35 @@ bXZ
 xCt
 scK
 gfr
-yee
-yee
-yee
-scK
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-cro
-xuA
+xzL
+xzL
+xzL
+vPK
+kaO
 kdw
+kdw
+kdw
+kdw
+ccw
+jfX
+nLu
+gPP
+cro
+nXJ
+rFo
 rRk
 nWH
-xuA
-kdw
+nXJ
+rFo
 rRk
 gtj
-lsQ
-lsQ
-lsQ
-whb
-whb
-sGa
-whb
+gGR
+gtj
+fNt
+fVn
+rWD
+hZk
+kGM
 whb
 whb
 whb
@@ -162190,39 +162264,39 @@ jPI
 dLa
 bPA
 wPo
-wPo
+vaX
 xCt
 xCt
-scK
+eFJ
 fPE
-yee
-yee
-scK
-sIR
-sIR
-scK
-scK
+xzL
+xzL
+vPK
+eZt
+kdw
+qRR
+rqF
 mSL
-mSL
-scK
-sIR
-sIR
+qRR
+jfX
+jxQ
+ofB
 lwr
 bOT
 kdw
-ecV
+wpu
 nWH
 bOT
 kdw
-ecV
-gtj
-lsQ
-lsQ
-lsQ
-whb
-whb
-iad
-whb
+wpu
+rCz
+bjz
+bjz
+vGg
+hCX
+hZk
+tjy
+kGM
 whb
 whb
 whb
@@ -162611,34 +162685,34 @@ ibP
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-xCt
-xCt
-xCt
+gQh
+gQh
+gQh
+gQh
+nvH
+nvH
+nvH
 xlO
 vXL
-vXL
+ffw
 wPo
 wPo
-mym
+bPA
 sWm
-scK
 eFJ
-scK
-vdR
-scK
-sIR
-sIR
-scK
+eFJ
+vVo
+fSS
+qRR
+iJF
+gps
+eFJ
 hbl
-kZR
-kZR
-mSL
-sIR
-sIR
+asP
+wFB
+asP
+jfX
+jfX
 lwr
 xgi
 kdw
@@ -162647,14 +162721,14 @@ nWH
 xgi
 kdw
 ecV
-gtj
-wQS
-whb
-whb
-whb
-whb
-iad
-whb
+bjz
+jdl
+nDe
+lUL
+mcL
+mcL
+uSL
+vvx
 whb
 whb
 whb
@@ -163043,49 +163117,49 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-xCt
-xCt
-jxQ
+gQh
+kYH
+kYH
+kYH
+kYH
+kYH
+bKC
+vXL
 jPI
-gTt
+jPI
+jPI
 vXL
 vXL
 sWm
 vaX
 qgT
-sIR
-sIR
-sIR
-sIR
-sIR
-scK
+jfX
+jfX
+cQX
+kdw
+thM
+eFJ
 hbl
-kZR
-kZR
-mSL
-sIR
-sIR
-otv
+asP
+wFB
+asP
+jfX
+xhv
+qRR
 tIz
 ufJ
 tIz
-eZt
+qRR
 tIz
 ufJ
 tIz
-rCz
-ipI
+bjz
+kdw
 tRJ
-whb
-whb
-whb
-iad
+tRJ
+gOi
+gOi
+tRJ
 whb
 whb
 whb
@@ -163475,32 +163549,32 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+gQh
+kYH
+gQh
+gQh
+gQh
+gQh
+jxS
 nvH
 xCt
 xCt
 soz
-xrC
-xrC
-scK
-scK
-kJN
-sIR
-sIR
-sIR
-sIR
-sIR
-scK
-scK
-gGR
-lqS
-scK
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+jfX
+jfX
+qRR
+lcD
+lcD
+qRR
+rqF
+mSL
+qRR
+jfX
 cUC
 cUC
 hSv
@@ -163892,46 +163966,46 @@ lOc
 lOc
 whb
 whb
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+kYH
+gQh
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-scK
-scK
-scK
-nvH
-xrC
-scK
-xrC
-bjz
-dKR
-vPH
-soz
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+vdR
+eDb
+sAY
+cro
+jfX
+jfX
+xxR
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
 cUC
 cUC
 cUC
@@ -164324,40 +164398,40 @@ rba
 lOc
 whb
 whb
+gQh
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+kYH
+gQh
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-scK
+eFJ
 gYi
 pGh
 rAt
 fnf
 fnf
-scK
-qcz
-jfX
-jfX
+bSL
+kdw
+gPd
+kdw
 cGQ
-sIR
-sIR
-hnp
+jfX
+jfX
+jfX
 hnp
 hnp
 hnp
@@ -164366,12 +164440,12 @@ hnp
 hnp
 cUC
 cUC
-sIR
-otv
+jfX
+qRR
 tIz
 ufJ
 tIz
-otv
+qRR
 tIz
 ufJ
 tIz
@@ -164756,49 +164830,49 @@ pEv
 lOc
 lOc
 whb
+gQh
+kYH
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
+gQh
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-scK
+eFJ
 ftF
 yjj
 vZw
 oLX
 lWE
-scK
-twA
-bFa
-jfX
+bSL
+kdw
+kdw
+kdw
 yjd
-sIR
-hnp
+jfX
+jfX
+lqS
 wpu
 wpu
+ecV
 wpu
 wpu
+ecV
 wpu
-wpu
-wpu
-wpu
-cUC
-sIR
+foc
+jfX
 lwr
 xgi
 kdw
@@ -164808,7 +164882,7 @@ xgi
 kdw
 ecV
 gtj
-wQS
+whb
 whb
 whb
 whb
@@ -165188,6 +165262,9 @@ pEv
 xtk
 lOc
 whb
+gQh
+kYH
+gQh
 whb
 whb
 whb
@@ -165204,41 +165281,38 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-scK
+eFJ
 faZ
-scK
+eFJ
 iFf
 yjj
 yjj
 wMC
-scK
+eFJ
 ady
-vLn
-wpu
-soz
-sIR
+aJC
+vPH
+cro
+jfX
+jfX
 hnp
+ecV
 wpu
 wpu
-wpu
-wpu
-wpu
+ecV
 wpu
 wpu
 wpu
 hnp
-sIR
+jfX
 lwr
-xuA
+nXJ
 kdw
-ecV
+wpu
 lwr
-xuA
+nXJ
 kdw
-ecV
+wpu
 kGM
 whb
 whb
@@ -165619,10 +165693,10 @@ iQm
 pEv
 lOc
 lOc
-whb
-whb
-whb
-whb
+gQh
+gQh
+kYH
+gQh
 whb
 whb
 whb
@@ -165639,38 +165713,38 @@ vqG
 vqG
 whb
 whb
-scK
-ueZ
+eFJ
+kdd
 asP
 asP
-soz
+eFJ
 nQo
 uNi
-scK
-scK
+eFJ
+eFJ
 dlu
 dlu
-scK
-sIR
+eFJ
+jfX
+jfX
 hnp
 wpu
 wpu
 wpu
 wpu
 wpu
-wpu
+ecV
 wpu
 hnp
-sIR
-sIR
+jfX
 cro
 bOT
-kdw
+kJN
 cZt
 lwr
 bOT
-kdw
-tjy
+kJN
+gTt
 kGM
 whb
 whb
@@ -166049,12 +166123,12 @@ lOc
 lOc
 dHW
 iQm
-lOc
-whb
-whb
-whb
-whb
-whb
+tyx
+kYH
+kYH
+kYH
+kYH
+gQh
 whb
 whb
 whb
@@ -166071,7 +166145,7 @@ ajL
 vqG
 whb
 whb
-soz
+eFJ
 hHr
 lAw
 asP
@@ -166083,19 +166157,19 @@ vEr
 sLa
 bqs
 eFJ
-sIR
-hnp
+jfX
+jfX
+foc
+wpu
+ecV
 wpu
 wpu
 wpu
 wpu
 wpu
-wpu
-hnp
-sIR
-sIR
-sIR
-soz
+lqS
+jfX
+qRR
 gns
 gns
 bjz
@@ -166104,7 +166178,7 @@ ipI
 ipI
 bjz
 iGo
-scK
+eFJ
 whb
 whb
 whb
@@ -166483,10 +166557,10 @@ sZS
 iQm
 vqG
 vqG
-whb
-whb
-whb
-whb
+gQh
+gQh
+gQh
+gQh
 whb
 whb
 whb
@@ -166503,41 +166577,41 @@ pvy
 vqG
 whb
 whb
-scK
+eFJ
 ueZ
 asP
 asP
-soz
-nQo
+eFJ
+yjj
 yjj
 yjj
 qYX
 yjj
 yjj
 dbS
-sIR
-sIR
+jfX
+jfX
+jfX
 hnp
 hnp
 hnp
 hnp
 hnp
 hnp
-sIR
-sIR
-sIR
-sIR
+hnp
+jfX
+jfX
 tVH
 dpu
 vTh
 vTh
-vTh
+axp
 sRH
 cqQ
 ooc
 qdY
-scK
-scK
+eFJ
+eFJ
 whb
 whb
 whb
@@ -166935,9 +167009,9 @@ deZ
 lOc
 lOc
 whb
-scK
+eFJ
 rQm
-scK
+eFJ
 kuP
 yjj
 yjj
@@ -166945,20 +167019,20 @@ qNj
 lDE
 uUV
 pLA
-bKC
+iel
 eFJ
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
+jfX
+xhv
 qff
 bnO
 aIy
@@ -166969,7 +167043,7 @@ kdw
 mny
 kdw
 aeZ
-scK
+eFJ
 whb
 whb
 whb
@@ -167368,7 +167442,7 @@ kdP
 vqG
 whb
 whb
-scK
+eFJ
 nQK
 yjj
 yjj
@@ -167383,15 +167457,15 @@ tHT
 soz
 eFJ
 jlt
-hTq
+jlt
 eFJ
-scK
-scK
-soz
+dlu
+dlu
+nIe
 hfH
-eFJ
+qRR
 uAi
-eFJ
+qRR
 aYO
 kdw
 gdY
@@ -167401,7 +167475,7 @@ kdw
 dZH
 jXm
 sRH
-scK
+eFJ
 whb
 whb
 whb
@@ -167800,7 +167874,7 @@ iQm
 vqG
 whb
 whb
-scK
+eFJ
 mNl
 ejG
 sIR
@@ -167812,14 +167886,14 @@ qDe
 vch
 qww
 vXL
-ccw
-xxR
-fac
+vPK
 sIR
-wpu
-scK
+sIR
+sIR
+sIR
+cro
 oPu
-dru
+lmJ
 nfP
 krP
 xuJ
@@ -167833,7 +167907,7 @@ guE
 wpu
 wpu
 sRH
-scK
+eFJ
 whb
 whb
 whb
@@ -168232,24 +168306,24 @@ iQm
 lOc
 whb
 whb
-scK
-scK
+eFJ
+eFJ
 guE
 wpu
 guE
-scK
+eFJ
 fHn
 oOP
 vHS
 iAa
 lGe
 qtm
-ccw
-cWj
-asP
-sIR
-jYg
-eFJ
+vPK
+fqM
+fqM
+fqM
+fqM
+cro
 prR
 lmJ
 ewB
@@ -168265,7 +168339,7 @@ ecV
 ecV
 wpu
 sRH
-scK
+eFJ
 whb
 whb
 whb
@@ -168665,11 +168739,11 @@ lOc
 whb
 whb
 whb
-scK
+eFJ
 mHZ
 aVV
 lPe
-scK
+eFJ
 wXq
 sJX
 eGq
@@ -168677,10 +168751,10 @@ tHn
 hQG
 nyf
 rhw
-eFJ
+dOe
 bIc
 dJa
-bjz
+hCf
 rhw
 gXU
 lmJ
@@ -168694,10 +168768,10 @@ gns
 gns
 mQq
 wpu
-kdd
 wpu
-scK
-scK
+wpu
+eFJ
+eFJ
 whb
 whb
 whb
@@ -169097,22 +169171,22 @@ vqG
 whb
 whb
 whb
-scK
-scK
-soz
-scK
-scK
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
 mHZ
 wpu
 eGq
 pji
 akg
 oIe
-eFJ
-uAi
-uAi
-bjz
-bjz
+rhw
+tbs
+oPU
+tfS
+cWj
 eFJ
 utb
 lmJ
@@ -169125,10 +169199,10 @@ rKz
 jiJ
 bMT
 wNU
-scK
-scK
-scK
-scK
+eFJ
+eFJ
+eFJ
+eFJ
 whb
 whb
 whb
@@ -169533,18 +169607,18 @@ whb
 whb
 whb
 whb
-bjz
+eFJ
 kXo
 wpu
 bOa
 iGg
 utv
-iAa
-kxR
-nvH
-whb
-whb
-whb
+uAG
+eFJ
+kRu
+ben
+dlE
+skm
 rhw
 kkU
 lmJ
@@ -169965,18 +170039,18 @@ whb
 whb
 whb
 whb
-nvH
+eFJ
 wpu
 wpu
 soz
-nvH
+eFJ
 gbe
 gbe
-nvH
-nvH
-whb
-whb
-whb
+eFJ
+fqM
+ogI
+ogI
+ogI
 rhw
 jvZ
 lmJ
@@ -170397,18 +170471,18 @@ whb
 whb
 whb
 whb
-scK
-scK
-nvH
-nvH
-nvH
-nvH
-nvH
-nvH
-whb
-whb
-whb
-whb
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+eFJ
+ete
+kcM
+lGk
+dru
 eFJ
 eFJ
 fqM
@@ -170837,10 +170911,10 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
+bjD
+pUM
+pUM
+bjD
 whb
 rhw
 kAT
@@ -171275,14 +171349,14 @@ whb
 whb
 whb
 eFJ
+vVo
+uAi
+vVo
 uAi
 uAi
+rqF
 uAi
-uAi
-uAi
-eFJ
-uAi
-uAi
+rqF
 uAi
 eFJ
 whb
@@ -267618,7 +267692,7 @@ hON
 avb
 lys
 bmu
-scK
+bjz
 oGO
 lrs
 uEX
@@ -270206,11 +270280,11 @@ bWA
 qRR
 uwW
 idl
-idl
+aum
 mQe
-bjz
-fIL
-fIL
+idl
+jYg
+nXf
 hFG
 oGO
 rSC
@@ -270639,10 +270713,10 @@ scK
 wqF
 idl
 idl
-aum
-nvH
+idl
+idl
 xHB
-gPP
+rRb
 oGO
 rSC
 lrs
@@ -271068,13 +271142,13 @@ pQc
 rvT
 njY
 scK
-iJF
-idl
-idl
+wqF
+ihq
+aIl
 wwF
-nvH
-fZL
-fZL
+idl
+gMO
+nXf
 fZL
 jaY
 uEX
@@ -271500,13 +271574,13 @@ fwH
 uAi
 uAi
 scK
+pXx
 scK
 scK
 scK
 scK
-scK
-iyZ
-nXf
+mym
+rRb
 hJH
 uun
 uEX
@@ -271925,7 +271999,7 @@ hGX
 lZO
 jTy
 vnK
-jfX
+ddp
 epj
 lme
 kdw
@@ -271937,7 +272011,7 @@ iTw
 gNw
 mUn
 lrs
-gLf
+mXk
 rRb
 lrs
 lrs
@@ -272369,7 +272443,7 @@ iTw
 iWT
 iWT
 lrs
-gLf
+dKR
 rRb
 lrs
 lrs
@@ -272793,7 +272867,7 @@ jfX
 vPK
 xrZ
 kdw
-cWN
+auL
 njY
 soz
 bwd
@@ -272802,7 +272876,7 @@ aCn
 wfx
 fZL
 xTU
-lrs
+uEX
 lrs
 lrs
 lrs
@@ -273225,7 +273299,7 @@ tnc
 rhw
 bna
 kdw
-cWN
+auL
 njY
 scK
 ibs
@@ -274079,7 +274153,7 @@ vVo
 vVo
 qRR
 wTy
-dhP
+xQX
 tWl
 jfX
 jfX
@@ -274508,7 +274582,7 @@ gMO
 nvH
 mVl
 qUr
-aTg
+aIb
 rct
 dhP
 vQT
@@ -274949,7 +275023,7 @@ gGL
 kdw
 kdw
 kdw
-kdw
+aNp
 dbq
 vfx
 kdw
@@ -275375,7 +275449,7 @@ bOT
 kdw
 sUG
 dhP
-dhP
+xQX
 cjQ
 kdw
 eDw
@@ -275385,7 +275459,7 @@ kdw
 nPb
 xrZ
 kdw
-gPd
+vLn
 kdw
 scK
 iWT

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -13398,6 +13398,10 @@
 "dhP" = (
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
+"dhT" = (
+/obj/structure/roguewindow/harem3,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/under/town/sewer)
 "dif" = (
 /obj/structure/stairs{
 	dir = 1
@@ -294025,7 +294029,7 @@ rRb
 pfC
 kUa
 rHd
-hXj
+dhT
 bnG
 abS
 rRb

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1182,9 +1182,6 @@
 "aoN" = (
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/bograt/north)
-"aoT" = (
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "aoW" = (
 /obj/effect/landmark/start/martyr,
 /turf/open/floor/rogue/churchbrick,
@@ -2553,7 +2550,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
 "aFT" = (
-/turf/closed/wall/mineral/rogue/decostone/long,
+/turf/closed,
 /area/rogue/under/cave)
 "aFV" = (
 /obj/effect/decal/cobbleedge{
@@ -3918,10 +3915,6 @@
 /obj/structure/flora/roguetree/pine,
 /turf/open/floor/rogue/snowrough,
 /area/rogue/outdoors/mountains/decap/rockhill)
-"aWD" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "aWF" = (
 /obj/machinery/light/rogue/firebowl,
 /obj/structure/lever/wall{
@@ -12613,6 +12606,7 @@
 	pixel_x = 10;
 	pixel_y = -10
 	},
+/obj/machinery/light/rogue/candle/red/r,
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "cZw" = (
@@ -17797,10 +17791,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
-"ejY" = (
-/obj/machinery/light/rogue/candle/blue/l,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "ekg" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /obj/item/storage/roguebag,
@@ -18556,38 +18546,6 @@
 /obj/item/roguestatue/glass,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/wizarddungeon)
-"euh" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Special Toys";
-	pixel_x = 4
-	},
-/obj/item/dildo/wood{
-	pixel_y = -4
-	},
-/obj/item/dildo/iron{
-	pixel_x = 5
-	},
-/obj/item/dildo/wood{
-	pixel_x = 10;
-	pixel_y = -4
-	},
-/obj/item/dildo/iron{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/berrypoison,
-/obj/item/rogueweapon/whip,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/lockpickring/mundane,
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "eui" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8;
@@ -24293,15 +24251,6 @@
 	icon_state = "concretefloor1"
 	},
 /area/rogue/indoors/town/bath)
-"fLZ" = (
-/obj/structure/lever/wall{
-	dir = 8;
-	name = "Toy Shop Shutters";
-	pixel_y = 4;
-	redstone_id = "gambleaccess"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "fMe" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/twig,
@@ -25979,56 +25928,30 @@
 	pixel_y = 17
 	},
 /obj/item/clothing/under/roguetown/trou/leathertights,
-/obj/item/clothing/under/roguetown/trou/leathertights,
-/obj/item/clothing/under/roguetown/heavy_leather_pants/shorts,
 /obj/item/clothing/under/roguetown/heavy_leather_pants/shorts,
 /obj/item/clothing/suit/roguetown/armor/leather/vest/sailor,
-/obj/item/clothing/suit/roguetown/armor/leather/vest/sailor,
-/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini,
-/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini,
-/obj/item/clothing/suit/roguetown/armor/leather/bikini,
 /obj/item/clothing/suit/roguetown/armor/leather/bikini,
 /obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/gloves/roguetown/leather,
 /obj/item/clothing/gloves/roguetown/leather,
 /obj/item/clothing/under/roguetown/trou/beltpants,
-/obj/item/clothing/under/roguetown/trou/beltpants,
-/obj/item/clothing/shoes/roguetown/ridingboots,
 /obj/item/clothing/shoes/roguetown/ridingboots,
 /obj/item/clothing/mask/rogue/sack,
-/obj/item/clothing/mask/rogue/sack,
 /obj/item/clothing/head/roguetown/menacing,
-/obj/item/clothing/head/roguetown/menacing,
-/obj/item/rope/chain,
-/obj/item/rope/chain,
-/obj/item/rogueweapon/whip,
-/obj/item/rogueweapon/whip,
 /obj/item/clothing/cloak/battlenun,
 /obj/item/clothing/cloak/battlenun,
 /obj/item/clothing/cloak/raincloak/furcloak/black,
-/obj/item/clothing/cloak/raincloak/furcloak/black,
-/obj/item/clothing/cloak/raincloak/mortus,
 /obj/item/clothing/cloak/raincloak/mortus,
 /obj/item/clothing/cloak/thief_cloak/yoruku,
-/obj/item/clothing/cloak/thief_cloak/yoruku,
 /obj/item/clothing/cloak/volfmantle,
-/obj/item/clothing/cloak/volfmantle,
-/obj/item/clothing/cloak/darkcloak/bear,
 /obj/item/clothing/cloak/darkcloak,
-/obj/item/clothing/cloak/poncho,
 /obj/item/clothing/cloak/poncho,
 /obj/item/clothing/head/roguetown/nun,
 /obj/item/clothing/suit/roguetown/shirt/robe/nun,
 /obj/item/clothing/suit/roguetown/shirt/robe/tabardblack,
 /obj/item/clothing/suit/roguetown/shirt/leo_robe,
 /obj/item/clothing/cloak/forrestercloak,
-/obj/item/clothing/mask/rogue/blindfold,
-/obj/item/clothing/mask/rogue/blindfold,
 /obj/item/clothing/suit/roguetown/shirt/leo_robe/leopard,
 /obj/item/clothing/suit/roguetown/shirt/robe/eora,
-/obj/item/clothing/suit/roguetown/shirt/robe/hierophant,
-/obj/item/clothing/suit/roguetown/shirt/robe/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "ggu" = (
@@ -29387,13 +29310,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/town/sewer)
-"gYH" = (
-/obj/item/paper/scroll,
-/obj/item/paper/scroll,
-/obj/item/natural/feather,
-/obj/structure/table/vtable,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "gYJ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -32408,7 +32324,8 @@
 /area/rogue/indoors/town/manor/rockhill)
 "hJU" = (
 /obj/structure/closet/crate/roguecloset/lord{
-	name = "Persuasion"
+	name = "Persuasion";
+	lockid = "nightman"
 	},
 /obj/structure/curtain/black{
 	open = 0;
@@ -34093,20 +34010,6 @@
 "ieu" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
-"iey" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/maidendrape{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "ieK" = (
 /obj/structure/fluff/railing/border/west,
 /obj/structure/chair/wood/rogue,
@@ -34130,14 +34033,6 @@
 "ieN" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/outdoors/mountains)
-"ieR" = (
-/obj/machinery/light/rogue/candle/blue/r,
-/obj/structure/table/vtable/v2,
-/obj/structure/roguemachine/mail{
-	mailtag = "Whitevein Office"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "ieU" = (
 /obj/structure/table/wood{
 	icon_state = "map4"
@@ -34458,32 +34353,6 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
-"iia" = (
-/obj/structure/fluff/walldeco/maidensigil{
-	pixel_y = -32
-	},
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Leashes";
-	pixel_x = -4
-	},
-/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
-/obj/item/leash/leather,
-/obj/item/leash/chain,
-/obj/item/leash/chain,
-/obj/item/leash/leather,
-/obj/item/leash/chain,
-/obj/item/leash/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "iiD" = (
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/woodturned,
@@ -46001,7 +45870,9 @@
 /area/rogue/outdoors/bograt/above)
 "laS" = (
 /obj/structure/closet/crate/chest/neu_iron{
-	name = "Recovery"
+	name = "Recovery";
+	locked = 1;
+	lockid = "nightman"
 	},
 /obj/item/storage/belt/rogue/surgery_bag/full,
 /obj/item/reagent_containers/glass/bottle/rogue/healthpotnew,
@@ -48812,9 +48683,6 @@
 /obj/structure/bars/pipe,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
-"lMC" = (
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/under/cave)
 "lME" = (
 /obj/item/paper/scroll,
 /obj/structure/table/wood/long_table,
@@ -54152,7 +54020,8 @@
 "naf" = (
 /obj/structure/mineral_door/bars{
 	lockid = "nightman";
-	name = "Cell Door"
+	name = "Cell Door";
+	locked = 1
 	},
 /obj/structure/bars/passage/shutter{
 	redstone_id = "nmcell"
@@ -54672,46 +54541,6 @@
 "nfP" = (
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
-"nfQ" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Tools";
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/glass/bottle/alchemical/fermented_crab{
-	pixel_x = -10;
-	pixel_y = 13
-	},
-/obj/item/clothing/mask/cigarette/pipe,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "ngc" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -55934,12 +55763,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
-"nvM" = (
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "nvQ" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -60366,7 +60189,8 @@
 /area/rogue/outdoors/rtfield/rockhill/above)
 "ozu" = (
 /obj/structure/closet/crate/roguecloset/lord{
-	name = "Punishment"
+	name = "Punishment";
+	lockid = "nightman"
 	},
 /obj/item/clothing/mask/rogue/facemask,
 /obj/item/clothing/head/roguetown/menacing{
@@ -62320,22 +62144,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
-"oXT" = (
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	pixel_y = -3
-	},
-/obj/structure/bell_common,
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/obj/structure/bars/passage/shutter{
-	name = "Toy Shop";
-	redstone_id = "gambleaccess"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/cave)
 "oXU" = (
 /obj/structure/plasticflaps,
 /turf/open/water/river{
@@ -63666,6 +63474,7 @@
 /obj/structure/fluff/walldeco/maidensigil{
 	pixel_y = -32
 	},
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "poJ" = (
@@ -69084,38 +68893,21 @@
 	name = "Standard Outfits"
 	},
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
 /obj/item/clothing/shirt/dress/courtesan,
-/obj/item/clothing/shirt/dress/courtesan,
-/obj/item/clothing/shirt/dress/hw_dress,
 /obj/item/clothing/shirt/dress/hw_dress,
 /obj/item/clothing/shirt/dress/skyrim_dress,
-/obj/item/clothing/shirt/dress/skyrim_dress,
-/obj/item/clothing/shirt/dress/skyrim_taven,
 /obj/item/clothing/shirt/dress/skyrim_taven,
 /obj/item/clothing/suit/roguetown/shirt/dress,
-/obj/item/clothing/suit/roguetown/shirt/dress,
-/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
 /obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
 /obj/item/clothing/suit/roguetown/shirt/dress/emerald,
-/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown,
 /obj/item/clothing/suit/roguetown/shirt/dress/gown,
 /obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
 /obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
 /obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/maid,
 /obj/item/clothing/suit/roguetown/shirt/dress/maid,
 /obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
 /obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/under/roguetown/skirt/knee,
 /obj/item/clothing/under/roguetown/skirt/knee,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
@@ -72893,40 +72685,16 @@
 /area/rogue/under/underdark/rockhill)
 "rFB" = (
 /obj/structure/closet/crate/roguecloset{
-	name = "Silk Outfits"
+	name = "Elegant Outfits"
 	},
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
-/obj/item/clothing/mask/rogue/exoticsilkmask/red,
-/obj/item/clothing/mask/rogue/exoticsilkmask/red,
-/obj/item/clothing/mask/rogue/exoticsilkmask/green,
-/obj/item/clothing/mask/rogue/exoticsilkmask/green,
-/obj/item/clothing/mask/rogue/exoticsilkmask,
-/obj/item/clothing/mask/rogue/exoticsilkmask,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/obj/item/legwears/silk,
-/obj/item/legwears/silk,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/lordcloak/ladycloak,
-/obj/item/clothing/cloak/lordcloak/ladycloak,
 /obj/item/clothing/cloak/duelistcape,
-/obj/item/clothing/cloak/duelistcape,
-/obj/item/clothing/head/roguetown/duelisthat,
 /obj/item/clothing/mask/rogue/duelmask,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/head/roguetown/duelisthat,
+/obj/item/clothing/cloak/lordcloak/ladycloak,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
+/obj/item/legwears/silk,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "rFK" = (
@@ -73863,6 +73631,7 @@
 	pixel_x = -10;
 	pixel_y = -10
 	},
+/obj/machinery/light/rogue/candle/red/l,
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "rRm" = (
@@ -74554,17 +74323,6 @@
 "sbb" = (
 /turf/open/water/river/muddy,
 /area/rogue/outdoors/bograt/north)
-"sbj" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/structure/chair/wood/rogue/chair5{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "sbn" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -75569,14 +75327,6 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
-"sno" = (
-/obj/structure/roguemachine/vendor/bathhouse{
-	keycontrol = "nightmaiden"
-	},
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 4
-	},
-/area/rogue/under/cave)
 "snp" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -77789,13 +77539,6 @@
 "sPu" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/manor/rockhill)
-"sPx" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/cave)
 "sPA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/roguegrass/herb/salvia,
@@ -78873,22 +78616,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
-"tcZ" = (
-/obj/structure/bars{
-	icon_state = "barsbent";
-	layer = 2.81
-	},
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable";
-	pixel_y = -3
-	},
-/obj/structure/bars/passage/shutter{
-	name = "Toy Shop";
-	redstone_id = "gambleaccess"
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/under/cave)
 "tdk" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/cloth,
@@ -80210,6 +79937,9 @@
 	icon_state = "borderfall";
 	pixel_y = -8
 	},
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ttd" = (
@@ -81406,10 +81136,6 @@
 "tIq" = (
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/town/sewer)
-"tIz" = (
-/obj/structure/roguewindow/harem1,
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "tIG" = (
 /obj/structure/bed/rogue/inn{
 	dir = 1
@@ -82749,82 +82475,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/town/sewer)
 "tYx" = (
-/obj/structure/fluff/wallclock{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/nightmaiden,
-/obj/item/roguekey/nightmaiden,
-/obj/item/storage/keyring,
-/obj/item/storage/keyring,
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux1";
-	name = "room I key"
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux1";
-	name = "room I key"
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux2";
-	name = "room II key";
-	pixel_x = 9;
-	pixel_y = -11
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux2";
-	name = "room II key";
-	pixel_x = 9;
-	pixel_y = -11
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux3";
-	name = "room III key";
-	pixel_y = 7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux3";
-	name = "room III key";
-	pixel_y = 7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux4";
-	name = "room IV key";
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "lux4";
-	name = "room IV key";
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "steam";
-	name = "steam room key"
-	},
-/obj/item/roguekey/nightmaiden{
-	lockid = "steam";
-	name = "steam room key"
-	},
-/obj/item/roguekey/nightmaiden{
-	icon_state = "spikekey";
-	lockid = "punishroom";
-	name = "punishment room key";
-	pixel_y = 4;
-	pixel_x = 10
-	},
-/obj/item/roguekey/nightmaiden{
-	icon_state = "spikekey";
-	lockid = "punishroom";
-	name = "punishment room key";
-	pixel_y = 4;
-	pixel_x = 10
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cave)
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/indoors/town/bath)
 "tYC" = (
 /obj/item/flashlight/flare/torch/metal,
 /obj/structure/closet/crate/chest{
@@ -83273,12 +82927,6 @@
 	dir = 8
 	},
 /area/rogue/indoors)
-"ufe" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/cave)
 "ufg" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless,
@@ -83796,12 +83444,27 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/exposed/town/keep)
 "umj" = (
-/obj/effect/decal/carpet/kover_darkred{
-	dir = 8;
-	pixel_x = 15;
-	pixel_y = 17
+/obj/structure/closet/crate/roguecloset{
+	name = "Elegant Outfits"
 	},
-/obj/item/roguebin/water,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
+/obj/item/clothing/mask/rogue/exoticsilkmask/red,
+/obj/item/clothing/mask/rogue/exoticsilkmask/red,
+/obj/item/clothing/mask/rogue/exoticsilkmask/green,
+/obj/item/clothing/mask/rogue/exoticsilkmask/green,
+/obj/item/clothing/mask/rogue/exoticsilkmask,
+/obj/item/clothing/mask/rogue/exoticsilkmask,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "umm" = (
@@ -86149,13 +85812,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
-"uQa" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = 0;
-	pixel_y = -2
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "uQm" = (
 /obj/structure/fluff/walldeco/customflag/rockhill,
 /turf/closed/wall/mineral/rogue/stone,
@@ -86784,41 +86440,6 @@
 	dir = 9
 	},
 /area/rogue/outdoors/town/roofs)
-"uXF" = (
-/obj/machinery/light/rogue/candle/blue/r,
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Favours";
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/spice,
-/obj/item/reagent_containers/powder/spice,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
-/obj/item/perfume/random{
-	pixel_x = 5;
-	pixel_y = 0
-	},
-/obj/item/perfume/random{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "uXG" = (
 /obj/structure/fluff/customsign{
 	icon_state = "signwrote";
@@ -87662,18 +87283,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
-"vjo" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_y = -32
-	},
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cave)
 "vjp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -88583,17 +88192,10 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/shelter/bog)
-"vuU" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Front Office"
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cave)
 "vuV" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
-/area/rogue/under/cave)
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "vvb" = (
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/cobble,
@@ -91033,13 +90635,6 @@
 /obj/item/book/rogue/bibble,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church/chapel)
-"wbo" = (
-/obj/structure/roguemachine/atm{
-	location_tag = "Whitevein";
-	pixel_y = 0
-	},
-/turf/closed/wall/mineral/rogue/stonebrick,
-/area/rogue/under/cave)
 "wbq" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -96340,9 +95935,6 @@
 /obj/structure/flora/roguegrass/bush,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"xrr" = (
-/turf/open/floor/rogue/carpet,
-/area/rogue/under/cave)
 "xrx" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -155786,7 +155378,7 @@ qRR
 rct
 wpu
 qiF
-rct
+tvr
 qRR
 whb
 whb
@@ -156218,7 +155810,7 @@ nIe
 rct
 iXl
 dHo
-rct
+tvr
 qRR
 whb
 whb
@@ -157082,7 +156674,7 @@ rct
 mVl
 cAQ
 kdw
-rct
+tvr
 jJJ
 kdw
 qRR
@@ -157514,7 +157106,7 @@ rct
 mVl
 pCp
 kdw
-rct
+tvr
 pCp
 kdw
 wDt
@@ -157944,10 +157536,10 @@ kdw
 bJx
 rct
 mVl
-rct
+tvr
 sOC
 eFJ
-rct
+tvr
 sOC
 qRR
 qRR
@@ -158378,7 +157970,7 @@ qRR
 mVl
 lsQ
 thM
-siB
+tvr
 lsQ
 thM
 qRR
@@ -158810,7 +158402,7 @@ jdK
 mVl
 rmv
 kdw
-rct
+tvr
 xuA
 kdw
 qRR
@@ -161396,7 +160988,7 @@ bAd
 dlB
 qRR
 nIe
-pQc
+vuV
 pQc
 pQc
 cWN
@@ -162261,7 +161853,7 @@ idl
 mVl
 cAm
 pQc
-pQc
+cAc
 pQc
 cWN
 kQO
@@ -163129,7 +162721,7 @@ ccw
 ruk
 dru
 cEf
-vPK
+tYx
 nXJ
 hTq
 rRk
@@ -163561,7 +163153,7 @@ qRR
 gsi
 xzL
 ete
-vPK
+tYx
 bOT
 kdw
 wpu
@@ -163981,7 +163573,7 @@ bPA
 sWm
 qRR
 qRR
-rct
+tvr
 fSS
 qRR
 kZR
@@ -163993,7 +163585,7 @@ wFB
 asP
 jfX
 jfX
-vPK
+tYx
 xgi
 kdw
 ecV
@@ -164426,13 +164018,13 @@ asP
 jfX
 jfX
 qRR
-rct
+tvr
 wFB
-rct
+tvr
 qRR
-rct
+tvr
 wFB
-rct
+tvr
 bjz
 jfX
 bjz
@@ -165722,13 +165314,13 @@ cUC
 wqK
 nAc
 qRR
-tIz
+tvr
 wFB
-tIz
+tvr
 qRR
-rct
+tvr
 wFB
-tIz
+tvr
 isM
 blj
 bjz
@@ -166153,7 +165745,7 @@ ecV
 wpu
 foc
 jfX
-vPK
+tYx
 xgi
 kdw
 ecV
@@ -166585,7 +166177,7 @@ wpu
 mqO
 myK
 jfX
-vPK
+tYx
 nXJ
 kdw
 wpu
@@ -167017,7 +166609,7 @@ wpu
 wpu
 osw
 jfX
-vPK
+tYx
 bOT
 kJN
 cZt
@@ -168739,8 +168331,8 @@ qRR
 jlt
 jlt
 qRR
-rct
-rct
+tvr
+tvr
 nIe
 hfH
 nIe
@@ -242173,16 +241765,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -242605,16 +242197,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -243037,16 +242629,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-lMC
 aFT
 aFT
-vuU
 aFT
 aFT
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -243469,16 +243061,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-wbo
-fLZ
-ejY
-aoT
-tYx
-iia
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -243901,16 +243493,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-oXT
-aWD
-uQa
-ufe
-ufe
-sbj
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -244333,16 +243925,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-tcZ
-aoT
-uQa
-xrr
-xrr
-vjo
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -244765,16 +244357,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-sno
-gYH
-uQa
-sPx
-sPx
-iey
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -245197,16 +244789,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-vuV
-ieR
-nvM
-uXF
-nfQ
-euh
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -245629,16 +245221,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -246061,16 +245653,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc
@@ -246493,16 +246085,16 @@ cjc
 cjc
 cjc
 cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
-cjc
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
+aFT
 cjc
 cjc
 cjc

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -925,9 +925,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/dungeon1)
-"alu" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy,
-/area/rogue/indoors/town/bath)
 "alx" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -2220,6 +2217,14 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors/town/physician)
+"aCh" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "aCi" = (
 /obj/structure/bed/rogue/inn/double{
 	dir = 1
@@ -3389,6 +3394,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
+"aQf" = (
+/obj/structure/well,
+/turf/open/floor/rogue/grass,
+/area/rogue/outdoors/rtfield/eora)
 "aQp" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/mountains/decap/rockhill)
@@ -4287,6 +4296,7 @@
 /obj/item/candle/yellow,
 /obj/item/candle/yellow,
 /obj/effect/decal/cleanable/dirt/cobweb,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "bby" = (
@@ -4509,7 +4519,7 @@
 "ben" = (
 /obj/structure/table/wood/map/six,
 /turf/open/floor/carpet/red,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "bet" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -4731,6 +4741,15 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/Academy)
+"bhV" = (
+/obj/item/reagent_containers/glass/cup/skull,
+/obj/item/reagent_containers/glass/cup/skull,
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "bif" = (
 /obj/effect/decal/cobbleedge{
 	dir = 9
@@ -4841,6 +4860,11 @@
 	},
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/beach/harbor)
+"bjm" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/town/sewer)
 "bjv" = (
 /obj/structure/flora/hotspring_rocks,
 /turf/open/floor/rogue/cobble,
@@ -4860,8 +4884,9 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/bath)
 "bjD" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
-/area/rogue/under/cavewet)
+/obj/structure/fermentation_keg/water,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "bjN" = (
 /obj/structure/bed/rogue/inn/wool{
 	dir = 1
@@ -4956,6 +4981,21 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"blb" = (
+/obj/structure/chair/wood/rogue/chair3{
+	dir = 8
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
+"blj" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "suspicious metal wall";
+	density = 0
+	},
+/area/rogue/indoors/town/bath)
 "bll" = (
 /obj/structure/flora/newleaf,
 /obj/structure/fluff/railing/wood{
@@ -6477,14 +6517,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
-"bEp" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 8;
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
 "bEv" = (
 /obj/structure/table/vtable/v2,
 /obj/machinery/light/rogue/candle{
@@ -6853,6 +6885,12 @@
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
+"bJA" = (
+/obj/structure/stairs/stone{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/cell)
 "bJK" = (
 /obj/structure/table/wood/poor,
 /obj/item/paper,
@@ -6904,12 +6942,6 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/grove)
-"bKh" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
 "bKn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
@@ -7117,34 +7149,6 @@
 /obj/structure/curtain/purple,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
-"bMi" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Collars/Restraints";
-	pixel_x = 4
-	},
-/obj/item/leash/chain,
-/obj/item/leash/chain,
-/obj/item/leash/leather,
-/obj/item/leash/leather,
-/obj/item/clothing/neck/roguetown/collar/catbell,
-/obj/item/clothing/neck/roguetown/collar/catbell,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/obj/item/clothing/neck/roguetown/collar/leather,
-/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
-/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
-/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
-/obj/item/clothing/neck/roguetown/collar/cowbell,
-/obj/item/clothing/neck/roguetown/collar/cowbell,
-/obj/item/clothing/neck/roguetown/cursed_collar,
-/obj/item/clothing/neck/roguetown/cursed_collar,
-/obj/item/clothing/mask/rogue/blindfold,
-/obj/item/clothing/mask/rogue/blindfold,
-/obj/item/clothing/mask/rogue/blindfold,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "bMj" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cave)
@@ -7216,7 +7220,7 @@
 "bMZ" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "bNh" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/grassyel,
@@ -7484,6 +7488,9 @@
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
+"bQb" = (
+/turf/open/water/cleanshallow,
+/area/rogue/indoors/town/bath)
 "bQi" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -8190,6 +8197,36 @@
 /obj/structure/chair/hotspring_bench/right,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/rtfield/eora)
+"bXx" = (
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Drugs";
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/spice,
+/obj/item/reagent_containers/powder/spice,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/luxwine,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "bXB" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
@@ -10289,7 +10326,7 @@
 "cyJ" = (
 /obj/machinery/light/rogue/torchholder/c,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "cyM" = (
 /obj/structure/closet/crate/roguecloset{
 	keylock = 1;
@@ -10871,11 +10908,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors)
-"cFp" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/long{
-	dir = 1
-	},
-/area/rogue/indoors/town/bath)
 "cFu" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -11829,6 +11861,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/under/cave)
+"cPb" = (
+/obj/machinery/light/rogue/candle/floorcandle,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "cPc" = (
 /obj/item/reagent_containers/glass/bottle/clayfancyvase{
 	pixel_x = 7;
@@ -12053,7 +12089,7 @@
 	},
 /obj/item/flint,
 /turf/open/floor/rogue/church,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "cRu" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 8
@@ -12653,6 +12689,11 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"dau" = (
+/obj/structure/spider/stickyweb,
+/obj/structure/spider/stickyweb,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "daw" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -12666,6 +12707,9 @@
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor/rockhill)
+"daA" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/indoors/town/bath)
 "daI" = (
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /obj/item/clothing/suit/roguetown/armor/gambeson,
@@ -13704,7 +13748,7 @@
 "dlE" = (
 /obj/structure/table/wood/map/three,
 /turf/open/floor/carpet/red,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "dlG" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/carpet/purple,
@@ -13986,6 +14030,13 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor/rockhill)
+"dps" = (
+/obj/structure/chair/stool/rogue,
+/obj/structure/fluff/walldeco/maidensigil{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "dpu" = (
 /obj/structure/stairs{
 	dir = 1
@@ -14246,6 +14297,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
+"dsC" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "dsD" = (
 /mob/living/carbon/human/species/skeleton/npc/pirate,
 /turf/open/floor/rogue/wood,
@@ -14321,6 +14376,13 @@
 /obj/item/natural/rock,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"dtO" = (
+/obj/structure/fermentation_keg,
+/obj/machinery/light/rogue/candle/blue{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "dtS" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 4
@@ -14626,6 +14688,9 @@
 "dxv" = (
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor/rockhill)
+"dxP" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
+/area/rogue/indoors/town/bath)
 "dya" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -15138,9 +15203,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor/rockhill)
-"dDM" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
-/area/rogue/indoors/town/bath)
 "dDP" = (
 /obj/structure/rack/rogue,
 /obj/structure/spider/stickyweb,
@@ -15177,12 +15239,21 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"dEc" = (
+/obj/item/candle/skull/lit,
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "dEf" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /obj/structure/bed/rogue{
 	dir = 1
 	},
 /obj/machinery/light/rogue/candle/red,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -32
+	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "dEr" = (
@@ -15358,6 +15429,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement/keep)
+"dGL" = (
+/obj/structure/roguemachine/drugmachine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/indoors/town/bath)
 "dGS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/imp,
 /turf/open/floor/rogue/concrete,
@@ -16238,7 +16313,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
 "dRw" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
+/obj/structure/fluff/statue/small,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/indoors/town/bath)
 "dRx" = (
 /obj/structure/lever/wall{
@@ -17294,6 +17370,12 @@
 /obj/effect/spawner/lootdrop/potion_vitals,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
+"eew" = (
+/obj/structure/bondage/torture_table/lever,
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "eez" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	lockid = "blacksmith"
@@ -17946,6 +18028,34 @@
 "emH" = (
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
+"emL" = (
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Collars/Restraints";
+	pixel_x = 4
+	},
+/obj/item/leash/chain,
+/obj/item/leash/chain,
+/obj/item/leash/leather,
+/obj/item/leash/leather,
+/obj/item/clothing/neck/roguetown/collar/catbell,
+/obj/item/clothing/neck/roguetown/collar/catbell,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/clothing/neck/roguetown/collar/cowbell,
+/obj/item/clothing/neck/roguetown/collar/cowbell,
+/obj/item/clothing/neck/roguetown/cursed_collar,
+/obj/item/clothing/neck/roguetown/cursed_collar,
+/obj/item/clothing/mask/rogue/blindfold,
+/obj/item/clothing/mask/rogue/blindfold,
+/obj/item/clothing/mask/rogue/blindfold,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "emO" = (
 /obj/structure/spider/stickyweb{
 	color = "#d1cdc7"
@@ -18114,11 +18224,6 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
-"epa" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet)
 "epj" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -18665,11 +18770,6 @@
 /obj/structure/fermentation_keg/whitewine,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement/keep)
-"ewG" = (
-/obj/machinery/light/rogue/torchholder/c,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet)
 "ewL" = (
 /obj/structure/flora/roguegrass/herb/salvia,
 /turf/open/floor/rogue/grassyel,
@@ -20029,6 +20129,10 @@
 /obj/structure/fermentation_keg/water,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/inq)
+"eMm" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/swamp,
+/area/rogue/under/cave)
 "eMv" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/tile,
@@ -20136,36 +20240,6 @@
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/sewer)
-"eOc" = (
-/obj/structure/closet/crate/roguecloset/dark{
-	keylock = 1;
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Drugs";
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/ozium,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/powder/moondust,
-/obj/item/reagent_containers/powder/spice,
-/obj/item/reagent_containers/powder/spice,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/redwine,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/wine,
-/obj/item/reagent_containers/glass/bottle/rogue/luxwine,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/reagent_containers/glass/bottle/rogue/elfred,
-/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "eOd" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21365,6 +21439,15 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
+"fcM" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/roguemachine/mail{
+	mailtag = "Whitevein - Office"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "fcQ" = (
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -23756,14 +23839,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
-"fGx" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 4;
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
 "fGy" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/cavewet/wizarddungeon)
@@ -24099,8 +24174,12 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/under/town/basement/tavern)
 "fJX" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/outdoors/beach/harbor)
 "fKc" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border/west,
@@ -25126,7 +25205,12 @@
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/church/chapel)
 "fVn" = (
-/turf/open/water/bath,
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall"
+	},
 /area/rogue/under/cavewet)
 "fVv" = (
 /obj/structure/bars/passage/shutter{
@@ -25194,6 +25278,13 @@
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors/shelter/bog)
+"fWn" = (
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "fWo" = (
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/cobblerock,
@@ -26287,11 +26378,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
-"glC" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/under/cavewet)
 "glG" = (
 /obj/item/paper{
 	pixel_y = 7
@@ -26446,20 +26532,13 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors)
 "gne" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall";
+	density = 0
 	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	pixel_x = -8;
-	pixel_y = -20
-	},
-/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "gnf" = (
 /obj/structure/closet/dirthole/closed/loot,
@@ -26548,7 +26627,7 @@
 	color = "#a1254a"
 	},
 /obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "gor" = (
 /obj/structure/fluff/walldeco/church/line{
@@ -26760,6 +26839,13 @@
 /obj/effect/landmark/quest_spawner/hard,
 /turf/open/floor/rogue/snowpatchy,
 /area/rogue/outdoors/woodsrat/above)
+"gri" = (
+/obj/structure/plasticflaps,
+/obj/structure/spider/stickyweb,
+/turf/open/water/river{
+	icon_state = "rockwd"
+	},
+/area/rogue/under/town/sewer)
 "grk" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /obj/item/natural/glass_shard,
@@ -28088,7 +28174,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "gJj" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/roguegrass/thorn_bush,
@@ -28302,7 +28388,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "gLD" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -28499,9 +28585,9 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/manor/rockhill)
 "gOi" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_line"
-	},
+/obj/structure/plasticflaps,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet)
 "gOo" = (
 /obj/structure/plasticflaps,
@@ -28721,6 +28807,11 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/town/sewer)
+"gRQ" = (
+/obj/structure/plasticflaps,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "gRV" = (
 /obj/machinery/light/rogue/candle/blue{
 	pixel_x = 14
@@ -28911,10 +29002,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bograt/sunken)
-"gUa" = (
-/obj/structure/plasticflaps,
-/turf/open/water/swamp,
-/area/rogue/under/cavewet)
 "gUg" = (
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/sewer)
@@ -29094,6 +29181,9 @@
 "gVZ" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
+"gWi" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy,
+/area/rogue/indoors/town/bath)
 "gWn" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/shop)
@@ -29486,6 +29576,10 @@
 "haq" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/outdoors/town/roofs)
+"haA" = (
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/indoors/town/bath)
 "haC" = (
 /obj/structure/fluff/alch,
 /obj/machinery/light/rogue/candle/blue,
@@ -29849,6 +29943,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
+"hdY" = (
+/obj/effect/decal/cleanable/blood/splatter/walls,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
+/area/rogue/indoors/town/bath)
 "hef" = (
 /obj/structure/chair/bench/couchablack,
 /obj/machinery/light/roguestreet/orange/walllamp{
@@ -30241,6 +30339,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/bograt/above)
+"hkc" = (
+/obj/structure/fluff/walldeco/med{
+	pixel_x = 0;
+	pixel_y = -32;
+	layer = 2
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "hkd" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/shelter/mountains)
@@ -30249,6 +30355,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/mountains/decap/rockhill)
+"hks" = (
+/obj/structure/fluff/walldeco/med5,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/indoors/town/bath)
 "hkv" = (
 /obj/machinery/light/roguestreet/orange{
 	pixel_x = 40;
@@ -30347,44 +30457,6 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield/rockhill)
-"hlE" = (
-/obj/structure/closet/crate/roguecloset{
-	name = "Silk Outfits"
-	},
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
-/obj/item/clothing/mask/rogue/exoticsilkmask/red,
-/obj/item/clothing/mask/rogue/exoticsilkmask/red,
-/obj/item/clothing/mask/rogue/exoticsilkmask/green,
-/obj/item/clothing/mask/rogue/exoticsilkmask/green,
-/obj/item/clothing/mask/rogue/exoticsilkmask,
-/obj/item/clothing/mask/rogue/exoticsilkmask,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/obj/item/legwears/silk,
-/obj/item/legwears/silk,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
-/obj/item/clothing/cloak/lordcloak/ladycloak,
-/obj/item/clothing/cloak/lordcloak/ladycloak,
-/obj/item/clothing/cloak/duelistcape,
-/obj/item/clothing/cloak/duelistcape,
-/obj/item/clothing/head/roguetown/duelisthat,
-/obj/item/clothing/mask/rogue/duelmask,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "hlG" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Bog - Eastern Tower"
@@ -31367,6 +31439,14 @@
 /obj/item/clothing/ring/signet,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor/rockhill)
+"hys" = (
+/obj/structure/table/cooling,
+/obj/structure/bars/shop,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "bathhousetunnel"
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/cell)
 "hyu" = (
 /obj/structure/table/wood/poor,
 /obj/item/rope/chain,
@@ -31717,11 +31797,12 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave)
 "hCX" = (
-/obj/structure/hotspring{
-	icon_state = "lilypetals2"
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 9
 	},
-/turf/open/water/bath,
-/area/rogue/under/cavewet)
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/outdoors/beach/harbor)
 "hDc" = (
 /obj/structure/fluff/walldeco/customflag/rockhill,
 /turf/closed/wall/mineral/rogue/stone,
@@ -32068,9 +32149,6 @@
 /obj/item/pestle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
-"hGL" = (
-/turf/closed/wall/mineral/rogue/pipe/joint/one,
-/area/rogue/under/cavewet)
 "hGM" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -32324,6 +32402,44 @@
 /obj/item/scomstone/bad/garrison,
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/rockhill)
+"hJU" = (
+/obj/structure/closet/crate/roguecloset/lord{
+	name = "Persuasion"
+	},
+/obj/structure/curtain/black{
+	open = 0;
+	opacity = 1;
+	icon_state = "curtain-closed"
+	},
+/obj/item/clothing/neck/roguetown/cursed_collar,
+/obj/item/clothing/neck/roguetown/cursed_collar,
+/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
+/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
+/obj/item/chastity/chastity_belt,
+/obj/item/chastity/chastity_belt/anal,
+/obj/item/chastity/chastity_belt/spiked,
+/obj/item/chastity/chastity_belt/spiked_anal,
+/obj/item/chastity/cursed,
+/obj/item/chastity/cursed,
+/obj/item/chastity/chastity_cage/spiked_anal,
+/obj/item/chastity/chastity_cage/spiked,
+/obj/item/chastity/intersex/spiked,
+/obj/item/chastity/intersex,
+/obj/item/chastity/chastity_cage,
+/obj/item/chastity/chastity_cage/anal,
+/obj/item/chastity/chastity_cage/flat,
+/obj/item/chastity/chastity_cage/flat/anal,
+/obj/item/chastity/chastity_cage/flat/spiked,
+/obj/item/chastity/chastity_cage/flat/spiked_anal,
+/obj/item/chastity/chastity_cage/spiked,
+/obj/item/chastity/chastity_cage/spiked_anal,
+/obj/item/chastity,
+/obj/item/dildo/steel,
+/obj/item/dildo/steel,
+/obj/item/dildo/silver,
+/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "hJV" = (
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/dirt,
@@ -32638,10 +32754,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
-"hNV" = (
-/obj/structure/roguemachine/drugmachine,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
-/area/rogue/indoors/town/bath)
 "hNW" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
@@ -32977,7 +33089,7 @@
 	color = "#a1254a"
 	},
 /obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/churchbrick,
+/turf/open/floor/carpet/purple,
 /area/rogue/indoors/town/bath)
 "hSw" = (
 /obj/structure/rack/rogue,
@@ -33425,10 +33537,8 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/beach/harbor)
 "hXj" = (
-/obj/structure/roguewindow/harem3{
-	opacity = 1
-	},
-/turf/closed,
+/obj/structure/roguewindow/harem3,
+/turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "hXp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -33576,7 +33686,7 @@
 	dir = 8
 	},
 /turf/open/water/bath,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "hZr" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -34213,7 +34323,6 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/church/chapel)
 "ihp" = (
-/obj/structure/fluff/pillow/magenta,
 /obj/effect/decal/cobbleedge{
 	dir = 4;
 	icon_state = "borderfall";
@@ -34225,16 +34334,37 @@
 	icon_state = "borderfall";
 	pixel_y = 8
 	},
-/obj/structure/rack/rogue/shelf,
 /obj/machinery/light/rogue/candle/red/r,
-/turf/open/floor/carpet/red,
+/obj/structure/table/wood/poor,
+/obj/item/reagent_containers/glass/cup/golden/small,
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/cup/golden/small{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/redwine{
+	pixel_x = -6;
+	pixel_y = 45
+	},
+/obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine{
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "ihq" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
 	locked = 1;
-	lockid = "dungeon";
-	name = "Bathhouse"
+	lockid = "nightman";
+	name = "Whitevein Transfer"
+	},
+/obj/structure/bars/passage/steel{
+	redstone_id = "bathhousetunnel"
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
@@ -34312,10 +34442,6 @@
 "ihR" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsrat/above)
-"ihS" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet)
 "ihU" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -35498,6 +35624,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach/harbor)
+"izZ" = (
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "Cell Isolation";
+	redstone_id = "nmcell"
+	},
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "iAa" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/indoors/town/bath)
@@ -35582,6 +35717,9 @@
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bograt/sunken)
+"iBZ" = (
+/turf/closed/wall/mineral/rogue/pipe/joint/eight,
+/area/rogue/indoors/town/bath)
 "iCa" = (
 /obj/structure/stairs{
 	dir = 4
@@ -35843,6 +35981,17 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/ocean,
 /area/rogue/outdoors/beach/harbor)
+"iET" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/blocks/paving,
+/area/rogue/indoors/town/bath)
+"iEX" = (
+/obj/item/candle/skull/lit,
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "iEY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/mineral/random/rogue/med,
@@ -36331,8 +36480,18 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cavewet/wizarddungeon)
 "iLj" = (
-/turf/open/floor/rogue/tile/tilerg,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/under/town/sewer)
+"iLk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 4;
+	pixel_x = 9
+	},
+/obj/machinery/light/rogue/lanternpost{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/outdoors/beach/harbor)
 "iLl" = (
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/warden)
@@ -36496,6 +36655,12 @@
 /obj/structure/fluff/statue/knightalt/r,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/manor/rockhill)
+"iNl" = (
+/obj/machinery/light/rogue/candle/floorcandle,
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "iNq" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 1
@@ -36621,19 +36786,6 @@
 "iPg" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs/keep)
-"iPk" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
-	icon_state = "iron_line";
-	max_integrity = 2000;
-	name = "suspicious metal wall";
-	density = 0
-	},
-/area/rogue/indoors/town/bath)
-"iPr" = (
-/obj/machinery/light/rogue/torchholder/c,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet)
 "iPs" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pick/aalloy,
@@ -37778,9 +37930,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
 "jdl" = (
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/under/cavewet)
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "jdr" = (
 /obj/structure/stairs/fancy/r{
 	dir = 1
@@ -37962,9 +38114,6 @@
 	},
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors)
-"jfS" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/long,
-/area/rogue/indoors/town/bath)
 "jfV" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -38590,7 +38739,6 @@
 "jnz" = (
 /obj/structure/fluff/railing/border/east,
 /obj/structure/table/wood/long_table/right,
-/obj/item/reagent_containers/glass/bucket,
 /obj/structure/roguemachine/withdraw,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/sewer)
@@ -39354,7 +39502,7 @@
 "jxQ" = (
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/town/sewer)
+/area/rogue/indoors/town/bath)
 "jxS" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/cavewet)
@@ -40373,6 +40521,12 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hay,
 /area/rogue/indoors)
+"jJP" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "jJS" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light/rogue/candle/blue,
@@ -41765,7 +41919,7 @@
 	},
 /obj/structure/shisha/hookah,
 /turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "kcO" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass/nospawn,
@@ -42452,12 +42606,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
-"kjN" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Whitevein - Kitchen"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "kjP" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/under/town/sewer)
@@ -42755,15 +42903,13 @@
 /turf/closed/wall/mineral/rogue/roofwall/outercorner/dir1,
 /area/rogue/indoors/inq/office)
 "kmW" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/chair/bench/couchablack,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall";
+	pixel_y = 8
 	},
-/obj/structure/fluff/pillow/magenta{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 1
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "knh" = (
 /obj/structure/bars/passage/shutter{
@@ -43369,6 +43515,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church/chapel)
+"kvc" = (
+/obj/structure/bars,
+/obj/structure/bars/passage/shutter{
+	redstone_id = "nmcell"
+	},
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "kvf" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8;
@@ -43477,6 +43632,9 @@
 	},
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter/mountains)
+"kwm" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/cand,
+/area/rogue/indoors/town/bath)
 "kwp" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/under/underdarker/rockhill)
@@ -43609,7 +43767,7 @@
 "kxR" = (
 /obj/structure/roguewindow/harem1,
 /turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "kxU" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -43667,6 +43825,10 @@
 /obj/structure/bed/rogue/shit,
 /obj/effect/spawner/lootdrop/general_loot_low,
 /turf/open/floor/rogue/dirt/road,
+/area/rogue/under/cavewet)
+"kyW" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet)
 "kyX" = (
 /obj/structure/table/wood{
@@ -43948,6 +44110,9 @@
 /area/rogue/indoors/town)
 "kCD" = (
 /turf/open/floor/rogue/grasscold,
+/area/rogue/under/cavewet)
+"kCF" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/under/cavewet)
 "kCH" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -44307,6 +44472,11 @@
 /obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/dungeon1)
+"kHM" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "kHO" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -44394,7 +44564,7 @@
 "kIL" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "kIO" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/cavewet)
@@ -45662,6 +45832,10 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach/harbor)
+"kZb" = (
+/obj/machinery/light/rogue/torchholder/l,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/cell)
 "kZj" = (
 /obj/structure/fluff/statue/gargoyle{
 	pixel_y = 10
@@ -45728,6 +45902,17 @@
 /area/rogue/outdoors/town/rockhill)
 "kZR" = (
 /obj/structure/rack/rogue/shelf,
+/obj/item/reagent_containers/glass/bottle/rogue/wine{
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine{
+	pixel_y = 32
+	},
+/obj/item/reagent_containers/glass/bottle/rogue/wine{
+	pixel_x = 6;
+	pixel_y = 32
+	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kZS" = (
@@ -45810,6 +45995,27 @@
 	dir = 1
 	},
 /area/rogue/outdoors/bograt/above)
+"laS" = (
+/obj/structure/closet/crate/chest/neu_iron{
+	name = "Recovery"
+	},
+/obj/item/storage/belt/rogue/surgery_bag/full,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew,
+/obj/item/reagent_containers/glass/bottle/rogue/healthpotnew,
+/obj/structure/curtain/black{
+	open = 0;
+	opacity = 1;
+	icon_state = "curtain-closed"
+	},
+/obj/item/natural/bundle/cloth/bandage/full,
+/obj/item/natural/bundle/cloth/bandage/full,
+/obj/item/bodypart/l_arm/prosthetic/woodleft,
+/obj/item/bodypart/r_arm/prosthetic/woodright,
+/obj/item/bodypart/l_leg/prosthetic,
+/obj/item/bodypart/r_leg/prosthetic,
+/obj/item/reagent_containers/glass/bottle/rogue/strong_antidote,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "lbd" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
@@ -47046,6 +47252,9 @@
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/chapel)
+"lrx" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/under/cavewet)
 "lrU" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
 	dir = 1
@@ -47203,6 +47412,16 @@
 	icon_state = "wooden_floor2"
 	},
 /area/rogue/indoors/town/shop)
+"lus" = (
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	pixel_y = -8
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "lut" = (
 /obj/effect/decal/remains/human,
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf_undead,
@@ -47413,6 +47632,12 @@
 	dir = 4
 	},
 /area/rogue/outdoors/town/roofs)
+"lwZ" = (
+/obj/structure/bars,
+/obj/structure/bars,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "lxe" = (
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
@@ -47815,11 +48040,9 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/outdoors/town/rockhill)
 "lDm" = (
-/obj/structure/roguewindow/harem3{
-	opacity = 1
-	},
+/obj/structure/roguewindow/harem3,
 /obj/machinery/light/rogue/candle/red,
-/turf/open/floor/rogue/tile,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/sewer)
 "lDE" = (
 /obj/structure/fluff/railing/border{
@@ -48040,7 +48263,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "lGl" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/naturalstone,
@@ -48617,6 +48840,9 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/west)
+"lNl" = (
+/turf/closed/wall/mineral/rogue/pipe/corners/one,
+/area/rogue/under/town/sewer)
 "lNn" = (
 /obj/structure/roguewindow/openclose/reinforced{
 	dir = 1
@@ -49193,7 +49419,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/concrete,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "lUW" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/indoors)
@@ -49773,7 +49999,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "max" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/manor{
@@ -49966,8 +50192,8 @@
 	name = "Mage's Tower"
 	})
 "mcL" = (
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cavewet)
+/turf/closed/wall/mineral/rogue/decostone/mossy/long,
+/area/rogue/indoors/town/bath)
 "mcN" = (
 /turf/closed/wall/mineral/rogue/roofwall/innercorner/dir1,
 /area/rogue/indoors/town)
@@ -50191,8 +50417,6 @@
 /area/rogue/outdoors/town/rockhill)
 "mgl" = (
 /obj/structure/table/wood/long_table,
-/obj/item/rogueweapon/huntingknife/stoneknife,
-/obj/item/kitchen/rollingpin,
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
@@ -50205,6 +50429,11 @@
 "mgA" = (
 /obj/structure/bondage/chains,
 /turf/open/floor/rogue/dirt,
+/area/rogue/indoors/town/bath)
+"mgB" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/long{
+	dir = 1
+	},
 /area/rogue/indoors/town/bath)
 "mgE" = (
 /obj/structure/fluff/railing/border{
@@ -51793,15 +52022,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
-"mxI" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
-	icon_state = "iron_line";
-	max_integrity = 2000;
-	name = "damaged metal wall";
-	density = 0
-	},
-/area/rogue/under/cavewet)
 "mxM" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -51889,6 +52109,13 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
+"myK" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 1;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "myT" = (
 /obj/structure/chair/bench{
 	dir = 1
@@ -52561,6 +52788,12 @@
 "mHE" = (
 /turf/closed/wall/mineral/rogue/tent,
 /area/rogue/outdoors/bograt/above)
+"mHF" = (
+/obj/effect/decal/cleanable/blood/splatter/walls,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
+/area/rogue/indoors/town/bath)
 "mHK" = (
 /obj/structure/fluff/wallclock,
 /obj/machinery/light/rogue/candle/l,
@@ -52770,7 +53003,7 @@
 	icon_state = "lilypetals2"
 	},
 /turf/open/water/bath,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "mKg" = (
 /obj/structure/stairs{
 	dir = 4
@@ -53912,6 +54145,18 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield/rockhill)
+"naf" = (
+/obj/structure/mineral_door/bars{
+	lockid = "nightman";
+	name = "Cell Door"
+	},
+/obj/structure/bars/passage/shutter{
+	redstone_id = "nmcell"
+	},
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "naj" = (
 /obj/structure/table/wood{
 	icon_state = "longtable";
@@ -54526,15 +54771,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bograt/sunken)
-"ngJ" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
-	icon_state = "iron_line";
-	max_integrity = 2000;
-	name = "damaged metal wall";
-	density = 0
-	},
-/area/rogue/indoors/town/bath)
 "ngN" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -54758,6 +54994,10 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
+"njo" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "njq" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -55005,9 +55245,6 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "nnJ" = (
-/obj/machinery/light/rogue/candle/blue{
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/debris/woody{
 	dir = 1
 	},
@@ -56278,7 +56515,7 @@
 	name = "Steaming Room"
 	},
 /turf/open/floor/rogue/concrete,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "nDh" = (
 /obj/structure/table/wood/fancy,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -56999,13 +57236,6 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woodsrat/south)
-"nNv" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 1;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
 "nNz" = (
 /obj/machinery/light/rogue/firebowl/standing/green,
 /turf/open/floor/rogue/cobblerock,
@@ -58338,10 +58568,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/above)
 "odm" = (
-/obj/structure/fluff/railing/border{
-	dir = 10;
-	pixel_x = 32;
-	pixel_y = 32
+/obj/structure/fluff/pillow/magenta,
+/obj/structure/shisha/hookah{
+	pixel_x = -1;
+	pixel_y = 7
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -58627,7 +58857,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ogI" = (
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
 "ogP" = (
 /obj/structure/stairs,
@@ -58787,6 +59019,15 @@
 "ojI" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/shelter/mountains)
+"ojK" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
+"ojN" = (
+/obj/structure/fluff/walldeco/chains,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "ojQ" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -59033,6 +59274,9 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue)
+"omy" = (
+/turf/closed/wall/mineral/rogue/pipe/joint/one,
+/area/rogue/under/cavewet)
 "omA" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 1
@@ -59634,7 +59878,7 @@
 	color = "#a1254a"
 	},
 /turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "otC" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
@@ -59681,6 +59925,11 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/blocks/platform,
 /area/rogue/indoors/town/bath)
+"otU" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "otW" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/wood{
@@ -60111,6 +60360,40 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield/rockhill/above)
+"ozu" = (
+/obj/structure/closet/crate/roguecloset/lord{
+	name = "Punishment"
+	},
+/obj/item/clothing/mask/rogue/facemask,
+/obj/item/clothing/head/roguetown/menacing{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/rogueweapon/whip{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/rogueweapon/surgery/cautery/branding,
+/obj/structure/curtain/black{
+	open = 0;
+	opacity = 1;
+	icon_state = "curtain-closed"
+	},
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/leash/chain,
+/obj/item/leash/chain,
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/rogueweapon/huntingknife/cleaver,
+/obj/item/rogueweapon/huntingknife/idagger/silver,
+/obj/item/rogueweapon/huntingknife/idagger/navaja,
+/obj/item/reagent_containers/glass/bottle/rogue/stampoison,
+/obj/item/reagent_containers/glass/bottle/rogue/berrypoison,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "ozB" = (
 /obj/structure/curtain/brown{
 	icon_state = "curtain-closed";
@@ -60554,6 +60837,15 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
+"oGQ" = (
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	desc = "These candles produces a heady vapor, warding away the less pleasing scents of the sewer.";
+	name = "scented candles";
+	pixel_y = 4;
+	plane = -7
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "oGS" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/watcher,
 /turf/open/floor/rogue/metal/barograte,
@@ -61945,15 +62237,6 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/town/grove)
-"oWR" = (
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	desc = "These candles produces a heady vapor, warding away the less pleasing scents of the sewer.";
-	name = "scented candles";
-	pixel_y = 4;
-	plane = -7
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
 "oWX" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -62234,6 +62517,18 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/mutated,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave)
+"pax" = (
+/obj/effect/decal/cobbleedge{
+	dir = 8;
+	icon_state = "borderfall";
+	pixel_x = -8
+	},
+/obj/effect/decal/cobbleedge{
+	icon_state = "borderfall";
+	pixel_y = -8
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "paz" = (
 /obj/structure/chair/wood/rogue{
 	dir = 1
@@ -62569,15 +62864,13 @@
 /obj/structure/fluff/walldeco/bigpainting/lake{
 	pixel_x = -28
 	},
-/obj/structure/shisha/hookah{
-	pixel_x = -1;
-	pixel_y = 7
+/obj/structure/chair/bench/couchablack/r,
+/obj/effect/decal/cobbleedge{
+	dir = 1;
+	icon_state = "borderfall";
+	pixel_y = 8
 	},
-/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "peK" = (
 /obj/structure/table/wood{
@@ -62646,6 +62939,8 @@
 /obj/item/millstone,
 /obj/item/reagent_containers/glass/bucket/pot,
 /obj/machinery/light/rogue/candle/red,
+/obj/item/kitchen/rollingpin,
+/obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "pfF" = (
@@ -63363,6 +63658,12 @@
 /obj/structure/roguewindow/stained/silver,
 /turf/closed/wall/mineral/rogue/decostone/mossy,
 /area/rogue/indoors/town/church)
+"pox" = (
+/obj/structure/fluff/walldeco/maidensigil{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "poJ" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/blocks/green,
@@ -63603,7 +63904,7 @@
 "pqY" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "pri" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -64523,7 +64824,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "pCR" = (
 /obj/structure/stairs{
 	dir = 8
@@ -65002,7 +65303,7 @@
 /turf/open/water/river{
 	icon_state = "rockwd"
 	},
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "pId" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/machinery/light/rogue/firebowl/standing/green,
@@ -65121,11 +65422,6 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"pJo" = (
-/obj/structure/plasticflaps,
-/obj/structure/spider/stickyweb,
-/turf/open/floor/rogue/dirt,
-/area/rogue/under/cavewet)
 "pJw" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -65156,15 +65452,6 @@
 	dir = 1
 	},
 /area/rogue/under/town/sewer)
-"pKf" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/roguemachine/mail{
-	mailtag = "Whitevein - Office"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "pKn" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
@@ -65313,6 +65600,13 @@
 	icon_state = "stonewindow"
 	},
 /area/rogue/indoors/town/garrison)
+"pMV" = (
+/obj/effect/decal/carpet/kover_darkred{
+	pixel_x = 16;
+	pixel_y = 10
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "pMW" = (
 /obj/machinery/light/rogue/candle/green/r,
 /obj/structure/table/vtable/v2,
@@ -65692,6 +65986,11 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/grassgrey,
 /area/rogue/outdoors/bograt/sunken)
+"pQC" = (
+/obj/structure/plasticflaps,
+/obj/structure/spider/stickyweb,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "pQD" = (
 /obj/item/natural/rock/coal,
 /turf/open/water/cleanshallow,
@@ -66582,6 +66881,13 @@
 /obj/item/bedsheet/rogue/double_pelt,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors)
+"qdD" = (
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Whitevein - Purification Chamber"
+	},
+/obj/machinery/light/rogue/candle/red/r,
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "qdH" = (
 /obj/structure/fluff/statue/gargoyle/candles,
 /obj/effect/decal/cobbleedge{
@@ -68770,11 +69076,45 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/rhgoblinencampment)
 "qFk" = (
-/obj/structure/roguewindow/harem3{
-	opacity = 1
+/obj/structure/closet/crate/roguecloset{
+	name = "Standard Outfits"
 	},
-/turf/open/floor/rogue/tile,
-/area/rogue/under/town/sewer)
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
+/obj/item/clothing/shirt/dress/courtesan,
+/obj/item/clothing/shirt/dress/courtesan,
+/obj/item/clothing/shirt/dress/hw_dress,
+/obj/item/clothing/shirt/dress/hw_dress,
+/obj/item/clothing/shirt/dress/skyrim_dress,
+/obj/item/clothing/shirt/dress/skyrim_dress,
+/obj/item/clothing/shirt/dress/skyrim_taven,
+/obj/item/clothing/shirt/dress/skyrim_taven,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
+/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
+/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
+/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/maid,
+/obj/item/clothing/suit/roguetown/shirt/dress/maid,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/under/roguetown/skirt/knee,
+/obj/item/clothing/under/roguetown/skirt/knee,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "qFr" = (
 /obj/structure/closet/crate/chest{
 	lockid = "butcher";
@@ -68971,6 +69311,10 @@
 /obj/structure/flora/roguegrass/herb/symphitum,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/bograt/sunken)
+"qHU" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "qHW" = (
 /obj/structure/fluff/walldeco/vinez,
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -69987,11 +70331,17 @@
 	},
 /obj/item/natural/bone,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "qWY" = (
 /obj/structure/fluff/railing/corner/north_east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach/harbor)
+"qXc" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Whitevein - Kitchen"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "qXk" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/cobblerock,
@@ -70389,9 +70739,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/rtfield/rockhill/above)
-"rcQ" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/cand,
-/area/rogue/indoors/town/bath)
 "rcR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -72542,42 +72889,40 @@
 /area/rogue/under/underdark/rockhill)
 "rFB" = (
 /obj/structure/closet/crate/roguecloset{
-	name = "Standard Outfits"
+	name = "Silk Outfits"
 	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
-/obj/item/clothing/shirt/dress/courtesan,
-/obj/item/clothing/shirt/dress/courtesan,
-/obj/item/clothing/shirt/dress/hw_dress,
-/obj/item/clothing/shirt/dress/hw_dress,
-/obj/item/clothing/shirt/dress/skyrim_dress,
-/obj/item/clothing/shirt/dress/skyrim_dress,
-/obj/item/clothing/shirt/dress/skyrim_taven,
-/obj/item/clothing/shirt/dress/skyrim_taven,
-/obj/item/clothing/suit/roguetown/shirt/dress,
-/obj/item/clothing/suit/roguetown/shirt/dress,
-/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
-/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
-/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
-/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
-/obj/item/clothing/suit/roguetown/shirt/dress/maid,
-/obj/item/clothing/suit/roguetown/shirt/dress/maid,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/under/roguetown/skirt,
-/obj/item/clothing/under/roguetown/skirt/knee,
-/obj/item/clothing/under/roguetown/skirt/knee,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
+/obj/item/clothing/mask/rogue/exoticsilkmask/red,
+/obj/item/clothing/mask/rogue/exoticsilkmask/red,
+/obj/item/clothing/mask/rogue/exoticsilkmask/green,
+/obj/item/clothing/mask/rogue/exoticsilkmask/green,
+/obj/item/clothing/mask/rogue/exoticsilkmask,
+/obj/item/clothing/mask/rogue/exoticsilkmask,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
+/obj/item/legwears/silk,
+/obj/item/legwears/silk,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/lordcloak/ladycloak,
+/obj/item/clothing/cloak/lordcloak/ladycloak,
+/obj/item/clothing/cloak/duelistcape,
+/obj/item/clothing/cloak/duelistcape,
+/obj/item/clothing/head/roguetown/duelisthat,
+/obj/item/clothing/mask/rogue/duelmask,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "rFK" = (
@@ -72934,6 +73279,10 @@
 "rKu" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woodsrat/south)
+"rKx" = (
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/under/town/sewer)
 "rKz" = (
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = -5
@@ -73643,13 +73992,6 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor/rockhill)
-"rTM" = (
-/obj/structure/chair/stool/rogue,
-/obj/structure/fluff/walldeco/maidensigil{
-	pixel_y = -32
-	},
-/turf/open/floor/rogue/tile/harem2,
-/area/rogue/indoors/town/bath)
 "rTW" = (
 /obj/structure/stairs/cw{
 	dir = 4
@@ -73877,7 +74219,7 @@
 	icon_state = "lilypetals2"
 	},
 /turf/open/water/bath,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "rWK" = (
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
@@ -73900,6 +74242,15 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
+"rWT" = (
+/obj/machinery/light/rogue/candle/red{
+	pixel_y = -32
+	},
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "rWV" = (
 /obj/structure/mineral_door/wood/towner/generic/two_keys,
 /obj/structure/stairs{
@@ -75015,7 +75366,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "sks" = (
 /obj/structure/closet/crate/chest{
 	lockid = "clinic"
@@ -75305,8 +75656,9 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
 "snX" = (
-/obj/structure/lever/wall{
-	redstone_id = "rd_escape"
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 8
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach/harbor)
@@ -76461,7 +76813,7 @@
 	alpha = 90
 	},
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "sEl" = (
 /obj/structure/stairs{
 	dir = 4
@@ -76542,7 +76894,7 @@
 "sEU" = (
 /obj/item/natural/bone,
 /turf/open/floor/rogue/cobble/mossy,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/cell)
 "sEV" = (
 /obj/structure/fluff/railing/border{
 	pixel_y = -8
@@ -77452,6 +77804,11 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/grove)
+"sPS" = (
+/obj/structure/bars,
+/obj/structure/spider/stickyweb,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "sPT" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/warden)
@@ -77690,6 +78047,9 @@
 	},
 /obj/structure/stairs/stone{
 	dir = 8
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
@@ -78995,6 +79355,15 @@
 "tja" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/indoors/town/church/chapel)
+"tjg" = (
+/obj/structure/pillory{
+	lockid = list("nightmaiden");
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/churchbrick{
+	icon_state = "concretefloor1"
+	},
+/area/rogue/indoors/town/bath)
 "tjl" = (
 /obj/machinery/light/rogue/candle/red,
 /obj/structure/stairs/stone{
@@ -79045,7 +79414,7 @@
 	icon_state = "lilypetals2"
 	},
 /turf/open/water/bath,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "tjA" = (
 /obj/structure/glowshroom{
 	icon_state = "glowshroom2"
@@ -80609,7 +80978,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
 "tDl" = (
-/obj/structure/roguewindow/harem3,
+/obj/structure/roguewindow/harem3{
+	opacity = 1
+	},
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/sewer)
 "tDq" = (
@@ -83734,10 +84105,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
-"upu" = (
-/obj/structure/roguewindow/harem1,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
-/area/rogue/indoors/town/bath)
 "upE" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
 /area/rogue/indoors/town/church/chapel)
@@ -84053,6 +84420,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"utN" = (
+/obj/structure/plasticflaps,
+/turf/open/water/swamp,
+/area/rogue/under/cavewet)
 "utT" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -84534,6 +84905,8 @@
 	lockid = "steam";
 	name = "steam room key"
 	},
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "uzr" = (
@@ -84586,6 +84959,9 @@
 	name = "escape shutters";
 	redstone_id = "rd_escape"
 	},
+/obj/effect/decal/cleanable/dirt/cobweb{
+	dir = 1
+	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "uzI" = (
@@ -84637,13 +85013,9 @@
 	},
 /area/rogue/under/cavewet)
 "uAi" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
-	icon_state = "iron_line";
-	max_integrity = 2000;
-	name = "damaged metal wall"
-	},
-/area/rogue/under/cavewet)
+/obj/structure/fluff/walldeco/med3,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/indoors/town/bath)
 "uAj" = (
 /obj/structure/table/vtable/v2{
 	name = "Dissection Table"
@@ -84799,7 +85171,7 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/bars,
 /turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/area/rogue/indoors/town/bath)
 "uCi" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/naturalstone,
@@ -85185,6 +85557,14 @@
 /mob/living/carbon/human/species/goblin/npc/hell,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
+"uIs" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "uIv" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/infernal/imp,
 /turf/open/floor/rogue/grassred,
@@ -86056,7 +86436,7 @@
 	pixel_y = 22
 	},
 /turf/closed/wall/mineral/rogue/pipe,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "uSR" = (
 /obj/structure/stairs{
 	dir = 4
@@ -88258,11 +88638,9 @@
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "vvx" = (
-/turf/closed/wall/mineral/rogue/pipe{
-	icon_state = "iron_corner";
-	dir = 4
-	},
-/area/rogue/under/cavewet)
+/obj/item/reagent_containers/food/snacks/smallrat,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/town/sewer)
 "vvH" = (
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
@@ -88721,6 +89099,9 @@
 /area/rogue/outdoors/woodsrat/north)
 "vBv" = (
 /obj/structure/bed/rogue,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 32
+	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "vBy" = (
@@ -88784,10 +89165,6 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
-"vCf" = (
-/obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "vCh" = (
 /obj/effect/landmark/quest_spawner/medium,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -88988,6 +89365,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/Academy)
+"vES" = (
+/obj/machinery/light/rogue/firebowl,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/indoors/town/bath)
 "vET" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/cobble,
@@ -89807,12 +90188,10 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
 "vQR" = (
-/obj/structure/rack/rogue,
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	desc = "These candles produces a heady vapor, warding away the less pleasing scents of the sewer.";
-	name = "scented candles";
-	pixel_y = 4;
-	plane = -7
+/obj/structure/curtain/black{
+	open = 0;
+	opacity = 1;
+	icon_state = "curtain-closed"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/sewer)
@@ -90050,6 +90429,9 @@
 	dir = 10;
 	pixel_x = 32;
 	pixel_y = 32
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
@@ -90405,6 +90787,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/manor/rockhill)
+"vYK" = (
+/obj/structure/roguemachine/noticeboard,
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/outdoors/beach/harbor)
 "vYS" = (
 /obj/effect/decal/cleanable/debris/glassy,
 /turf/open/floor/rogue/cobble,
@@ -91699,6 +92085,10 @@
 /area/rogue/indoors/town/shop)
 "wpn" = (
 /obj/structure/chair/stool/rogue,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = 27
+	},
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "wpu" = (
@@ -91789,7 +92179,7 @@
 	color = "#a1254a"
 	},
 /turf/open/floor/rogue/churchmarble,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "wqH" = (
 /obj/structure/table/wood{
 	icon_state = "largetable"
@@ -91833,6 +92223,20 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet)
+"wqT" = (
+/obj/structure/mineral_door/wood/donjon{
+	dir = 1;
+	locked = 1;
+	lockid = "nightman";
+	name = "Purification"
+	},
+/obj/structure/curtain/magenta{
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/bath)
 "wqY" = (
 /obj/effect/decal/herringbone{
 	dir = 4
@@ -91880,6 +92284,9 @@
 /area/rogue/indoors/town/warden)
 "wrE" = (
 /obj/machinery/light/rogue/candle/red,
+/obj/structure/fluff/walldeco/maidensigil{
+	pixel_y = -32
+	},
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors/town/bath)
 "wrG" = (
@@ -92077,6 +92484,13 @@
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue)
+"wuF" = (
+/obj/structure/lever{
+	redstone_id = "bathhousetunnel";
+	name = "Whitevein Transfer"
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/indoors/town/cell)
 "wuJ" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grasscold,
@@ -93681,6 +94095,11 @@
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
+"wNH" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "wNK" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -94545,9 +94964,6 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
-"wYO" = (
-/turf/closed/wall/mineral/rogue/pipe/joint/eight,
-/area/rogue/under/cavewet)
 "wYS" = (
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass,
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass,
@@ -94884,9 +95300,14 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/Academy)
 "xdC" = (
-/obj/structure/fluff/statue/small,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
-/area/rogue/indoors/town/bath)
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall";
+	density = 0
+	},
+/area/rogue/under/cavewet)
 "xdD" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/roguecoin/copper/pile,
@@ -96042,9 +96463,8 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
 "xtk" = (
-/obj/machinery/light/rogue/firebowl/standing,
-/turf/open/floor/rogue/blocks,
-/area/rogue/indoors/town/cell)
+/turf/closed/wall/mineral/rogue/pipe/line,
+/area/rogue/under/town/sewer)
 "xtn" = (
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
@@ -96102,7 +96522,7 @@
 	icon_state = "lilypetals2"
 	},
 /turf/open/water/bath,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "xtV" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -96393,14 +96813,8 @@
 /turf/closed/wall/mineral/rogue/decostone/mossy,
 /area/rogue/under/cave/skeletoncrypt)
 "xxR" = (
-/obj/structure/bars/pipe{
-	dir = 1;
-	layer = 2;
-	pixel_x = 10;
-	pixel_y = -10
-	},
-/turf/open/water/bath,
-/area/rogue/under/cavewet)
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
+/area/rogue/indoors/town/bath)
 "xxY" = (
 /obj/machinery/light/rogue/firebowl/off,
 /turf/open/floor/rogue/grass,
@@ -97249,7 +97663,7 @@
 "xHB" = (
 /obj/structure/ladder,
 /turf/open/floor/rogue/cobble,
-/area/rogue/under/town/sewer)
+/area/rogue/indoors/town/bath)
 "xHD" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /obj/structure/flora/roguegrass/bush/wall/tall,
@@ -98722,11 +99136,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
-"ybz" = (
-/obj/structure/plasticflaps,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/rogue/concrete,
-/area/rogue/under/cavewet)
 "ybD" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/leather,
@@ -99232,9 +99641,9 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
 "yhm" = (
-/obj/structure/rack/rogue,
 /obj/item/clothing/shoes/roguetown/boots,
 /obj/item/clothing/shoes/roguetown/boots,
+/obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/sewer)
 "yho" = (
@@ -99251,7 +99660,7 @@
 	pixel_x = 14
 	},
 /turf/open/floor/rogue/church,
-/area/rogue/under/cavewet)
+/area/rogue/indoors/town/bath)
 "yht" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town/rockhill)
@@ -151036,7 +151445,7 @@ whb
 whb
 whb
 whb
-whb
+tcf
 whb
 whb
 whb
@@ -151464,11 +151873,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+ocN
+ocN
+ocN
+eee
+rKx
 whb
 whb
 whb
@@ -151897,16 +152306,16 @@ whb
 whb
 whb
 whb
+ocN
+eee
+eee
 whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
+qRR
+qRR
+qRR
 whb
 whb
 whb
@@ -152331,16 +152740,16 @@ whb
 whb
 whb
 whb
+ptr
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xwE
+qRR
+qRR
+hdY
+vES
+nIe
+qRR
+qRR
 whb
 whb
 whb
@@ -152762,17 +153171,17 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+uEX
+uEX
+xwE
+bjm
+mVl
+cPb
+ojN
+vXL
+vXL
+dEc
+mVl
 whb
 whb
 whb
@@ -153196,15 +153605,15 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xwE
+xwE
+mHF
+fWn
+vXL
+tjg
+njo
+eew
+mVl
 whb
 whb
 whb
@@ -153629,14 +154038,14 @@ cFQ
 dSk
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xwE
+lwZ
+iEX
+jdl
+dsC
+vXL
+iNl
+mVl
 whb
 whb
 whb
@@ -154061,14 +154470,14 @@ asJ
 gUT
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+kCF
+qRR
+nIe
+kvc
+kvc
+naf
+kvc
+qRR
 whb
 whb
 whb
@@ -154494,14 +154903,14 @@ kWV
 mzu
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+mVl
+ozu
+jPI
+jPI
+jPI
+jPI
+bjD
+qRR
 whb
 whb
 whb
@@ -154926,14 +155335,14 @@ bFT
 xeg
 xeg
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+mVl
+hJU
+jPI
+jPI
+jPI
+jPI
+bhV
+mVl
 whb
 whb
 whb
@@ -155358,17 +155767,17 @@ jll
 hUG
 xeg
 xeg
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+mVl
+laS
+jPI
+jPI
+jPI
+jPI
+hkc
+qRR
+rct
+qRR
+rct
 qRR
 rct
 wpu
@@ -155790,18 +156199,18 @@ sFx
 sFx
 sFx
 xeg
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-qRR
+mVl
+nIe
+qdD
+blb
+blb
+izZ
+jPI
+wqT
+xzC
+sFi
+pax
+nIe
 rct
 iXl
 dHo
@@ -156222,17 +156631,17 @@ sFx
 sFx
 sFx
 xeg
-whb
+mVl
 qRR
-qRR
-qRR
-qRR
-whb
-qRR
-qRR
-rct
-qRR
-rct
+bWA
+uAi
+hks
+lrx
+bWA
+nIe
+dKR
+aCi
+ttc
 qRR
 qRR
 eFJ
@@ -156662,9 +157071,9 @@ qRR
 mVl
 qRR
 bMh
-xzC
-sFi
-gne
+kdw
+kdw
+bJx
 rct
 mVl
 cAQ
@@ -157093,10 +157502,10 @@ jfX
 uZs
 mVl
 qRR
-qRR
-dKR
-aCi
-ttc
+nIe
+ufJ
+ufJ
+lus
 rct
 mVl
 pCp
@@ -158388,11 +158797,11 @@ lNK
 pnx
 qRR
 mVl
-pkM
+nIe
 ojQ
 jfX
 jfX
-aPn
+jfX
 jdK
 mVl
 rmv
@@ -158822,7 +159231,7 @@ bWA
 qRR
 mVl
 kmW
-jfX
+pMV
 jfX
 uzk
 qRR
@@ -159257,7 +159666,7 @@ peE
 jfX
 bUS
 xBi
-mVl
+nIe
 mVl
 kZS
 asP
@@ -159684,11 +160093,11 @@ qRR
 yee
 wpn
 mVl
-mVl
+nIe
 ihp
 jfX
 jfX
-jfX
+pox
 mVl
 mVl
 qcz
@@ -160115,7 +160524,7 @@ mVl
 hSV
 yee
 yee
-hSV
+iET
 dww
 nIe
 qKV
@@ -161432,9 +161841,9 @@ gGR
 gGR
 gGR
 isM
-gOi
-gOi
-dId
+gns
+gns
+cgV
 whb
 whb
 whb
@@ -161866,8 +162275,8 @@ fac
 bjz
 yhp
 cRt
-tRJ
-dId
+bjz
+cgV
 whb
 whb
 whb
@@ -162286,11 +162695,11 @@ bWA
 bWA
 qRR
 gns
-ngJ
+gne
 bjz
 gns
-ngJ
-ngJ
+gne
+gne
 bjz
 cgV
 gGR
@@ -162299,7 +162708,7 @@ wxx
 mKf
 hZk
 xtR
-kGM
+gtj
 whb
 whb
 whb
@@ -162728,10 +163137,10 @@ gtj
 gGR
 gtj
 fNt
-fVn
+wpu
 rWD
 hZk
-kGM
+gtj
 whb
 whb
 whb
@@ -163160,10 +163569,10 @@ rCz
 bjz
 bjz
 vGg
-hCX
+ecV
 hZk
 tjy
-kGM
+gtj
 whb
 whb
 whb
@@ -163589,13 +163998,13 @@ xgi
 kdw
 ecV
 bjz
-jdl
+bnf
 nDe
 lUL
-mcL
-mcL
+vaX
+vaX
 uSL
-vvx
+iGo
 whb
 whb
 whb
@@ -163986,8 +164395,8 @@ whb
 whb
 gQh
 kIL
-kYH
-kYH
+pOm
+pOm
 sEj
 gJb
 ddp
@@ -164000,11 +164409,11 @@ vXL
 ocS
 vaX
 qgT
-jfX
-jfX
+asP
+asP
 cQX
 kdw
-rTM
+dps
 qRR
 hbl
 asP
@@ -164014,19 +164423,19 @@ jfX
 jfX
 qRR
 rct
-ufJ
+wFB
 rct
 qRR
 rct
-ufJ
+wFB
 rct
 bjz
 jfX
-tRJ
-tRJ
-gOi
-gOi
-tRJ
+bjz
+bjz
+gns
+gns
+bjz
 whb
 whb
 whb
@@ -164432,9 +164841,9 @@ bWA
 bWA
 bWA
 qRR
-vCf
+ojK
 jfX
-hNV
+dGL
 lcD
 lcD
 qRR
@@ -164849,16 +165258,16 @@ gQh
 gQh
 gQh
 gQh
-kYH
+pOm
 gQh
 gQh
 whb
-dDM
-fJX
-fJX
-fJX
-fJX
-dDM
+daA
+dxP
+dxP
+dxP
+dxP
+daA
 qRR
 aNp
 vdR
@@ -165267,21 +165676,21 @@ whb
 whb
 gQh
 kIL
-kYH
-kYH
-kYH
+pOm
+pOm
+pOm
 bMZ
-kYH
-kYH
-kYH
-kYH
-kYH
-kYH
-kYH
-kYH
-kYH
-myI
-kYH
+pOm
+pOm
+pOm
+pOm
+pOm
+pOm
+pOm
+pOm
+pOm
+bJA
+pOm
 gQh
 whb
 whb
@@ -165298,27 +165707,27 @@ kdw
 cGQ
 jfX
 mym
-oWR
+oGQ
 cUC
-nNv
+myK
 jAb
 uob
-bEp
+uIs
 hnp
 cUC
 wqK
 nAc
 qRR
 tIz
-ufJ
+wFB
 tIz
 qRR
 rct
-ufJ
+wFB
 tIz
 isM
-iPk
-tRJ
+blj
+bjz
 whb
 whb
 whb
@@ -165698,9 +166107,9 @@ lOc
 lOc
 whb
 gQh
-kYH
-kYH
-kYH
+pOm
+pOm
+pOm
 gLB
 gQh
 gQh
@@ -165750,7 +166159,7 @@ kdw
 ecV
 gtj
 ikY
-pJo
+gRQ
 rqt
 ikY
 whb
@@ -166126,12 +166535,12 @@ iQm
 gBq
 gBq
 pEv
-xtk
+lOc
 lOc
 whb
 gQh
 cyJ
-kYH
+pOm
 sEj
 qWQ
 gQh
@@ -166148,9 +166557,9 @@ whb
 whb
 whb
 whb
-dDM
+daA
 faZ
-dDM
+daA
 iFf
 yjj
 yjj
@@ -166170,7 +166579,7 @@ kfv
 wpu
 wpu
 mqO
-nNv
+myK
 jfX
 vPK
 nXJ
@@ -166180,9 +166589,9 @@ vPK
 nXJ
 kdw
 wpu
-wYO
-mxI
-mxI
+iBZ
+xdC
+xdC
 dId
 ikY
 whb
@@ -166557,13 +166966,13 @@ uRf
 fmd
 iQm
 iQm
-pEv
-lOc
-lOc
+wuF
+hys
+kZb
 gQh
 gQh
-kYH
-kYH
+pOm
+pOm
 sEU
 sEj
 gQh
@@ -166587,8 +166996,8 @@ asP
 eFJ
 nQo
 uNi
-dRw
-dDM
+xxR
+daA
 rct
 rct
 qRR
@@ -166611,13 +167020,13 @@ cZt
 vPK
 bOT
 kJN
-xxR
-kGM
+cZt
+gtj
 whb
 whb
 kGM
-iPr
-ihS
+kyW
+qHU
 whb
 whb
 whb
@@ -166992,8 +167401,8 @@ dHW
 iQm
 ihq
 mar
-kYH
-kYH
+pOm
+pOm
 pCP
 gQh
 gQh
@@ -167012,7 +167421,7 @@ ajL
 vqG
 whb
 whb
-dRw
+xxR
 hHr
 lAw
 asP
@@ -167041,8 +167450,8 @@ gns
 gns
 bjz
 gns
-ngJ
-ngJ
+gne
+gne
 bjz
 iGo
 qRR
@@ -167458,14 +167867,14 @@ yjj
 dbS
 jfX
 kgP
-bKh
+jJP
 kfv
 hnp
 grO
 kFp
 hnp
 osw
-fGx
+aCh
 aRM
 jfX
 tVH
@@ -167876,9 +168285,9 @@ deZ
 lOc
 lOc
 whb
-dDM
+daA
 rQm
-dDM
+daA
 kuP
 yjj
 yjj
@@ -168314,12 +168723,12 @@ nQK
 yjj
 yjj
 vPh
-dRw
-dDM
-rcQ
+xxR
+daA
+kwm
 rct
 rct
-alu
+gWi
 tHT
 qRR
 qRR
@@ -168741,7 +169150,7 @@ iQm
 vqG
 whb
 whb
-dDM
+daA
 mNl
 ejG
 iJY
@@ -169173,8 +169582,8 @@ iQm
 lOc
 whb
 whb
-dDM
-dDM
+daA
+daA
 guE
 wpu
 guE
@@ -169207,12 +169616,12 @@ ecV
 wpu
 sRH
 ipI
-hGL
-uAi
-ybz
-uAi
-uAi
-uAi
+omy
+fVn
+gOi
+fVn
+fVn
+fVn
 whb
 whb
 whb
@@ -169606,7 +170015,7 @@ lOc
 whb
 whb
 whb
-dRw
+xxR
 mHZ
 aVV
 lPe
@@ -170038,10 +170447,10 @@ vqG
 whb
 whb
 whb
-dDM
-fJX
-fJX
-dDM
+daA
+dxP
+dxP
+daA
 eFJ
 mHZ
 wpu
@@ -170474,7 +170883,7 @@ whb
 whb
 whb
 whb
-cFp
+mgB
 kXo
 wpu
 bOa
@@ -170906,18 +171315,18 @@ whb
 whb
 whb
 whb
-cFp
+mgB
 wpu
 wpu
-rcQ
-alu
+kwm
+gWi
 gbe
 gbe
 mVl
 pcI
-ogI
-ogI
-ogI
+fqM
+fqM
+fqM
 mVl
 jvZ
 lmJ
@@ -171338,13 +171747,13 @@ whb
 whb
 whb
 whb
-alu
-jfS
-jfS
-jfS
-alu
-jfS
-jfS
+gWi
+mcL
+mcL
+mcL
+gWi
+mcL
+mcL
 qRR
 otv
 kcM
@@ -171778,10 +172187,10 @@ whb
 whb
 whb
 whb
-bjD
+qRR
 kxR
 kxR
-bjD
+qRR
 whb
 mVl
 kAT
@@ -172232,7 +172641,7 @@ whb
 whb
 whb
 whb
-epa
+otU
 rqt
 whb
 whb
@@ -173959,7 +174368,7 @@ whb
 whb
 whb
 rqt
-ihS
+qHU
 whb
 whb
 whb
@@ -176115,7 +176524,7 @@ whb
 whb
 whb
 whb
-gUa
+utN
 whb
 whb
 whb
@@ -176979,7 +177388,7 @@ whb
 whb
 whb
 whb
-ewG
+wNH
 whb
 whb
 whb
@@ -177409,7 +177818,7 @@ whb
 whb
 whb
 whb
-glC
+ogI
 rqt
 rqt
 ikY
@@ -179565,7 +179974,7 @@ whb
 whb
 whb
 whb
-iPr
+kyW
 gRs
 gRs
 gRs
@@ -261625,10 +262034,10 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
+uvY
+eee
+vvx
+eee
 vRu
 vRu
 vRu
@@ -262057,10 +262466,10 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
+eee
+eee
+uEX
+uEX
 vRu
 vRu
 vRu
@@ -262492,7 +262901,7 @@ vRu
 vRu
 vRu
 vRu
-vRu
+sPS
 vRu
 vRu
 vRu
@@ -262923,10 +263332,10 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
+uEX
+uEX
+fZL
+fZL
 vRu
 vRu
 vRu
@@ -263355,13 +263764,13 @@ vRu
 vRu
 vRu
 vRu
+fQu
+pQC
+sPS
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
+fIL
 vRu
 vRu
 vRu
@@ -263787,14 +264196,14 @@ vRu
 vRu
 vRu
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+fZL
+fZL
+fZL
+dau
+kHM
+kHM
+uEX
+mXk
 vRu
 vRu
 vRu
@@ -264214,17 +264623,17 @@ xzp
 rnf
 rnf
 vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
-vRu
+cWU
+eMm
+eMm
+cWU
+eMm
+fIL
+mXk
+mXk
+mXk
+mXk
+fIL
 vRu
 uDH
 uDH
@@ -264646,7 +265055,7 @@ xzp
 xzp
 rnf
 vRu
-vRu
+eMm
 bMj
 pKo
 bMj
@@ -268974,7 +269383,7 @@ ycI
 slx
 mVl
 fdF
-iLj
+pQc
 ggn
 vPK
 bOT
@@ -269407,9 +269816,9 @@ sla
 mVl
 kTh
 pQc
-rFB
+qFk
 pkM
-xdC
+dRw
 sPd
 kdw
 eQv
@@ -269839,9 +270248,9 @@ lyG
 mVl
 wYJ
 pQc
-hlE
+rFB
 dww
-xdC
+dRw
 sPd
 kdw
 eQv
@@ -270285,7 +270694,7 @@ cAc
 pQc
 pQc
 sak
-kjN
+qXc
 feE
 bjz
 ctJ
@@ -271151,7 +271560,7 @@ gPP
 mQe
 idl
 jxQ
-nXf
+bjz
 hFG
 oGO
 rSC
@@ -271583,7 +271992,7 @@ idl
 idl
 idl
 xHB
-rRb
+scK
 oGO
 rSC
 lrs
@@ -272014,8 +272423,8 @@ xQX
 idl
 wwF
 idl
-gMO
-nXf
+bQb
+bjz
 fZL
 jaY
 uEX
@@ -272432,10 +272841,10 @@ csO
 qRR
 bng
 bWA
-upu
+haA
 bWA
 bWA
-xdC
+dRw
 bWA
 fwH
 bWA
@@ -272447,7 +272856,7 @@ scK
 scK
 scK
 uCg
-rRb
+scK
 hJH
 uun
 uEX
@@ -273726,10 +274135,10 @@ xWK
 xHs
 lyG
 mVl
-pKf
-eOc
+fcM
+bXx
 mom
-bMi
+emL
 jfX
 vPK
 xrZ
@@ -277189,8 +277598,8 @@ rct
 bWA
 qRR
 bWA
-upu
-upu
+haA
+haA
 bWA
 qRR
 iWT
@@ -284964,7 +285373,7 @@ vyv
 hOw
 xdp
 fXe
-rRb
+iLj
 gLf
 rSC
 rSC
@@ -291889,7 +292298,7 @@ rRb
 bbx
 gMO
 rRb
-otg
+rRb
 otg
 hFG
 voO
@@ -292320,7 +292729,7 @@ ibB
 aKd
 jbj
 nnJ
-rRb
+dtO
 rRb
 iCS
 rRb
@@ -294903,7 +295312,7 @@ pEv
 pUC
 pmJ
 gUg
-gUg
+ueL
 ueL
 dSs
 uzG
@@ -295342,7 +295751,7 @@ rRb
 rRb
 iyZ
 lDm
-qFk
+hXj
 pjr
 hpc
 cjs
@@ -295781,7 +296190,7 @@ utj
 abS
 pAd
 utj
-utj
+rWT
 rRb
 lrs
 rSC
@@ -296214,11 +296623,11 @@ bJj
 rEg
 kjP
 xsI
-lrs
-lrs
+lNl
+xtk
 rQO
-lrs
-lrs
+xtk
+xtk
 ugy
 aeQ
 woQ
@@ -296646,7 +297055,7 @@ abS
 qUs
 cao
 vBv
-lrs
+lRp
 lrs
 kdN
 lrs
@@ -297078,7 +297487,7 @@ vbY
 rEg
 kjP
 kjP
-lrs
+lRp
 lrs
 kdN
 lrs
@@ -297510,8 +297919,8 @@ abS
 lYr
 lYr
 vQR
-lrs
-lrs
+dnW
+gri
 kdN
 lrs
 lrs
@@ -303117,9 +303526,9 @@ qeC
 vKd
 qeC
 vKd
-qeC
 vKd
-qeC
+vKd
+vKd
 vKd
 qeC
 vKd
@@ -303549,9 +303958,9 @@ euP
 aBv
 euP
 idK
-euP
-euP
-euP
+vKd
+vKd
+vKd
 idK
 euP
 aBv
@@ -303981,9 +304390,9 @@ euP
 sde
 euP
 euP
-euP
-euP
-euP
+fJX
+vYK
+vKd
 snX
 euP
 uUT
@@ -304413,10 +304822,10 @@ euP
 meJ
 euP
 euP
-euP
-euP
-euP
-euP
+fJX
+vKd
+vKd
+snX
 euP
 meJ
 euP
@@ -304844,11 +305253,11 @@ euP
 euP
 msN
 euP
-euP
-euP
-euP
-euP
-euP
+idK
+hCX
+iLk
+hCX
+idK
 euP
 msN
 euP
@@ -635429,7 +635838,7 @@ gtm
 pHj
 uKJ
 mot
-pEc
+aQf
 pEc
 dMS
 qCD

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -921,6 +921,11 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
+"alg" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_line"
+	},
+/area/rogue/under/town/sewer)
 "all" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -1591,7 +1596,7 @@
 /obj/structure/roguemachine/scomm/l{
 	scom_tag = "Bath House - Mess Hall"
 	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "auq" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -2911,11 +2916,45 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "aKd" = (
-/obj/structure/closet/crate/chest/old_crate,
-/obj/structure/fluff/walldeco/customflag{
-	pixel_y = 32
+/obj/item/roguekey/roomi{
+	lockid = "rd1";
+	name = "rogue den room I key"
 	},
-/turf/open/floor/rogue/blocks,
+/obj/item/roguekey/roomi{
+	lockid = "rd1";
+	name = "rogue den room I key"
+	},
+/obj/item/roguekey/roomi{
+	lockid = "rd2";
+	name = "rogue den room II key"
+	},
+/obj/item/roguekey/roomi{
+	lockid = "rd2";
+	name = "rogue den room II key"
+	},
+/obj/item/roguekey/roomi{
+	lockid = "rdmain";
+	name = "rogue den backroom key"
+	},
+/obj/item/roguekey/roomi{
+	lockid = "rdmain";
+	name = "rogue den backroom key"
+	},
+/obj/item/roguekey{
+	desc = "This old key opens the peddler for the local lowtown eatery.";
+	icon_state = "brownkey";
+	lockid = "rdpeddlar";
+	name = "rogue den peddlar key";
+	pixel_x = -7
+	},
+/obj/item/roguekey{
+	desc = "This old key opens the peddler for the local lowtown eatery.";
+	icon_state = "brownkey";
+	lockid = "rdpeddlar";
+	name = "rogue den peddlar key";
+	pixel_x = -7
+	},
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/town/sewer)
 "aKf" = (
 /obj/structure/fluff/railing/border{
@@ -3437,9 +3476,6 @@
 /area/rogue/outdoors/bograt/above)
 "aQE" = (
 /obj/structure/ladder,
-/obj/structure/bars/grille{
-	dir = 8
-	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
 "aQF" = (
@@ -3947,8 +3983,8 @@
 	mailtag = "Whitevein"
 	},
 /obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable"
+	dir = 10;
+	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
@@ -4295,6 +4331,40 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/beach/harbor)
+"bbx" = (
+/obj/structure/closet/crate/roguecloset/dark,
+/obj/machinery/light/rogue/candle/blue,
+/obj/item/reagent_containers/glass/cup/tin/small,
+/obj/item/reagent_containers/glass/cup/tin/small,
+/obj/item/reagent_containers/glass/cup/tin/small,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/reagent_containers/glass/cup/wooden,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/cooking/platter,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/spoon,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/kitchen/fork,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "bby" = (
 /obj/structure/table/wood/poor,
 /obj/item/toy/cards/deck,
@@ -4563,7 +4633,7 @@
 "beZ" = (
 /obj/structure/bars/passage/shutter{
 	name = "Escape Route";
-	redstone_id = "night_escape"
+	redstone_id = "rd_escape"
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
@@ -5168,10 +5238,10 @@
 /turf/open/floor/rogue/dirt/nospawn,
 /area/rogue/outdoors/bogsafe)
 "bnf" = (
-/obj/structure/table/wood{
-	icon_state = "longtable"
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 4
 	},
-/obj/structure/rack/rogue/shelf,
+/obj/structure/fluff/wallclock,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "bng" = (
@@ -5599,7 +5669,7 @@
 "btc" = (
 /obj/structure/chair/stool/rogue,
 /obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/candle/blue,
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "btf" = (
@@ -7336,6 +7406,10 @@
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/roofs/keep)
+"bOT" = (
+/obj/structure/chair/bench/couchamagenta/r,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "bOW" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -8054,6 +8128,9 @@
 "bWx" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bogsafe)
+"bWA" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/indoors/town/bath)
 "bWE" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	locked = 1
@@ -8315,6 +8392,7 @@
 /obj/effect/decal/cleanable/dirt/cobweb{
 	dir = 1
 	},
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "cau" = (
@@ -9727,6 +9805,11 @@
 /obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/mountains)
+"cro" = (
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/closed,
+/area/rogue/indoors/town/bath)
 "crA" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/hexstone,
@@ -14013,6 +14096,16 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
+"dqX" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 8
+	},
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "drd" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mudcrab,
 /turf/open/floor/rogue/dirt,
@@ -14432,6 +14525,15 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/warden)
+"dww" = (
+/obj/structure/chair/bench/couchamagenta,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "dwz" = (
 /obj/machinery/light/rogue/firebowl/standing/green,
 /turf/open/floor/rogue/concrete{
@@ -15049,6 +15151,7 @@
 /obj/structure/bed/rogue{
 	dir = 1
 	},
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "dEr" = (
@@ -16232,9 +16335,16 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
 "dSs" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
-/turf/open/floor/rogue/dirt,
+/obj/structure/mineral_door/wood/donjon{
+	lockid = "rdmain";
+	locked = 1;
+	name = "escape door"
+	},
+/obj/structure/bars/passage/shutter{
+	name = "escape route";
+	redstone_id = "rd_escape"
+	},
+/turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "dSu" = (
 /obj/item/reagent_containers/glass/cup/silver/small,
@@ -16675,6 +16785,7 @@
 	redstone_id = "whitevein_desk"
 	},
 /obj/machinery/light/rogue/candle/blue/r,
+/obj/machinery/light/rogue/candle/floorcandle/pink,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "dYP" = (
@@ -17638,6 +17749,10 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/exposed/town/keep)
+"ejY" = (
+/obj/structure/closet/crate/roguecloset/dark,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "ekg" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /obj/item/storage/roguebag,
@@ -20063,6 +20178,12 @@
 /obj/item/reagent_containers/food/snacks/rogue/friedrat,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
+"eOx" = (
+/obj/structure/chair/wood/rogue/chair5{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "eOB" = (
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
@@ -20240,12 +20361,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "eQv" = (
-/obj/structure/mineral_door/wood/red{
-	locked = 1;
-	lockid = "nightmaiden";
-	name = "Employee Lounge"
+/obj/structure/stairs/stone{
+	dir = 1
 	},
-/turf/open/floor/rogue/churchrough,
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "eQK" = (
 /turf/open/floor/rogue/blocks,
@@ -20909,6 +21029,31 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
+"eZc" = (
+/obj/structure/closet/crate/roguecloset/dark,
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/paper{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/natural/feather,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "eZe" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "street_shop01";
@@ -21250,6 +21395,15 @@
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
+"fdF" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/structure/mirror,
+/obj/item/azure_lipstick/black,
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "fdM" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/indoors/town/manor/rockhill)
@@ -21311,6 +21465,9 @@
 /obj/structure/bondage/torture_table/lever,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/dungeon1)
+"feE" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
+/area/rogue/under/town/sewer)
 "feF" = (
 /obj/structure/table/wood/long_table/right,
 /obj/effect/spawner/lootdrop/valuable_candle_spawner,
@@ -25551,6 +25708,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/harbor)
+"gga" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/sewer)
 "ggb" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8;
@@ -25583,6 +25746,15 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor/rockhill)
+"ggn" = (
+/obj/structure/closet/crate/roguecloset,
+/obj/effect/decal/carpet/kover_darkred{
+	dir = 8;
+	pixel_x = 15;
+	pixel_y = 17
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "ggu" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -26156,7 +26328,6 @@
 /turf/open/water/bath,
 /area/rogue/indoors/town/church)
 "gnR" = (
-/obj/effect/spawner/lootdrop/roguetown/sewers,
 /obj/structure/closet/crate/roguecloset/dark,
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
@@ -27030,6 +27201,16 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/town/grove)
+"gzz" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable";
+	name = "Massage Table"
+	},
+/obj/structure/mirror,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "gzD" = (
 /obj/structure/closet/crate/roguecloset/dark,
 /obj/structure/curtain/magenta,
@@ -27992,6 +28173,13 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/beach/harbor)
+"gMu" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/item/natural/glass_shard,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "gME" = (
 /obj/structure/rack/rogue,
 /obj/item/quiver/sling/iron,
@@ -30294,6 +30482,12 @@
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark/rockhill/west)
+"hpc" = (
+/obj/structure/roguemachine/vendor{
+	keycontrol = "rdpeddlar"
+	},
+/turf/closed/wall/mineral/rogue/wooddark/window,
+/area/rogue/under/town/sewer)
 "hpj" = (
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/garrison)
@@ -31408,6 +31602,11 @@
 /obj/structure/bars/cemetery,
 /turf/open/water/swamp,
 /area/rogue/outdoors/bograt/sunken)
+"hEa" = (
+/obj/structure/table/wood/poor,
+/obj/machinery/light/rogue/candle/blue/l,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/sewer)
 "hEd" = (
 /obj/structure/bearpelt{
 	pixel_x = -13;
@@ -33023,7 +33222,10 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/beach/harbor)
 "hXj" = (
-/turf/closed/wall/mineral/rogue/wooddark/window,
+/obj/structure/roguewindow/harem3{
+	opacity = 1
+	},
+/turf/closed,
 /area/rogue/under/town/sewer)
 "hXp" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
@@ -33370,6 +33572,10 @@
 /obj/structure/fluff/walldeco/maidendrape,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement)
+"ibB" = (
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/sewer)
 "ibE" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle/dir4,
 /area/rogue/indoors/inq/office)
@@ -35121,6 +35327,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"iBH" = (
+/obj/structure/chair/stool/rogue{
+	pixel_y = -2
+	},
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "iBJ" = (
 /obj/machinery/light/rogue/candle/off,
 /turf/open/floor/rogue/cobble,
@@ -37100,6 +37313,10 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/manor/rockhill)
+"jbj" = (
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/blocks,
+/area/rogue/under/town/sewer)
 "jbr" = (
 /obj/item/storage/roguebag,
 /obj/item/storage/roguebag,
@@ -39467,6 +39684,20 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/church/chapel)
+"jEN" = (
+/obj/structure/chair/wood/rogue/chair5,
+/obj/structure/roguemachine/mail{
+	mailtag = "Rogue's Den"
+	},
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/cobweb,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/sewer)
 "jEO" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/water/bath,
@@ -39832,6 +40063,17 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
+"jJq" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/obj/effect/decal/carpet/kover_darkred{
+	dir = 8;
+	pixel_x = 15;
+	pixel_y = 17
+	},
+/turf/open/floor/rogue/ruinedwood/turned,
+/area/rogue/under/town/sewer)
 "jJu" = (
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/ruinedwood/chevron,
@@ -40293,6 +40535,11 @@
 	dir = 4;
 	locked = 1;
 	lockid = "nightmaiden"
+	},
+/obj/structure/curtain/magenta{
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
@@ -44660,6 +44907,15 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cave/goblinfort)
+"kSf" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 31
+	},
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "kSl" = (
 /obj/structure/flora/roguegrass/swampweed,
 /turf/open/floor/rogue/grass,
@@ -44727,6 +44983,16 @@
 /area/rogue/indoors/town/cell{
 	warden_area = 1
 	})
+"kTh" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable";
+	name = "Massage Table"
+	},
+/obj/structure/mirror,
+/obj/item/alch/rosa,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "kTj" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/rogue/meat_rotten,
@@ -44813,6 +45079,12 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
+"kUa" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "kUf" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -46836,6 +47108,11 @@
 "lwm" = (
 /turf/open/floor/rogue/hay,
 /area/rogue/outdoors/exposed/town/keep)
+"lwr" = (
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "lwu" = (
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "vertw"
@@ -47278,6 +47555,13 @@
 "lDc" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/outdoors/town/rockhill)
+"lDm" = (
+/obj/structure/roguewindow/harem3{
+	opacity = 1
+	},
+/obj/machinery/light/rogue/candle/red,
+/turf/open/floor/rogue/tile,
+/area/rogue/under/town/sewer)
 "lDE" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -48061,6 +48345,7 @@
 	lockid = "nightmaiden";
 	name = "Employees Only"
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "lME" = (
@@ -49674,9 +49959,9 @@
 /area/rogue/outdoors/town/rockhill)
 "mgl" = (
 /obj/structure/table/wood/long_table,
-/obj/machinery/light/rogue/candle/blue,
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/item/kitchen/rollingpin,
+/obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "mgx" = (
@@ -50129,6 +50414,10 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/basement)
+"mkY" = (
+/obj/structure/fluff/pillow/magenta,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "mle" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -50711,9 +51000,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "mrD" = (
-/obj/structure/flora/roguegrass/swampweed,
-/turf/open/water/swamp,
-/area/rogue/under/town/sewer)
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
+/area/rogue/indoors/town/bath)
 "mrH" = (
 /obj/machinery/light/rogue/torchholder/hotspring,
 /turf/open/floor/rogue/grassyel,
@@ -52386,6 +52674,7 @@
 	lockid = "nightmaiden";
 	name = "Dressing Room"
 	},
+/obj/structure/curtain/magenta,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "mLV" = (
@@ -54457,7 +54746,12 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
 "nnJ" = (
-/obj/structure/bed/rogue/shit,
+/obj/machinery/light/rogue/candle/blue{
+	pixel_y = -32
+	},
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "nnM" = (
@@ -55270,6 +55564,12 @@
 /obj/item/natural/bundle/cloth/bandage,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/shelter/woodsrat)
+"nxG" = (
+/obj/structure/chair/stool/rogue{
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "nxH" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -56035,8 +56335,12 @@
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/woodsrat/above)
 "nIe" = (
-/turf/closed/wall/mineral/rogue/decostone/cand,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/under/town/sewer)
+"nIo" = (
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "nIw" = (
 /obj/structure/rack/rogue/shelf/big{
 	icon_state = "shelf_biggest";
@@ -56705,8 +57009,9 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "nQT" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 8
+/obj/structure/mineral_door/wood{
+	lockid = "rd1";
+	name = "room 1"
 	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
@@ -57367,6 +57672,14 @@
 	icon_state = "plating2"
 	},
 /area/rogue/outdoors/beach/harbor)
+"nXJ" = (
+/obj/structure/chair/bench/couchamagenta,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "nXL" = (
 /obj/structure/table/church/m,
 /obj/item/clothing/neck/roguetown/psicross/noc{
@@ -59362,6 +59675,15 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/shelter/mountains)
+"owS" = (
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Employees Only"
+	},
+/obj/structure/curtain/magenta,
+/turf/closed,
+/area/rogue/indoors/town/bath)
 "oxd" = (
 /obj/structure/closet/crate/roguecloset{
 	keylock = 1;
@@ -59578,6 +59900,10 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"ozR" = (
+/obj/machinery/light/rogue/candle/blue,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "ozS" = (
 /turf/closed/wall/mineral/rogue/decostone/end{
 	dir = 8
@@ -62067,8 +62393,9 @@
 /area/rogue/indoors/town/shop)
 "pfC" = (
 /obj/structure/closet/crate/chest/old_crate,
-/obj/structure/table/wood/large_table/middle_west,
-/obj/effect/spawner/lootdrop/roguetown/sewers,
+/obj/item/millstone,
+/obj/item/reagent_containers/glass/bucket/pot,
+/obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "pfF" = (
@@ -62360,6 +62687,7 @@
 /area/rogue/outdoors/exposed/town/keep)
 "pjr" = (
 /obj/structure/mineral_door/swing_door,
+/obj/structure/curtain/black,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "pjs" = (
@@ -63205,6 +63533,12 @@
 /obj/structure/plasticflaps,
 /turf/open/water/swamp,
 /area/rogue/under/town/sewer)
+"pty" = (
+/obj/structure/roguemachine/scomm{
+	scom_tag = "Rogue's Den Office"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/sewer)
 "ptA" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -63326,6 +63660,13 @@
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church)
+"pva" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "pvc" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
 	dir = 1
@@ -63616,6 +63957,11 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/dwarfin/rockhill)
+"pzk" = (
+/obj/structure/chair/bench/couchamagenta/r,
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "pzl" = (
 /obj/structure/mineral_door/wood/violet{
 	chat_color_name = "room";
@@ -65355,6 +65701,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
+"pUJ" = (
+/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
+/obj/structure/spider/stickyweb,
+/turf/open/water/swamp,
+/area/rogue/under/town/sewer)
 "pUK" = (
 /obj/structure/flora/newtree,
 /turf/open/floor/rogue/dirt,
@@ -67282,6 +67633,9 @@
 	icon_state = "roofg"
 	},
 /area/rogue/outdoors/rtfield/rockhill/above)
+"qur" = (
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/under/town/sewer)
 "qut" = (
 /obj/structure/table/wood,
 /obj/structure/bars/shop,
@@ -68185,7 +68539,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/cave/rhgoblinencampment)
 "qFk" = (
-/obj/structure/roguewindow/harem3,
+/obj/structure/roguewindow/harem3{
+	opacity = 1
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "qFr" = (
@@ -68574,6 +68930,15 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/town/grove)
+"qKT" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable";
+	name = "Massage Table"
+	},
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "qKU" = (
 /obj/structure/bars/steel,
 /turf/open/floor/rogue/cobblerock,
@@ -68833,7 +69198,7 @@
 	pixel_x = 2;
 	pixel_y = -1
 	},
-/turf/open/floor/rogue/dirt/road,
+/turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "qNe" = (
 /obj/structure/flora/rogueshroom,
@@ -69121,6 +69486,9 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/shop)
+"qRR" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/indoors/town/bath)
 "qSd" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -70775,6 +71143,19 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/rockhill)
+"rpV" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -32
+	},
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
+	},
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "rqa" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp,
@@ -71712,6 +72093,14 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet/wizarddungeon)
+"rBQ" = (
+/obj/structure/curtain/black,
+/obj/structure/mineral_door/wood{
+	lockid = "rdmain";
+	name = "bedroom"
+	},
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/town/sewer)
 "rBV" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/wood,
@@ -72019,6 +72408,10 @@
 "rFu" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/underdark/rockhill)
+"rFB" = (
+/obj/structure/closet/crate/roguecloset,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "rFK" = (
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/blocks,
@@ -72106,7 +72499,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/underdark/rockhill/west)
 "rHd" = (
-/obj/structure/fermentation_keg/random/water,
+/obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "rHl" = (
@@ -73112,6 +73505,11 @@
 /obj/item/reagent_containers/powder/starsugar,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/inq/basement)
+"rUt" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
+	dir = 1
+	},
+/area/rogue/indoors/town/bath)
 "rUv" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -73966,7 +74364,7 @@
 /obj/structure/bars/grille{
 	dir = 8
 	},
-/obj/machinery/light/rogue/candle/blue/r,
+/obj/machinery/light/rogue/candle/red,
 /turf/open/transparent/openspace,
 /area/rogue/under/town/sewer)
 "sfb" = (
@@ -74691,6 +75089,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/garrison)
+"snX" = (
+/obj/structure/lever/wall{
+	redstone_id = "rd_escape"
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/beach/harbor)
 "snY" = (
 /obj/structure/chair/wood/rogue/fancy{
 	dir = 8
@@ -75471,6 +75875,13 @@
 	icon_state = "glowshroom2"
 	},
 /turf/open/floor/rogue/blocks/paving,
+/area/rogue/under/town/sewer)
+"syY" = (
+/obj/structure/curtain/black,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
 "syZ" = (
 /obj/structure/flora/roguetree/pine,
@@ -76807,6 +77218,10 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
+"sPd" = (
+/obj/machinery/light/rogue/candle/floorcandle/pink,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "sPm" = (
 /obj/item/rope/chain,
 /turf/open/floor/rogue/naturalstone,
@@ -77262,6 +77677,13 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"sVJ" = (
+/obj/machinery/light/rogue/candle/blue,
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "sVK" = (
 /obj/structure/mineral_door/wood{
 	locked = 1;
@@ -78890,6 +79312,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/harbor)
+"tpn" = (
+/obj/structure/table/wood{
+	icon_state = "longtable";
+	name = "Massage Table"
+	},
+/obj/structure/mirror,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "tpx" = (
 /obj/structure/table/wood/poor,
 /obj/structure/fluff/walldeco/rpainting{
@@ -79951,6 +80381,10 @@
 /obj/structure/closet/dirthole/grave,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave/goblinfort)
+"tDl" = (
+/obj/structure/roguewindow/harem3,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/under/town/sewer)
 "tDq" = (
 /obj/structure/roguewindow/openclose,
 /turf/open/floor/rogue/wood,
@@ -80633,26 +81067,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/warden)
 "tMf" = (
-/obj/structure/closet/crate/roguecloset/dark,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/book/rogue/cooking,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/spoon,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/kitchen/fork,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/item/cooking/platter,
-/obj/effect/decal/cleanable/dirt/cobweb{
-	dir = 1
+/obj/structure/curtain/black,
+/obj/structure/mineral_door/wood{
+	lockid = "rdmain";
+	name = "office"
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "tMg" = (
 /obj/structure/table/wood/poor,
@@ -82722,6 +83142,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/exposed/town/keep)
+"umj" = (
+/obj/structure/closet/crate/roguecloset/inn/chest,
+/obj/effect/decal/carpet/kover_darkred{
+	dir = 8;
+	pixel_x = 15;
+	pixel_y = 17
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "umm" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/naturalstone,
@@ -83634,6 +84063,10 @@
 /obj/effect/landmark/start/nightman,
 /obj/effect/landmark/start/nightman,
 /obj/effect/landmark/start/nightman,
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "uwX" = (
@@ -83830,6 +84263,17 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/tavern)
+"uzG" = (
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/obj/structure/lever/wall{
+	dir = 4;
+	name = "escape shutters";
+	redstone_id = "rd_escape"
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "uzI" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/water/swamp/deep,
@@ -85020,6 +85464,9 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors)
+"uQa" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/under/town/sewer)
 "uQm" = (
 /obj/structure/fluff/walldeco/customflag/rockhill,
 /turf/closed/wall/mineral/rogue/stone,
@@ -86582,10 +87029,12 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/manor/rockhill)
 "vkD" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 8
+/obj/structure/curtain/black,
+/obj/structure/mineral_door/wood{
+	lockid = "rdmain";
+	name = "backroom"
 	},
-/turf/open/floor/rogue/blocks,
+/turf/open/floor/rogue/concrete,
 /area/rogue/under/town/sewer)
 "vkO" = (
 /obj/structure/stairs/stone{
@@ -87214,8 +87663,7 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
 "vsL" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/fermentation_keg/random/beer,
+/obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/sewer)
 "vsN" = (
@@ -87549,6 +87997,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/mountains/decap/rockhill)
+"vwA" = (
+/obj/structure/chair/wood/rogue/chair5,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "vwB" = (
 /turf/open/floor/rogue/woodturned,
 /area/rogue/outdoors/beach/harbor)
@@ -87794,6 +88246,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
+"vzL" = (
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable";
+	name = "Massage Table"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "vzO" = (
 /obj/structure/fluff/wallclock{
 	pixel_x = -1
@@ -88939,8 +89399,11 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vPK" = (
-/obj/structure/roguewindow/harem2,
-/turf/closed/wall/mineral/rogue/stonebrick,
+/obj/structure/roguewindow/harem1,
+/obj/structure/drape/zybantine,
+/turf/closed/wall/mineral/rogue/decostone/long{
+	dir = 1
+	},
 /area/rogue/indoors/town/bath)
 "vPM" = (
 /obj/structure/rack/rogue,
@@ -89271,6 +89734,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/beach/harbor)
+"vUb" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "vUh" = (
 /obj/structure/fluff/railing/border{
 	dir = 10;
@@ -90259,6 +90728,13 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue)
+"whD" = (
+/obj/structure/bed/rogue/shit,
+/obj/effect/decal/cleanable/debris/woody{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/town/sewer)
 "whG" = (
 /obj/structure/fluff/walldeco/vinez/blue,
 /turf/closed/mineral/rogue,
@@ -90528,6 +91004,11 @@
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
+"wkZ" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	icon_state = "iron_corner"
+	},
+/area/rogue/under/town/sewer)
 "wle" = (
 /obj/structure/fluff/traveltile{
 	aportalgoesto = "gobdun1";
@@ -93640,7 +94121,6 @@
 /obj/effect/decal/cleanable/debris/woody{
 	dir = 1
 	},
-/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/town/sewer)
 "wXi" = (
@@ -93763,6 +94243,7 @@
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_y = 32
 	},
+/obj/item/roguebin/water,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "wYS" = (
@@ -95244,8 +95725,9 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "xsI" = (
-/obj/structure/mineral_door/wood/deadbolt{
-	dir = 4
+/obj/structure/mineral_door/wood{
+	name = "room 2";
+	lockid = "rd2"
 	},
 /turf/open/floor/rogue/tile/brownbrick,
 /area/rogue/under/town/sewer)
@@ -182193,7 +182675,7 @@ oNE
 iFM
 whb
 whb
-whb
+eQK
 whb
 sjG
 rHO
@@ -267288,15 +267770,15 @@ iyZ
 rRb
 beZ
 iyZ
-dWF
-dWF
-rRb
-dWF
+feE
+uQa
+uQa
+uQa
 nIe
-scK
-nvH
-nvH
-nvH
+bWA
+bWA
+bWA
+rUt
 iyZ
 iyZ
 iyZ
@@ -267720,15 +268202,15 @@ eFJ
 uAi
 jOU
 uAi
-eFJ
-pQc
+cro
+dww
 aum
-pQc
-pQc
-pQc
-pQc
-pQc
-scK
+rpV
+lwr
+vUb
+iBH
+nIo
+rhw
 cAc
 cAc
 cAc
@@ -268149,17 +268631,17 @@ aDi
 ycI
 slx
 rhw
-pQc
+fdF
 iLj
-pQc
+ggn
 vPK
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
+bOT
+kdw
+mkY
+lwr
+vzL
+nxG
+kdw
 qut
 cAc
 cAc
@@ -268581,17 +269063,17 @@ fIA
 osR
 sla
 rhw
+kTh
 pQc
-pQc
-pQc
-vPK
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
+rFB
+mrD
+rUt
+sPd
+kdw
+eQv
+kdw
+kdw
+kdw
 qut
 cAc
 cAc
@@ -269015,16 +269497,16 @@ lyG
 rhw
 wYJ
 pQc
-pQc
-scK
-wYJ
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
-scK
+rFB
+mrD
+rUt
+sPd
+kdw
+eQv
+kdw
+kdw
+kdw
+rhw
 cAc
 cAc
 cAc
@@ -269445,17 +269927,17 @@ uzF
 hSA
 eGj
 rhw
+tpn
 pQc
-pQc
-pQc
+umj
 vPK
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
+nXJ
+kdw
+dqX
+lwr
+vwA
+vUb
+kdw
 xoa
 cAc
 cAc
@@ -269877,18 +270359,18 @@ xWK
 aZr
 gIO
 rhw
-pQc
+gzz
 pQc
 pQc
 vPK
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
-pQc
-scK
+pzk
+kdw
+kSf
+lwr
+vwA
+qKT
+eOx
+eFJ
 rRb
 jSA
 rRb
@@ -270312,15 +270794,15 @@ eFJ
 eFJ
 scK
 mLT
-scK
-scK
-scK
-scK
-eQv
-scK
-scK
-scK
-scK
+qRR
+uAi
+owS
+uAi
+uAi
+uAi
+uAi
+uAi
+eFJ
 cAc
 cAc
 cAc
@@ -271175,7 +271657,7 @@ nAB
 csO
 rhw
 aWD
-pQc
+ejY
 pQc
 pQc
 pQc
@@ -277225,7 +277707,7 @@ lct
 vuV
 aFT
 flB
-xZo
+jJq
 meU
 wvM
 dWF
@@ -290628,11 +291110,11 @@ udz
 rRb
 rSC
 rSC
-lrs
+alg
+alg
+alg
+wkZ
 rRb
-ocN
-ocN
-otg
 otg
 otg
 otg
@@ -291057,13 +291539,13 @@ nXf
 mnj
 rSC
 udz
-rSC
-rSC
-lrs
+iyZ
+iyZ
+iyZ
 rRb
 rRb
-rRb
-lrs
+bbx
+gMO
 rRb
 otg
 otg
@@ -291489,12 +291971,12 @@ lrs
 ueL
 gUg
 gUg
-uEX
-lrs
-lrs
-rRb
+iyZ
+jEN
+hEa
+ibB
 aKd
-crg
+jbj
 nnJ
 rRb
 rRb
@@ -291921,10 +292403,10 @@ gUg
 gUg
 rSC
 rSC
-fIL
-lrs
-lrs
-lrs
+iyZ
+pty
+qur
+gga
 tMf
 crg
 vsL
@@ -292353,9 +292835,9 @@ udz
 rSC
 rSC
 rSC
-uEX
-lrs
-lrs
+iyZ
+rBQ
+tDl
 rRb
 rRb
 vkD
@@ -292785,12 +293267,12 @@ gYE
 fZL
 uEX
 rRb
-rRb
-rRb
-lrs
+iyZ
+sVJ
+eZc
 rRb
 pfC
-hHp
+kUa
 rHd
 hXj
 bnG
@@ -293217,9 +293699,9 @@ hoW
 hTE
 hTE
 nXf
-mrD
 rRb
-lrs
+syY
+tDl
 rRb
 mgl
 hHp
@@ -293647,15 +294129,15 @@ pEv
 pUC
 gUg
 fIL
-uEX
-pYo
 fIL
+pYo
 rRb
-lrs
+ozR
+gMu
 rRb
 jnz
 rme
-hHp
+kUa
 emE
 lRr
 bTH
@@ -294078,20 +294560,20 @@ gLU
 pEv
 pUC
 pmJ
-uEX
-uEX
-uEX
+gUg
+gUg
+ueL
 dSs
+uzG
+whD
 rRb
-lrs
-lrs
 qNc
 sCc
 hHp
 hKJ
 lRr
 bTH
-rEg
+qUs
 dEf
 gnR
 rRb
@@ -294511,16 +294993,16 @@ pUC
 pUC
 gUg
 xPb
-ocN
-uEX
 eee
+fZL
 rRb
-lrs
-lrs
-qFk
+rRb
+rRb
+iyZ
+lDm
 qFk
 pjr
-hXj
+hpc
 cjs
 abS
 rEg
@@ -294944,10 +295426,10 @@ jyI
 gUg
 qPM
 ueL
-jaY
+pUJ
 eee
 rRb
-lrs
+qUs
 wXg
 tby
 iMI
@@ -295811,13 +296293,13 @@ euP
 euP
 rRb
 dWF
-lrs
+qUs
 jPD
 jPD
 utj
 iMI
 utj
-iMI
+pva
 abS
 qUs
 cao
@@ -296243,8 +296725,8 @@ euP
 euP
 euP
 dWF
-lrs
 rEg
+kjP
 rEg
 jPD
 jlj
@@ -299701,7 +300183,7 @@ euP
 euP
 euP
 euP
-lrs
+alg
 lrs
 lrs
 lrs
@@ -303160,7 +303642,7 @@ euP
 euP
 euP
 euP
-euP
+snX
 euP
 uUT
 euP

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -112,15 +112,9 @@
 	},
 /area/rogue/outdoors/town/roofs)
 "abd" = (
-/obj/structure/chair/stool/rogue,
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = 8;
-	dir = 1
-	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/obj/structure/bars/steel,
+/turf/closed/wall/mineral/rogue/stonebrick,
+/area/rogue/under/town/sewer)
 "abl" = (
 /obj/machinery/light/rogue/chand,
 /turf/open/transparent/openspace,
@@ -1594,14 +1588,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
 "aum" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 4;
-	pixel_x = 5
-	},
 /obj/structure/roguemachine/scomm/l{
 	scom_tag = "Bath House - Mess Hall"
 	},
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "auq" = (
 /obj/structure/fluff/railing/corner/north_east,
@@ -2804,10 +2794,6 @@
 	dir = 1
 	},
 /area/rogue/outdoors/town/roofs)
-"aIu" = (
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "aIy" = (
 /obj/structure/fluff/pillow/magenta{
 	dir = 8;
@@ -3957,30 +3943,13 @@
 /turf/open/floor/rogue/snowrough,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "aWD" = (
-/obj/item/cooking/platter/pewter,
-/obj/item/cooking/platter/pewter,
-/obj/item/cooking/platter/pewter,
-/obj/item/cooking/platter/pewter,
-/obj/item/reagent_containers/glass/bowl/iron,
-/obj/item/reagent_containers/glass/bowl/iron,
-/obj/item/reagent_containers/glass/bowl/iron,
-/obj/item/reagent_containers/glass/bowl/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/spoon/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/kitchen/fork/iron,
-/obj/item/cooking/pan,
-/obj/item/flint,
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
+/obj/structure/roguemachine/mail{
+	mailtag = "Whitevein"
 	},
-/obj/structure/closet/crate/roguecloset/inn,
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "longtable"
+	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "aWF" = (
@@ -5198,6 +5167,13 @@
 /obj/structure/flora/roguetree,
 /turf/open/floor/rogue/dirt/nospawn,
 /area/rogue/outdoors/bogsafe)
+"bnf" = (
+/obj/structure/table/wood{
+	icon_state = "longtable"
+	},
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "bng" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
 	dir = 8
@@ -5748,6 +5724,10 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
+"buy" = (
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/sewer)
 "buE" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -8498,15 +8478,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/underdarker/rockhill)
-"ccW" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "cdc" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9127,9 +9098,6 @@
 	},
 /obj/structure/fluff/railing/border{
 	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
@@ -9818,17 +9786,6 @@
 "csO" = (
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/indoors/town/tavern)
-"csQ" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "csT" = (
 /turf/closed/wall/mineral/rogue/stone/red_moss,
 /area/rogue/under/cave/dungeon1)
@@ -10327,33 +10284,9 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
-"cAb" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "cAc" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable";
-	pixel_y = -4
-	},
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small{
-	pixel_x = -8
-	},
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/town/sewer)
 "cAg" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_y = 32
@@ -12407,10 +12340,6 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/exposed/town/keep)
-"cXo" = (
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "cXr" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -12729,22 +12658,11 @@
 /turf/open/floor/rogue/AzureSand,
 /area/rogue/outdoors/beach/harbor)
 "dbq" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
-	},
-/obj/structure/fluff/walldeco/maidensigil,
 /obj/machinery/light/rogue/candle/blue/r{
 	pixel_y = 5
 	},
-/obj/structure/fluff/clock{
-	pixel_y = 10
+/obj/structure/stairs/stone{
+	dir = 1
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
@@ -12903,19 +12821,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors)
-"dcv" = (
-/obj/structure/closet/crate/chest/crate,
-/obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
-/obj/item/millstone{
-	pixel_x = 8;
-	pixel_y = 19
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 4;
-	pixel_y = 0
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "dcG" = (
 /obj/effect/wisp/prestidigitation{
 	color = "#ff370f";
@@ -13376,27 +13281,6 @@
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsafe)
-"div" = (
-/obj/item/clothing/suit/roguetown/armor/corset,
-/obj/item/clothing/suit/roguetown/armor/corset,
-/obj/item/clothing/suit/roguetown/armor/leather/bikini,
-/obj/item/clothing/under/roguetown/trou/beltpants,
-/obj/item/clothing/under/roguetown/trou/leathertights,
-/obj/item/clothing/wrists/roguetown/bracers/leather,
-/obj/item/clothing/shoes/roguetown/ridingboots,
-/obj/item/clothing/head/roguetown/menacing,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/suit/roguetown/armor/leather/bikini,
-/obj/structure/closet/crate/roguecloset/inn{
-	lockid = "nightmaiden";
-	name = "Dressing Closet"
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
 "diA" = (
 /obj/item/chair/rogue,
 /obj/machinery/light/rogue/torchholder/l,
@@ -13795,6 +13679,9 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
+"dnb" = (
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/sewer)
 "dne" = (
 /mob/living/simple_animal/hostile/retaliate/goose,
 /obj/structure/curtain/green,
@@ -13809,6 +13696,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town)
+"dnv" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/sewer)
 "dnw" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -13934,17 +13827,6 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
-"doO" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "doR" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bogsafe)
@@ -16962,15 +16844,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
-"eaO" = (
-/obj/machinery/light/rogue/oven/west,
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "eaQ" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/volcanic,
@@ -19476,13 +19349,6 @@
 "eFm" = (
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/church/basement)
-"eFp" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/effect/landmark/start/nightmaiden,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "eFq" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/closed/wall/mineral/rogue/decostone/mossy/end{
@@ -19718,16 +19584,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"eHI" = (
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/obj/item/clothing/mask/cigarette/pipe{
-	pixel_y = 5
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "eHO" = (
 /obj/structure/floordoor/gatehatch/inner{
 	redstone_id = "gatelava"
@@ -20118,13 +19974,6 @@
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bograt/west)
-"eNa" = (
-/obj/effect/decal/herringbone,
-/obj/structure/curtain/magenta{
-	color = "#a1254a"
-	},
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/bath)
 "eNp" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -20214,19 +20063,6 @@
 /obj/item/reagent_containers/food/snacks/rogue/friedrat,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
-"eOw" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/obj/machinery/gear_painter,
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
 "eOB" = (
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
@@ -20404,14 +20240,12 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "eQv" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Employee Lounge"
 	},
-/obj/structure/fermentation_keg/whitewine{
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "eQK" = (
 /turf/open/floor/rogue/blocks,
@@ -22821,61 +22655,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/outdoors/rtfield/rockhill/above)
-"fvU" = (
-/obj/item/clothing/under/roguetown/loincloth{
-	pixel_y = 4
-	},
-/obj/item/clothing/under/roguetown/loincloth{
-	layer = 4.1;
-	pixel_y = 4
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless/random{
-	layer = 4.1;
-	pixel_y = 16
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless/random{
-	pixel_y = 16
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless/red{
-	layer = 4.1;
-	pixel_x = 5;
-	pixel_y = 16
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless/red{
-	pixel_x = 5;
-	pixel_y = 16
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy/black{
-	layer = 4.1;
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy/black{
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/random,
-/obj/item/clothing/suit/roguetown/shirt/dress/gen/random,
-/obj/item/clothing/under/roguetown/skirt/random,
-/obj/item/clothing/under/roguetown/skirt/random,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
-/obj/item/legwears/fishnet/black,
-/obj/item/legwears/fishnet/black,
-/obj/item/legwears/fishnet/red,
-/obj/item/legwears/fishnet/red,
-/obj/structure/closet/crate/roguecloset/inn{
-	lockid = "nightmaiden";
-	name = "Dressing Closet"
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/obj/item/clothing/under/roguetown/trou/formal,
-/obj/item/clothing/suit/roguetown/shirt/undershirt/formal,
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
 "fwi" = (
 /turf/open/water/swamp,
 /area/rogue/indoors/shelter/mountains)
@@ -26068,17 +25847,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/rockhill)
-"gkG" = (
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable";
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/glass/bowl{
-	pixel_y = -8
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "gkL" = (
 /obj/structure/stairs/stone,
 /obj/structure/stairs/stone,
@@ -26870,15 +26638,6 @@
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/woodsrat/south)
-"gtS" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/effect/decal/herringbone{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "gtU" = (
 /obj/structure/stairs,
 /turf/open/floor/rogue/wood,
@@ -27642,6 +27401,14 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/town/rockhill)
+"gEP" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4;
+	locked = 1;
+	name = "Bathroom"
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/sewer)
 "gES" = (
 /obj/structure/rack/rogue,
 /obj/item/flashlight/flare/torch/lantern,
@@ -28536,16 +28303,6 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
-"gQT" = (
-/obj/structure/chair/wood/rogue/fancy{
-	dir = 8;
-	pixel_x = -9
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "gQW" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/cobble/mossy,
@@ -29174,9 +28931,6 @@
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
 	},
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
@@ -29907,23 +29661,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/rockhill)
-"hgT" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/obj/item/cooking/platter{
-	pixel_y = -5
-	},
-/obj/item/reagent_containers/food/snacks/rogue/meat/salami{
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/food/snacks/rogue/bread{
-	pixel_x = 13;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "hhz" = (
 /obj/machinery/light/rogue/torchholder,
 /turf/closed/wall/mineral/rogue/decostone/end{
@@ -33151,12 +32888,6 @@
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/cave)
-"hVw" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "hVx" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -34432,14 +34163,6 @@
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
-"imx" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/fermentation_keg/random/water,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "imK" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -36151,15 +35874,6 @@
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/cavewet/wizarddungeon)
 "iLj" = (
-/obj/structure/bookcase/random{
-	density = 0;
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
 /turf/open/floor/rogue/tile/tilerg,
 /area/rogue/indoors/town/bath)
 "iLl" = (
@@ -38434,12 +38148,6 @@
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"jnN" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "jnO" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -39513,14 +39221,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"jBS" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/stairs{
-	dir = 8
-	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
 "jBY" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -40228,9 +39928,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/inq)
-"jKG" = (
-/turf/closed/mineral/rogue,
-/area/rogue/indoors/town/bath)
 "jKI" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless{
@@ -40759,28 +40456,6 @@
 /obj/structure/fluff/walldeco/psybanner/red,
 /turf/closed/wall/mineral/rogue/decostone/end,
 /area/rogue/indoors/town/church)
-"jRu" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/obj/structure/mirror{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/item/dye_brush,
-/obj/item/hair_dye_cream,
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/obj/structure/table/wood{
-	dir = 6;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
 "jRC" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/manor/rockhill)
@@ -40847,7 +40522,12 @@
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor/rockhill)
 "jSA" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Storeroom"
+	},
+/turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/sewer)
 "jSF" = (
 /obj/structure/fluff/railing/border,
@@ -43481,13 +43161,6 @@
 "kyF" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/cell)
-"kyJ" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8;
-	layer = 2
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "kyR" = (
 /obj/structure/curtain/brown,
 /obj/structure/roguewindow/openclose,
@@ -45563,47 +45236,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/shelter/mountains)
-"lax" = (
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/structure/closet/crate/roguecloset,
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = 8;
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
 "laC" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -45903,11 +45535,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bogsafe)
-"lfA" = (
-/obj/structure/bookcase/random,
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
 "lfE" = (
 /obj/structure/fluff/railing/border/north,
 /turf/open/floor/rogue/metal/barograte,
@@ -45920,17 +45547,6 @@
 /obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/church/basement)
-"lfT" = (
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
-	},
-/obj/structure/curtain/magenta{
-	color = "#a1254a"
-	},
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/bath)
 "lfV" = (
 /turf/closed/wall/mineral/rogue/roofwall/center,
 /area/rogue/outdoors/rtfield/rockhill/above)
@@ -46455,6 +46071,16 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/exposed/town/keep)
+"lme" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem1,
+/area/rogue/indoors/town/bath)
 "lmf" = (
 /obj/structure/stairs/stone,
 /obj/structure/fluff/railing/border{
@@ -48006,15 +47632,6 @@
 "lHE" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/outdoors/town/roofs)
-"lHJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "lHK" = (
 /obj/structure/flora/newtree,
 /turf/closed/mineral/random/rogue,
@@ -48434,13 +48051,6 @@
 /obj/item/rogueweapon/mace/warhammer/steel/paalloy,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/town/church/chapel)
-"lMt" = (
-/obj/structure/table/wood{
-	dir = 8;
-	icon_state = "largetable"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "lMv" = (
 /obj/structure/bars/pipe,
 /turf/open/transparent/openspace,
@@ -48449,7 +48059,7 @@
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
 	lockid = "nightmaiden";
-	name = "Employee Lounge"
+	name = "Employees Only"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
@@ -48616,14 +48226,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_x = 32
-	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "lON" = (
@@ -48709,18 +48311,6 @@
 /obj/item/natural/rock/gem,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue)
-"lPI" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "lPJ" = (
 /obj/item/reagent_containers/glass/bottle/rogue/healthpot{
 	pixel_y = 8
@@ -50056,29 +49646,6 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor/rockhill)
-"mfL" = (
-/obj/item/paper,
-/obj/item/paper{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/natural/feather,
-/obj/item/trash/candle{
-	pixel_x = 10
-	},
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
-	},
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = 8;
-	dir = 1
-	},
-/obj/structure/roguemachine/mail{
-	mailtag = "Whitevein"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
 "mfU" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/general_loot_mid,
@@ -52814,10 +52381,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church)
 "mLT" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/roguegrass/herb/salvia,
-/turf/open/water/cleanshallow,
-/area/rogue/under/town/sewer)
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Dressing Room"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "mLV" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/blocks,
@@ -53439,9 +53009,6 @@
 /obj/item/reagent_containers/glass/cup/steel{
 	pixel_x = -12;
 	pixel_y = 5
-	},
-/obj/item/candle/skull/lit{
-	pixel_y = 2
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
@@ -55628,11 +55195,6 @@
 /obj/structure/closet/crate/drawer/random,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/physician)
-"nwv" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/bookcase/random,
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
 "nwA" = (
 /obj/structure/bookcase/random/archive,
 /obj/item/recipe_book/survival,
@@ -56564,10 +56126,6 @@
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"nJt" = (
-/mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
-/turf/open/water/sewer,
-/area/rogue/under/town/sewer)
 "nJu" = (
 /obj/item/natural/stone{
 	pixel_y = -12
@@ -56793,6 +56351,10 @@
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
 	dir = 4
+	},
+/obj/item/roguebin/trash{
+	pixel_x = -3;
+	pixel_y = 9
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
@@ -58625,14 +58187,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
-"ojb" = (
-/obj/structure/fluff/railing/border,
-/obj/structure/globe{
-	pixel_x = 21;
-	pixel_y = 1
-	},
-/turf/closed/wall/mineral/rogue/decostone,
-/area/rogue/indoors/town/bath)
 "oji" = (
 /obj/item/roguecoin/copper,
 /obj/item/roguecoin/gold,
@@ -59490,12 +59044,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/inq/basement)
-"osV" = (
-/obj/effect/decal/herringbone{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "osW" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobble,
@@ -63704,24 +63252,6 @@
 	dir = 9
 	},
 /area/rogue/outdoors/town/roofs)
-"puj" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/obj/item/perfume/random,
-/obj/structure/mirror{
-	pixel_x = -32;
-	pixel_y = 0
-	},
-/obj/structure/table/wood{
-	dir = 5;
-	icon_state = "largetable"
-	},
-/obj/machinery/light/rogue/candle/blue,
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
 "puk" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood,
@@ -63926,9 +63456,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
-"pwW" = (
-/turf/closed/wall/mineral/rogue/decostone/end,
-/area/rogue/indoors/town/bath)
 "pxh" = (
 /obj/structure/fluff/psycross/psycrucifix/stone,
 /turf/open/floor/rogue/blocks,
@@ -64874,24 +64401,6 @@
 	color = "#d4ffcf"
 	},
 /area/rogue/under/cave/skeletoncrypt)
-"pIg" = (
-/obj/structure/rack/rogue/shelf{
-	pixel_y = 30
-	},
-/obj/item/candle/yellow{
-	pixel_x = -8;
-	pixel_y = 37
-	},
-/obj/item/candle/yellow{
-	pixel_x = 3;
-	pixel_y = 37
-	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/bath)
 "pIk" = (
 /obj/structure/chair/wood/rogue,
 /obj/effect/landmark/start/absolver,
@@ -66328,18 +65837,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
-"qbE" = (
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "qbG" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield/rockhill)
@@ -66618,15 +66115,6 @@
 "qfD" = (
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/town/roofs)
-"qfF" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/effect/decal/herringbone{
-	dir = 10
-	},
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "qfG" = (
 /obj/machinery/light/rogue/forge,
 /turf/open/floor/rogue/metal,
@@ -67431,20 +66919,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"qpw" = (
-/obj/structure/table/wood{
-	dir = 9;
-	icon_state = "largetable";
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/glass/cup/wooden,
-/obj/machinery/light/rogue/candle/floorcandle{
-	icon_state = "floorcandlee1";
-	pixel_x = 19;
-	pixel_y = -18
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "qpE" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -67809,9 +67283,10 @@
 	},
 /area/rogue/outdoors/rtfield/rockhill/above)
 "qut" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
-	dir = 4
-	},
+/obj/structure/table/wood,
+/obj/structure/bars/shop,
+/obj/structure/bars/passage/shutter,
+/turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "qux" = (
 /turf/open/floor/rogue/cobble/mossy,
@@ -68140,34 +67615,6 @@
 /obj/effect/wisp/prestidigitation,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet/wizarddungeon)
-"qyx" = (
-/obj/effect/decal/cobbleedge{
-	icon_state = "borderfall";
-	pixel_y = -8
-	},
-/obj/structure/closet/crate/roguecloset/inn/chest{
-	keylock = 1;
-	lockid = "nightmaiden";
-	name = "Fancy Closet";
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
-/obj/item/clothing/shoes/roguetown/anklets,
-/obj/item/clothing/shoes/roguetown/anklets,
-/obj/item/clothing/mask/rogue/exoticsilkmask,
-/obj/item/clothing/mask/rogue/exoticsilkmask,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
-/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
-/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
-/obj/item/legwears/silk,
-/obj/item/legwears/silk,
-/obj/item/legwears/silk/random,
-/obj/item/legwears/silk/random,
-/turf/open/floor/rogue/blocks/paving,
-/area/rogue/indoors/town/bath)
 "qyz" = (
 /obj/machinery/light/rogue/candle,
 /obj/item/grown/log/tree/small,
@@ -68639,7 +68086,8 @@
 "qDY" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
-	locked = 1
+	locked = 1;
+	name = "Bathroom"
 	},
 /obj/effect/spawner/trap,
 /obj/structure/bars/passage/shutter{
@@ -68823,17 +68271,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/indoors/shelter/mountains)
-"qGA" = (
-/obj/effect/decal/carpet/square{
-	pixel_x = 19;
-	pixel_y = -9
-	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_x = -2;
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/bath)
 "qGD" = (
 /obj/structure/rack/rogue,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
@@ -70665,7 +70102,7 @@
 /obj/structure/mineral_door/wood/red{
 	locked = 1;
 	lockid = "nightmaiden";
-	name = "Toy Shop Access"
+	name = "Front Office"
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
@@ -72251,12 +71688,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/under/cavewet)
-"rBh" = (
-/obj/structure/roguewindow/harem2,
-/turf/closed/wall/mineral/rogue/decostone/end{
-	dir = 8
-	},
-/area/rogue/indoors/town/bath)
 "rBC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -73659,9 +73090,6 @@
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
 "rUh" = (
@@ -74132,6 +73560,18 @@
 	},
 /turf/open/floor/rogue/volcanic,
 /area/rogue/outdoors/bograt/above)
+"sak" = (
+/obj/structure/bondage/gloryhole{
+	color = "#97999c"
+	},
+/obj/structure/curtain/magenta{
+	color = "#a1254a";
+	icon_state = "curtain-closed";
+	opacity = 1;
+	open = 0
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/sewer)
 "san" = (
 /obj/structure/floordoor/gatehatch/outer,
 /obj/structure/fluff/railing/border{
@@ -74197,6 +73637,11 @@
 "sbb" = (
 /turf/open/water/river/muddy,
 /area/rogue/outdoors/bograt/north)
+"sbj" = (
+/obj/machinery/light/rogue/candle/blue,
+/obj/item/roguebin/water,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/under/town/sewer)
 "sbn" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -75358,10 +74803,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
 "spx" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 32
 	},
-/turf/open/floor/rogue/tile,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
 "spz" = (
 /obj/structure/chair/wood/rogue{
@@ -77424,12 +76869,6 @@
 	icon_state = "vertw"
 	},
 /area/rogue/indoors)
-"sQk" = (
-/obj/structure/chair/wood/rogue{
-	dir = 1
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "sQr" = (
 /obj/machinery/light/rogue/firebowl{
 	status = 1
@@ -77733,6 +77172,9 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
+/obj/structure/fermentation_keg/whitewine{
+	pixel_y = 5
+	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "sUO" = (
@@ -78018,13 +77460,6 @@
 /obj/structure/flora/roguegrass/bush/wall/tall,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
-"sXU" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/fluff/wallclock,
-/turf/open/floor/rogue/tile/harem,
-/area/rogue/indoors/town/bath)
 "sYe" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -78383,6 +77818,11 @@
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/rtfield/rockhill/above)
+"tcx" = (
+/obj/structure/flora/roguegrass/water/reeds,
+/obj/structure/flora/roguegrass/water/reeds,
+/turf/open/water/sewer,
+/area/rogue/under/town/sewer)
 "tcA" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
@@ -79266,6 +78706,10 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor/rockhill)
+"tnc" = (
+/obj/structure/curtain/magenta,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "tnd" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/rogue/blocks,
@@ -79600,10 +79044,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/rogue/greenstone,
 /area/rogue/under/town/sewer)
-"trC" = (
-/obj/structure/bookcase/random,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
 "trD" = (
 /obj/structure/bars/grille{
 	dir = 1
@@ -81391,6 +80831,14 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/bograt/sunken)
+"tOu" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 4;
+	locked = 1;
+	name = "Confessional"
+	},
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors/town/bath)
 "tOx" = (
 /obj/structure/stairs/stone{
 	dir = 8
@@ -84248,7 +83696,8 @@
 "uxU" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
-	locked = 1
+	locked = 1;
+	name = "Bathroom"
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/church)
@@ -84451,7 +83900,8 @@
 "uAq" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
-	locked = 1
+	locked = 1;
+	name = "Bathroom"
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
@@ -84627,15 +84077,6 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
-"uCM" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
 "uCO" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -85053,61 +84494,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/tavern)
-"uJg" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/obj/structure/rack/rogue/shelf/biggest,
-/obj/item/candle/eora{
-	pixel_x = 1;
-	pixel_y = 0
-	},
-/obj/item/candle/eora{
-	pixel_x = -4;
-	pixel_y = 0
-	},
-/obj/item/candle/eora{
-	pixel_x = -8;
-	pixel_y = 0
-	},
-/obj/item/candle/eora{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/candle/eora{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/candle/eora{
-	pixel_x = 0;
-	pixel_y = 7
-	},
-/obj/item/candle/eora{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/candle/eora{
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/item/natural/cloth{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/item/storage/roguebag{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/structure/fluff/walldeco/bigpainting{
-	pixel_x = 0
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 1;
-	icon_state = "borderfall";
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "uJh" = (
 /turf/open/floor/rogue/rooftop,
 /area/rogue/outdoors/town/roofs)
@@ -86576,15 +85962,6 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/money,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
-"vbX" = (
-/obj/machinery/light/rogue/hearth{
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/glass/bucket/pot{
-	pixel_y = 4
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
 "vbY" = (
 /obj/structure/bars/grille{
 	dir = 8
@@ -87112,6 +86489,13 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church/chapel)
+"vjo" = (
+/obj/structure/mineral_door/wood/deadbolt{
+	dir = 1;
+	name = "Confessional"
+	},
+/turf/closed,
+/area/rogue/under/town/sewer)
 "vjp" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -87193,16 +86577,6 @@
 	color = "#d4ffcf"
 	},
 /area/rogue/under/cave/skeletoncrypt)
-"vkf" = (
-/obj/structure/fluff/walldeco/rpainting{
-	pixel_x = -32
-	},
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "vkB" = (
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/herringbone,
@@ -87648,15 +87022,6 @@
 /obj/item/clothing/under/roguetown/trou,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"vrf" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/stairs/stone{
-	dir = 1
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "vrh" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/royalblack,
@@ -89251,9 +88616,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/rockhill)
-"vKO" = (
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town/bath)
 "vKR" = (
 /obj/item/natural/cloth,
 /obj/item/reagent_containers/glass/bucket,
@@ -89577,9 +88939,8 @@
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "vPK" = (
-/obj/structure/table/wood,
-/obj/item/candle/skull/lit,
-/turf/open/floor/rogue/concrete,
+/obj/structure/roguewindow/harem2,
+/turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/indoors/town/bath)
 "vPM" = (
 /obj/structure/rack/rogue,
@@ -89861,18 +89222,6 @@
 "vTo" = (
 /turf/open/water/swamp,
 /area/rogue/under/underdarker/rockhill)
-"vTq" = (
-/obj/item/reagent_containers/glass/bowl,
-/obj/structure/table/wood{
-	dir = 10;
-	icon_state = "largetable"
-	},
-/obj/machinery/light/rogue/candle/floorcandle{
-	pixel_x = 15;
-	pixel_y = 8
-	},
-/turf/open/floor/carpet/inn,
-/area/rogue/indoors/town/bath)
 "vTv" = (
 /obj/structure/fluff/big_chain,
 /turf/open/lava,
@@ -91707,6 +91056,17 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
+"wrE" = (
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = 0;
+	pixel_y = -2
+	},
+/obj/structure/curtain/magenta,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_x = 32
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "wrG" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -92081,12 +91441,7 @@
 	dir = 6
 	},
 /obj/machinery/light/rogue/candle/blue/l,
-/obj/machinery/light/rogue/candle/floorcandle{
-	icon_state = "floorcandlee1";
-	pixel_x = -4;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/concrete,
+/turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/town/sewer)
 "wwL" = (
 /obj/structure/closet/dirthole/closed,
@@ -93657,16 +93012,6 @@
 "wOD" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/indoors)
-"wOG" = (
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_x = -32
-	},
-/obj/structure/chair/wood/rogue{
-	dir = 4;
-	pixel_x = 6
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town/bath)
 "wOH" = (
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_y = 33
@@ -94414,6 +93759,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/beach/harbor)
+"wYJ" = (
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "wYS" = (
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass,
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass,
@@ -94739,12 +94090,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/Academy)
-"xdf" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town/bath)
 "xdj" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/indoors/town)
@@ -94758,11 +94103,6 @@
 "xdC" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
-	},
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
 	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
@@ -95544,6 +94884,14 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/manor/rockhill)
+"xoa" = (
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Kitchen"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "xoc" = (
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -96476,19 +95824,6 @@
 "xAt" = (
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/rockhill)
-"xAv" = (
-/obj/structure/fluff/railing/border{
-	layer = 4.2;
-	dir = 1
-	},
-/obj/structure/curtain/magenta{
-	color = "#a1254a";
-	icon_state = "curtain-closed";
-	opacity = 1;
-	open = 0
-	},
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/bath)
 "xAx" = (
 /obj/structure/stairs{
 	dir = 8
@@ -97524,7 +96859,8 @@
 "xNk" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
-	locked = 1
+	locked = 1;
+	name = "Bathroom"
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
@@ -97797,11 +97133,6 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
 "xQB" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
@@ -99082,11 +98413,10 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/sewer)
 "yho" = (
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
+/obj/machinery/light/rogue/candle{
+	pixel_y = -32
 	},
-/obj/structure/flora/roguegrass/herb/salvia,
-/turf/open/water/cleanshallow,
+/turf/open/floor/rogue/tile/harem,
 /area/rogue/under/town/sewer)
 "yhp" = (
 /obj/structure/fluff/walldeco/church/line,
@@ -267538,8 +266868,8 @@ gLf
 gLf
 gLf
 gLf
-uEX
-uEX
+gLf
+gLf
 gLf
 gLf
 gLf
@@ -267958,8 +267288,8 @@ iyZ
 rRb
 beZ
 iyZ
-jSA
-rRb
+dWF
+dWF
 rRb
 dWF
 nIe
@@ -267968,15 +267298,15 @@ nvH
 nvH
 nvH
 iyZ
-rRb
-oQo
-pVn
-fQu
-kSY
 iyZ
-lrs
 iyZ
-uEX
+iyZ
+iyZ
+iyZ
+iyZ
+tcx
+iyZ
+mXk
 gLf
 gUg
 gUg
@@ -268387,26 +267717,26 @@ lyG
 lyG
 eSt
 eFJ
-eFJ
+uAi
 jOU
+uAi
 eFJ
-aIu
-vkf
+pQc
 aum
-wOG
-aIu
-eFJ
-uAi
-uAi
+pQc
+pQc
+pQc
+pQc
+pQc
 scK
-lrs
-rRb
-gLf
-rSC
-rSC
-keb
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
 iyZ
-lrs
+oGO
 lrs
 uEX
 gLf
@@ -268819,26 +268149,26 @@ aDi
 ycI
 slx
 rhw
-bng
+pQc
 iLj
-bng
-cXo
-qpw
-hgT
-vTq
-sQk
-bng
-puj
-jRu
-scK
-rRb
+pQc
+vPK
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+qut
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
 iyZ
-gLf
-rSC
-rSC
-gLf
-rRb
-lrs
+oGO
 lrs
 ctJ
 udz
@@ -269251,26 +268581,26 @@ fIA
 osR
 sla
 rhw
-trC
-iel
-nwv
-cXo
-gkG
-cAb
-eHI
-sQk
-rBh
-qGA
-nfP
-div
-rRb
+pQc
+pQc
+pQc
+vPK
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+qut
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
 iyZ
-gLf
-rSC
-mnj
-pzt
-nXf
-lrs
+otg
 lrs
 ctJ
 udz
@@ -269683,26 +269013,26 @@ lyG
 lyG
 lyG
 rhw
-lax
-iel
-lfA
-jnN
-doO
-gQT
-csQ
-spx
-xAv
-nfP
-nfP
-fvU
+wYJ
+pQc
+pQc
+scK
+wYJ
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+scK
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
 rRb
-sjc
-gLf
-rSC
-rSC
-gLf
-rRb
-lrs
+otg
 lrs
 uEX
 gLf
@@ -270115,29 +269445,29 @@ uzF
 hSA
 eGj
 rhw
-abd
-iel
-ojb
-jBS
-imx
-vbX
+pQc
+pQc
+pQc
+vPK
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+xoa
 cAc
-uCM
-vKO
-pIg
-nfP
-qyx
+cAc
+cAc
+cAc
+cAc
+cAc
 rRb
-gLf
-rSC
-rSC
-gLf
-gLf
-rRb
-lrs
+ctJ
 iyZ
-rSC
-rSC
+lrs
+oGO
 rSC
 gLf
 ctJ
@@ -270547,28 +269877,28 @@ xWK
 aZr
 gIO
 rhw
-mfL
-dhP
-gtS
-hVw
-lHJ
-xdf
-ccW
-tcZ
-eNa
-vTB
-nfP
-eOw
+pQc
+pQc
+pQc
+vPK
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+pQc
+scK
 rRb
-gLf
-nJt
-gLf
-gLf
-lrs
+jSA
 rRb
+rRb
+rRb
+rRb
+rRb
+ctJ
+rSC
 oGO
-rSC
-rSC
 rSC
 rSC
 gLf
@@ -270980,23 +270310,23 @@ xWK
 fLn
 eFJ
 eFJ
-sXU
-qfF
-osV
-osV
-osV
-osV
-osV
-eFJ
-lfT
-pwW
 scK
-rRb
-gLf
-rSC
-gLf
-lrs
-lrs
+mLT
+scK
+scK
+scK
+scK
+eQv
+scK
+scK
+scK
+scK
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
 rRb
 hFG
 oGO
@@ -271412,23 +270742,23 @@ ckL
 iMj
 orb
 rhw
-uJg
-kyJ
+bnf
 pQc
 pQc
 pQc
 pQc
 pQc
-kyJ
-vrf
+pQc
+pQc
+rvT
 njY
 scK
-pzt
-pzt
-rSC
-agM
-rSC
-lrs
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
 rRb
 rSC
 uEX
@@ -271845,23 +271175,23 @@ nAB
 csO
 rhw
 aWD
-dcv
-eaO
-lMt
-qbE
+pQc
+pQc
+pQc
+pQc
 xQB
-qKV
+pQc
 pQc
 rvT
 njY
 scK
-gLf
-gLf
-gLf
-gLf
-rSC
-rSC
-mXk
+cAc
+cAc
+cAc
+cAc
+cAc
+cAc
+rRb
 uEX
 jaY
 uEX
@@ -272291,8 +271621,8 @@ iWT
 iWT
 iWT
 iWT
-gLf
-gLf
+rRb
+rRb
 nXf
 hJH
 uun
@@ -272714,7 +272044,7 @@ jTy
 vnK
 ggb
 epj
-vAm
+lme
 qUr
 pQc
 jZb
@@ -274872,10 +274202,10 @@ gGL
 wTZ
 wTZ
 uqT
-eFJ
+scK
 tWl
 eFJ
-jfX
+tnc
 qLo
 cUF
 eFJ
@@ -275300,7 +274630,7 @@ rct
 mYd
 vQT
 cUC
-eFp
+cQX
 wTZ
 wTZ
 eDw
@@ -276162,7 +275492,7 @@ ufe
 gYH
 xdC
 lOH
-lPI
+lOH
 cjQ
 tcZ
 wTZ
@@ -276170,7 +275500,7 @@ fUP
 eDw
 qDT
 nPb
-vfx
+wrE
 gPd
 gPd
 oxB
@@ -276590,11 +275920,11 @@ gMO
 gMO
 nvH
 xrC
-vPK
-eQv
-qut
-uAi
-qut
+sIR
+ebt
+dhP
+spx
+dhP
 dbq
 rUg
 iia
@@ -277017,15 +276347,15 @@ vRu
 vRu
 vRu
 tQZ
+tLK
 gMO
-gMO
-gMO
-lMF
+iyZ
+iyZ
 nvH
-eFJ
+tOu
 soz
 eFJ
-jKG
+eFJ
 eFJ
 wqF
 ieR
@@ -277451,14 +276781,14 @@ vRu
 tQZ
 gMO
 gMO
-gMO
-gMO
-gMO
-lrs
-lrs
-thM
-gMO
-mLT
+wRU
+sbj
+dnb
+dnv
+dnb
+vjo
+lqt
+lqt
 wwF
 qMQ
 aQY
@@ -277881,15 +277211,15 @@ vRu
 vRu
 vRu
 tQZ
-tQZ
+gMO
 tLK
-gMO
-gMO
-lEn
-lrs
-lrs
+iyZ
+iyZ
+gEP
+iyZ
+gEP
 rRb
-yho
+dpJ
 bJl
 lct
 vuV
@@ -278313,13 +277643,13 @@ vRu
 vRu
 vRu
 vRu
-vRu
+tLK
 gMO
 gMO
-mXk
-gMO
-gMO
-lrs
+iyZ
+buy
+sak
+yho
 thM
 gMO
 iHh
@@ -278748,10 +278078,10 @@ tQZ
 tQZ
 pvK
 uEX
-gMO
-tLK
-gMO
-gMO
+iyZ
+iyZ
+iyZ
+iyZ
 rRb
 dpJ
 iHh
@@ -280048,7 +279378,7 @@ ocN
 uEX
 uEX
 gMO
-maJ
+abd
 gLf
 gLf
 xRq

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -925,6 +925,9 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cave/dungeon1)
+"alu" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy,
+/area/rogue/indoors/town/bath)
 "alx" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -4857,7 +4860,7 @@
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/indoors/town/bath)
 "bjD" = (
-/turf/closed/wall/mineral/rogue/decostone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/under/cavewet)
 "bjN" = (
 /obj/structure/bed/rogue/inn/wool{
@@ -5508,7 +5511,6 @@
 /area/rogue)
 "bsp" = (
 /obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "bst" = (
@@ -6475,6 +6477,14 @@
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/indoors/shelter/mountains)
+"bEp" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "bEv" = (
 /obj/structure/table/vtable/v2,
 /obj/machinery/light/rogue/candle{
@@ -6894,6 +6904,12 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/grove)
+"bKh" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "bKn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
@@ -7100,6 +7116,34 @@
 /obj/item/clothing/under/roguetown/trou/beltpants,
 /obj/structure/curtain/purple,
 /turf/open/floor/rogue/churchmarble,
+/area/rogue/indoors/town/bath)
+"bMi" = (
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Collars/Restraints";
+	pixel_x = 4
+	},
+/obj/item/leash/chain,
+/obj/item/leash/chain,
+/obj/item/leash/leather,
+/obj/item/leash/leather,
+/obj/item/clothing/neck/roguetown/collar/catbell,
+/obj/item/clothing/neck/roguetown/collar/catbell,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/obj/item/clothing/neck/roguetown/collar/leather,
+/obj/item/clothing/neck/roguetown/collar/leather/nomagic,
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/clothing/neck/roguetown/gorget/forlorncollar,
+/obj/item/clothing/neck/roguetown/collar/cowbell,
+/obj/item/clothing/neck/roguetown/collar/cowbell,
+/obj/item/clothing/neck/roguetown/cursed_collar,
+/obj/item/clothing/neck/roguetown/cursed_collar,
+/obj/item/clothing/mask/rogue/blindfold,
+/obj/item/clothing/mask/rogue/blindfold,
+/obj/item/clothing/mask/rogue/blindfold,
+/turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "bMj" = (
 /turf/closed/wall/mineral/rogue/stone,
@@ -10827,6 +10871,11 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors)
+"cFp" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/long{
+	dir = 1
+	},
+/area/rogue/indoors/town/bath)
 "cFu" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -15089,6 +15138,9 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor/rockhill)
+"dDM" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue,
+/area/rogue/indoors/town/bath)
 "dDP" = (
 /obj/structure/rack/rogue,
 /obj/structure/spider/stickyweb,
@@ -16052,12 +16104,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/grove)
-"dQD" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = "Whitevein - Kitchen"
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "dQH" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -16192,10 +16238,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/beach/harbor)
 "dRw" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 8
-	},
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/cand,
 /area/rogue/indoors/town/bath)
 "dRx" = (
 /obj/structure/lever/wall{
@@ -18071,6 +18114,11 @@
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/vault)
+"epa" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "epj" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 1;
@@ -18617,6 +18665,11 @@
 /obj/structure/fermentation_keg/whitewine,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement/keep)
+"ewG" = (
+/obj/machinery/light/rogue/torchholder/c,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "ewL" = (
 /obj/structure/flora/roguegrass/herb/salvia,
 /turf/open/floor/rogue/grassyel,
@@ -20083,6 +20136,36 @@
 /obj/item/reagent_containers/food/snacks/deadmouse,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/town/sewer)
+"eOc" = (
+/obj/structure/closet/crate/roguecloset/dark{
+	keylock = 1;
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Drugs";
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/ozium,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/moondust,
+/obj/item/reagent_containers/powder/spice,
+/obj/item/reagent_containers/powder/spice,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/redwine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/whitewine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/wine,
+/obj/item/reagent_containers/glass/bottle/rogue/luxwine,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/reagent_containers/glass/bottle/rogue/elfred,
+/obj/item/reagent_containers/glass/bottle/rogue/emberwine,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "eOd" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -21151,7 +21234,7 @@
 	icon_state = "2,0";
 	pixel_x = 32
 	},
-/turf/closed/wall/mineral/rogue/decostone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/bath)
 "fbi" = (
 /obj/structure/flora/newleaf,
@@ -21820,6 +21903,43 @@
 	pixel_y = 4;
 	pixel_x = 10
 	},
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/nightmaiden,
+/obj/item/roguekey/nightmaiden{
+	icon_state = "spikekey";
+	lockid = "punishroom";
+	name = "punishment room key";
+	pixel_y = 4;
+	pixel_x = 10
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux1";
+	name = "room I key"
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux2";
+	name = "room II key";
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux3";
+	name = "room III key";
+	pixel_y = 7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "lux4";
+	name = "room IV key";
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/item/roguekey/nightmaiden{
+	lockid = "steam";
+	name = "steam room key"
+	},
+/obj/item/storage/keyring,
+/obj/item/storage/keyring,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fiD" = (
@@ -22774,7 +22894,18 @@
 "fuU" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/machinery/light/rogue/candle/red/l,
-/obj/item/storage/keyring/nightman,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/paper/scroll,
+/obj/item/natural/feather,
+/obj/item/natural/feather,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "fuW" = (
@@ -23625,6 +23756,14 @@
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/physician)
+"fGx" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 4;
+	pixel_x = 1;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "fGy" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/cavewet/wizarddungeon)
@@ -23960,7 +24099,7 @@
 /turf/open/floor/carpet/inn,
 /area/rogue/under/town/basement/tavern)
 "fJX" = (
-/turf/closed/wall/mineral/rogue/stone/blue_moss,
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/bath)
 "fKc" = (
 /obj/structure/fluff/railing/border,
@@ -25736,12 +25875,65 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor/rockhill)
 "ggn" = (
-/obj/structure/closet/crate/roguecloset,
+/obj/structure/closet/crate/roguecloset{
+	name = "Leather/Dress Up"
+	},
 /obj/effect/decal/carpet/kover_darkred{
 	dir = 8;
 	pixel_x = 15;
 	pixel_y = 17
 	},
+/obj/item/clothing/under/roguetown/trou/leathertights,
+/obj/item/clothing/under/roguetown/trou/leathertights,
+/obj/item/clothing/under/roguetown/heavy_leather_pants/shorts,
+/obj/item/clothing/under/roguetown/heavy_leather_pants/shorts,
+/obj/item/clothing/suit/roguetown/armor/leather/vest/sailor,
+/obj/item/clothing/suit/roguetown/armor/leather/vest/sailor,
+/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini,
+/obj/item/clothing/suit/roguetown/armor/leather/hide/bikini,
+/obj/item/clothing/suit/roguetown/armor/leather/bikini,
+/obj/item/clothing/suit/roguetown/armor/leather/bikini,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/wrists/roguetown/bracers/leather,
+/obj/item/clothing/gloves/roguetown/leather,
+/obj/item/clothing/gloves/roguetown/leather,
+/obj/item/clothing/under/roguetown/trou/beltpants,
+/obj/item/clothing/under/roguetown/trou/beltpants,
+/obj/item/clothing/shoes/roguetown/ridingboots,
+/obj/item/clothing/shoes/roguetown/ridingboots,
+/obj/item/clothing/mask/rogue/sack,
+/obj/item/clothing/mask/rogue/sack,
+/obj/item/clothing/head/roguetown/menacing,
+/obj/item/clothing/head/roguetown/menacing,
+/obj/item/rope/chain,
+/obj/item/rope/chain,
+/obj/item/rogueweapon/whip,
+/obj/item/rogueweapon/whip,
+/obj/item/clothing/cloak/battlenun,
+/obj/item/clothing/cloak/battlenun,
+/obj/item/clothing/cloak/raincloak/furcloak/black,
+/obj/item/clothing/cloak/raincloak/furcloak/black,
+/obj/item/clothing/cloak/raincloak/mortus,
+/obj/item/clothing/cloak/raincloak/mortus,
+/obj/item/clothing/cloak/thief_cloak/yoruku,
+/obj/item/clothing/cloak/thief_cloak/yoruku,
+/obj/item/clothing/cloak/volfmantle,
+/obj/item/clothing/cloak/volfmantle,
+/obj/item/clothing/cloak/darkcloak/bear,
+/obj/item/clothing/cloak/darkcloak,
+/obj/item/clothing/cloak/poncho,
+/obj/item/clothing/cloak/poncho,
+/obj/item/clothing/head/roguetown/nun,
+/obj/item/clothing/suit/roguetown/shirt/robe/nun,
+/obj/item/clothing/suit/roguetown/shirt/robe/tabardblack,
+/obj/item/clothing/suit/roguetown/shirt/leo_robe,
+/obj/item/clothing/cloak/forrestercloak,
+/obj/item/clothing/mask/rogue/blindfold,
+/obj/item/clothing/mask/rogue/blindfold,
+/obj/item/clothing/suit/roguetown/shirt/leo_robe/leopard,
+/obj/item/clothing/suit/roguetown/shirt/robe/eora,
+/obj/item/clothing/suit/roguetown/shirt/robe/hierophant,
+/obj/item/clothing/suit/roguetown/shirt/robe/monk,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "ggu" = (
@@ -26095,6 +26287,11 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
+"glC" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/under/cavewet)
 "glG" = (
 /obj/item/paper{
 	pixel_y = 7
@@ -28714,6 +28911,10 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bograt/sunken)
+"gUa" = (
+/obj/structure/plasticflaps,
+/turf/open/water/swamp,
+/area/rogue/under/cavewet)
 "gUg" = (
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/sewer)
@@ -30146,6 +30347,44 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/rtfield/rockhill)
+"hlE" = (
+/obj/structure/closet/crate/roguecloset{
+	name = "Silk Outfits"
+	},
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtred,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt/skirtgreen,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
+/obj/item/storage/belt/rogue/leather/exoticsilkbelt,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/red,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra/green,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
+/obj/item/clothing/suit/roguetown/shirt/exoticsilkbra,
+/obj/item/clothing/mask/rogue/exoticsilkmask/red,
+/obj/item/clothing/mask/rogue/exoticsilkmask/red,
+/obj/item/clothing/mask/rogue/exoticsilkmask/green,
+/obj/item/clothing/mask/rogue/exoticsilkmask/green,
+/obj/item/clothing/mask/rogue/exoticsilkmask,
+/obj/item/clothing/mask/rogue/exoticsilkmask,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkydress,
+/obj/item/legwears/silk,
+/obj/item/legwears/silk,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
+/obj/item/clothing/suit/roguetown/shirt/dress/silkdress/weddingdress,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat,
+/obj/item/clothing/cloak/lordcloak/ladycloak,
+/obj/item/clothing/cloak/lordcloak/ladycloak,
+/obj/item/clothing/cloak/duelistcape,
+/obj/item/clothing/cloak/duelistcape,
+/obj/item/clothing/head/roguetown/duelisthat,
+/obj/item/clothing/mask/rogue/duelmask,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "hlG" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Bog - Eastern Tower"
@@ -30338,10 +30577,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor/rockhill)
-"hnK" = (
-/obj/structure/roguemachine/drugmachine,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red,
-/area/rogue/indoors/town/bath)
 "hnO" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/chair/wood/rogue/chair3{
@@ -31833,6 +32068,9 @@
 /obj/item/pestle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
+"hGL" = (
+/turf/closed/wall/mineral/rogue/pipe/joint/one,
+/area/rogue/under/cavewet)
 "hGM" = (
 /obj/structure/fluff/railing/border{
 	dir = 5;
@@ -32400,6 +32638,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
+"hNV" = (
+/obj/structure/roguemachine/drugmachine,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
+/area/rogue/indoors/town/bath)
 "hNW" = (
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
@@ -32844,7 +33086,6 @@
 	dir = 8
 	},
 /obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "hTE" = (
@@ -33601,10 +33842,6 @@
 /obj/structure/closet/crate/roguecloset/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
-"icN" = (
-/obj/structure/roguemachine/atm,
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "icW" = (
 /obj/structure/stairs{
 	dir = 8
@@ -34075,6 +34312,10 @@
 "ihR" = (
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsrat/above)
+"ihS" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "ihU" = (
 /obj/structure/chair/wood/rogue/chair3{
 	dir = 8
@@ -36380,6 +36621,19 @@
 "iPg" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/town/roofs/keep)
+"iPk" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "suspicious metal wall";
+	density = 0
+	},
+/area/rogue/indoors/town/bath)
+"iPr" = (
+/obj/machinery/light/rogue/torchholder/c,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "iPs" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pick/aalloy,
@@ -37708,6 +37962,9 @@
 	},
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/indoors)
+"jfS" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/long,
+/area/rogue/indoors/town/bath)
 "jfV" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -41507,7 +41764,6 @@
 	dir = 1
 	},
 /obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/cavewet)
 "kcO" = (
@@ -42196,6 +42452,12 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
+"kjN" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Whitevein - Kitchen"
+	},
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "kjP" = (
 /turf/closed/wall/mineral/rogue/wooddark/horizontal,
 /area/rogue/under/town/sewer)
@@ -43559,7 +43821,6 @@
 	pixel_y = 32
 	},
 /obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/bath)
 "kAU" = (
@@ -44263,7 +44524,6 @@
 	pixel_y = 8
 	},
 /obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "kJR" = (
@@ -48413,6 +48673,7 @@
 /obj/item/reagent_containers/powder/moondust,
 /obj/item/reagent_containers/glass/bottle/rogue/poison,
 /obj/item/reagent_containers/glass/bottle/rogue/emberwine,
+/obj/item/reagent_containers/glass/bottle/rogue/elfblue,
 /turf/open/floor/rogue/churchbrick{
 	icon_state = "concretefloor1"
 	},
@@ -50674,9 +50935,41 @@
 	keylock = 1;
 	locked = 1;
 	lockid = "nightmaiden";
-	name = "Special Toys";
+	name = "Smokeables";
 	pixel_x = 4
 	},
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/reagent_containers/food/snacks/grown/rogue/pipeweeddry,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/clothing/mask/cigarette/pipe/westman,
+/obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "mon" = (
@@ -51500,6 +51793,15 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
+"mxI" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall";
+	density = 0
+	},
+/area/rogue/under/cavewet)
 "mxM" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -54224,6 +54526,15 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/bograt/sunken)
+"ngJ" = (
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall";
+	density = 0
+	},
+/area/rogue/indoors/town/bath)
 "ngN" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
@@ -55586,15 +55897,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/physician)
-"nyE" = (
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	desc = "These candles produces a heady vapor, warding away the less pleasing scents of the sewer.";
-	name = "scented candles";
-	pixel_y = 4;
-	plane = -7
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
 "nyI" = (
 /obj/structure/stairs/stone/ccwdown{
 	dir = 4
@@ -56697,6 +56999,13 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/woodsrat/south)
+"nNv" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 1;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "nNz" = (
 /obj/machinery/light/rogue/firebowl/standing/green,
 /turf/open/floor/rogue/cobblerock,
@@ -57703,7 +58012,7 @@
 /area/rogue/outdoors/rtfield/rockhill/above)
 "nYX" = (
 /obj/structure/roguemachine/drugmachine,
-/turf/closed/wall/mineral/rogue/decostone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/indoors/town/bath)
 "nZh" = (
 /obj/structure/stairs/stone,
@@ -61636,6 +61945,15 @@
 	},
 /turf/open/floor/rogue/grassred,
 /area/rogue/indoors/town/grove)
+"oWR" = (
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	desc = "These candles produces a heady vapor, warding away the less pleasing scents of the sewer.";
+	name = "scented candles";
+	pixel_y = 4;
+	plane = -7
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/indoors/town/bath)
 "oWX" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/woodclub,
@@ -63230,7 +63548,7 @@
 "pqv" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
-/turf/open/floor/carpet/red,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/indoors/town/bath)
 "pqx" = (
 /obj/structure/fluff/railing/border{
@@ -64803,6 +65121,11 @@
 /obj/structure/fluff/statue/gargoyle/moss/candles,
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
+"pJo" = (
+/obj/structure/plasticflaps,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/rogue/dirt,
+/area/rogue/under/cavewet)
 "pJw" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -64833,6 +65156,15 @@
 	dir = 1
 	},
 /area/rogue/under/town/sewer)
+"pKf" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/roguemachine/mail{
+	mailtag = "Whitevein - Office"
+	},
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "pKn" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/naturalstone,
@@ -65427,7 +65759,8 @@
 	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
 	icon_state = "iron_line";
 	max_integrity = 2000;
-	name = "damaged metal wall"
+	name = "damaged metal wall";
+	density = 0
 	},
 /area/rogue/under/town/sewer)
 "pRV" = (
@@ -70056,6 +70389,9 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/rtfield/rockhill/above)
+"rcQ" = (
+/turf/closed/wall/mineral/rogue/decostone/mossy/cand,
+/area/rogue/indoors/town/bath)
 "rcR" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4
@@ -72205,22 +72541,49 @@
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/underdark/rockhill)
 "rFB" = (
-/obj/structure/closet/crate/roguecloset,
+/obj/structure/closet/crate/roguecloset{
+	name = "Standard Outfits"
+	},
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/sexy,
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
+/obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless,
+/obj/item/clothing/shirt/dress/courtesan,
+/obj/item/clothing/shirt/dress/courtesan,
+/obj/item/clothing/shirt/dress/hw_dress,
+/obj/item/clothing/shirt/dress/hw_dress,
+/obj/item/clothing/shirt/dress/skyrim_dress,
+/obj/item/clothing/shirt/dress/skyrim_dress,
+/obj/item/clothing/shirt/dress/skyrim_taven,
+/obj/item/clothing/shirt/dress/skyrim_taven,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/suit/roguetown/shirt/dress,
+/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
+/obj/item/clothing/suit/roguetown/shirt/dress/amiradress,
+/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
+/obj/item/clothing/suit/roguetown/shirt/dress/emerald,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/fallgown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/summergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/gown/wintergown,
+/obj/item/clothing/suit/roguetown/shirt/dress/maid,
+/obj/item/clothing/suit/roguetown/shirt/dress/maid,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/suit/roguetown/shirt/undershirt/lowcut,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/under/roguetown/skirt,
+/obj/item/clothing/under/roguetown/skirt/knee,
+/obj/item/clothing/under/roguetown/skirt/knee,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
 "rFK" = (
 /obj/structure/fermentation_keg/beer,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cavewet)
-"rFS" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/roguemachine/mail{
-	mailtag = "Whitevein - Office"
-	},
-/turf/open/floor/rogue/churchbrick,
-/area/rogue/indoors/town/bath)
 "rGf" = (
 /turf/closed/wall/mineral/rogue/stone/window{
 	icon_state = "stonewindow"
@@ -73047,7 +73410,7 @@
 	icon_state = "0,1";
 	pixel_x = -32
 	},
-/turf/closed/wall/mineral/rogue/decostone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/blue/long,
 /area/rogue/indoors/town/bath)
 "rQs" = (
 /obj/structure/closet/crate/roguecloset/dark{
@@ -73280,6 +73643,13 @@
 	dir = 4
 	},
 /area/rogue/indoors/town/manor/rockhill)
+"rTM" = (
+/obj/structure/chair/stool/rogue,
+/obj/structure/fluff/walldeco/maidensigil{
+	pixel_y = -32
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "rTW" = (
 /obj/structure/stairs/cw{
 	dir = 4
@@ -76906,7 +77276,9 @@
 /obj/structure/fluff/walldeco/maidendrape{
 	pixel_y = 0
 	},
-/turf/closed/wall/mineral/rogue/stone/moss,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long{
+	dir = 1
+	},
 /area/rogue/indoors/town/bath)
 "sMP" = (
 /obj/structure/stairs{
@@ -83362,6 +83734,10 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/rtfield/rockhill)
+"upu" = (
+/obj/structure/roguewindow/harem1,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/long,
+/area/rogue/indoors/town/bath)
 "upE" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
 /area/rogue/indoors/town/church/chapel)
@@ -83551,7 +83927,6 @@
 	pixel_x = 3;
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "urX" = (
@@ -84262,8 +84637,13 @@
 	},
 /area/rogue/under/cavewet)
 "uAi" = (
-/turf/closed/wall/mineral/rogue/decostone/long,
-/area/rogue/indoors/town/bath)
+/turf/closed/wall/mineral/rogue/pipe{
+	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
+	icon_state = "iron_line";
+	max_integrity = 2000;
+	name = "damaged metal wall"
+	},
+/area/rogue/under/cavewet)
 "uAj" = (
 /obj/structure/table/vtable/v2{
 	name = "Dissection Table"
@@ -86776,7 +87156,7 @@
 /area/rogue/outdoors/town/grove)
 "vhJ" = (
 /obj/structure/roguemachine/bathvend,
-/turf/closed/wall/mineral/rogue/decostone,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red,
 /area/rogue/indoors/town/bath)
 "vhN" = (
 /obj/structure/closet/crate/drawer{
@@ -88283,7 +88663,8 @@
 	desc = "Solid steel made into an impenetrable obstacle. This stretch of wall however seems to have thin hairline cracks in it's bronzed coating.";
 	icon_state = "iron_line";
 	max_integrity = 2000;
-	name = "damaged metal wall"
+	name = "damaged metal wall";
+	density = 0
 	},
 /area/rogue/under/cave/skeletoncrypt)
 "vAR" = (
@@ -88403,6 +88784,10 @@
 	first_time_text = "Tower of the Magos";
 	name = "Mage's Tower"
 	})
+"vCf" = (
+/obj/structure/roguemachine/atm,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "vCh" = (
 /obj/effect/landmark/quest_spawner/medium,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -94160,6 +94545,9 @@
 	},
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/bath)
+"wYO" = (
+/turf/closed/wall/mineral/rogue/pipe/joint/eight,
+/area/rogue/under/cavewet)
 "wYS" = (
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass,
 /obj/item/clothing/suit/roguetown/armor/leather/cuirass,
@@ -94496,10 +94884,8 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/indoors/town/Academy)
 "xdC" = (
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end,
-/turf/closed/wall/mineral/rogue/decostone/mossy/red/end{
-	dir = 4
-	},
+/obj/structure/fluff/statue/small,
+/turf/closed/wall/mineral/rogue/decostone/mossy/red/cand,
 /area/rogue/indoors/town/bath)
 "xdD" = (
 /obj/structure/rack/rogue/shelf/biggest,
@@ -94757,7 +95143,6 @@
 	pixel_y = -15
 	},
 /obj/structure/shisha/hookah,
-/obj/item/reagent_containers/food/snacks/grown/rogue/swampweeddry,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "xhx" = (
@@ -98336,6 +98721,11 @@
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/cobble/mossy,
+/area/rogue/under/cavewet)
+"ybz" = (
+/obj/structure/plasticflaps,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/rogue/concrete,
 /area/rogue/under/cavewet)
 "ybD" = (
 /obj/structure/rack/rogue,
@@ -154547,12 +154937,12 @@ whb
 whb
 whb
 whb
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+bWA
+bWA
+bWA
+bWA
+qRR
 whb
 whb
 whb
@@ -154979,12 +155369,12 @@ whb
 whb
 whb
 whb
-eFJ
+qRR
 rct
 wpu
 qiF
 rct
-eFJ
+qRR
 whb
 whb
 whb
@@ -155411,12 +155801,12 @@ whb
 whb
 whb
 whb
-eFJ
+qRR
 rct
 iXl
 dHo
 rct
-eFJ
+qRR
 whb
 whb
 whb
@@ -155833,27 +156223,27 @@ sFx
 sFx
 xeg
 whb
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+qRR
+qRR
+qRR
 whb
-eFJ
-eFJ
+qRR
+qRR
 rct
-eFJ
+qRR
 rct
-eFJ
-eFJ
+qRR
+qRR
 eFJ
 wDt
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+bWA
+bWA
+bWA
+bWA
+bWA
+qRR
 whb
 whb
 whb
@@ -156264,28 +156654,28 @@ sFx
 rCO
 nvn
 xeg
-eFJ
-eFJ
+qRR
+qRR
 lRY
 oMw
-eFJ
-eFJ
-eFJ
+qRR
+mVl
+qRR
 bMh
 xzC
 sFi
 gne
 rct
-eFJ
+mVl
 cAQ
 kdw
 rct
 jJJ
 kdw
-eFJ
+qRR
 wpu
 wpu
-eFJ
+mVl
 whb
 whb
 whb
@@ -156696,19 +157086,19 @@ sFx
 sFx
 sFx
 xeg
-eFJ
+qRR
 lXl
 xkd
 jfX
 uZs
-eFJ
-eFJ
-eFJ
+mVl
+qRR
+qRR
 dKR
 aCi
 ttc
 rct
-eFJ
+mVl
 pCp
 kdw
 rct
@@ -156717,7 +157107,7 @@ kdw
 wDt
 jNf
 twA
-eFJ
+mVl
 whb
 whb
 whb
@@ -157140,17 +157530,17 @@ odm
 kdw
 bJx
 rct
-eFJ
+mVl
 rct
 sOC
 eFJ
 rct
 sOC
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+qRR
+qRR
+qRR
+qRR
 whb
 whb
 whb
@@ -157560,30 +157950,30 @@ lwH
 haM
 xeg
 xeg
-eFJ
+qRR
 rOm
 gjr
 jfX
 uZs
-eFJ
+mVl
 wAU
 vTB
 tUd
 atr
 sTl
-eFJ
-eFJ
+qRR
+mVl
 lsQ
 thM
 siB
 lsQ
 thM
-eFJ
+qRR
 eFJ
 xkI
 jYg
-eFJ
-eFJ
+qRR
+qRR
 whb
 whb
 whb
@@ -157992,30 +158382,30 @@ xeg
 rwR
 xeg
 dXU
-eFJ
-eFJ
+qRR
+qRR
 lNK
 pnx
-eFJ
-eFJ
-xCt
+qRR
+mVl
+pkM
 ojQ
 jfX
 jfX
 aPn
 jdK
-eFJ
+mVl
 rmv
 kdw
 rct
 xuA
 kdw
-eFJ
+qRR
 jUB
 qcz
 qcz
 jYg
-eFJ
+mVl
 whb
 whb
 whb
@@ -158426,28 +158816,28 @@ xeg
 xeg
 qRR
 qRR
+bWA
+bWA
+bWA
 qRR
-qRR
-qRR
-qRR
-scK
+mVl
 kmW
 jfX
 jfX
 uzk
-eFJ
-eFJ
-eFJ
+qRR
+mVl
+qRR
 wBa
-eFJ
-eFJ
+qRR
+qRR
 wBa
-eFJ
+qRR
 uvz
 fqM
 qcz
 tTb
-eFJ
+mVl
 whb
 whb
 whb
@@ -158857,29 +159247,29 @@ wDf
 fJP
 xeg
 qRR
-qRR
+mVl
 hSV
 yee
 vLn
-qRR
-fJX
+mVl
+mVl
 peE
 jfX
 bUS
 xBi
-eFJ
-eFJ
+mVl
+mVl
 kZS
 asP
 qcz
 qcz
 asP
-eFJ
+qRR
 fqM
 fqM
 qcz
 xAL
-eFJ
+mVl
 whb
 whb
 whb
@@ -159289,18 +159679,18 @@ wDf
 kJh
 xeg
 qRR
-qRR
+mVl
 qRR
 yee
 wpn
-qRR
-eFJ
+mVl
+mVl
 ihp
 jfX
 jfX
 jfX
-eFJ
-eFJ
+mVl
+mVl
 qcz
 qcz
 kvU
@@ -159311,7 +159701,7 @@ emc
 soD
 sxH
 bFa
-eFJ
+mVl
 whb
 whb
 whb
@@ -159721,29 +160111,29 @@ rpp
 fJP
 xeg
 qRR
-qRR
+mVl
 hSV
 yee
 yee
 hSV
-eFJ
-eFJ
+dww
+nIe
 qKV
 mmt
 tFU
 eFJ
-eFJ
+qRR
 bzy
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+bWA
+bWA
+bWA
+bWA
+qRR
+bWA
+bWA
+bWA
+qRR
 whb
 whb
 whb
@@ -160153,7 +160543,7 @@ xeg
 lOm
 xeg
 qRR
-qRR
+mVl
 qRR
 wrE
 qRR
@@ -160166,12 +160556,12 @@ pQc
 wJD
 cWN
 dlB
-eFJ
+qRR
 hUU
 yeY
 vuC
 rTJ
-eFJ
+mVl
 gGR
 gGR
 gGR
@@ -160585,7 +160975,7 @@ nBT
 xCt
 xCt
 qRR
-qRR
+mVl
 hSV
 yee
 yee
@@ -160603,7 +160993,7 @@ kdd
 otP
 kdd
 taK
-eFJ
+mVl
 gGR
 gGR
 gGR
@@ -161021,7 +161411,7 @@ qRR
 qRR
 eFJ
 qRR
-qRR
+nIe
 idl
 mVl
 cAm
@@ -161030,12 +161420,12 @@ axp
 pQc
 cWN
 fBN
-eFJ
+qRR
 aSr
 bKu
 oNk
 oxg
-eFJ
+mVl
 gGR
 gGR
 gGR
@@ -161462,12 +161852,12 @@ pQc
 pQc
 cWN
 kQO
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+bWA
+bWA
+bWA
+bWA
+qRR
 gGR
 gGR
 gGR
@@ -161885,7 +162275,7 @@ fSS
 eFJ
 fSS
 qRR
-qRR
+nIe
 sIL
 qRR
 nIe
@@ -161896,11 +162286,11 @@ bWA
 bWA
 qRR
 gns
-ipI
+ngJ
 bjz
 gns
-ipI
-ipI
+ngJ
+ngJ
 bjz
 cgV
 gGR
@@ -162744,7 +163134,7 @@ wPo
 vaX
 xCt
 xCt
-eFJ
+qRR
 fPE
 gTt
 gTt
@@ -163176,14 +163566,14 @@ wPo
 wPo
 bPA
 sWm
-eFJ
-eFJ
+qRR
+qRR
 rct
 fSS
 qRR
 kZR
 gps
-eFJ
+qRR
 hbl
 asP
 wFB
@@ -163614,8 +164004,8 @@ jfX
 jfX
 cQX
 kdw
-thM
-eFJ
+rTM
+qRR
 hbl
 asP
 wFB
@@ -164037,14 +164427,14 @@ nvH
 xCt
 xCt
 soz
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-icN
+qRR
+bWA
+bWA
+bWA
+qRR
+vCf
 jfX
-hnK
+hNV
 lcD
 lcD
 qRR
@@ -164463,13 +164853,13 @@ kYH
 gQh
 gQh
 whb
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+dDM
+fJX
+fJX
+fJX
+fJX
+dDM
+qRR
 aNp
 vdR
 dOe
@@ -164494,8 +164884,8 @@ vOe
 jfX
 jfX
 jfX
-jfX
 vOe
+jfX
 pHV
 vTW
 vTW
@@ -164908,12 +165298,12 @@ kdw
 cGQ
 jfX
 mym
-nyE
+oWR
 cUC
-hnp
+nNv
 jAb
 uob
-hnp
+bEp
 hnp
 cUC
 wqK
@@ -164927,7 +165317,7 @@ rct
 ufJ
 tIz
 isM
-ipI
+iPk
 tRJ
 whb
 whb
@@ -165359,10 +165749,10 @@ xgi
 kdw
 ecV
 gtj
-whb
-whb
-whb
-whb
+ikY
+pJo
+rqt
+ikY
 whb
 whb
 whb
@@ -165758,14 +166148,14 @@ whb
 whb
 whb
 whb
-eFJ
+dDM
 faZ
-eFJ
+dDM
 iFf
 yjj
 yjj
 wMC
-eFJ
+qRR
 ady
 vPH
 sAY
@@ -165780,7 +166170,7 @@ kfv
 wpu
 wpu
 mqO
-hnp
+nNv
 jfX
 vPK
 nXJ
@@ -165790,11 +166180,11 @@ vPK
 nXJ
 kdw
 wpu
-kGM
-whb
-whb
-whb
-whb
+wYO
+mxI
+mxI
+dId
+ikY
 whb
 whb
 whb
@@ -166197,11 +166587,11 @@ asP
 eFJ
 nQo
 uNi
-eFJ
-eFJ
+dRw
+dDM
 rct
 rct
-eFJ
+qRR
 eDb
 bTz
 wpu
@@ -166225,9 +166615,9 @@ xxR
 kGM
 whb
 whb
-whb
-whb
-whb
+kGM
+iPr
+ihS
 whb
 whb
 whb
@@ -166622,7 +167012,7 @@ ajL
 vqG
 whb
 whb
-eFJ
+dRw
 hHr
 lAw
 asP
@@ -166633,7 +167023,7 @@ wGF
 vEr
 sLa
 bqs
-eFJ
+qRR
 kah
 foc
 wpu
@@ -166651,15 +167041,15 @@ gns
 gns
 bjz
 gns
-ipI
-ipI
+ngJ
+ngJ
 bjz
 iGo
-eFJ
+qRR
 whb
+kGM
 whb
-whb
-whb
+rqt
 whb
 whb
 whb
@@ -167068,14 +167458,14 @@ yjj
 dbS
 jfX
 kgP
-hnp
+bKh
 kfv
 hnp
 grO
 kFp
 hnp
 osw
-hnp
+fGx
 aRM
 jfX
 tVH
@@ -167087,11 +167477,11 @@ rct
 cqQ
 ooc
 qdY
-eFJ
-eFJ
+nIe
+qRR
+kGM
 whb
-whb
-whb
+rqt
 whb
 whb
 whb
@@ -167486,9 +167876,9 @@ deZ
 lOc
 lOc
 whb
-eFJ
+dDM
 rQm
-eFJ
+dDM
 kuP
 yjj
 yjj
@@ -167497,7 +167887,7 @@ lDE
 uUV
 pLA
 iel
-eFJ
+qRR
 qKT
 jfX
 vOe
@@ -167520,10 +167910,10 @@ kdw
 mny
 kdw
 aeZ
-eFJ
+qRR
+kGM
 whb
-whb
-whb
+ikY
 whb
 whb
 whb
@@ -167924,24 +168314,24 @@ nQK
 yjj
 yjj
 vPh
-soz
-scK
-scK
+dRw
+dDM
+rcQ
 rct
 rct
-eFJ
+alu
 tHT
-soz
-eFJ
+qRR
+qRR
 jlt
 jlt
-eFJ
+qRR
 rct
 rct
 nIe
 hfH
-qRR
-uAi
+nIe
+bWA
 qRR
 aYO
 kdw
@@ -167952,10 +168342,10 @@ kdw
 dZH
 jXm
 sRH
-eFJ
+qRR
+kGM
 whb
-whb
-whb
+ikY
 whb
 whb
 whb
@@ -168351,12 +168741,12 @@ iQm
 vqG
 whb
 whb
-eFJ
+dDM
 mNl
 ejG
 iJY
 lhs
-scK
+eFJ
 bbL
 tyJ
 qDe
@@ -168374,7 +168764,7 @@ lmJ
 nfP
 krP
 xuJ
-rhw
+nIe
 nRw
 jdP
 urC
@@ -168384,10 +168774,10 @@ guE
 wpu
 wpu
 sRH
-eFJ
+qRR
+kGM
 whb
-whb
-whb
+ikY
 whb
 whb
 whb
@@ -168783,8 +169173,8 @@ iQm
 lOc
 whb
 whb
-eFJ
-eFJ
+dDM
+dDM
 guE
 wpu
 guE
@@ -168806,7 +169196,7 @@ lmJ
 ewB
 krP
 sat
-rhw
+mVl
 sGL
 pLH
 gfd
@@ -168816,13 +169206,13 @@ ecV
 ecV
 wpu
 sRH
-eFJ
-whb
-whb
-whb
-whb
-whb
-whb
+ipI
+hGL
+uAi
+ybz
+uAi
+uAi
+uAi
 whb
 whb
 whb
@@ -169216,7 +169606,7 @@ lOc
 whb
 whb
 whb
-eFJ
+dRw
 mHZ
 aVV
 lPe
@@ -169227,19 +169617,19 @@ eGq
 tHn
 hQG
 nyf
-rhw
+qRR
 aIb
 bIc
 dJa
 hCf
-rhw
+qRR
 gXU
 lmJ
 kTL
 krP
 kbd
-eFJ
-uAi
+mVl
+qRR
 gns
 gns
 gns
@@ -169247,11 +169637,11 @@ mQq
 wpu
 iXl
 wpu
-eFJ
-eFJ
+qRR
+qRR
 whb
 whb
-whb
+rqt
 whb
 whb
 whb
@@ -169648,10 +170038,10 @@ vqG
 whb
 whb
 whb
-eFJ
-eFJ
-eFJ
-eFJ
+dDM
+fJX
+fJX
+dDM
 eFJ
 mHZ
 wpu
@@ -169659,12 +170049,12 @@ eGq
 pji
 akg
 oIe
-rhw
+nIe
 tbs
 oPU
 tfS
 cWj
-eFJ
+mVl
 utb
 lmJ
 gts
@@ -169676,14 +170066,14 @@ rKz
 jiJ
 bMT
 wNU
-eFJ
-eFJ
-eFJ
-eFJ
+qRR
+bWA
+bWA
+qRR
 whb
 whb
 whb
-whb
+rqt
 whb
 whb
 whb
@@ -170084,19 +170474,19 @@ whb
 whb
 whb
 whb
-eFJ
+cFp
 kXo
 wpu
 bOa
 iGg
 utv
 uAG
-eFJ
+mVl
 kRu
 ben
 dlE
 skm
-rhw
+mVl
 kkU
 lmJ
 nEC
@@ -170107,15 +170497,15 @@ fAH
 guE
 wpu
 lPe
-scK
+qRR
 whb
 whb
 whb
 whb
 whb
 whb
-whb
-whb
+tdR
+rqt
 whb
 whb
 whb
@@ -170516,19 +170906,19 @@ whb
 whb
 whb
 whb
-eFJ
+cFp
 wpu
 wpu
-soz
-eFJ
+rcQ
+alu
 gbe
 gbe
-eFJ
+mVl
 pcI
 ogI
 ogI
 ogI
-rhw
+mVl
 jvZ
 lmJ
 nfP
@@ -170545,11 +170935,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+tdR
+tdR
+rqt
+tdR
+tCh
 whb
 tRJ
 fbF
@@ -170948,20 +171338,20 @@ whb
 whb
 whb
 whb
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
-eFJ
+alu
+jfS
+jfS
+jfS
+alu
+jfS
+jfS
+qRR
 otv
 kcM
 lGk
 wqF
-eFJ
-eFJ
+qRR
+qRR
 fqM
 fqM
 fqM
@@ -170971,20 +171361,20 @@ fAH
 wpu
 wpu
 lPe
-scK
+qRR
 whb
 whb
 whb
 whb
+tdR
+tdR
 whb
+rqt
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+tCh
+tCh
+tCh
+tCh
 whb
 whb
 whb
@@ -171393,12 +171783,12 @@ kxR
 kxR
 bjD
 whb
-rhw
+mVl
 kAT
 pqv
 nvl
 cFG
-eFJ
+qRR
 jNp
 rrC
 nQS
@@ -171411,11 +171801,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+ikY
+tCh
+tdR
+tdR
+tdR
 whb
 whb
 whb
@@ -171825,25 +172215,25 @@ whb
 whb
 whb
 whb
-eFJ
+qRR
 vVo
-uAi
+nIe
 vVo
-uAi
-uAi
+qRR
+qRR
 rqF
-uAi
+qRR
 rqF
-uAi
-eFJ
+qRR
+qRR
 whb
 whb
 whb
 whb
 whb
 whb
-whb
-whb
+epa
+rqt
 whb
 whb
 whb
@@ -172274,7 +172664,7 @@ whb
 whb
 whb
 whb
-whb
+rqt
 whb
 whb
 whb
@@ -172705,8 +173095,8 @@ whb
 whb
 whb
 whb
-whb
-whb
+rqt
+rqt
 whb
 whb
 whb
@@ -173137,7 +173527,7 @@ whb
 whb
 whb
 whb
-whb
+rqt
 whb
 whb
 whb
@@ -173568,8 +173958,8 @@ whb
 whb
 whb
 whb
-whb
-whb
+rqt
+ihS
 whb
 whb
 whb
@@ -173999,8 +174389,8 @@ whb
 whb
 whb
 whb
-whb
-whb
+rqt
+rqt
 whb
 whb
 whb
@@ -174431,7 +174821,7 @@ whb
 whb
 whb
 whb
-whb
+rqt
 whb
 whb
 whb
@@ -174862,8 +175252,8 @@ whb
 whb
 whb
 whb
-whb
-whb
+ikY
+rqt
 whb
 whb
 whb
@@ -175294,7 +175684,7 @@ whb
 whb
 whb
 rqt
-whb
+ikY
 whb
 whb
 whb
@@ -175725,7 +176115,7 @@ whb
 whb
 whb
 whb
-rqt
+gUa
 whb
 whb
 whb
@@ -176589,7 +176979,7 @@ whb
 whb
 whb
 whb
-rqt
+ewG
 whb
 whb
 whb
@@ -177019,7 +177409,7 @@ whb
 whb
 whb
 whb
-oxC
+glC
 rqt
 rqt
 ikY
@@ -177882,7 +178272,7 @@ whb
 whb
 whb
 whb
-gRs
+sSG
 tdR
 whb
 whb
@@ -178314,7 +178704,7 @@ whb
 rqt
 whb
 whb
-gRs
+sSG
 whb
 whb
 whb
@@ -179175,7 +179565,7 @@ whb
 whb
 whb
 whb
-rqt
+iPr
 gRs
 gRs
 gRs
@@ -268150,10 +268540,10 @@ lyG
 lyG
 lyG
 eSt
-eFJ
-uAi
+qRR
+bWA
 jOU
-uAi
+bWA
 vPK
 nXJ
 kdw
@@ -268582,7 +268972,7 @@ lyG
 aDi
 ycI
 slx
-rhw
+mVl
 fdF
 iLj
 ggn
@@ -269014,7 +269404,7 @@ jib
 fIA
 osR
 sla
-rhw
+mVl
 kTh
 pQc
 rFB
@@ -269446,12 +269836,12 @@ lyG
 lyG
 lyG
 lyG
-rhw
+mVl
 wYJ
 pQc
-rFB
+hlE
 dww
-dRw
+xdC
 sPd
 kdw
 eQv
@@ -269878,7 +270268,7 @@ xWK
 uzF
 hSA
 eGj
-rhw
+mVl
 tpn
 pQc
 umj
@@ -269895,7 +270285,7 @@ cAc
 pQc
 pQc
 sak
-dQD
+kjN
 feE
 bjz
 ctJ
@@ -270310,7 +270700,7 @@ xWK
 xWK
 aZr
 gIO
-rhw
+mVl
 gzz
 tag
 pQc
@@ -270322,7 +270712,7 @@ vPK
 fUP
 vzL
 eOx
-eFJ
+nIe
 scK
 jSA
 scK
@@ -270742,9 +271132,9 @@ pJj
 xWK
 xWK
 fLn
-eFJ
-eFJ
-eFJ
+qRR
+bWA
+bWA
 mLT
 qRR
 bWA
@@ -272042,14 +272432,14 @@ csO
 qRR
 bng
 bWA
+upu
 bWA
 bWA
+xdC
 bWA
-eFJ
-uAi
 fwH
-uAi
-uAi
+bWA
+bWA
 scK
 bvJ
 scK
@@ -272912,9 +273302,9 @@ jfX
 vPK
 vfx
 ycM
-qRR
+nIe
 jAu
-scK
+qRR
 jiQ
 iTw
 iWT
@@ -273336,17 +273726,17 @@ xWK
 xHs
 lyG
 mVl
-rFS
+pKf
+eOc
 mom
-mom
-mom
+bMi
 jfX
 vPK
 xrZ
 kdw
 auL
 njY
-soz
+mVl
 bwd
 cBf
 aCn
@@ -273769,16 +274159,16 @@ lyG
 lyG
 mVl
 tnc
-eFJ
+qRR
 jbC
-eFJ
+qRR
 tnc
-rhw
+nIe
 bna
 kdw
 auL
 njY
-scK
+mVl
 ibs
 iTw
 iWT
@@ -274208,9 +274598,9 @@ jfX
 gZt
 kdw
 nWH
-qRR
+nIe
 jAu
-eFJ
+qRR
 cBf
 iTw
 oWI
@@ -274642,7 +275032,7 @@ xrZ
 kdw
 xrZ
 cUF
-qRR
+mVl
 mQj
 wbD
 rDV
@@ -275506,7 +275896,7 @@ vfx
 kdw
 kdw
 jnW
-scK
+mVl
 iYW
 lqu
 cBf
@@ -275938,7 +276328,7 @@ xrZ
 kdw
 xhv
 bmr
-scK
+mVl
 iWT
 cBf
 iTw
@@ -276370,7 +276760,7 @@ fzf
 aTg
 qoJ
 uFw
-scK
+mVl
 fee
 ffE
 cBf
@@ -276788,21 +277178,21 @@ nvH
 qRR
 rct
 rct
-qRR
+nIe
 bWA
 bWA
-qRR
-uAi
+nIe
+bWA
 kKd
 oTd
 rct
-uAi
-qRR
-bWA
-bWA
 bWA
 qRR
-scK
+bWA
+upu
+upu
+bWA
+qRR
 iWT
 iTw
 ffE

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -4562,7 +4562,7 @@
 "beZ" = (
 /obj/structure/bars/passage/shutter{
 	name = "Escape Route";
-	redstone_id = "rd_escape"
+	redstone_id = "night_escape"
 	},
 /turf/open/floor/rogue/greenstone,
 /area/rogue/indoors/town/bath)
@@ -35584,6 +35584,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/light/rogue/candle/l,
+/obj/effect/landmark/start/nightmaiden,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "iBJ" = (
@@ -88344,6 +88345,7 @@
 	pixel_x = 16;
 	pixel_y = -4
 	},
+/obj/effect/landmark/start/nightmaiden,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/bath)
 "vwB" = (
@@ -96680,7 +96682,6 @@
 	lockid = "manor"
 	},
 /obj/item/bottle_kit,
-/obj/item/reagent_containers/peppermill,
 /obj/item/rogueweapon/huntingknife/chefknife{
 	pixel_x = 5;
 	pixel_y = 1

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -222,12 +222,20 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "acp" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
 	},
-/obj/machinery/light/rogue/candle/blue/r,
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/candle/l{
+	pixel_x = 32
+	},
+/obj/structure/flora/roguegrass/bush/westleach{
+	pixel_y = 13
+	},
+/obj/item/roguebin/water{
+	anchored = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "acB" = (
 /obj/structure/bed/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1577,11 +1585,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/tavern)
 "auL" = (
-/obj/machinery/light/rogue/candle/l{
-	light_power = 0
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/carpet/purple,
+/area/rogue/under/cavewet)
 "auR" = (
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/dirt,
@@ -3282,17 +3290,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/rtfield/rockhill)
-"aPk" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/crown{
-	pixel_x = -32
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
 "aPr" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/church)
@@ -13539,9 +13536,15 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/cavewet)
 "dlE" = (
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1
+	},
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/under/cavewet)
 "dlG" = (
 /obj/structure/table/wood/poor,
 /turf/open/floor/carpet/purple,
@@ -17677,12 +17680,11 @@
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
 "emc" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/structure/chair/wood/rogue,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/obj/structure/roguewindow/harem2,
+/obj/structure/fluff/railing/border/west,
+/obj/structure/fluff/railing/border/east,
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/cavewet)
 "emd" = (
 /obj/structure/flora/rogueshroom{
 	icon_state = "mush2"
@@ -18692,9 +18694,12 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/outdoors/woodsrat/north)
 "eyL" = (
+/obj/structure/fluff/pillow/magenta{
+	dir = 1
+	},
 /obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/red,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/carpet/purple,
+/area/rogue/under/cavewet)
 "eyO" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -19092,12 +19097,16 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "eDb" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 1
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
+/obj/item/reagent_containers/glass/cup/wooden{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "eDc" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/table/wood{
@@ -24071,18 +24080,9 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsrat/south)
 "fNt" = (
-/obj/structure/bed/rogue/inn/double{
-	dir = 1
-	},
-/obj/item/bedsheet/rogue/double_pelt{
-	dir = 1
-	},
-/obj/effect/decal/carpet/kover_purple{
-	pixel_x = 16;
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/candle/l,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/cavewet)
 "fNw" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -27544,14 +27544,13 @@
 	},
 /area/rogue/under/cavewet)
 "gGR" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
+/obj/structure/stairs/stone{
+	dir = 8
 	},
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
+/obj/structure/stairs/stone{
+	dir = 8
 	},
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "gGU" = (
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
@@ -28024,14 +28023,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
-"gNl" = (
-/obj/effect/decal/cobbleedge{
-	dir = 8;
-	icon_state = "borderfall";
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
 "gNu" = (
 /obj/machinery/light/rogue/lanternpost,
 /turf/open/floor/rogue/grass,
@@ -30138,11 +30129,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "hnp" = (
-/obj/machinery/light/rogue/candle/blue/l,
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/churchmarble,
+/turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "hnr" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle{
@@ -39906,13 +39893,21 @@
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
 "jJJ" = (
-/obj/item/bedsheet/rogue/fabric,
-/obj/structure/bed/rogue/inn,
+/obj/structure/bed/rogue/inn{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric{
+	dir = 1
+	},
+/obj/machinery/light/rogue/candle/l{
+	pixel_x = 0;
+	pixel_y = -32
+	},
 /obj/structure/curtain/magenta{
 	alpha = 200
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "jJO" = (
 /obj/machinery/light/rogue/torchholder/l,
 /turf/open/floor/rogue/hay,
@@ -40160,20 +40155,13 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/shelter/bog)
 "jNf" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/obj/machinery/light/rogue/candle/l{
-	pixel_x = 32
-	},
-/obj/structure/flora/roguegrass/bush/westleach{
-	pixel_y = 13
-	},
-/obj/item/roguebin/water{
-	anchored = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/obj/structure/table/wood/large_table,
+/obj/item/hair_dye_cream,
+/obj/item/dye_brush,
+/obj/structure/mirror,
+/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
+/turf/open/floor/carpet/purple,
+/area/rogue/under/cavewet)
 "jNg" = (
 /obj/structure/pillory/reinforced{
 	lockid = list("inquisition")
@@ -41172,12 +41160,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/shelter/mountains)
 "kaO" = (
-/obj/structure/mineral_door/wood/bath/courtesan,
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/indoors/town/bath)
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/cavewet)
 "kaP" = (
 /turf/open/floor/rogue/grasscold,
 /area/rogue/outdoors/woodsafe)
@@ -42989,9 +42974,18 @@
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsafe)
 "kvU" = (
-/obj/machinery/light/rogue/candle,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/obj/structure/bed/rogue/inn/double{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/double_pelt{
+	dir = 1
+	},
+/obj/effect/decal/carpet/kover_purple{
+	pixel_x = 16;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet/purple,
+/area/rogue/under/cavewet)
 "kwc" = (
 /obj/item/natural/worms/leech,
 /obj/item/natural/worms/leech{
@@ -43913,15 +43907,11 @@
 /turf/open/water/swamp,
 /area/rogue/under/cavewet)
 "kIL" = (
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	pixel_x = 1;
-	pixel_y = -7
+/obj/structure/curtain/magenta{
+	alpha = 200
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 8
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/cavewet)
 "kIO" = (
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/cavewet)
@@ -44605,11 +44595,9 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
 "kRu" = (
-/obj/structure/roguewindow/harem2,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/carpet/red,
+/area/rogue/under/cavewet)
 "kRJ" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -45236,6 +45224,9 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/rockhill)
+"kZR" = (
+/turf/open/floor/rogue/church,
+/area/rogue/indoors/town/bath)
 "kZU" = (
 /obj/structure/stairs/stone/ccwdown{
 	dir = 1
@@ -45389,11 +45380,8 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/town/sewer)
 "lcD" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/cavewet)
 "lcH" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -46485,12 +46473,9 @@
 /area/rogue/outdoors/woodsrat/south)
 "lqS" = (
 /obj/structure/stairs/stone{
-	dir = 1
+	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/churchrough,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "lqX" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -47531,7 +47516,7 @@
 	pixel_y = -10
 	},
 /turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "lGl" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/naturalstone,
@@ -51292,14 +51277,6 @@
 /obj/item/cooking/platter,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/warden)
-"myt" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
-	},
-/obj/item/candle/eora/lit,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
 "myw" = (
 /obj/structure/bed/rogue/inn/wool{
 	pixel_x = 3;
@@ -51347,12 +51324,6 @@
 	icon_state = "horzw"
 	},
 /area/rogue/indoors/town/church/chapel)
-"mzd" = (
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
 "mzh" = (
 /obj/structure/globe,
 /turf/open/floor/rogue/cobble/mossy,
@@ -52871,14 +52842,8 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/underdarker/rockhill)
 "mSL" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/obj/structure/fluff/walldeco/stone{
-	pixel_y = 32
-	},
-/obj/machinery/light/rogue/candle/floorcandle,
-/turf/open/floor/rogue/churchrough,
+/obj/structure/roguewindow/harem1,
+/turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/bath)
 "mSN" = (
 /obj/structure/stairs/stone{
@@ -52912,12 +52877,6 @@
 "mTw" = (
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/Academy)
-"mTJ" = (
-/obj/structure/fluff/pillow/magenta{
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
 "mTM" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -58056,13 +58015,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town)
 "ogI" = (
-/obj/effect/decal/cobbleedge{
-	dir = 4;
-	icon_state = "borderfall";
-	pixel_x = 8
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/carpet/red,
+/area/rogue/under/cavewet)
 "ogP" = (
 /obj/structure/stairs,
 /obj/structure/fluff/railing/border{
@@ -65512,11 +65466,15 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "pXx" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/machinery/light/rogue/candle/floorcandle/pink{
+	pixel_x = 1;
+	pixel_y = -7
 	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/under/cavewet)
 "pXB" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
 	dir = 4
@@ -66279,10 +66237,10 @@
 /area/rogue/indoors/shelter/bog)
 "qiF" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "qiH" = (
 /obj/structure/closet/crate/roguecloset/lord{
 	lockid = "physician"
@@ -68016,21 +67974,11 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/cavewet)
 "qDX" = (
-/obj/structure/bed/rogue/inn{
-	dir = 1
+/obj/structure/fluff/walldeco/church/line{
+	dir = 8
 	},
-/obj/item/bedsheet/rogue/fabric{
-	dir = 1
-	},
-/obj/machinery/light/rogue/candle/l{
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/under/cavewet)
 "qDY" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	dir = 4;
@@ -68538,11 +68486,11 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town/bath)
 "qKV" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/obj/structure/roguewindow/harem2,
+/obj/structure/fluff/railing/border/west,
+/obj/structure/fluff/railing/border/east,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/under/cavewet)
 "qLc" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood{
@@ -70715,14 +70663,11 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/town/rockhill)
 "rqF" = (
-/obj/structure/stairs/stone{
-	dir = 1
+/obj/structure/closet/crate/roguecloset/inn/south{
+	lockid = ""
 	},
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "rqJ" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/outdoors/town/roofs/keep)
@@ -71886,16 +71831,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/grove)
 "rFo" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "tablewood1"
+/obj/structure/mineral_door/wood/red{
+	locked = 1;
+	lockid = "nightmaiden";
+	name = "Dormitory"
 	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_x = 11;
-	pixel_y = 1
-	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cavewet)
 "rFu" = (
 /turf/closed/mineral/random/rogue/med,
 /area/rogue/under/underdark/rockhill)
@@ -74334,17 +74276,9 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/under/town/basement)
 "skm" = (
-/obj/structure/bed/rogue/inn{
-	dir = 1
-	},
-/obj/item/bedsheet/rogue/fabric{
-	dir = 1
-	},
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "sks" = (
 /obj/structure/closet/crate/chest{
 	lockid = "clinic"
@@ -74691,11 +74625,9 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/bath)
 "soD" = (
-/obj/structure/curtain/magenta{
-	alpha = 200
-	},
-/turf/open/floor/rogue/tile/brownbrick,
-/area/rogue/indoors/town/bath)
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cavewet)
 "soL" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -77625,8 +77557,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/shelter/mountains)
 "tbs" = (
+/obj/structure/fluff/walldeco/church/line{
+	dir = 4
+	},
+/obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "tbu" = (
 /obj/structure/stairs/stone,
 /obj/structure/fluff/railing/border{
@@ -77996,10 +77932,11 @@
 /area/rogue/outdoors/woodsrat/north)
 "tfS" = (
 /obj/structure/fluff/walldeco/church/line{
-	dir = 8
+	dir = 4
 	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "tfU" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/cleanshallow,
@@ -81156,15 +81093,17 @@
 /turf/open/floor/rogue/grasscold,
 /area/rogue/under/cave/goblinfort)
 "tTb" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 1
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/candle/eora,
+/obj/item/soap/bath{
+	pixel_y = -10
 	},
-/obj/machinery/light/rogue/candle/floorcandle/pink{
-	pixel_x = 1;
-	pixel_y = -7
-	},
-/turf/open/floor/rogue/tile/brick,
-/area/rogue/indoors/town/bath)
+/obj/structure/closet/crate/roguecloset/inn,
+/turf/open/floor/carpet/purple,
+/area/rogue/under/cavewet)
 "tTi" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/sword/sabre/stalker,
@@ -82871,7 +82810,7 @@
 "uob" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "uoc" = (
 /obj/structure/chair/bench/couch,
 /obj/machinery/light/rogue/candle/l,
@@ -83906,9 +83845,11 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
 "uAG" = (
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/fluff/walldeco/church/line{
+	dir = 1
+	},
+/turf/open/floor/rogue/tile/brick,
+/area/rogue/under/cavewet)
 "uAL" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -88249,15 +88190,11 @@
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/shelter/mountains)
 "vGg" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/machinery/light/rogue/candle/l{
+	light_power = 0
 	},
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4;
-	pixel_x = 2
-	},
-/turf/open/floor/rogue/churchmarble,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "vGj" = (
 /obj/structure/fluff/statue/abyssor,
 /turf/open/floor/rogue/churchmarble,
@@ -91499,11 +91436,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
 "wxx" = (
-/obj/structure/closet/crate/roguecloset/inn/south{
-	lockid = ""
+/obj/structure/mineral_door/wood/bath/courtesan,
+/obj/structure/curtain/magenta{
+	alpha = 200
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/concrete,
+/area/rogue/under/cavewet)
 "wxy" = (
 /obj/effect/landmark/start/tailor,
 /turf/open/floor/carpet/red,
@@ -91793,13 +91731,13 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/bath)
 "wBa" = (
-/obj/structure/table/wood/large_table,
-/obj/item/hair_dye_cream,
-/obj/item/dye_brush,
-/obj/structure/mirror,
-/obj/machinery/light/rogue/candle/floorcandle/alt/pink,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
+/obj/item/bedsheet/rogue/fabric,
+/obj/structure/bed/rogue/inn,
+/obj/structure/curtain/magenta{
+	alpha = 200
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cavewet)
 "wBe" = (
 /obj/structure/flora/rogueshroom{
 	pixel_y = -5
@@ -92002,9 +91940,8 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bogsafe)
 "wDt" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/carpet/purple,
+/area/rogue/under/cavewet)
 "wDz" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/naturalstone,
@@ -92170,12 +92107,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/garrison)
 "wFB" = (
-/obj/structure/fluff/walldeco/church/line{
-	dir = 4
+/obj/structure/curtain/magenta{
+	alpha = 200
 	},
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/ruinedwood/spiral,
-/area/rogue/indoors/town/bath)
+/turf/open/floor/rogue/tile/brownbrick,
+/area/rogue/under/cavewet)
 "wFJ" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -94295,10 +94231,17 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
 "xhv" = (
-/obj/structure/closet/crate/drawer,
-/obj/machinery/light/rogue/candle,
+/obj/structure/bed/rogue/inn{
+	dir = 1
+	},
+/obj/item/bedsheet/rogue/fabric{
+	dir = 1
+	},
+/obj/structure/curtain/magenta{
+	alpha = 200
+	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town/bath)
+/area/rogue/under/cavewet)
 "xhx" = (
 /obj/item/natural/poo/cow,
 /turf/open/floor/rogue/cobble/mossy,
@@ -94566,17 +94509,13 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/garrison)
 "xkI" = (
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/candle/eora,
-/obj/item/soap/bath{
-	pixel_y = -10
+/obj/structure/table/wood{
+	dir = 1;
+	icon_state = "tablewood1"
 	},
-/obj/structure/closet/crate/roguecloset/inn,
-/turf/open/floor/carpet/purple,
-/area/rogue/indoors/town/bath)
+/obj/item/candle/eora/lit,
+/turf/open/floor/rogue/ruinedwood/spiral,
+/area/rogue/under/cavewet)
 "xkX" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -95781,11 +95720,10 @@
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/woodsrat/above)
 "xAL" = (
-/obj/structure/roguewindow/harem2,
-/obj/structure/fluff/railing/border/west,
-/obj/structure/fluff/railing/border/east,
-/turf/open/floor/rogue/churchrough,
-/area/rogue/indoors/town/bath)
+/obj/structure/closet/crate/drawer,
+/obj/machinery/light/rogue/candle,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/under/cavewet)
 "xAO" = (
 /obj/structure/closet/crate/roguecloset{
 	keylock = 1;
@@ -146282,11 +146220,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+jxS
+aSH
+jxS
+jxS
+jxS
 whb
 whb
 whb
@@ -146714,11 +146652,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+emc
+fVn
+dlE
+emc
+jxS
 whb
 whb
 whb
@@ -147146,11 +147084,11 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
+emc
+fVn
+uAG
+emc
+jxS
 whb
 whb
 whb
@@ -147578,16 +147516,16 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+jxS
+jxS
+wFB
+jxS
+jxS
+jxS
+jxS
+jxS
+jxS
+jxS
 whb
 whb
 whb
@@ -148010,16 +147948,16 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xks
+kvU
+lcD
+qKV
+kvU
+fNt
+jxS
+fVn
+fVn
+jxS
 whb
 whb
 whb
@@ -148442,16 +148380,16 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xks
+eyL
+lcD
+qKV
+auL
+lcD
+wFB
+qDX
+pXx
+jxS
 whb
 whb
 whb
@@ -148874,17 +148812,17 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xks
+qKV
+kIL
+xks
+qKV
+kIL
+aSH
+jxS
+jxS
+aSH
+jxS
 whb
 whb
 whb
@@ -149306,18 +149244,18 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+xks
+jNf
+kaO
+qKV
+jNf
+kaO
+jxS
+jxS
+xAL
+xhv
+gQh
+jxS
 whb
 whb
 whb
@@ -149738,18 +149676,18 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+aSH
+tTb
+lcD
+qKV
+lGk
+lcD
+jxS
+rqF
+fuF
+fuF
+jJJ
+gQh
 whb
 whb
 whb
@@ -150170,18 +150108,18 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+jxS
+jxS
+wxx
+jxS
+jxS
+wxx
+jxS
+ogI
+ogI
+fuF
+soD
+aSH
 whb
 whb
 whb
@@ -150602,18 +150540,18 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+jxS
+xkI
+wDt
+vGg
+fuF
+wDt
+aSH
+kRu
+ogI
+fuF
+wBa
+jxS
 whb
 whb
 whb
@@ -151034,18 +150972,18 @@ whb
 whb
 whb
 whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+aSH
+skm
+fuF
+uob
+eDb
+uob
+rFo
+qiF
+acp
+tbs
+tfS
+gQh
 whb
 whb
 whb
@@ -154059,18 +153997,18 @@ whb
 whb
 whb
 xCt
-xCt
-soz
-xCt
-xCt
-xCt
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
+rmv
+rmv
+rmv
+rmv
+rmv
+rmv
 whb
 whb
 whb
@@ -154491,18 +154429,18 @@ whb
 whb
 whb
 xCt
-kRu
-wpu
-tTb
-kRu
-xCt
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
+rmv
+rmv
+rmv
+rmv
+rmv
+rmv
 whb
 whb
 whb
@@ -154923,18 +154861,18 @@ whb
 whb
 whb
 xCt
-kRu
-wpu
-qiF
-kRu
-xCt
-whb
-whb
-whb
-whb
-whb
-whb
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
+rmv
+rmv
+rmv
+rmv
+rmv
+rmv
 whb
 whb
 whb
@@ -155355,18 +155293,18 @@ soz
 scK
 fJX
 xCt
-xCt
-xCt
-soD
-xCt
-xCt
-xCt
-xCt
-xCt
-xCt
-xCt
-whb
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
+rmv
 whb
 whb
 whb
@@ -155787,18 +155725,18 @@ xzC
 sFi
 gne
 xCt
-xrC
-fNt
-pQc
-xAL
-fNt
-dlE
-xCt
-wpu
-wpu
-xCt
-whb
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
+rmv
 whb
 whb
 whb
@@ -156219,18 +156157,18 @@ qNw
 aCi
 ttc
 fJX
-xrC
-eDb
-pQc
-xAL
-mTJ
-pQc
-soD
-tfS
-kIL
-xCt
-whb
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
+rmv
 whb
 whb
 whb
@@ -156651,18 +156589,18 @@ odm
 asP
 bJx
 fJX
-xrC
-xAL
-mzd
-xrC
-xAL
-mzd
-soz
-xCt
-xCt
-soz
-xCt
-whb
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+rmv
 whb
 whb
 whb
@@ -157083,18 +157021,18 @@ tvr
 gJb
 sTl
 xrC
-xrC
-wBa
-uAG
-xAL
-wBa
-uAG
-xCt
-xCt
-xhv
-skm
-nvH
-xCt
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -157515,18 +157453,18 @@ xQX
 pQc
 pQc
 qtm
-soz
-xkI
-pQc
-xAL
-lGk
-pQc
-xCt
-wxx
-tbs
-tbs
-qDX
-nvH
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -157947,18 +157885,18 @@ sAY
 pQc
 uzk
 soz
-xCt
-xCt
-kaO
-xCt
-xCt
-kaO
-xCt
-fqM
-fqM
-tbs
-wDt
-soz
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -158379,18 +158317,18 @@ sAY
 bUS
 jdK
 fJX
-xCt
-myt
-asP
-auL
-tbs
-asP
-soz
-eyL
-fqM
-tbs
-jJJ
-xCt
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -158811,18 +158749,18 @@ sAY
 goe
 xBi
 fJX
-soz
-kvU
-tbs
-uob
-rFo
-uob
-bzy
-lcD
-jNf
-emc
-wFB
-nvH
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
+lsQ
 whb
 whb
 whb
@@ -161829,12 +161767,12 @@ yee
 yee
 scK
 sIR
-cNQ
-acp
-cNQ
-aPk
-ogI
-vGg
+sIR
+sIR
+sIR
+sIR
+sIR
+sIR
 sIR
 sIR
 cro
@@ -162261,12 +162199,12 @@ yee
 yee
 scK
 sIR
-dyT
-soz
-eFJ
+sIR
+scK
+scK
 mSL
-rqF
-pXx
+mSL
+scK
 sIR
 sIR
 lwr
@@ -162694,11 +162632,11 @@ vdR
 scK
 sIR
 sIR
-xrC
-rvT
-sIR
+scK
 hbl
-sIR
+kZR
+kZR
+mSL
 sIR
 sIR
 lwr
@@ -163126,11 +163064,11 @@ sIR
 sIR
 sIR
 sIR
-xrC
-rvT
-sIR
+scK
 hbl
-sIR
+kZR
+kZR
+mSL
 sIR
 sIR
 otv
@@ -163557,14 +163495,14 @@ sIR
 sIR
 sIR
 sIR
-cNQ
-soz
-eFJ
+sIR
+scK
+scK
 gGR
 lqS
-qKV
-sIR
-sIR
+scK
+cUC
+cUC
 hSv
 cUC
 cUC
@@ -163989,14 +163927,14 @@ sIR
 sIR
 sIR
 sIR
-dyT
-hnp
-dyT
-gNl
-gNl
-pXx
 sIR
 sIR
+sIR
+sIR
+sIR
+cUC
+cUC
+cUC
 hSv
 cUC
 cUC
@@ -164419,15 +164357,15 @@ jfX
 cGQ
 sIR
 sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+hnp
+hnp
+hnp
+hnp
+hnp
+hnp
+hnp
+cUC
+cUC
 sIR
 otv
 tIz
@@ -164850,16 +164788,16 @@ bFa
 jfX
 yjd
 sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+hnp
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+cUC
 sIR
 lwr
 xgi
@@ -165282,16 +165220,16 @@ vLn
 wpu
 soz
 sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+hnp
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+hnp
 sIR
 lwr
 xuA
@@ -165714,15 +165652,15 @@ dlu
 dlu
 scK
 sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+hnp
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+hnp
 sIR
 sIR
 cro
@@ -166146,14 +166084,14 @@ sLa
 bqs
 eFJ
 sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+hnp
+wpu
+wpu
+wpu
+wpu
+wpu
+wpu
+hnp
 sIR
 sIR
 sIR
@@ -166579,12 +166517,12 @@ yjj
 dbS
 sIR
 sIR
-sIR
-sIR
-sIR
-sIR
-sIR
-sIR
+hnp
+hnp
+hnp
+hnp
+hnp
+hnp
 sIR
 sIR
 sIR

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -14183,6 +14183,7 @@
 	pixel_x = 16;
 	pixel_y = -2
 	},
+/obj/effect/landmark/start/nightmaiden,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "drd" = (
@@ -14200,6 +14201,7 @@
 	pixel_x = -6;
 	pixel_y = 4
 	},
+/obj/effect/landmark/start/nightmaiden,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "drA" = (
@@ -18473,6 +18475,7 @@
 /area/rogue/outdoors/town/roofs)
 "ete" = (
 /obj/structure/fluff/pillow/magenta,
+/obj/effect/landmark/start/nightmaiden,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/bath)
 "etg" = (
@@ -26160,6 +26163,10 @@
 "gjI" = (
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/bograt/above)
+"gkh" = (
+/obj/effect/landmark/start/nightmaiden,
+/turf/open/floor/rogue/churchbrick,
+/area/rogue/indoors/town/bath)
 "gkj" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church"
@@ -50749,6 +50756,7 @@
 /area/rogue/under/town/basement)
 "mkY" = (
 /obj/structure/fluff/pillow/magenta,
+/obj/effect/landmark/start/nightmaiden,
 /turf/open/floor/rogue/tile/harem2,
 /area/rogue/indoors/town/bath)
 "mle" = (
@@ -61471,6 +61479,10 @@
 /obj/item/candle/yellow/lit,
 /turf/open/floor/carpet/red,
 /area/rogue/under/cave)
+"oQr" = (
+/obj/effect/landmark/start/nightman,
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "oQy" = (
 /turf/open/floor/rogue/ruinedwood/herringbone,
 /area/rogue/indoors/town)
@@ -64348,6 +64360,12 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/tavern)
+"pzn" = (
+/obj/structure/roguemachine/mail/l{
+	mailtag = "Whitevein - Employee Lounge"
+	},
+/turf/open/floor/rogue/tile/harem2,
+/area/rogue/indoors/town/bath)
 "pzo" = (
 /turf/open/floor/rogue/grassred,
 /area/rogue)
@@ -94631,6 +94649,10 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/bograt/above)
+"xap" = (
+/obj/effect/landmark/start/nightmaiden,
+/turf/open/floor/rogue/churchrough,
+/area/rogue/indoors/town/bath)
 "xas" = (
 /obj/structure/closet/crate/coffin,
 /obj/item/natural/bone,
@@ -156668,7 +156690,7 @@ mVl
 qRR
 bMh
 kdw
-kdw
+oQr
 bJx
 rct
 mVl
@@ -268551,7 +268573,7 @@ jOU
 bWA
 vPK
 nXJ
-kdw
+pzn
 rpV
 vPK
 vUb
@@ -269411,7 +269433,7 @@ osR
 sla
 mVl
 kTh
-pQc
+xap
 qFk
 pkM
 dRw
@@ -270275,7 +270297,7 @@ hSA
 eGj
 mVl
 tpn
-pQc
+xap
 umj
 vPK
 nXJ
@@ -273300,9 +273322,9 @@ lVR
 orb
 mVl
 lwr
+gkh
 jfX
-jfX
-jfX
+gkh
 jfX
 vPK
 vfx


### PR DESCRIPTION
## About The Pull Request

Recently found myself playing a lot within the Bathhouse. Have had a LOT of fun with actually playing the role 'as intended', acting as a middleman between the Keep and Antags in Hightown, including hiring spies and thieves to play political games. 

After playing more on Dunworld and Desert Town, and speaking to a lot of other Bathhouse mains, we came up with a list of things we would want to see changed. In the end I felt somewhat inspired to renovate the whole of Whitevein.

<details> 
<summary> In depth details, don't read if you want to be surprised!: </summary>
I kept the overall size, shape and layout _mostly_ the same, but have rethemed it somewhat. The previous venue was somewhat on the 'seedier' end, and while that is FINE, I felt like making it more luxuriously themed would fit the role and actual RP we have encountered, also making it feel a little closer to the one on Dunworld (and I just think it looks much more interesting without being TOO visually loud). There's a LOT of quality of life adjustments, the largest of which are a vomitorium for the kitchen, and a storeroom for booze barrels (with a water source). 

On top of that, the layout for the upstairs front of house has changed dramatically to better suit the RP encounters we usually have, a larger front office and lobby area with better 'traffic flow' including a side area for more quickly dealing with thieves who wish to sell items, and the ability to securely lock the lobby with hidden bars. 

The staff area upstairs was completely changed, the dressing room is more cozy and now contains the escape tunnel as well as some more themed outfits (and the desert specific bra which is super nice). There is a small staff lounge and a dedicated kitchen to allow the Whitevein to more properly cater for high end guests by preparing full meals for them.

The downstairs staff area is mostly the same layout wise, though the doors have been replaced with a small office area surrounding the stairs. The nightmaster's room has been made a little larger and given a 'negotiation room'. This is present on Desert Town and I liked the idea a LOT. Whilst there is already the 'punishment room', this is more clearly aimed at BDSM play with clients, while the new room is directly attached to the NM's room and designed to actual interrogate/torture those whom decide to cross the NM. I added a potential (though difficult) escape/rescue route above it through a small cave which can be climbed up into a small tunnel next to the main river for more interesting antag interaction. A similar 'old path' with a grate was added to the new wine cellar, again leading to the sewers.

For the rest of the downstairs, I added a larger and more decorate pool area to the relatively unused central space. The old 'free rooms' have been removed to add a locker room for bathers and a dedicated large room for playing dice games, with appropriate storage. I added new 'free' rooms to the bottom area and relocated the steam room. There is also another new 'outside' path here, accessed through a secret wall to the right of the steam room, leading to the caves which pass under the rogue's den (which I think adds a cool 'smuggling' route. Though this is also bar protected at round start to prevent instant entry (a door may be needed which I can add in future. The dedicated luxury rooms are mostly unchanged, bar style adjustments (though original theming is intact).

I also added a passage between the punishment room and the keep dungeons. A locked door at each end which uses the NM key lets the NM potentially access the dungeons directly, the intent here is to provide a more direct form of prisoner transfer between the keep and the Bathhouse (as this is something we have done often). I think this is more thematic as well as convenient while also again opening more antag options (I like connectivity). While both ends of this corridor are on the NM's keys, the dungeon end starts locked behind bars and shutters which are only openable from the dungeoneer's side. I felt this was the best compromise, it means the NM cannot just waltz in uninvited, the dungeoneer will need to open it for them. 

The Rogue's den has also gotten some touchups, as I have also had fun playing here as the role of a sort of 'lower tier' NM, working with thug roleplayer's and other 'lower tier' antags in the town. To help facilitate this I added a little back office with a SCOM and a HERMES, with a peddler in the bar. The aim here was to make it somewhat analogous to the lowtown inn, more able now to actually be able to be run as an establishment without major initial investment of time/skills. The two bedrooms have keys, the peddlar and the back office. There is a small escape hatch at the back of the 'quarters', again for cool roleplay options as well as a new escape tunnel from the rogue's den which goes directly into the outflowing river. These rooms are not locked by default, so anyone can come here and 'claim' it. 

Also there were no fireplaces anywhere, it was very easy to get cold while working here, so i've added them to most rooms. 

</details>

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<details> 
<summary>Images (contains spoilers of cool secrets, don't look unless you want to be spoiled!) </summary>
_Passageway for accessing the NM's Dungeon_
<img width="810" height="738" alt="image" src="https://github.com/user-attachments/assets/58f48f27-71f0-4ebb-bf6e-81143000887b" />

_Entrance, Lobby and Front of House_
<img width="1302" height="1105" alt="image" src="https://github.com/user-attachments/assets/328a3e47-cf16-4a6d-a06f-ff2e24f6ce22" />
<img width="1481" height="1324" alt="image" src="https://github.com/user-attachments/assets/3828d49f-95cc-4470-a496-e03482748dcd" />
<img width="1220" height="878" alt="image" src="https://github.com/user-attachments/assets/7a7e2f0f-da65-445a-ab85-23362f3fcd57" />

_New upstairs staff area corridor, dressing rooms, lounge, kitchen and cellar_
<img width="878" height="1218" alt="image" src="https://github.com/user-attachments/assets/48c2ba3e-d8b0-4836-9c96-495c7baea785" />
<img width="1160" height="842" alt="image" src="https://github.com/user-attachments/assets/cd5a7399-4700-454f-ab62-6697ae90727e" />
<img width="1132" height="906" alt="image" src="https://github.com/user-attachments/assets/536cb4c2-49b2-4181-9fac-9c9ef6cc253c" />
<img width="1155" height="965" alt="image" src="https://github.com/user-attachments/assets/9a5bb642-2b87-4490-a550-eee8b91abf1e" />
<img width="1169" height="936" alt="image" src="https://github.com/user-attachments/assets/b4e3ab99-b63f-4b47-8e6c-bc1147065661" />

_Downstairs staff area, new small office, and the restyled rooms here_
<img width="930" height="1283" alt="image" src="https://github.com/user-attachments/assets/78214db0-5d0a-41d7-81c9-57561235bac6" />
<img width="1215" height="890" alt="image" src="https://github.com/user-attachments/assets/29da9668-b2fb-40ad-a2b7-30ad6b809c43" />
<img width="1131" height="925" alt="image" src="https://github.com/user-attachments/assets/5efd75e4-f14b-475b-948f-98dae6516e0c" />
<img width="874" height="751" alt="image" src="https://github.com/user-attachments/assets/ba03dc79-9a87-4524-b9bc-30f281b2bfe5" />
<img width="785" height="768" alt="image" src="https://github.com/user-attachments/assets/6630c9b8-591f-4081-8b0c-db05ea340ba8" />

_New public downstairs with large pool, 4 free private spaces (up from three old ones, redone and moved), locker room and game room (luxury rooms are mostly the same so not pictured_
<img width="1231" height="896" alt="image" src="https://github.com/user-attachments/assets/9620cef6-d31d-40ca-9203-1ae5957b147e" />
<img width="1268" height="893" alt="image" src="https://github.com/user-attachments/assets/469f7029-b136-47fe-9e8c-be1cfe02d534" />
<img width="1230" height="786" alt="image" src="https://github.com/user-attachments/assets/1bcc8f71-80c5-4c9b-a168-a6bdf0d90e29" />
<img width="1200" height="1198" alt="image" src="https://github.com/user-attachments/assets/47adc509-9990-4f9a-8139-0a3c0e57d6d9" />
<img width="1244" height="791" alt="image" src="https://github.com/user-attachments/assets/245f976d-3f18-4d1e-b4dd-5625fb62f382" />
<img width="1011" height="1025" alt="image" src="https://github.com/user-attachments/assets/074bdeec-1c9c-4b58-970b-3573e399db86" />

_NM's quarters (vault unchanged, lighting changed since this screenshot, a little too dark here), and new negotiation room with isolation cell, the bars in the top of the cell connect to the cave mentioned before. Lockers contain various torture/control implements and medical supplies_
<img width="1237" height="762" alt="image" src="https://github.com/user-attachments/assets/5fd33d44-ebfc-4510-8afb-c1a024769d39" />
<img width="1045" height="932" alt="image" src="https://github.com/user-attachments/assets/c40672ed-fbb5-43c2-a1b6-46d649d9586b" />
<img width="760" height="770" alt="image" src="https://github.com/user-attachments/assets/4e57f805-1cdb-4536-ab7f-31cfcc142676" />
<img width="438" height="192" alt="image" src="https://github.com/user-attachments/assets/c8658c62-a876-4cd2-aaef-89a0ebacf046" />
<img width="382" height="221" alt="image" src="https://github.com/user-attachments/assets/81edd3b5-597e-4f27-8fde-b49dbe114163" />
<img width="617" height="329" alt="image" src="https://github.com/user-attachments/assets/437eebc8-432d-4575-adf0-ee2dc686d653" />
<img width="580" height="634" alt="image" src="https://github.com/user-attachments/assets/00df9db0-3235-48d0-83d8-60604bda1f33" />

_Dungeon passage_
<img width="486" height="413" alt="image" src="https://github.com/user-attachments/assets/fc6ab63b-baf3-41fa-96ba-50298c53bf9c" />
<img width="666" height="557" alt="image" src="https://github.com/user-attachments/assets/270a0f3e-61fa-4550-b096-fb3e72fdb8d0" />
<img width="566" height="437" alt="image" src="https://github.com/user-attachments/assets/2052fe07-31e5-482f-bac6-dca03674120f" />

_Passage connecting to underground caves near rogue's den_
<img width="1022" height="679" alt="image" src="https://github.com/user-attachments/assets/3f4ed9d4-2573-4e1a-bf92-73c78396aa58" />

_Rogue's Den_
<img width="1239" height="1085" alt="image" src="https://github.com/user-attachments/assets/aa50e8ce-1e72-4038-876d-646f8e21181d" />
<img width="1138" height="756" alt="image" src="https://github.com/user-attachments/assets/66453f82-4946-4a26-ad17-419d53141671" />
<img width="1020" height="645" alt="image" src="https://github.com/user-attachments/assets/a852d1a6-2ae0-4a6f-90f5-2b854c160062" />
<img width="604" height="521" alt="image" src="https://github.com/user-attachments/assets/f180ef75-bbb3-47ea-8cb2-08c0cb89ee55" />
<img width="728" height="637" alt="image" src="https://github.com/user-attachments/assets/03dd44b4-beeb-423f-ac32-accfaf337c3c" />

_Also added a noticeboard to the docks, I just like to see these used more (and close to Rogue's Den)_
<img width="471" height="395" alt="image" src="https://github.com/user-attachments/assets/01559cbb-ed0c-45d6-92b8-5ee6dabc15c3" />

_StrongDMM Map Images_
<img width="897" height="797" alt="image" src="https://github.com/user-attachments/assets/b07b9549-60b5-4bc8-b606-681192711597" />
<img width="1348" height="1089" alt="image" src="https://github.com/user-attachments/assets/f1dbc96e-e2a2-42cb-84eb-589daa235978" />
<img width="1014" height="926" alt="image" src="https://github.com/user-attachments/assets/96db17a9-f3aa-4d56-a3f0-f9872a373593" />


</details>

## Why It's Good For The Game

Both of these areas have really helped me see how much fun and in-depth roleplay can be achieved on this server with the right environment and players. These changes are intended to provide even better locations for this sort of gameplay, RP focused but still also capable of good mechanical stuff and QOL.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: The Whitevein has been remodelled extensively
map: The Rogue's Den has also had some additions to allow it to function better as a 'proper' inn and hideout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
