### PR TITLE
Gives Miraclist Zizites grave mark

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/zybantu.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/zybantu.dm
@@ -76,10 +76,9 @@
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 				backl = /obj/item/storage/backpack/rogue/satchel
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
-	switch(H.patron?.type)
-		if(/datum/patron/inhumen/zizo)
-			H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
-			H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
+				if(H.patron?.type == /datum/patron/inhumen/zizo)
+					H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
+					H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
 
 //Just the nomad clothes.
 /obj/item/clothing/cloak/cape/nomad

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/zybantu.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/zybantu.dm
@@ -76,6 +76,10 @@
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
 				backl = /obj/item/storage/backpack/rogue/satchel
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+	switch(H.patron?.type)
+		if(/datum/patron/inhumen/zizo)
+			H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
+			H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
 
 //Just the nomad clothes.
 /obj/item/clothing/cloak/cape/nomad


### PR DESCRIPTION


## About The Pull Request

Another skeleton summoner that needs the ability to control their summons, Many such cases. <!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Its a web edit sire <!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I think necromancers having the ability to actually use their summons in a way that is not destructive to their teammates is a good idea. Every Necromancer class should get this.<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

Adds Gravemark and order minions to Miraclist Dunewell nomad<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


