### PR TITLE
Removes Excidium browser persistence - closes it when not adjacent to the machine

### DIFF
--- a/code/modules/roguetown/roguemachine/bounty.dm
+++ b/code/modules/roguetown/roguemachine/bounty.dm
@@ -42,6 +42,9 @@
 	var/list/choices = list("Consult Bounties", "Set Bounty", "Print List of Bounties", "Remove Bounty", "Collect Change")
 	var/selection = input(user, "The Excidium listens", src) as null|anything in choices
 
+	if(!Adjacent(user, src)) // User can move while selecting, sanity check
+		return
+
 	switch(selection)
 
 		if("Consult Bounties")
@@ -84,11 +87,25 @@
 		bounty_found = TRUE
 
 	if(bounty_found)
-		var/datum/browser/popup = new(user, "BOUNTIES", "", 500, 300)
+		var/datum/browser/popup = new(user, "BOUNTIES", "", 500, 300, src)
 		popup.set_content(consult_menu)
 		popup.open()
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(user_moved))
 	else
 		say("No bounties are currently active.")
+
+/// Subscribes to COMSIG_MOVABLE_MOVED to prevent the user from having bounty screen open when not adjacent to the machine
+/obj/structure/roguemachine/bounty/proc/user_moved(mob/former_user)
+	SIGNAL_HANDLER
+
+	if(!istype(former_user))
+		return
+
+	if(Adjacent(former_user, src))
+		return
+
+	UnregisterSignal(former_user, COMSIG_MOVABLE_MOVED)
+	former_user << browse(null, "window=BOUNTIES")
 
 /obj/structure/roguemachine/bounty/proc/remove_bounty(mob/living/carbon/human/user)
 	var/list/bounty_list = list()


### PR DESCRIPTION
## About The Pull Request

This PR fixes unwanted behavior of EXCIDIUM browser popup. By simply subscribing to signals and adding a sanity check, we can now prevent players from keeping the window open even when not adjacent to the machine.

## Testing Evidence

https://github.com/user-attachments/assets/d7b15a0e-a7cd-4356-920c-29d2c43d02b6

## Why It's Good For The Game

The ability to keep EXCIDIUM browser popup open on screen at all times invalidates the need to buy an enchanted bounty scroll. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: EXCIDIUM browser popup will now autoclose when the user is not adjacent to the machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
