### PR TITLE
[AZURE PORT] Add river controller subsystem for performance, rivers can move objects

### DIFF
--- a/code/controllers/subsystem/rivers.dm
+++ b/code/controllers/subsystem/rivers.dm
@@ -1,0 +1,31 @@
+SUBSYSTEM_DEF(rivers)
+	name = "Rivers"
+	flags = SS_KEEP_TIMING | SS_NO_INIT
+	wait = 0.5 SECONDS
+	var/list/processing = list()
+	var/list/currentrun = list()
+
+/datum/controller/subsystem/rivers/stat_entry()
+	..("ACTIVE RIVER TILES:[processing.len]")
+
+
+/datum/controller/subsystem/rivers/fire(resumed = 0)
+	if (!resumed || !src.currentrun.len)
+		src.currentrun = processing.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while(currentrun.len)
+		var/turf/open/water/river/thing = currentrun[currentrun.len]
+		currentrun.len--
+		if(!QDELETED(thing))
+			thing.process_river()
+		else
+			processing -= thing
+		if (MC_TICK_CHECK)
+			return
+
+/datum/controller/subsystem/rivers/Recover()
+	if (istype(SSrivers.processing))
+		processing = SSrivers.processing

--- a/code/controllers/subsystem/rivers.dm
+++ b/code/controllers/subsystem/rivers.dm
@@ -17,15 +17,24 @@ SUBSYSTEM_DEF(rivers)
 	var/list/currentrun = src.currentrun
 
 	while(currentrun.len)
-		var/turf/open/water/river/thing = currentrun[currentrun.len]
+		var/turf/thing = currentrun[currentrun.len]
 		currentrun.len--
-		if(!QDELETED(thing))
-			thing.process_river()
-		else
+		if(!istype(thing, /turf/open/water/river))
 			processing -= thing
-		if (MC_TICK_CHECK)
+			continue
+		var/turf/open/water/river/river = thing
+		if(!QDELETED(river))
+			river.process_river()
+		else
+			processing -= river
+
+		if(MC_TICK_CHECK)
 			return
 
 /datum/controller/subsystem/rivers/Recover()
 	if (istype(SSrivers.processing))
 		processing = SSrivers.processing
+
+/turf/open/water/river/Destroy()
+	STOP_PROCESSING(SSrivers, src)
+	..()

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -612,7 +612,7 @@
 /turf/open/water/river/get_heuristic_slowdown(mob/traverser, travel_dir)
 	var/const/UPSTREAM_PENALTY = 2 //Ratwood edit, Azure: 4
 	var/const/DOWNSTREAM_BONUS = -2 //Ratwood edit, Azure: -1
-	var/const/SIDESTREAM_PENALTY = 2
+	var/const/SIDESTREAM_PENALTY = 1 //Ratwood edit, Azure: 2
 	. = ..()
 	if(traverser.is_floor_hazard_immune())
 		return

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -226,7 +226,7 @@
 					playsound(AM, pick('sound/foley/watermove (1).ogg','sound/foley/watermove (2).ogg'), 100, FALSE)
 				if(istype(oldLoc, type) && (get_dir(src, oldLoc) != SOUTH))
 					water_overlay.layer = ABOVE_MOB_LAYER
-					water_overlay.plane = water_overlay.plane = GAME_PLANE_HIGHEST
+					water_overlay.plane = GAME_PLANE_HIGHEST
 				else
 					spawn(6)
 						if(AM.loc == src)
@@ -570,7 +570,6 @@
 	slowdown = 5
 	wash_in = TRUE
 	swim_skill = TRUE
-	var/river_processing
 	swimdir = TRUE
 
 /turf/open/water/river/muddy
@@ -608,13 +607,12 @@
 
 /turf/open/water/river/Entered(atom/movable/AM, atom/oldLoc)
 	. = ..()
-	if(isliving(AM))
-		if(!river_processing)
-			river_processing = addtimer(CALLBACK(src, PROC_REF(process_river)), 5, TIMER_STOPPABLE)
+	START_PROCESSING(SSrivers, src)
 
 /turf/open/water/river/get_heuristic_slowdown(mob/traverser, travel_dir)
-	var/const/UPSTREAM_PENALTY = 2
-	var/const/DOWNSTREAM_BONUS = -2
+	var/const/UPSTREAM_PENALTY = 2 //Ratwood edit, Azure: 4
+	var/const/DOWNSTREAM_BONUS = -2 //Ratwood edit, Azure: -1
+	var/const/SIDESTREAM_PENALTY = 2
 	. = ..()
 	if(traverser.is_floor_hazard_immune())
 		return
@@ -625,15 +623,30 @@
 		. += DOWNSTREAM_BONUS // faster!
 	else if(travel_dir == GLOB.reverse_dir[dir]) // upriver
 		. += UPSTREAM_PENALTY // slower
+	else 
+		. += SIDESTREAM_PENALTY // sidestream walking isn't free, bro
 
 /turf/open/water/river/proc/process_river()
-	river_processing = null
+	var/found_movable = FALSE
 	for(var/atom/movable/A in contents)
+		found_movable = TRUE
 		for(var/obj/structure/S in src)
 			if(S.obj_flags & BLOCK_Z_OUT_DOWN)
 				return
 		if((A.loc == src))
 			A.ConveyorMove(dir)
+
+	if(found_movable)
+		STOP_PROCESSING(SSrivers, src)
+		return
+
+/turf/open/water/river/CanPass(atom/movable/mover, turf/target)
+	if(isliving(mover))
+		var/mob/mover_mob = mover
+		// prevent NPCs from constantly trying to go against the flow
+		if(!mover_mob.mind && get_dir(src, mover) == dir)
+			return FALSE
+	return ..()
 
 /turf/open/water/ocean
 	name = "salt water"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -381,6 +381,7 @@
 #include "code\controllers\subsystem\ping.dm"
 #include "code\controllers\subsystem\pollution.dm"
 #include "code\controllers\subsystem\radio.dm"
+#include "code\controllers\subsystem\rivers.dm"
 #include "code\controllers\subsystem\rogueroundsplayed.dm"
 #include "code\controllers\subsystem\runechat.dm"
 #include "code\controllers\subsystem\server_maint.dm"


### PR DESCRIPTION
## About The Pull Request

- PORT 1: https://github.com/Azure-Peak/Azure-Peak/pull/4830
- PORT 2: https://github.com/Azure-Peak/Azure-Peak/pull/4913
- PORT 3: https://github.com/Azure-Peak/Azure-Peak/pull/5457

Rivers will now have their own subsystem instead of stacking timers which is bad for performance. Rivers will now also move objects (movable atoms) inside them.


Edited changes for Ratwood Keep: Kept the same old upstream/downstream delay bonuses, on azure peak rivers are actually quite strong, I don't want to touch the balance here

_**Thank you, to the people who have coded these PRs <3**_
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/ac2f0a8a-db95-4d14-bba2-b328c59dbff7


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="856" height="1199" alt="525659534-4b0f2dbf-7dff-46df-a7b5-8630b8d2e5f5" src="https://github.com/user-attachments/assets/6e9eb297-4ee4-4ecb-9d40-b5f3429e6759" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Throwing anything into a river will now cause it to process and shift downstream.
fix: Rivers now stop processing when there's nothing in them.
fix: NPCs no longer try to swim upstream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
