### PR TITLE
Natural Armor Flight Fix for Harpies

### DIFF
--- a/code/modules/surgery/organs/feature_organs/wings.dm
+++ b/code/modules/surgery/organs/feature_organs/wings.dm
@@ -98,6 +98,12 @@
 
 /obj/effect/proc_holder/spell/self/harpy_flight/cast(mob/living/carbon/human/user)
 	var/harpy_AC = user.highest_ac_worn()
+	// Natural/innate skin armor (e.g. Natural Armor virtue) occupies the shirt slot but is part of the body - don't let it block flight
+	if(harpy_AC != ARMOR_CLASS_NONE && istype(user.wear_shirt, /obj/item/clothing/suit/roguetown/armor/regenerating/skin))
+		harpy_AC = ARMOR_CLASS_NONE
+		for(var/obj/item/clothing/C in list(user.wear_armor, user.wear_pants, user.wear_wrists, user.gloves, user.head, user.shoes, user.wear_neck, user.wear_mask, user.wear_ring))
+			if(C.armor_class > harpy_AC)
+				harpy_AC = C.armor_class
 	if(harpy_AC == ARMOR_CLASS_NONE)
 		if(!user.buckled)
 			if(!user.pulledby)


### PR DESCRIPTION
## About The Pull Request
- 'Fixes' natural armor preventing harpies from taking flight.

## Testing Evidence
<img width="635" height="431" alt="harpynatarmortest" src="https://github.com/user-attachments/assets/83864f3c-a188-4af5-bee7-2e5877938e16" />

## Why It's Good For The Game
Currently you can take this virtue as a harpy, and then suffer permanent no-flight, despite it being a part of your actual body. Harpies are already pretty fragile, and since you use up a virtue to make yourself less squishy (in comparison to a +CON stat boost), you end up maiming yourself entirely for half of the purpose of being a harpy... to fly. Nobody noticed before, perhaps. But I think this will be fine.

## Changelog
:cl:
fix: Natural armor virtue now no longer prevents harpy flight from happening.
/:cl:
