### PR TITLE
Removes popular gay slang from the accent censor

### DIFF
--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -90,9 +90,6 @@
 		"retarded": "dimwitted",
 		"retards": "dimwits",
 		"zape": "ravage",
-		"zaped": "ravaged",
-		"zaggot": "sodomite",
-		"zomo": "sodomite",
-		"zomosexual": "sodomite"
+		"zaped": "ravaged"
     }
 }


### PR DESCRIPTION
## About The Pull Request

Zaggot, zomo, and zomosexual are words used almost exclusively by gay players to communicate with other gay players. This was essentially our own slang that we enjoyed using. There's absolutely no reason for it to get censored.

## Why It's Good For The Game

I don't assume this was done maliciously, but this was basically censorship and erasure of part of the gay culture of Ratwood without any real reason behind it. No one was offended by these terms, and no one (to my knowledge) ever used them in an offensive manner. 
