### PR TITLE
fixes wood dropping essance of the wilds instead of lumber

### DIFF
--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -68,7 +68,7 @@
 			new lumber(get_turf(src))
 				// Scaling is less steep than tanning as lumberjacking is easier to level and get
 			if(prob(skill_level + user.goodluck(2)))
-				new /obj/item/natural/cured/essence(get_turf(user))
+				new /obj/item/grown/log/tree/small/essence(get_turf(user))
 				if(!sound_played)
 					sound_played = TRUE
 					to_chat(user, span_warning("Dendor weeps..."))


### PR DESCRIPTION
## About The Pull Request

this broke months ago back when we did the AP parity pr. AP never had essence of lumber but made trees drop essance of wilds instead and it got override. making the only way to still get it via chopping tree stumps

## Testing Evidence
none yet left as draft
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

bug fix, having to cut 20 tree stumps for one for my t2 cog is agonizing and wild essance is supost to reward hunters

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fix trees dropping essance of the wilds instead of essence lumber
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
