### PR TITLE
You get +3 spellpoints! And YOU get +3 spell points! Arcyne Potential is no longer restricted, but...

### DIFF
--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -48,7 +48,7 @@
 	range = 3
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	spell_tier = 1
+	spell_tier = 2
 	invocation_type = "none"
 	sound = 'sound/misc/area.ogg' //This sound doesnt play for some reason. Fix me.
 	associated_skill = /datum/skill/magic/arcane

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
@@ -10,7 +10,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	gesture_required = TRUE // Mobility spell
-	spell_tier = 1
+	spell_tier = 2
 	invocations = list("Saltus!")
 	invocation_type = "whisper"
 	hide_charge_effect = TRUE

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -2,16 +2,15 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert or Critical Resistance) get only prestidigitation. Everyone else get +3 spellpoints and T1 Arcyne Potential if they don't have any Arcyne."
+	custom_text = "You gain +3 spellpoints and T1 Arcyne Potential, which comes with a limited, mostly flavor and non-combat spell list. If you already have skills with magic, you gain +1 level and +3 spell points."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE))
-			ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
-			recipient.mind?.adjust_spellpoints(3)
+		ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
+		recipient.mind?.adjust_spellpoints(3)
 	else
 		recipient.mind?.adjust_spellpoints(3) // 3 extra spellpoints since you don't get any spell point from the skill anymore
 	

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -2,7 +2,7 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "You gain +3 spellpoints and T1 Arcyne Potential, which comes with a limited, mostly flavor and non-combat spell list. If you already have skills with magic, you gain +1 level and +3 spell points."
+	custom_text = "You gain +2 spellpoints and T1 Arcyne Potential, which comes with a limited, mostly flavor and non-combat spell list. If you already have skills with magic, you gain +1 level and +3 spell points."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -10,9 +10,9 @@
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
 		ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
-		recipient.mind?.adjust_spellpoints(3)
+		recipient.mind?.adjust_spellpoints(2) // balance. message + darkvision/longstrider is agreee to be too strong, so pick one or the other
 	else
-		recipient.mind?.adjust_spellpoints(3) // 3 extra spellpoints since you don't get any spell point from the skill anymore
+		recipient.mind?.adjust_spellpoints(3) // everyone else that already has arcane gets their full 3, behavior unchanged
 	
 /datum/virtue/combat/devotee
 	name = "Devotee"


### PR DESCRIPTION
## About The Pull Request

This PR removes the restriction from Arcyne Potential.
Previously, if you had DODGE EXPERT, MEDIUM/HEAVY ARMOR, CRIT RESISTANCE or ANY OF THE ANTI-PAIN TRAITS? You could not receive the T1 Arcyne access given by this trait, only Prestidigitation. Now, anyone has access to the limited, flavored spell list... With a caveat.

**INVISIBILITY** and **LEAP** are now T2 spells, meaning only spellblades/mages+ can access them.
Why? Because they're two extremely powerful mobility spells, and I don't think they should be given out freely.

Also, if you were on the list of people who would previously not qualify (by not being an arcane user as-is), then you only get 2 points instead of 3. 
Why? So you can pick between wasting an entire virtue on a SINGLE "powerful" spell like darkvision or longstrider, OR two flavorful spells like mirror transform, campfire, etc...

## Testing Evidence

spell_tier = 1 -> 2
3 line change total
here's your local Valiant Warrior duke and his mighty armor training with spellpoints attached.
<img width="826" height="324" alt="image" src="https://github.com/user-attachments/assets/14d4234d-e331-4ce9-b99a-9c485184d094" />


## Why It's Good For The Game

Flavor. Let people take mirror transform or message or whatever the hell else if they want to, they're giving up an entire trait for 1, maybe 2 spells at best.

## Changelog

:cl:
balance: arcyne potential is no longer limited by crit/dodge/pain trait/armor proficiency. if you previously did not qualify for this trait, you now do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
