### PR TITLE
No More Vampire Wizards

### DIFF
--- a/code/modules/jobs/job_types/roguetown/trader/scholar.dm
+++ b/code/modules/jobs/job_types/roguetown/trader/scholar.dm
@@ -5,7 +5,7 @@
 	subclass_social_rank = SOCIAL_RANK_YEOMAN
 	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_INTELLECTUAL, TRAIT_SEEPRICES_SHITTY, TRAIT_GOODWRITER, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT, TRAIT_SMITHING_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_SURVIVAL_EXPERT, TRAIT_HOMESTEAD_EXPERT)
 	class_select_category = CLASS_CAT_TRADER
-	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT, CTAG_LICKER_WRETCH)
+	category_tags = list(CTAG_PILGRIM, CTAG_COURTAGENT)
 	cmode_music = 'sound/music/cmode/towner/combat_towner3.ogg'
 	vice_restrictions = list(/datum/charflaw/unintelligible)
 


### PR DESCRIPTION
## About The Pull Request

This PR removes "Traveling Scholar" from the list of subclasses offered by the licker wretch subclass.

## Testing Evidence

<img width="553" height="317" alt="dreamseeker_2026-04-26_10-37-26" src="https://github.com/user-attachments/assets/84b4d1fd-f75a-4100-baee-4bfb6ff56af4" />
<img width="540" height="317" alt="dreamseeker_2026-04-26_10-37-35" src="https://github.com/user-attachments/assets/c5d70cb8-419f-4439-a953-9d99f9d33143" />
<img width="553" height="334" alt="dreamseeker_2026-04-26_10-37-43" src="https://github.com/user-attachments/assets/d4a7af60-51a5-495e-b4b0-5412235f6221" />
<img width="515" height="310" alt="dreamseeker_2026-04-26_10-37-48" src="https://github.com/user-attachments/assets/ec348741-9c18-4ba3-9971-e156fa092da8" />

## Why It's Good For The Game

Vampires are not meant to be slinging fireballs and teleporting away from people and blasting them away with waves of magic and etc. etc., They already get crazy good coven abilities- vampires with this class have been a pretty major balance concern, and a bit of a headache for staff. Let's just get rid of it. Mages are already strong enough- they don't need to be vampires too. All the other mage subclasses are not included in the licker class selection for balance concerns- this one was simply missed.