### PR TITLE
Changes to make bandit/wretch scaling actually do something (and slightly lowered bandit cap)

### DIFF
--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -88,10 +88,10 @@
 	if(!category)
 		return 0
 
-	var/category_key = lowertext("[category]")
+	var/category_key = LOWER_TEXT(category)
 	var/list/alive_minds = list()
 	for(var/datum/antagonist/A in GLOB.antagonists)
-		if(lowertext("[A.roundend_category]") != category_key)
+		if(LOWER_TEXT(A.roundend_category) != category_key)
 			continue
 		if(!A.owner?.current)
 			continue
@@ -106,7 +106,7 @@
 		return ""
 
 	var/display_name = capitalize(category)
-	var/category_key = lowertext("[category]")
+	var/category_key = LOWER_TEXT(category)
 	var/list/category_to_job = list(
 		"bandits" = "Bandit",
 		"wretches" = "Wretch",

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -126,7 +126,7 @@
 			var/cap_slots = category_hard_caps[category_key]
 			if(isnull(cap_slots))
 				cap_slots = max(antag_job.total_positions, 0)
-			display_name = "[display_name] [open_slots] ([cap_slots]) Alive: [alive_count]"
+			display_name = "[display_name] Current Slots(Cap): [open_slots] ([cap_slots]) Alive: [alive_count]"
 
 	return display_name
 

--- a/code/modules/admin/check_antagonists.dm
+++ b/code/modules/admin/check_antagonists.dm
@@ -84,6 +84,52 @@
 /datum/team/proc/is_gamemode_hero()
 	return FALSE
 
+/datum/admins/proc/get_alive_antag_count_for_category(category)
+	if(!category)
+		return 0
+
+	var/category_key = lowertext("[category]")
+	var/list/alive_minds = list()
+	for(var/datum/antagonist/A in GLOB.antagonists)
+		if(lowertext("[A.roundend_category]") != category_key)
+			continue
+		if(!A.owner?.current)
+			continue
+		if(A.owner.current.stat == DEAD)
+			continue
+		alive_minds[A.owner] = TRUE
+
+	return length(alive_minds)
+
+/datum/admins/proc/get_antag_category_display_name(category)
+	if(!category)
+		return ""
+
+	var/display_name = capitalize(category)
+	var/category_key = lowertext("[category]")
+	var/list/category_to_job = list(
+		"bandits" = "Bandit",
+		"wretches" = "Wretch",
+		"gnolls" = "Gnoll",
+		"assassins" = "Assassin",
+	)
+	var/list/category_hard_caps = list(
+		"bandits" = 8,
+		"wretches" = 10,
+	)
+
+	if(category_key in category_to_job)
+		var/datum/job/antag_job = SSjob.GetJob(category_to_job[category_key])
+		if(antag_job)
+			var/open_slots = max(antag_job.total_positions - antag_job.current_positions, 0)
+			var/alive_count = get_alive_antag_count_for_category(category)
+			var/cap_slots = category_hard_caps[category_key]
+			if(isnull(cap_slots))
+				cap_slots = max(antag_job.total_positions, 0)
+			display_name = "[display_name] [open_slots] ([cap_slots]) Alive: [alive_count]"
+
+	return display_name
+
 /datum/admins/proc/build_antag_listing()
 	var/list/sections = list()
 	var/list/priority_sections = list()
@@ -117,7 +163,7 @@
 			next_antag = all_antagonists[i+1]
 		if(!current_category)
 			current_category = current_antag.roundend_category
-			current_section += "<b>[capitalize(current_category)]</b><br>"
+			current_section += "<b>[get_antag_category_display_name(current_category)]</b><br>"
 			current_section += "<table cellspacing=5>"
 		current_section += current_antag.antag_listing_entry() // Name - (Traitor) - FLW | PM | TP
 

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -15,9 +15,9 @@
 
 /datum/round_event/migrant_wave/bandits/start()
 	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
-	bandit_job.total_positions = min(bandit_job.total_positions + 5, 10)
-	bandit_job.spawn_positions = min(bandit_job.spawn_positions + 5, 10)
-	if(bandit_job.total_positions < 6) // Not at max capacity, increasing goal.
+	bandit_job.total_positions = min(bandit_job.total_positions + 3, 8)
+	bandit_job.spawn_positions = min(bandit_job.spawn_positions + 3, 8)
+	if(bandit_job.total_positions < 8) // Not at max capacity, increasing goal.
 		SSmapping.retainer.bandit_goal += 3 * rand(200, 400)
 		SSrole_class_handler.bandits_in_round = TRUE
 		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)

--- a/code/modules/events/antagonist/solo/bandits.dm
+++ b/code/modules/events/antagonist/solo/bandits.dm
@@ -12,7 +12,7 @@
 
 	restricted_roles = DEFAULT_ANTAG_BLACKLISTED_ROLES
 	base_antags = 5
-	maximum_antags = 10
+	maximum_antags = 8
 
 	earliest_start = 0 SECONDS
 
@@ -26,8 +26,8 @@
 
 /datum/round_event/antagonist/solo/bandits/start()
 	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
-	bandit_job.total_positions = length(setup_minds)
-	bandit_job.spawn_positions = length(setup_minds)
+	bandit_job.total_positions = min(length(setup_minds), 8)
+	bandit_job.spawn_positions = min(length(setup_minds), 8)
 	SSmapping.retainer.bandit_goal = rand(200,400) + (length(setup_minds) * rand(200,400))
 	for(var/datum/mind/antag_mind as anything in setup_minds)
 		var/datum/job/J = SSjob.GetJob(antag_mind.current?.job)

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -117,15 +117,14 @@
 		return
 
 	var/player_count = length(GLOB.joined_player_list)
-	var/slots = 5
+	var/slots = 3
 
-	//Add 1 slot for every 12 players over 30.
-	if(player_count > 42)
-		var/extra = floor((player_count - 42) / 12)
-		slots += extra
-
-	//5 slots minimum, 7 maximum.
-	slots = min(slots, 9)
+	if(player_count > 100)
+		if(player_count <= 110)
+			slots = 4
+		else
+			// 111-120: 5 slots, then +1 per 10 players, capped at 8.
+			slots = min(8, 5 + floor((player_count - 111) / 10))
 
 	bandit_job.total_positions = slots
 	bandit_job.spawn_positions = slots

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -102,15 +102,14 @@
 		return
 
 	var/player_count = length(GLOB.joined_player_list)
-	var/slots = 5
+	var/slots = 3
 
-	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
-	if(player_count > 40)
-		var/extra = floor((player_count - 40) / 10)
-		slots += extra
-
-	//5 slots minimum, 10 maximum.
-	slots = min(slots, 10)
+	if(player_count > 100)
+		if(player_count <= 110)
+			slots = 4
+		else
+			// 111-120: 5 slots, then +1 per 10 players, capped at 10.
+			slots = min(10, 5 + floor((player_count - 111) / 10))
 
 	wretch_job.total_positions = slots
 	wretch_job.spawn_positions = slots


### PR DESCRIPTION
## About The Pull Request

Large amounts of antags facing up against a relatively small garrison has become a regular occurrence on the lower population rounds as of late. Looking at the old scaling in this table compared to the new, it's fairly obvious the issue, as even at our lowest population we will usually have ALL wretch and bandit slots open.

Bear in mind the variable this is decided upon is 'joined' players, this does not mean active, it just takes the number of roundstart players and adds to it whenever anyone latejoins, it does NOT decrease for anyone leaving/dead.

<img width="442" height="617" alt="image" src="https://github.com/user-attachments/assets/f30a4bd4-4b52-4a51-9de6-ca570048b53b" />

## Testing Evidence

Works fine with testing, but obviously limited in ability to test player counts. Logic is sound and is only changing numbers so should not cause problems.

## Why It's Good For The Game

I am admittedly biased as an admin who is often handling tickets at these hours. However. It's my argument that scaling is clearly not intended to work as it does currently, as these limits were set back in older times with a much lower player count in mind. this brings them up to something more sensible. We do not want to stop antagonists from having room to play at lower population numbers, but currently we see full wretch slots and a lot of bandits with very few garrison members at these hours and they usually are completely steamrolled. This should make it a little more fair and encourage antags to be more like their intended role (on the backfoot against an armed duchy) instead of literally overwhelming it. 


## Changelog

:cl:
balance: Bandit and Wretch slots now scale with more sensible population numbers. This will mostly only affect our lowest pop rounds and hopefully prevent significant overwhelming of the garrison. 
/:cl:


