### PR TITLE
Roguetest_NOOTHERZ

### DIFF
--- a/_maps/roguetest.json
+++ b/_maps/roguetest.json
@@ -6,6 +6,7 @@
 	"other_z": [
 		"_maps/map_files/otherz/banditmountain.json",
 		"_maps/map_files/otherz/vl_manor.json",
+		"_maps/map_files/otherz/avspawnrockhill.json",
 		"_maps/map_files/otherz/wretchfort.json"
 	],
 	"minetype": null,

--- a/_maps/roguetest_nootherz.dm
+++ b/_maps/roguetest_nootherz.dm
@@ -1,0 +1,1 @@
+#define FORCE_MAP "_maps/roguetest_nootherz.json"

--- a/_maps/roguetest_nootherz.json
+++ b/_maps/roguetest_nootherz.json
@@ -1,0 +1,15 @@
+{
+    "map_name": "Roguetest (no OtherZ)",
+    "map_path": "map_files/roguetest",
+    "map_file": "roguetest.dmm",
+	"traits": [{"Name": "Roguetest", "Up": true}, {"Down": true}],
+	"minetype": null,
+	"space_empty_levels": 0,
+	"space_ruin_levels": 0,
+	"shuttles": {
+	    "cargo": "cargo_rogue",
+	    "ferry": "ferry_base",
+	    "whiteship": "whiteship_box",
+	    "emergency": "emergency_rogue"
+    }
+}

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -16,6 +16,10 @@ endmap
 map roguetest
 endmap
 
+map roguetest_nootherz
+endmap
+
+
 map dun_world
 	votable
 endmap


### PR DESCRIPTION
## About The Pull Request

Not a player-facing update.

When testing things, there's now an option to load Roguetest without loading any of the OtherZ. 

## Testing Evidence

<img width="360" height="324" alt="image" src="https://github.com/user-attachments/assets/feb6e7b0-b77b-48e6-824b-22d5c5af6217" />

## Why It's Good For The Game

Useful for testing things as certain antagonists if you don't want to teleport to the wretchfort, and speeds up testing by a smidge.

## Changelog

:cl:
add: Roguetest_OtherZ option when changing the map to load roguetest without loading the bandit camp/wretch fort/etc.
/:cl: