### PR TITLE
Adds Tailor's Silverface Imports Tab

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -67,3 +67,98 @@
 	contains = list(
 					/obj/item/clothing/head/roguetown/roguehood/reinforced,
 				)
+
+// Exotic import stuff goes here. Should probably be a little pricier than normal stuff. 2x average? Be sure to name the purchase option so it relates to the actual item, but also what slot it fills.
+
+/datum/supply_pack/rogue/light_armor/import
+	group = "Imported Armor (Light)"
+
+/datum/supply_pack/rogue/light_armor/import/otavangambeson
+	name = "Otavan Fencing Gambeson"
+	cost = 60 // Base sellprice of 30
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/otavan)
+
+/datum/supply_pack/rogue/light_armor/import/otavanpants1
+	name = "Otavan Heavy Leather Trousers"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/heavy_leather_pants/otavan)
+
+/datum/supply_pack/rogue/light_armor/import/otavanpants2
+	name = "Otavan Fencing Trousers"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic)
+
+/datum/supply_pack/rogue/light_armor/import/aavnicgambeson
+	name = "Aavnic Fencing Gambeson"
+	cost = 50 // Base sellprice of 30, doesn't cover legs so slightly cheaper
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter)
+
+/datum/supply_pack/rogue/light_armor/import/caftan
+	name = "Padded Caftan"
+	cost = 60 // Base sellprice of 30
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/chargah)
+
+/datum/supply_pack/rogue/light_armor/import/kazenpants
+	name = "Kazengunese Heavy Leather Trousers"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun)
+
+/datum/supply_pack/rogue/light_armor/import/grenzhat
+	name = "Grenzelhoftian Plume Hat"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/head/roguetown/grenzelhofthat)
+
+/datum/supply_pack/rogue/light_armor/import/grenzhipshirt
+	name = "Grenzelhoftian Hip Shirt"
+	cost = 60 // Base sellprice of 30
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/grenzelhoft)
+
+/datum/supply_pack/rogue/light_armor/import/grenzpants
+	name = "Grenzelhoftian Paumpers"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/heavy_leather_pants/grenzelpants)
+
+/datum/supply_pack/rogue/light_armor/import/desertgambanormal
+	name = "Desert Gambeson"
+	cost = 45 // Base sellprice of 20
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/zyb)
+
+/datum/supply_pack/rogue/light_armor/import/zybgambaheavy
+	name = "Padded Desert Gambeson"
+	cost = 60 // Base sellprice of 30
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/zyb)
+
+/datum/supply_pack/rogue/light_armor/import/naledigamba
+	name = "Naledian Padded Gambeson"
+	cost = 60 // Base sellprice of 30
+	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex)
+
+/datum/supply_pack/rogue/light_armor/import/naleditrou
+	name = "Naledian Hardened Leather Chaqchur (Pants)"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/trou/leather/pontifex)
+
+/datum/supply_pack/rogue/light_armor/import/zybtrou
+	name = "Baggy Hardened Leather Desert Pants"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/trou/leather/pontifex/zyb)
+
+/datum/supply_pack/rogue/light_armor/import/gronnarmor
+	name = "Gronnic Hardened Leather Armor"
+	cost = 45 // Base sellprice of 20
+	contains = list (/obj/item/clothing/suit/roguetown/armor/leather/heavy/gronn)
+
+/datum/supply_pack/rogue/light_armor/import/gronnpants
+	name = "Nomad Hardened Leather Pants"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/heavy_leather_pants/nomadpants)
+
+/datum/supply_pack/rogue/light_armor/import/gronnpantsalt
+	name = "Gronnic Leather Pants"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/under/roguetown/trou/leather/gronn)
+
+/datum/supply_pack/rogue/light_armor/import/gronnglovesleather
+	name = "Gronnic Fur-lined Heavy Leather Gloves"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/gloves/roguetown/angle/gronn)

--- a/code/modules/roguetown/roguemachine/merchant/_goldface.dm
+++ b/code/modules/roguetown/roguemachine/merchant/_goldface.dm
@@ -125,6 +125,7 @@
 		"Apparel",
 		"Wardrobe",
 		"Armor (Light)",
+		"Imported Armor (Light)",
 	)
 	categories_gamer = list()
 


### PR DESCRIPTION
## About The Pull Request

Adds an Exotic Light Armor tab to the tailor's silverface. Even have a fancy little comment in the code so people have a quick idea on how to add to it.

## Testing Evidence
<img width="569" height="881" alt="proof03" src="https://github.com/user-attachments/assets/8055ce17-efe6-4a5a-a4ac-244a326ef74c" />
<img width="549" height="368" alt="proof01" src="https://github.com/user-attachments/assets/a7ac74ae-0165-439b-96cb-4ec94223efdb" />
<img width="615" height="453" alt="proof02" src="https://github.com/user-attachments/assets/8a809b90-0d6c-42d0-9585-0de4013efe6f" />

## Why It's Good For The Game

Doesn't really affect the balance much? A lot of these items are nigh impossible to obtain either not having crafting recipes for whatever reason, or requiring stuff like master / legendary tailoring. I guess there's an argument it takes away from mercs, but like... We have _eight_ merc slots on a server that regularly sees 100+ players in a round. Plus it should help Light AC users have some actual cosmetic variance when there isn't a tailor around... And _not_ all look either like generic bandits or Grenzels.

Probably didn't add everything I should / could, but the way armors are sorted is... Unintuitive? At least to me. Plus with the foundation done, it should be fairly easy to expand in the future.

I'll admit I wasn't _super_ thorough adding stuff, but I was sure to not add things that seemed super unique (eg- "cut-throat's pants") or had powerful unique functions (a pair of Gronn gauntlets that look _really_ nice... but also have a 1.25x unarmed damage mod. Sadness) so hopefully it doesn't step too hard on certain classes' unique visual identities.

I mean, it _will_ at least a little, but I've heard a LOT of people beg for more armor variety so like... I feel like the increase in player fashion will outweigh the loss of unique identity. Needs of the many and all that.

## Changelog

:cl:
add: Added an Exotic Light Armor tab to the tailor's silverface.
add: Filled the Exotic Light Armor tab with a bunch of exotic light armors. Who could've seen that coming?
balance: Balanced(?) the exotic armors by making them cost slightly more than local light armors.
/:cl:

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
