### PR TITLE
Prevents fartraveling dead people

### DIFF
--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -24,6 +24,9 @@
 	if(departing_mob != user && departing_mob.client)
 		to_chat(user, "<span class='warning'>This one retains their free will. It's their choice if they want to leave the round or not.</span>")
 		return
+	if(departing_mob.stat == DEAD && !departing_mob.client) //died and respawned or disconnected, no free slots for far-traveling someone that already opened a slot
+		to_chat(user, "<span class='warning'>This one is long dead and has passed unto another place. They have already left.</span>")
+		return
 	if(alert("Are you sure you want to [departing_mob == user ? "depart the round for good (you" : "send this person away (they"] will be removed from the current round, the job slot freed)?", "Departing", "Confirm", "Cancel") != "Confirm")
 		return
 	if(user.incapacitated() || QDELETED(departing_mob) || (departing_mob != user && departing_mob.client) || get_dist(src, dropping) > 2 || get_dist(src, user) > 2)


### PR DESCRIPTION
## About The Pull Request

Title! Thankfully Xander mentioned that you can fartravel dead people, which made me realize the amount of exploits you could do with this. Mostly two major ones:

- You could kill someone, bury them (or wait for them to respawn, if you don't want to FORCE people out of a role), and then drag their corpse to the far travel point to open up a slot, meaning that dukes, knights, hands, princes, bishops, brigands, any role, even if they specifically have things such as `TRAIT_DNR` or `open_slots_on_death = FALSE`, could simply infinitely respawn as long as someone just drags their dead body to a far-travel point. 

<img width="820" height="394" alt="image" src="https://github.com/user-attachments/assets/e3deb08f-f5ff-4d27-b2d8-79d48604477c" />
<img width="334" height="207" alt="image" src="https://github.com/user-attachments/assets/751866f9-1915-43c6-8449-43d1855f8ec2" />
<img width="427" height="29" alt="image" src="https://github.com/user-attachments/assets/15bbb4f5-1838-4251-9053-814c0998cc07" />
<img width="281" height="120" alt="image" src="https://github.com/user-attachments/assets/ecd7e9e5-4705-44b7-8779-7732d37c72e1" />


- You could kill someone, wait for them to respawn with `open_slots_on_death = TRUE`, opening up a slot, and then far-travel their corpse, opening up a *second* slot, meaning that you can, technically speaking, obtain an infinite amount of slots, depending on how long you're willing to do it.

Both of these can be easily used to make a faction practically unkillable with infinite manpower, or just *steal* a role from someone if you were to far travel after them and join into the round as that role.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="868" height="596" alt="image" src="https://github.com/user-attachments/assets/0c37bff5-1878-4155-b695-b39a1df78932" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Exploit fix! Means that the roles that aren't supposed to reopen slots don't, and the ones that do don't do it twice. Luckly, you still can't far travel people when they're dead *and* connected.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed being able to far travel dead corpses, opening up a slot twice or opening a slot of a role that you shouldn't be able to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
