### PR TITLE
Revert Arcyne Potential +3 Spell Points for Combat Roles

### DIFF
--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -48,7 +48,7 @@
 	range = 3
 	warnie = "sydwarning"
 	movement_interrupt = FALSE
-	spell_tier = 2
+	spell_tier = 1
 	invocation_type = "none"
 	sound = 'sound/misc/area.ogg' //This sound doesnt play for some reason. Fix me.
 	associated_skill = /datum/skill/magic/arcane

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/leap.dm
@@ -10,7 +10,7 @@
 	no_early_release = TRUE
 	movement_interrupt = FALSE
 	gesture_required = TRUE // Mobility spell
-	spell_tier = 2
+	spell_tier = 1
 	invocations = list("Saltus!")
 	invocation_type = "whisper"
 	hide_charge_effect = TRUE

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -2,17 +2,18 @@
 /datum/virtue/combat/magical_potential
 	name = "Arcyne Potential"
 	desc = "I am talented in the Arcyne arts, expanding my capacity for magic. I have become more intelligent from its studies. Other effects depends on what training I chose to focus on at a later age."
-	custom_text = "You gain +2 spellpoints and T1 Arcyne Potential, which comes with a limited, mostly flavor and non-combat spell list. If you already have skills with magic, you gain +1 level and +3 spell points."
+	custom_text = "Classes that has a combat trait (Medium / Heavy Armor Training, Dodge Expert or Critical Resistance) get only prestidigitation. Everyone else get +3 spellpoints and T1 Arcyne Potential if they don't have any Arcyne."
 	added_skills = list(list(/datum/skill/magic/arcane, 1, 6))
 
 /datum/virtue/combat/magical_potential/apply_to_human(mob/living/carbon/human/recipient)
 	if (!recipient.get_skill_level(/datum/skill/magic/arcane)) // we can do this because apply_to is always called first
 		if (!recipient.mind?.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 			recipient.mind?.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
-		recipient.mind?.adjust_spellpoints(2) // balance. message + darkvision/longstrider is agreee to be too strong, so pick one or the other
+		if (!HAS_TRAIT(recipient, TRAIT_MEDIUMARMOR) && !HAS_TRAIT(recipient, TRAIT_HEAVYARMOR) && !HAS_TRAIT(recipient, TRAIT_DODGEEXPERT) && !HAS_TRAIT(recipient, TRAIT_CRITICAL_RESISTANCE))
+			ADD_TRAIT(recipient, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
+			recipient.mind?.adjust_spellpoints(3)
 	else
-		recipient.mind?.adjust_spellpoints(3) // everyone else that already has arcane gets their full 3, behavior unchanged
+		recipient.mind?.adjust_spellpoints(3) // 3 extra spellpoints since you don't get any spell point from the skill anymore
 	
 /datum/virtue/combat/devotee
 	name = "Devotee"


### PR DESCRIPTION
Reverts Rotwood-Vale/Ratwood-2.0#1455

I feel like there was a very good reason combat roles were restricted from arcyne potential's spells in the first place. They are not just 'flavour' additions, they have significant mechanical impacts?? Message has insane utility and mending is still absolutely powerful, even with the skill requirement. Arcane skill can be grinded out, and even without that, mending is still not useless or weak at all.

Combat roles should not have access to these spells with just a virtue.