### PR TITLE
Bandit Favor Distribution Rebalance

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1159,7 +1159,7 @@
 					if(bandit_player.owner?.current?.stat != DEAD)
 						active_bandits += bandit_player
 				var/bandit_count = length(active_bandits)
-				var/divisor = max(floor((bandit_count - 1) / 5) + 1, 1)
+				var/divisor = floor(max(bandit_count - 1, 0) / 5) + 1
 				var/share = floor(donatedamnt / divisor)
 				for(var/datum/antagonist/bandit/bandit_player in active_bandits)
 					record_round_statistic(STATS_SHRINE_VALUE, share)

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1158,7 +1158,9 @@
 				for(var/datum/antagonist/bandit/bandit_player in GLOB.antagonists)
 					if(bandit_player.owner?.current?.stat != DEAD)
 						active_bandits += bandit_player
-				var/share = round(donatedamnt / max(length(active_bandits) / 2, 1))
+				var/bandit_count = length(active_bandits)
+				var/divisor = max(floor((bandit_count - 1) / 5) + 1, 1)
+				var/share = floor(donatedamnt / divisor)
 				for(var/datum/antagonist/bandit/bandit_player in active_bandits)
 					record_round_statistic(STATS_SHRINE_VALUE, share)
 					bandit_player.favor += share

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1157,7 +1157,7 @@
 				var/list/active_bandits = list()
 				for(var/datum/antagonist/bandit/bandit_player in GLOB.antagonists)
 					active_bandits += bandit_player
-				var/share = donatedamnt / max(length(active_bandits) / 2, 1)
+				var/share = round(donatedamnt / max(length(active_bandits) / 2, 1))
 				for(var/datum/antagonist/bandit/bandit_player in active_bandits)
 					record_round_statistic(STATS_SHRINE_VALUE, share)
 					bandit_player.favor += share

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1156,7 +1156,8 @@
 				qdel(W)
 				var/list/active_bandits = list()
 				for(var/datum/antagonist/bandit/bandit_player in GLOB.antagonists)
-					active_bandits += bandit_player
+					if(bandit_player.owner?.current?.stat != DEAD)
+						active_bandits += bandit_player
 				var/share = round(donatedamnt / max(length(active_bandits) / 2, 1))
 				for(var/datum/antagonist/bandit/bandit_player in active_bandits)
 					record_round_statistic(STATS_SHRINE_VALUE, share)

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1154,14 +1154,15 @@
 			if(proceed_with_offer)
 				playsound(loc,'sound/items/carvty.ogg', 50, TRUE)
 				qdel(W)
-				for(var/mob/player in GLOB.player_list)
-					if(player.mind)
-						if(player.mind.has_antag_datum(/datum/antagonist/bandit))
-							var/datum/antagonist/bandit/bandit_players = player.mind.has_antag_datum(/datum/antagonist/bandit)
-							record_round_statistic(STATS_SHRINE_VALUE, W.get_real_price())
-							bandit_players.favor += donatedamnt
-							bandit_players.totaldonated += donatedamnt
-							to_chat(player, ("<font color='yellow'>[user.name] donates [donatedamnt] to the shrine! You now have [bandit_players.favor] favor.</font>"))
+				var/list/active_bandits = list()
+				for(var/datum/antagonist/bandit/bandit_player in GLOB.antagonists)
+					active_bandits += bandit_player
+				var/share = donatedamnt / max(length(active_bandits) / 2, 1)
+				for(var/datum/antagonist/bandit/bandit_player in active_bandits)
+					record_round_statistic(STATS_SHRINE_VALUE, share)
+					bandit_player.favor += share
+					bandit_player.totaldonated += share
+					to_chat(bandit_player.owner?.current, ("<font color='yellow'>[user.name] donates [donatedamnt] to the shrine! Matthios grants your share: [share]. You now have [bandit_player.favor] favor.</font>"))
 
 			else
 				to_chat(user, span_warning("This item isn't a good offering."))


### PR DESCRIPTION
## About The Pull Request

This PR adjusts how favor is distributed when bandits donate to the shrine. Below 6 bandits, each receives the full value. At 6 and beyond, the payout is divided by one additional factor for every 5 bandits, so 6-10 bandits split at half, 11-15 at a third, and so on. This prevents large bandit rounds from making shrine donations trivially lucrative. 

Please note that it does not count dead bandits. Also, the reason why I don't have more gradual steps for how favors are distributed is that I don't want bandits to have the excuse to start interrupting roleplay and have them default to min-maxxing everything, forsaking roleplay in the process. That's **NOT** what this game is about.

Alternatively, I could simply raise the price of items bought at the Hoardmaster directly for everyone, regardless of player count.

**This also improves the current logic in place compared to the original.**

## Testing Evidence

<img width="661" height="34" alt="banditproof" src="https://github.com/user-attachments/assets/c95880fa-604d-4576-85f5-356536c00e8a" />

I cannot duplicate six of myself sadly. But proof it works.

## Why It's Good For The Game

With this current arms race of balance, it seems more than necessary to start scaling everything back. With the SCOM nerf in #1444, that and this PR should begin that process. This seems important more than ever, since Tempo is currently being test-merged. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bandit favor distribution now scales with group size. Each bandit receives full favor from shrine donations until the group reaches six, at which point the payout is halved, with one additional divisor added for every five bandits beyond that.

/:cl:
