### PR TITLE
TDI begone attempt

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -30,14 +30,20 @@
 	bar.alpha = 0
 	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
-/datum/progressbar/proc/update(progress)
-	if(!tracked_clients)
-		tracked_clients = list()
-	for(var/mob/M in viewers(user, null))
-		if(M.client)
-			M.client.images |= bar
-			tracked_clients |= M.client
+	tracked_clients = list()
+	refresh_viewers()
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(refresh_viewers))
 
+/datum/progressbar/proc/refresh_viewers()
+	SIGNAL_HANDLER
+	for(var/mob/M in viewers(user, null))
+		var/client/C = M.client
+		if(!C || (C in tracked_clients))
+			continue
+		C.images |= bar
+		tracked_clients += C
+
+/datum/progressbar/proc/update(progress)
 	progress = CLAMP(progress, 0, goal)
 	last_progress = progress
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
@@ -51,6 +57,8 @@
 	animate(bar, pixel_y = dist_to_travel, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
 /datum/progressbar/Destroy()
+	if(user)
+		UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 	if(last_progress != goal)
 		bar.icon_state = "[bar.icon_state]_fail"
 	for(var/I in user.progressbars[bar.loc])

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -82,24 +82,20 @@
 		prefix = "LOOC (WP)"
 
 
-	var/list/mobs = list()
+	var/list/hearable = wp ? get_hearers_in_range(7, src) : get_hearers_in_view(7, src)
 	var/muted = prefs.muted
 	for(var/mob/M in GLOB.player_list)
-		var/added_text
-		var/is_admin = FALSE
 		var/client/C = M.client
-		if(!M.client)
+		if(!C)
 			continue
+		var/added_text = ""
+		var/is_admin = FALSE
 		if((C in GLOB.admins) && (C.prefs.admin_chat_toggles & CHAT_ADMINLOOC))
-			added_text += " ([mob.ckey]) [ADMIN_FLW(mob)] <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
-			is_admin = 1
-		mobs += C
-		if(C.prefs.chat_toggles & CHAT_OOC)
-			var/turf/speakturf = get_turf(M)
-			var/turf/sourceturf = get_turf(usr)
-			if(wp == 1 && (M in range (7, src)))
-				to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
-			else if(speakturf in get_hear(7, sourceturf))
-				to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
-			else if(is_admin == 1)
-				to_chat(C, "<font color='["#003458"]'><b>(R) <span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+			added_text = " ([mob.ckey]) [ADMIN_FLW(mob)] <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
+			is_admin = TRUE
+		if(!(C.prefs.chat_toggles & CHAT_OOC))
+			continue
+		if(M in hearable)
+			to_chat(C, "<font color='#6699CC'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+		else if(is_admin)
+			to_chat(C, "<font color='#003458'><b>(R) <span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -82,20 +82,24 @@
 		prefix = "LOOC (WP)"
 
 
-	var/list/hearable = wp ? get_hearers_in_range(7, src) : get_hearers_in_view(7, src)
+	var/list/mobs = list()
 	var/muted = prefs.muted
 	for(var/mob/M in GLOB.player_list)
-		var/client/C = M.client
-		if(!C)
-			continue
-		var/added_text = ""
+		var/added_text
 		var/is_admin = FALSE
-		if((C in GLOB.admins) && (C.prefs.admin_chat_toggles & CHAT_ADMINLOOC))
-			added_text = " ([mob.ckey]) [ADMIN_FLW(mob)] <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
-			is_admin = TRUE
-		if(!(C.prefs.chat_toggles & CHAT_OOC))
+		var/client/C = M.client
+		if(!M.client)
 			continue
-		if(M in hearable)
-			to_chat(C, "<font color='#6699CC'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
-		else if(is_admin)
-			to_chat(C, "<font color='#003458'><b>(R) <span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+		if((C in GLOB.admins) && (C.prefs.admin_chat_toggles & CHAT_ADMINLOOC))
+			added_text += " ([mob.ckey]) [ADMIN_FLW(mob)] <A href='?_src_=holder;[HrefToken()];mute=[ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>\[MUTE\]</font></a>"
+			is_admin = 1
+		mobs += C
+		if(C.prefs.chat_toggles & CHAT_OOC)
+			var/turf/speakturf = get_turf(M)
+			var/turf/sourceturf = get_turf(usr)
+			if(wp == 1 && (M in range (7, src)))
+				to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+			else if(speakturf in get_hear(7, sourceturf))
+				to_chat(C, "<font color='["#6699CC"]'><b><span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")
+			else if(is_admin == 1)
+				to_chat(C, "<font color='["#003458"]'><b>(R) <span class='prefix'>[prefix]:</span> <EM>[src.mob.name][added_text]:</EM> <span class='message'>[msg]</span></b></font>")


### PR DESCRIPTION
## About The Pull Request

hi.

progress bar is lagging shit.

viewer scan moved out of update() which was being hammered every tick. update() is now just a clamp + icon_state set
refresh_viewers() runs once on New() to seed the tracked clients list.
re-runs only when the user moves, via COMSIG_MOVABLE_MOVED. so a player walking mid craft still gets the bar shown to newly-visible viewers, but standing still does, and costs nothing.
tracked_clients check uses in instead of |=, skipping the linear find-and-append on EVERY ALREADY TRACKED CLIENT.
signal unregistered in Destroy() so we don't leak the hook.

## Testing Evidence

bismillah i hope it works.

## Why It's Good For The Game

at 150 average players with observers stacking, this should - within theory, drop progressbar/update from #1 self-cpu to a non-entry on the profiler. the viewers() calls only fire on actual movement now, not 4172 times in a screenshot i saw which caused me to put a bullet in my head.

## Changelog


:cl:
fix: unclogs the progressbar.
/:cl:
