### PR TITLE
Players saying "Zomosexual" or "Zape" will autocorrect to "Sodomite" or "Ravage

### DIFF
--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -20,8 +20,6 @@
 		"ohio": "underworld",
 		"fanum": "demon",
 		"cenat": "demon",
-		"mewing": "praying",
-		"mew": "pray",
 		"jesus": "gods",
 		"christ": "savior",
 		"boomers": "dotards",
@@ -66,7 +64,6 @@
 		"jelqing": "self abusing",
 		"jelq": "self abuse",
 		"gooning": "self abusing",
-		"cringe": "swive",
 		"bussing": "splendid",
 		"bussin": "splendid",
 		"lmao": "ha ha",
@@ -91,6 +88,11 @@
 		"sergant":  "sargent",
 		"retard": "dimwit",
 		"retarded": "dimwitted",
-		"retards": "dimwits"
+		"retards": "dimwits",
+		"zape": "ravage",
+		"zaped": "ravaged",
+		"zaggot": "sodomite",
+		"zomo": "sodomite",
+		"zomosexual": "sodomite"
     }
 }


### PR DESCRIPTION
## About The Pull Request

Also removes two or three old replacements that you can see under 'files changed'

## Testing Evidence

line change

## Why It's Good For The Game

People shouldn't be saying Zomosexual in-game.