### PR TITLE
FINALLY fixes "+" forcing you to whisper, when "#" does so without making attempts to bold your messages erroneously whispered

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -143,8 +143,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	if(check_emote(original_message, forced) || !can_speak_basic(original_message, ignore_spam, forced))
 		return
 
-	if(check_whisper(original_message, forced) || !can_speak_basic(original_message, ignore_spam, forced))
-		return
 	//RATWOOD SUBTLER START
 	if(check_subtler(original_message, forced) || !can_speak_basic(original_message, ignore_spam, forced))
 		return

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -167,13 +167,6 @@
 		emote(copytext_char(message, 2), intentional = !forced, custom_me = TRUE)
 		return 1
 
-/mob/proc/check_whisper(message, forced)
-	if(copytext_char(message, 1, 2) == "+")
-		var/text = copytext(message, 2)
-		var/boldcheck = findtext_char(text, "+")	//Check for a *second* + in the text, implying the message is meant to have something formatted as bold (+text+)
-		whisper(copytext_char(message, boldcheck ? 1 : 2),sanitize = FALSE)//already sani'd
-		return 1
-
 ///Check if the mob has a hivemind channel
 /mob/proc/hivecheck()
 	return 0


### PR DESCRIPTION
## About The Pull Request

i'm pretty sure this is holdover lifeweb code where "+" is how you whisper there, but we have TG's implementation of "#" whispering quite literally right below it

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="271" height="52" alt="image" src="https://github.com/user-attachments/assets/6de0d0e4-098e-46c3-b5f4-57985f960281" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

i can finally talk to people in a firm tone without fucking whispering what i'm trying to say

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: prefixing your message with "+" can no longer be used to whisper, use "#" instead
fix: attempting to type a bolded message will no longer erroneously make you whisper it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
