### PR TITLE
Absolvers can't be constructs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/absolutionist.dm
@@ -5,7 +5,7 @@
 	faction = "Station"
 	total_positions = 1 // THE ONE.
 	spawn_positions = 1
-	allowed_races = RACES_ALL_KINDS
+	allowed_races = RACES_NO_CONSTRUCT
 	allowed_patrons = list(/datum/patron/old_god) //Requires the character to be a practicing Psydonite.
 	tutorial = "Once, you were alone in this monastery; a chapel of stone, protecting a shard of Psydon's divinity. Now, you've a whole sect to shepherd - and their propensity for violence oft-clashes with your own vows of pacifism. Temper the floch with your wisdom, siphon away their wounds with your blessings, and guide the wayard towards absolution."
 	selection_color = JCOLOR_INQUISITION


### PR DESCRIPTION
## About The Pull Request

What it says on the tin

## Testing Evidence

1 line change.... trrrust me... It compiles...

## Why It's Good For The Game

Constructs have a lot of special weirdness that probably aren't supposed to be compatible with the absolver's special weirdness.

:cl:
balance: absolvers can no longer be constructs
/:cl: