### PR TITLE
ports hunger changes

### DIFF
--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -87,6 +87,7 @@
 		nutrition_amount *= 2
 	if (STASTR >= 11) // 5% increased nutrition loss for every STR above 11. the gainz don't come cheap
 		var/swole_malus = (10 - STASTR) * 0.05
+		nutrition_amount *= (1 + swole_malus)
 
 	if (nutrition >= NUTRITION_LEVEL_WELL_FED) // we've only just eaten recently so just flat out reduce the total loss by half
 		nutrition_amount *= 0.5

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -68,13 +68,9 @@
 
 /mob/living/proc/stamina_nutrition_mod(amt)
 	// to simulate exertion, we deduct a mob's nutrition whenever it takes an action that would give us fatigue.
-	var/nutrition_amount = amt * 0.15 // nutrition goes up to 1k at max (but constantly ticks down) so we need to work at a slightly bigger scale
-	var/athletics_skill = get_skill_level(/datum/skill/misc/athletics)
-	var/chip_amt = 2 + ceil(athletics_skill / 2)
+	var/nutrition_amount = amt * 0.075 // flat 1/2 of the old 0.15 rate
 
-	if (amt <= chip_amt)
-		if (athletics_skill && prob(athletics_skill * 16)) // 16% chance per athletics skill to straight up negate nutrition loss
-			return 0
+	if (amt <= 2)
 		if (amt == 2 && prob(STACON * 5)) // only sprinting knocks off 2 stamina at a time, so test this vs our con to see if we drop it
 			return 0
 
@@ -89,18 +85,8 @@
 
 	if (stamina >= (max_stamina * 0.7)) // if you've spent 70% of your max fatigue, the base amount you lose is doubled
 		nutrition_amount *= 2
-	if (STACON <= 9) // 10% extra nutrition loss for every CON below 9
-		var/low_end_malus = (10 - STACON) * 0.1
-		nutrition_amount *= (1 + low_end_malus)
-	if (STACON >= 11) // 5% less nutrition loss for every CON above 11
-		var/high_end_buff = (STACON - 10) * 0.05
-		nutrition_amount *= (1 - high_end_buff)
-	if (STASTR >= 11) // 7.5% increased nutrition loss for every STR above 11. the gainz don't come cheap
-		var/swole_malus = (10 - STASTR) * 0.075
-		nutrition_amount *= (1 + swole_malus)
-	if (athletics_skill)
-		var/athletics_bonus = athletics_skill * 0.05 //each rank of athletics gives us 5% less nutrition loss
-		nutrition_amount *= (1 - athletics_bonus)
+	if (STASTR >= 11) // 5% increased nutrition loss for every STR above 11. the gainz don't come cheap
+		var/swole_malus = (10 - STASTR) * 0.05
 
 	if (nutrition >= NUTRITION_LEVEL_WELL_FED) // we've only just eaten recently so just flat out reduce the total loss by half
 		nutrition_amount *= 0.5


### PR DESCRIPTION
## About The Pull Request

See https://github.com/Azure-Peak/Azure-Peak/pull/6655

## Testing Evidence

Compiles, loads, seems fine

## Why It's Good For The Game

see https://github.com/Azure-Peak/Azure-Peak/pull/6655

## Changelog

:cl: WeNeedMorePhoron, ported by Jamdrawers
balance: Removed most stats and athletics skills influence on hunger rate and then halved the flat hunger rate gain. Report if hunger happens too often. Str above 10 increases hunger rate by 5% per point instead of 7.5%
/:cl: