### PR TITLE
Adjusting Noc Miracles

### DIFF
--- a/code/datums/gods/patrons/divine/noc.dm
+++ b/code/datums/gods/patrons/divine/noc.dm
@@ -6,15 +6,15 @@
 	virtues = "Wisdom, Curiosity, Pursuit of Arcyne"
 	sins = "Ignorance, Censorship, Bookburning"
 	mob_traits = list(TRAIT_NIGHT_OWL, TRAIT_NOCSIGHT)
-	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison			= CLERIC_ORI,
-					/obj/effect/proc_holder/spell/invoked/noc_sight				= CLERIC_T0,
-					/obj/effect/proc_holder/spell/invoked/darkvision/miracle	= CLERIC_T0,
-					/obj/effect/proc_holder/spell/invoked/lesser_heal 			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/blood_heal			= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/invisibility/miracle	= CLERIC_T1,
-					/obj/effect/proc_holder/spell/invoked/blindness				= CLERIC_T2,
-					/obj/effect/proc_holder/spell/self/noc_spell_bundle			= CLERIC_T3,
-					/obj/effect/proc_holder/spell/invoked/resurrect/noc			= CLERIC_T4,
+	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison				= CLERIC_ORI,
+					/obj/effect/proc_holder/spell/targeted/touch/prestidigitation	= CLERIC_T0,
+					/obj/effect/proc_holder/spell/invoked/silence/miracle			= CLERIC_T0,//wisdom is knowing when to shut up, or to make someone shut up.
+					/obj/effect/proc_holder/spell/invoked/lesser_heal 				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/blood_heal				= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/invisibility/miracle		= CLERIC_T1,
+					/obj/effect/proc_holder/spell/invoked/blindness					= CLERIC_T2,
+					/obj/effect/proc_holder/spell/self/noc_spell_bundle				= CLERIC_T3,
+					/obj/effect/proc_holder/spell/invoked/resurrect/noc				= CLERIC_T4,
 	)
 	confess_lines = list(
 		"NOC IS NIGHT!",

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -93,17 +93,19 @@
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	associated_skill = /datum/skill/magic/holy
 	var/chosen_bundle
-	var/list/utility_bundle = list(	//Utility means exactly that. Nothing offensive and nothing that can affect another person negatively. (Barring Fetch)
+	var/list/utility_bundle = list(	//Utility means exactly that. Nothing offensive and nothing that can affect another person negatively, 11 spellpoints total. (Barring Fetch, and technically Create Campfire)
 		/obj/effect/proc_holder/spell/self/message,
 		/obj/effect/proc_holder/spell/invoked/leap,
 		/obj/effect/proc_holder/spell/invoked/mending,
+		/obj/effect/proc_holder/spell/invoked/create_campfire,
 		/obj/effect/proc_holder/spell/invoked/projectile/fetch,
 		/obj/effect/proc_holder/spell/invoked/blink,
 	)
-	var/list/offensive_bundle = list(	//This is not meant to make them combat-capable. A weak offensive, and mostly defensive option.
-		/obj/effect/proc_holder/spell/invoked/projectile/arcynebolt, // PLACEHOLDER
+	var/list/offensive_bundle = list(	//This is not meant to make them combat-capable. A weak offensive, and mostly defensive option. 9 spellpoints total.
+		/obj/effect/proc_holder/spell/invoked/wither/miracle,
 		/obj/effect/proc_holder/spell/self/conjure_armor/miracle,
 		/obj/effect/proc_holder/spell/invoked/conjure_weapon/miracle,
+		/obj/effect/proc_holder/spell/invoked/enchant_weapon, // Should be fine since Enchant Weapon has been nerfed over time, and Burning Blade is (sadly) no longer a thing. Some T4 clerics also don't get Arcane skill naturally, so they have to manually refresh this.
 	)
 	var/list/buff_bundle = list(	//Buffs! An Acolyte being a supportive caster is 100% what they already are, so this fits neatly. No debuffs -- every patron already has a plethora of those.
 		/obj/effect/proc_holder/spell/invoked/hawks_eyes::name 			= /obj/effect/proc_holder/spell/invoked/hawks_eyes,

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -569,10 +569,10 @@
 	name = "Moonlit Revival"
 	desc = "Revive the target at a cost, cast on yourself to check.<br>Targets intelligence will be sapped for a time, in addition they will be burned by moonlight."
 	required_items = list(
-		/obj/item/paper/scroll = 15
+		/obj/item/paper/scroll = 6
 	)
 	alt_required_items = list(
-		/obj/item/paper = 15
+		/obj/item/paper = 10
 	)
 	debuff_type = /datum/status_effect/debuff/noc_revival
 	overlay_state = "noc_revive"

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/wither.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/wither.dm
@@ -25,9 +25,9 @@
 	var/damage = 40
 
 /obj/effect/proc_holder/spell/invoked/wither/miracle
-    cost = 0
-    spell_tier = 0
-    associated_skill = /datum/skill/magic/holy
+	cost = 0
+	spell_tier = 0
+	associated_skill = /datum/skill/magic/holy
 
 /obj/effect/proc_holder/spell/invoked/wither/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])

--- a/code/modules/spells/spell_types/wizard/invoked_aoe/wither.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/wither.dm
@@ -24,11 +24,16 @@
 	var/strikerange = 14 // how many tiles the strike can reach
 	var/damage = 40
 
+/obj/effect/proc_holder/spell/invoked/wither/miracle
+    cost = 0
+    spell_tier = 0
+    associated_skill = /datum/skill/magic/holy
+
 /obj/effect/proc_holder/spell/invoked/wither/cast(list/targets, mob/user = usr)
 	var/turf/T = get_turf(targets[1])
 
 	var/turf/source_turf = get_turf(user)
-	
+
 	if(T.z != user.z)
 		to_chat(user, span_warning("You can't cast this spell on a different z-level!"))
 		return FALSE
@@ -66,7 +71,7 @@
 	duration = 1 SECONDS
 	layer = MASSIVE_OBJ_LAYER
 	alpha = 70
-	
+
 
 /obj/effect/temp_visual/wither_actual
 	icon = 'icons/effects/effects.dmi'
@@ -80,4 +85,4 @@
 	if(duration_override)
 		duration = duration_override
 	. = ..() // Call parent AFTER setting duration
-	
+

--- a/code/modules/spells/spell_types/wizard/invoked_single_target/silence.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/silence.dm
@@ -23,6 +23,14 @@
 	associated_skill = /datum/skill/magic/arcane
 	zizo_spell = TRUE
 
+/obj/effect/proc_holder/spell/invoked/silence/miracle
+	cost = 0
+	spell_tier = 0
+	associated_skill = /datum/skill/magic/holy
+	chargetime = 9
+	recharge_time = 120 SECONDS
+	invocations = list("Lunaria Silentium!")
+
 /obj/effect/proc_holder/spell/invoked/silence/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))
 		var/mob/living/carbon/target = targets[1]


### PR DESCRIPTION
## About The Pull Request

For the longest time, Noc had a few dead miracle picks (or nearly dead, anyway) as well as using a placeholder in one of his higher tier miracles. This changes things around to, hopefully, be a little more useful without overly affecting balance.

## Testing Evidence

<img width="1553" height="682" alt="proof01" src="https://github.com/user-attachments/assets/ea0613d6-779a-4d72-92d7-52f4e24e568a" />


## Why It's Good For The Game

T0 Spells:
Old -- Nocsight (view forward as if you had 15 perception) was... _Absurdly_ niche. Most who naturally get this spell already have ~13 perception by default, so this really only came up on people taking Devotee. And... Honestly, very, _very_ few people are taking Devotee on a combat class. Darkvision had a similar issue where just _being_ a Nocite gives you darkvision. True, you could buff people around you but I'm pretty sure most people didn't even know this _was_ an AoE spell?

New -- Presti is kind of obvious. Dude's the god of magic, so you get a tiny speck of it. Overlaps with Arcane Potential if you're a combat class, but you get +1 miracle instead of +1 arcane... Which means you can't get a buddy to use Enchant Weapon on you so it evens out. Also requires you to pick Noc over another god. Silence isn't super useful? Especially as it doesn't work on people with 3+ Arcane/Miracle. For Devotees we'll probably mostly see it used to shut someone up in court, or to stop someone from yelling while in Paincrit.

Which is actually the (lore) reason behind it: Noc's champions are supposed to purge the terrors of the night, and Silence helps with that. Quiet the injured, silence a heretic standing watch...

Also this opens up Wretches or Heretical Nocites using it to Silence someone for kidnapping which is nifty.

T4 Spells:
Noc Spellpack, Utility - Adds Create Campfire because of the new weather system. Honestly, it probably should've been in here originally but I think the OG devs were concerned about people using these as traps? Either way, the spell is basically one of the _the_ utility spells (warmth, healing more than one person at a time if very slowly, cooking) so I feel like it's earned a spot here.

Noc Spellpack, Combat: Trades Arcane Bolt for Wither. High level clerics already get Divine Bolt so... Arcane Bolt was kind of redundant? Wither, meanwhile, fits somewhat thematically by using the shadows against evil. Plus it lowers their DPS as Wither is harder to hit and does a mere 40 every 20 seconds. Also ties into the offensive spellpack giving them Conjure Weapon, so you can (briefly) fight on semi-equal footing. Also added Enchant Weapon _primarily_ for the Durability effect. It still scales on Arcane, so it needs to be manually refreshed for non-Acolytes or people w/o Arcane Potential. This also brings the spellpoint total of the Offensive spell list closer to the others (13 utility, 9 offense, 12 buff).

Secondary Changes:
- Miracle version of Silence added. Charges quicker but takes longer to cooldown. Shouldn't cause any problems as in either case it outright fails against people with 3+ Arcane/Miracle skill.

- Miracle version of Wither added. No change beyond scaling off Miracle instead of Arcane.

- Noc Resurrection changed from 15 scrolls/parchment to 6 / 10 respectively. Should cut down on Nocites leaving ten billion scrolls everywhere and bring it a little more in line with other resurrection material costs (6 scrolls is 2 logs). Also, now it's actually reasonable to actually gather the materials out of preplaced map resources. Parchment is cheaper because you're taking the time to cut the scrolls into parchments (1 scroll = 2 parchment). Noc Res, according to the code, causes you to take constant burn damage if you're outside at night until the debuff fades which considering how long nights are... Kind of harsh.

## Changelog

:cl:
add: Added a Noc Miracle variant of Silence. Quicker to cast, slower to cooldown.
add: Added a Miracle variant of Wither. No change, just scales off Miracle skill.
del: Removed Darksight and Nocvision from Noc (the spells are still around in the code)
balance: Added Noc Silence and Prestidigitation to Noc's T0 spell tier.
balance: Added Create Campfire to Noc's T4 Utility Spellpack
balance: Removed Arcane Bolt, added Wither, added Enchant Weapon to Noc's T4 Offense Spellpack
/:cl:

