### PR TITLE
Removes X-Ray Vision from Bat/Crow Witch Forms

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -31,7 +31,7 @@
 	movement_type = FLYING
 	speak_emote = list("squeaks")
 	base_intents = list(/datum/intent/bite)
-	sight = (SEE_TURFS|SEE_MOBS|SEE_OBJS|SEE_SELF)
+	sight = SEE_SELF
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 


### PR DESCRIPTION
## About The Pull Request
See title.

## Testing Evidence
<img width="985" height="717" alt="witchxrayfix" src="https://github.com/user-attachments/assets/54669fbf-97d9-4cd1-adca-7f44a285691b" />

## Why It's Good For The Game
X-ray vision wasn't good for the game. Pretty sure some people wanted this done, too. I dunno, I liked it for spying when bored but like... some people do kinda meta things with it. Best to do away with it unless you guys REALLY want to keep this.

## Changelog
:cl:
fix: Crow / Bat forms for witches no longer have X-Ray vision.
/:cl:
