### PR TITLE
New pvp virtues or bog is new viltrum empire now

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -110,6 +110,7 @@
 #define TRAIT_CHASTITY_SPIKED "Genital Spikes" // Causes discomfort during arousal.
 #define TRAIT_CHASTITY_LOCKED "Locked Chastity Device" // Prevents removal of the chastity device.
 #define TRAIT_EXTREME_TEMPERATURE_IMMUNE "Extreme Temperature Immunity" //immunitty to heatstroke and frostbite without damage reduction
+#define TRAIT_BOG_BORN "bog_born"
 
 //Hearthstone port (Tracking)
 #define TRAIT_PERFECT_TRACKER "Huntmaster" //Will always find any tracks and analyzes them perfectly.
@@ -535,7 +536,8 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_GANG_A = span_info("I belong to the Rontz Ratz gang"),
 	TRAIT_GANG_B = span_info("I belong to the Blortz Volves gang"),
 	TRAIT_EXTREME_TEMPERATURE_IMMUNE = span_info("I will not suffer ills from extreme temperatures, wether hot or cold, yet fire and ice can still harm me."),
-	TRAIT_TRIBAL = span_info("I belong to the Island's tribe.")
+	TRAIT_TRIBAL = span_info("I belong to the Island's tribe."),
+	TRAIT_BOG_BORN = span_greentext("I am from the bog. I gain the gifts of the mire, but suffer when entering civilized areas.")
 ))
 
 // trait accessor defines

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -1109,3 +1109,18 @@
 	name = "overheating"
 	desc = "My frame is overheating!"
 	icon_state = "fire"
+
+/datum/status_effect/debuff/bogborn_discomfort
+	id = "bogborn_discomfort"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/bogborn_discomfort
+	effectedstats = list(STATKEY_STR = -4, STATKEY_PER = -4, STATKEY_INT = -4, STATKEY_WIL = -4, STATKEY_CON = -4, STATKEY_SPD = -4, STATKEY_LCK = -4)
+
+/datum/status_effect/debuff/bogborn_discomfort/on_apply()
+	. = ..()
+	to_chat(owner, span_warning("The dry roads and ordered walls press upon me. I must return to the bog."))
+
+/atom/movable/screen/alert/status_effect/debuff/bogborn_discomfort
+	name = "Far from the Bog"
+	desc = "The air is too dry, the roads too clean, and the walls too still. I must return to the bog."
+	icon_state = "debuff"
+	color = "#6b453a"

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -40,6 +40,8 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 		guy.apply_status_effect(/datum/status_effect/buff/dungeoneerbuff)
 	if((src.holy_area == TRUE) && HAS_TRAIT(guy, TRAIT_VOTARY))//Top Church guys get a buff. Opposite to overt heretics.
 		guy.add_stress(/datum/stressevent/seeblessed)
+	if(((src.town_area == TRUE) || (src.warden_area == TRUE)) && HAS_TRAIT(guy, TRAIT_BOG_BORN) && guy.has_status_effect(/datum/status_effect/debuff/bogborn_discomfort))
+		guy.remove_status_effect(/datum/status_effect/debuff/bogborn_discomfort)
 	if((src.holy_area == TRUE) && HAS_TRAIT(guy, TRAIT_HOLYWARRIOR))
 		guy.apply_status_effect(/datum/status_effect/debuff/holy_blessing)
 	if((src.necra_area == TRUE) && !(guy.has_status_effect(/datum/status_effect/debuff/necrandeathdoorwilloss)||(guy.has_status_effect(/datum/status_effect/debuff/deathdoorwilloss)))) //Necra saps at wil

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -240,3 +240,62 @@
 	if(vanished_hide) //failsafe
 		to_chat(recipient, span_warning("My natural armor vanished! Perhaps some divine intervention might sort things out..."))
 
+
+//BOG BORN
+
+/datum/virtue/combat/ex_bog_guard
+	name = "Ex-Bog Guard"
+	desc = "I once wore the green tabard of Rockhill, standing watch over its wet roads, sunken fields, and reed-choked borders."
+	custom_text = "Gain +1 Strength, +1 Speed, +1 Intelligence,  +1 Willpower and +1 Constitution."
+	added_traits = list(TRAIT_BOG_BORN)
+
+/datum/virtue/combat/ex_bog_guard/apply_to_human(mob/living/carbon/human/recipient)
+	recipient.change_stat(STATKEY_STR, 1)
+	recipient.change_stat(STATKEY_SPD, 1)
+	recipient.change_stat(STATKEY_INT, 1)
+	recipient.change_stat(STATKEY_CON, 1)
+	recipient.change_stat(STATKEY_WIL, 1)
+
+/datum/virtue/combat/bog_born_mage
+	name = "Bog Mage"
+	desc = "I was once a scholar of Noc, chasing pale truths through ink, candlelight, and forbidden margins. Yet it was in the bogs, beneath dead mist and watching reeds, that I learned what no boor dared to teach."
+	custom_text = "Bog-Born. Gain +2 Speed, +2 Willpower, +2 Intelligence, and 6 spellpoints."
+	added_traits = list(TRAIT_BOG_BORN)
+	triumph_cost = 15
+
+/datum/virtue/combat/bog_born_mage/apply_to_human(mob/living/carbon/human/recipient)
+	if(!recipient.mind)
+		return
+
+	recipient.change_stat(STATKEY_SPD, 2)
+	recipient.change_stat(STATKEY_WIL, 2)
+	recipient.change_stat(STATKEY_INT, 2)
+	recipient.mind?.adjust_spellpoints(6)
+
+
+/datum/virtue/combat/bog_born_warrior
+	name = "Bog Raider"
+	desc = "I was a crusader once, sworn to return when the war was done. But the bog drank the roads, the years, and the memory of my wife, leaving only rusted steel and a man too stubborn to sink."
+	custom_text = "Bog-Born. Gain +2 Strength, +1 Speed, +2 Willpower, +1 Constitution."
+	added_traits = list(TRAIT_BOG_BORN)
+	triumph_cost = 15
+
+/datum/virtue/combat/bog_born_warrior/apply_to_human(mob/living/carbon/human/recipient)
+	recipient.change_stat(STATKEY_STR, 2)
+	recipient.change_stat(STATKEY_SPD, 1)
+	recipient.change_stat(STATKEY_WIL, 2)
+	recipient.change_stat(STATKEY_CON, 1)
+
+
+/datum/virtue/combat/bog_born_archer
+	name = "Bog Stalker"
+	desc = "I learned the hunt where fog smothers the eye and every pool may hide a grave. So devoted was I to Dendor that civilization became a distant rot, and I remained in the reeds, hunting beneath the gaze of leaf, mud, and silence."
+	custom_text = "Bog-Born. Gain +4 Perception, +2 Speed, +1 Strength, and +1 Willpower."
+	added_traits = list(TRAIT_BOG_BORN)
+	triumph_cost = 15
+
+/datum/virtue/combat/bog_born_archer/apply_to_human(mob/living/carbon/human/recipient)
+	recipient.change_stat(STATKEY_PER, 4)
+	recipient.change_stat(STATKEY_SPD, 2)
+	recipient.change_stat(STATKEY_STR, 1)
+	recipient.change_stat(STATKEY_WIL, 1)


### PR DESCRIPTION
## About The Pull Request

Adds 4 new Bog-Born virtues, 3 of which are paid (15 triumps)

Bog-Born characters are powerful outside civilized lands, but suffer heavily when entering town or warden-controlled areas. When a character with trait_Bog-Born enters a civilized zone, they receive the +Far from the Bog+ debuff, reducing all main stats by 4 until they leave the area.

New virtues:

Bog Mage (15 TRI)
 +2 Speed
+2 Willpower
 +2 Intelligence
 +6 spellpoints

Bog Raider (15 TRI)
+2 Strength
+1 Speed
+2 Willpower
+1 Constitution

Bog Stalker (15 TRI)
+4 Perception
+2 Speed
+1 Strength
+1 Willpower

Ex-Bog Guard (free)
 +1 Strength
+1 Speed
 +1 Intelligence
 +1 Constitution
+1 Willpower

Drawback for all those guys above:
Characters with the Bog-Born trait will recieve +Far from the Bog+ debuff once they decide to enter town_area or warden_area.
Debuff:
- -4 Strength
- -4 Perception
- -4 Intelligence
- -4 Willpower
- -4 Constitution
- -4 Speed
- -4 Luck

The debuff is removed when the character leaves the affected areas

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I think the map needs a remote lawless zone for pvp and min max enjoyers.

Right now, too many players are turning social areas into murder arenas. Peaceful roles and weaker characters often become targets for min-maxed combat builds(mages or 18 speed knaves with ++++ enchantments), especially when there are no active antagonists. Instead of creating interesting conflict, this often just becomes slaughter in civil areas (bored guards that break necks of towners for minor crimes incluided)
Rather than relying only on bans and reports, I think the game should give combat-focused players a proper place to fight. (we do follow pop slop anyway and 70% of server roles are combatants)

The idea is to separate the map into clearer expectations:

Civilized areas for people that dont want to enjoy 18 speed tabaxi knave that stabs them in Detroit style
A distant lawless area (bog) to let min maxers kill and murder each other in Viltrum empire style

Players who want to kill, cooperate with other antags against stronger enemies (keep) can pick those stuff and dissapear (i doubt that they were sourses of quality roleplay interactions anyway) 
This keeps that gameplay away from social alive places and gives peaceful roles more room to actually exist and do their stuff with less risk being killed in the center of the city by XX knight that got bored (he has full enchantments done but no antags around)

Also stronger virtues cost 15 tri (30 if you take virtuos) so the death will matter for those guys 

Also think we should kick out people to murder kill each other in bog with those cheat bog virtues or suffer from content removed coz everything is going to be turned into a weapon and used to commit mass murders