### PR TITLE
Ports broken-gear-falling

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -355,8 +355,8 @@
 				return
 			H.dropItemToGround(src, silent = TRUE)
 			H.update_fov_angles()
-			if(material_category == ARMOR_MAT_PLATE || material_category == ARMOR_MAT_CHAINMAIL)
-				do_sparks(2, TRUE, get_turf(H))
+			// if(material_category == ARMOR_MAT_PLATE || material_category == ARMOR_MAT_CHAINMAIL)//we don't have these variables yet, but it looks like it's just a visual spark effect
+			// 	do_sparks(2, TRUE, get_turf(H))
 			var/turnangle = (prob(10) ? 180 : prob(50) ? 270 : 90)
 			var/turndir = turn(H.dir, turnangle)
 			var/dist = rand(1, 3)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -60,6 +60,8 @@
 	var/cansnout = FALSE //for masks - can we MMB this to change it into a snouty sprite?
 	var/snouting = FALSE //do we have the snout-snug sprite toggled?
 
+	var/throw_on_break = FALSE//does it fall off your body when broken?
+
 /obj/item
 	var/blocking_behavior
 	var/wetness = 0
@@ -345,6 +347,22 @@
 		if(armorlist[x] > 0)
 			armorlist[x] = 0
 	..()
+	if(throw_on_break)
+		if(ishuman(loc))
+			var/mob/living/carbon/human/H = loc
+			var/throwprob = 80 + ((10 - H.STALUC) * 20)	// More FOR we have the less likely it is to happen.
+			if(!prob(throwprob))
+				return
+			H.dropItemToGround(src, silent = TRUE)
+			H.update_fov_angles()
+			if(material_category == ARMOR_MAT_PLATE || material_category == ARMOR_MAT_CHAINMAIL)
+				do_sparks(2, TRUE, get_turf(H))
+			var/turnangle = (prob(10) ? 180 : prob(50) ? 270 : 90)
+			var/turndir = turn(H.dir, turnangle)
+			var/dist = rand(1, 3)
+			var/current_turf = get_turf(H)
+			var/target_turf = get_ranged_target_turf(current_turf, turndir, dist)
+			throw_at(target_turf, dist, 6, H, FALSE)
 
 /obj/item/clothing/obj_fix(mob/user, full_repair = TRUE)
 	..()

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -8,6 +8,7 @@
 	var/modifies_speech = FALSE
 	var/mask_adjusted = 0
 	var/adjusted_flags = null
+	throw_on_break = TRUE
 
 	grid_width = 64
 	grid_height = 32

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -8,6 +8,7 @@
 	bloody_icon_state = "bodyblood"
 	grid_width = 64
 	grid_height = 32
+	throw_on_break = TRUE
 
 /obj/item/clothing/neck/worn_overlays(isinhands = FALSE)
 	. = list()

--- a/code/modules/clothing/rogueclothes/gloves/_gloves.dm
+++ b/code/modules/clothing/rogueclothes/gloves/_gloves.dm
@@ -10,5 +10,6 @@
 	siemens_coefficient = 1
 	max_heat_protection_temperature = 361
 	experimental_inhand = FALSE
+	throw_on_break = TRUE
 	/// Unarmed damage multiplier (for pure fists / wrestling only)
 	var/unarmed_bonus = 1

--- a/code/modules/clothing/rogueclothes/headwear/_head.dm
+++ b/code/modules/clothing/rogueclothes/headwear/_head.dm
@@ -14,6 +14,7 @@
 	experimental_inhand = FALSE
 	var/hidesnoutADJ = FALSE
 	var/overarmor = TRUE
+	throw_on_break = TRUE
 
 /obj/item/clothing/head/roguetown/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/clothing/rogueclothes/wrists.dm
+++ b/code/modules/clothing/rogueclothes/wrists.dm
@@ -10,6 +10,7 @@
 	experimental_inhand = FALSE
 	grid_width = 32
 	grid_height = 64
+	throw_on_break = TRUE
 	var/overarmor
 
 /obj/item/clothing/wrists/roguetown/MiddleClick(mob/user, params)

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -22,6 +22,7 @@
 
 	grid_width = 32
 	grid_height = 64
+	throw_on_break = TRUE
 
 /obj/item/clothing/shoes/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/Azure-Peak/Azure-Peak/pull/6917, adding a mechanic where certain types of equipment (gloves, boots, masks, helmets, bracers and neck-things) will have a high chance to fall off once Broken depending on luck (80% at 10 luck, .

The original is bundled in with another PR that's designed to make broken equipment immune to being destroyed unless very deliberately and slowly melted, but I don't think we have to be quite so precious about it.

## Testing Evidence

<img width="1175" height="732" alt="image" src="https://github.com/user-attachments/assets/a45ce7f6-8ed2-41af-a11b-00447bee0563" />

## Why It's Good For The Game

Litters the battlefield with wrecked equipment and providing a satisfying and visceral feedback on armour breakage. And makes undressing a defeated opponent that bit easier! Bit of dynamicness in combat.

## Changelog

:cl:
add: Armor (except for chest/leg armor) will now often fall off once broken
/:cl: