### PR TITLE
Balancejak the Arcane Trickster

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -246,9 +246,8 @@
 	traits_applied = list(TRAIT_ARCYNE_T2, TRAIT_DODGEEXPERT, TRAIT_LIGHT_STEP) //dodge expert has the potential for being a big pain on spellcasters,  so we take away their mage armor as a trade.
 	subclass_stats = list(
 		STATKEY_STR = -1,
-		STATKEY_INT = 2,
+		STATKEY_INT = 1,
 		STATKEY_PER = 1,
-		STATKEY_WIL = 1,
 		STATKEY_SPD = 2,
 	)
 


### PR DESCRIPTION
## About The Pull Request

Makes the Arcane Trickster not an (almost) objective upgrade to the thief.

## Testing Evidence

<img width="1211" height="913" alt="proof01" src="https://github.com/user-attachments/assets/50fa8254-7547-4637-bf03-ed7b8b50afa0" />

Using the Venardine race, if anyone's wondering why the stats don't line up with the changelog. Statpack was virtuous with no virtues taken.

## Why It's Good For The Game

Pretty straight forward, just lowers the stats of the Arcane Trickster a little so there's an actual tradeoff for being one instead of a regular thief. For some reason they had more stats than a thief on top of having magic? Now they don't!

For a more in-depth explanation why this matters: Arcane Trickster's access to magic can make one intent on being a nuisance _really_ hard, to borderline impossible, to pin down. Two int lets them easily hit the hardcap for spell scaling, as well as access to steel weapons for Conjure Weapon baseline, while one forces them to take intellectual and a statpack if they want that sweet 15. Especially if they want to max out invisibility's duration scaling.

Less willpower is obvious. Less stamina (and a common -stat in statpacks) so you have less room for error than a normal rogue. Play smart or suffer the consequences.

Tangentially makes them worse at combat with less stamina and worse feints, too. You got magic, be tricky! Or just keep doing what you're doing and Enchant Weapon: Force that cudgel of yours to break everyone's armor you maniac.

## Changelog


:cl:
balance: Arcane Trickster gets 1 less WIL and INT.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
