### PR TITLE
TWO LYVES

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
@@ -190,8 +190,13 @@
 
 		M.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)
 		M.apply_status_effect(/datum/status_effect/debuff/revived)
-		ADD_TRAIT(M, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
 		M.remove_status_effect(src)
+		addtimer(CALLBACK(src, PROC_REF(deathmark), M), 5 MINUTES)
+
+/datum/status_effect/buff/eoran_balm_effect/proc/deathmark(mob/victim)
+	if(victim.stat != DEAD)
+		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
+		to_chat(victim, span_danger("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))
 
 #define POM_FILTER "pom_aura"
 

--- a/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
@@ -190,6 +190,7 @@
 
 		M.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)
 		M.apply_status_effect(/datum/status_effect/debuff/revived)
+		ADD_TRAIT(M, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
 		M.remove_status_effect(src)
 
 #define POM_FILTER "pom_aura"

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -102,11 +102,16 @@
 		target.apply_status_effect(debuff_type)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
 		//Due to an increased cost and cooldown, these revival types heal quite a bit.
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
-		ADD_TRAIT(target, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
+		addtimer(CALLBACK(src, PROC_REF(deathmark), target), 5 MINUTES)
 		consume_items(target)
 		return TRUE
 	revert_cast()
 	return FALSE
+
+/obj/effect/proc_holder/spell/invoked/resurrect/proc/deathmark(mob/victim) // deathmark serves to give a grace period after revival before applying DNR
+	if(victim.stat != DEAD)
+		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
+		to_chat(victim, span_danger("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))
 
 /obj/effect/proc_holder/spell/invoked/resurrect/cast_check(skipcharge = 0,mob/user = usr)
 	if(!..())

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -102,6 +102,7 @@
 		target.apply_status_effect(debuff_type)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
 		//Due to an increased cost and cooldown, these revival types heal quite a bit.
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
+		ADD_TRAIT(target, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
 		consume_items(target)
 		return TRUE
 	revert_cast()

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -277,7 +277,7 @@
 		return
 
 	// Check if occupant is valid
-	if(!occupant.check_revive(user))
+	if(!occupant.check_(user))
 		return
 
 	// Prompt ghost
@@ -314,5 +314,5 @@
 
 		// Apply debuffs
 		occupant.apply_status_effect(/atom/movable/screen/alert/status_effect/debuff/revived)
-		ADD_TRAIT(M, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
+		ADD_TRAIT(occupant, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
 	return TRUE

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -314,5 +314,10 @@
 
 		// Apply debuffs
 		occupant.apply_status_effect(/atom/movable/screen/alert/status_effect/debuff/revived)
-		ADD_TRAIT(occupant, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
+		addtimer(CALLBACK(src, PROC_REF(deathmark), occupant), 5 MINUTES)
 	return TRUE
+
+/obj/structure/chair/frankenstein/proc/deathmark(mob/victim)
+	if(victim.stat != DEAD)
+		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
+		to_chat(victim, span_green("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -320,4 +320,4 @@
 /obj/structure/chair/frankenstein/proc/deathmark(mob/victim)
 	if(victim.stat != DEAD)
 		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
-		to_chat(victim, span_green("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))
+		to_chat(victim, span_danger("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -277,7 +277,7 @@
 		return
 
 	// Check if occupant is valid
-	if(!occupant.check_(user))
+	if(!occupant.check_revive(user))
 		return
 
 	// Prompt ghost

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -314,5 +314,5 @@
 
 		// Apply debuffs
 		occupant.apply_status_effect(/atom/movable/screen/alert/status_effect/debuff/revived)
-
+		ADD_TRAIT(M, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
 	return TRUE

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -98,8 +98,13 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
-	ADD_TRAIT(target, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.	
+	addtimer(CALLBACK(src, PROC_REF(deathmark), target), 5 MINUTES)
 	return TRUE
+
+/datum/surgery_step/infuse_lux/proc/deathmark(mob/victim)
+	if(victim.stat != DEAD)
+		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
+		to_chat(victim, span_danger("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))
 
 /datum/surgery_step/infuse_lux/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)
 	display_results(user, target, span_warning("I screwed up!"),

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -98,6 +98,7 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	ADD_TRAIT(target, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.	
 	return TRUE
 
 /datum/surgery_step/infuse_lux/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
+++ b/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
@@ -78,8 +78,13 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/leech_schizophrenia)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
-	ADD_TRAIT(target, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
+	addtimer(CALLBACK(src, PROC_REF(deathmark), target), 5 MINUTES)
 	return TRUE
+
+/datum/surgery_step/infuse_tick/proc/deathmark(mob/victim)
+	if(victim.stat != DEAD)
+		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
+		to_chat(victim, span_danger("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))
 
 /datum/surgery_step/infuse_tick/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)
 	display_results(user, target, span_warning("I screwed up!"),

--- a/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
+++ b/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
@@ -78,6 +78,7 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/leech_schizophrenia)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	ADD_TRAIT(target, TRAIT_DNR, "[type]") //you get one revival, value your lyfe.
 	return TRUE
 
 /datum/surgery_step/infuse_tick/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -363,9 +363,14 @@
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
 		consume_items(target)
 		return TRUE
-		ADD_TRAIT(target, TRAIT_DNR, "[type]")
+		addtimer(CALLBACK(src, PROC_REF(deathmark), target), 5 MINUTES)
 	revert_cast()
 	return FALSE
+
+/obj/effect/proc_holder/spell/invoked/evil_resurrect/proc/deathmark(mob/victim) // deathmark serves to give a grace period after revival before applying DNR
+	if(victim.stat != DEAD)
+		ADD_TRAIT(victim, TRAIT_DNR, TRAIT_GENERIC)
+		to_chat(victim, span_danger("My resurrection has taken a toll, should I fall again I will never be restored to lyfe"))
 
 /obj/effect/proc_holder/spell/invoked/evil_resurrect/cast_check(skipcharge = 0,mob/user = usr)
 	if(!..())

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -363,6 +363,7 @@
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
 		consume_items(target)
 		return TRUE
+		ADD_TRAIT(M, TRAIT_DNR, "[type]")
 	revert_cast()
 	return FALSE
 

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -363,7 +363,7 @@
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
 		consume_items(target)
 		return TRUE
-		ADD_TRAIT(M, TRAIT_DNR, "[type]")
+		ADD_TRAIT(target, TRAIT_DNR, "[type]")
 	revert_cast()
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request
This PR adds DNR to anyone who gets revived after a five minute timer. Limiting revival per character to once per round.

If I'm missing any revivals do let me know, I will be 100% honest I didn't even know that some gods like Ravox or Dendor HAD revivals given how infrequently they're used in comparison to Anastasis.

## Testing Evidence
It's a fairly simple change, but I can confirm that it compiles and I tested all revival methods including the generic ones. They all acted appropriately and added DNR to the revived.

EDIT: I tested the new timed versions too, they work as intended as well.

## Why It's Good For The Game
I'm sure that many players who have played any sort of leadership role or combat role have had enemies die and come back and die and come back etc. When there are no concrete risks from death, and no limit to how many times you can be revived it creates a rather unserious atmosphere around combat and killing.

Hopefully, it will encourage combat oriented players to take a step back and play more carefully, especially if they've already died once.

Also, I got good feedback about the idea on a previous PR:
<img width="909" height="274" alt="image" src="https://github.com/user-attachments/assets/16e5871f-dcc0-402d-81da-955ae629690d" />

## Changelog
:cl:
add: adding TRAIT_DNR to be applied after all revival methods. After a five minute timer that checks to make sure that the person is still alive. Should make sure that medical malpractice doesn't doom someone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
