### PR TITLE
Jingle-PLAP-jangle-SCHLOP | Bells Attachable To All Neckwear

### DIFF
--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -1178,7 +1178,7 @@
 		grassy_knoll = locate() in user.loc
 
 /datum/sex_controller/proc/find_ringing_collar()
-	var/obj/item/clothing/neck/roguetown/collar/collar
+	var/obj/item/clothing/neck/roguetown/collar
 	collar = user.get_item_by_slot(SLOT_NECK)
 	if(collar && istype(collar) && collar.bellsound)
 		collar_bell_user = TRUE
@@ -1190,14 +1190,6 @@
 	if(!target)
 		collar_bell_target = FALSE
 		return
-	collar = target.get_item_by_slot(SLOT_NECK)
-	if(collar && istype(collar) && collar.bellsound)
-		collar_bell_target = TRUE
-		var/datum/component/squeak/bell = collar.GetComponent(/datum/component/squeak)
-		if(bell && LAZYLEN(bell.override_squeak_sounds))
-			collar_sounds = bell.override_squeak_sounds
-		else
-			collar_sounds = SFX_COLLARJINGLE
 
 /datum/sex_controller/proc/inherent_perform_check(action_type, incapacitated)
 	var/datum/sex_action/action = SEX_ACTION(action_type)

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -1190,6 +1190,14 @@
 	if(!target)
 		collar_bell_target = FALSE
 		return
+	collar = target.get_item_by_slot(SLOT_NECK)
+	if(collar && istype(collar) && collar.bellsound)
+		collar_bell_target = TRUE
+		var/datum/component/squeak/bell = collar.GetComponent(/datum/component/squeak)
+		if(bell && LAZYLEN(bell.override_squeak_sounds))
+			collar_sounds = bell.override_squeak_sounds
+		else
+			collar_sounds = SFX_COLLARJINGLE
 
 /datum/sex_controller/proc/inherent_perform_check(action_type, incapacitated)
 	var/datum/sex_action/action = SEX_ACTION(action_type)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -8,6 +8,47 @@
 	alternate_worn_layer = NECK_LAYER
 	var/overarmor
 
+/obj/item/clothing/neck/roguetown/examine()
+	. = ..()
+	if(bell)
+		. += span_info("It has a <a href='?src=[REF(src)];removebell=1'>bell</a> attached.")
+
+/obj/item/clothing/neck/roguetown/Topic(href, href_list)
+	..()
+
+	if(!usr)
+		return
+
+	if(href_list["removebell"])
+		remove_bell(usr)
+
+/obj/item/clothing/neck/roguetown/proc/remove_bell(mob/user)
+	if(!bell)
+		return
+	if(!Adjacent(user))
+		to_chat(user, span_warning("As much as I'd love to snatch that bell, I'm not close enough."))
+		return
+	for(var/obj/item/catbell/bell in src)
+		user.put_in_hands(bell)
+		break
+	bell = FALSE
+	bellsound = FALSE
+	qdel(src.GetComponent(/datum/component/squeak))
+	to_chat(user, span_info("I remove the bell from [src]."))
+
+/obj/item/clothing/neck/roguetown/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/catbell))
+		var/obj/item/catbell/bell = I
+		if(src.bellsound || src.bell) //Already has a bell, can't attach another one.
+			to_chat(user, span_info("[src] already has a bell attached!"))
+			return
+		to_chat(user, span_info("I attach \the [bell] to [src]."))
+		src.bell = TRUE
+		src.bellsound = TRUE
+		src.AddComponent(/datum/component/squeak, bell.jingle_sounds, 50, 100, 1)
+		I.forceMove(src)
+	..()
+
 /obj/item/clothing/neck/roguetown/MiddleClick(mob/user, params)
 	. = ..()
 	if((user.zone_selected == BODY_ZONE_PRECISE_NOSE) && (cansnout == TRUE))

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -2030,6 +2030,14 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Catbell Collar"
 	path = /obj/item/clothing/neck/roguetown/collar/catbell
 
+/datum/loadout_item/catbell
+	name = "Catbell"
+	path = /obj/item/catbell
+
+/datum/loadout_item/cowbell
+	name = "Cowbell"
+	path = /obj/item/catbell/cow
+
 /datum/loadout_item/rope_leash
 	name = "Rope Leash"
 	path = /obj/item/leash


### PR DESCRIPTION
## About The Pull Request

you can now attach catbells and cowbells to any neck item that does not already have a bell. the bells are also removable by hand.

yes. it jingles when you're cracking your squire.

i've also added the bells to the loadout.

## Testing Evidence

<img width="356" height="118" alt="image" src="https://github.com/user-attachments/assets/aac5f78c-ec66-44cb-9234-1521c6b99427" />


## Why It's Good For The Game

knights should get to feel cute too sometimes

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cow and catbells are now attachable to all neckwear items.
add: Cow and catbells are now available in the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
