### PR TITLE
Grants the ability to make the Nobility to the Prelate. OR: How I learned to START worrying and HATE the span_'s 

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -1109,3 +1109,14 @@
 	name = "overheating"
 	desc = "My frame is overheating!"
 	icon_state = "fire"
+
+/datum/status_effect/debuff/nobilitylost
+	id = "nobilitylost"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/nobilitylost
+	duration = 20 MINUTES
+	effectedstats = list(STATKEY_LCK = -1, STATKEY_PER = -1, STATKEY_INT = -1)
+
+/atom/movable/screen/alert/status_effect/debuff/nobilitylost
+	name = "Lost Status"
+	desc = "I have lost my standing as a member of the Nobility! Astrata does not favour me!"
+	icon_state = "stressvb"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -2181,3 +2181,14 @@
 /atom/movable/screen/alert/status_effect/buff/oath_ring
 	name = "Oathmarked"
 	desc = "The oath drives me forward, so long as the reminder is kept near."
+
+/atom/movable/screen/alert/status_effect/buff/matthios_smile
+	name = "Matthios' Grin"
+	desc = "I can feel The Gilded God smile upon me! It bends the very strings of fate to my favor!"
+	icon_state = "buff"
+
+/datum/status_effect/buff/matthios_smile
+	id = "matthios_smile"
+	alert_type = /atom/movable/screen/alert/status_effect/buff/matthios_smile
+	effectedstats = list(STATKEY_LCK = 2)
+	duration = 40 MINUTES

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -2184,8 +2184,8 @@
 
 /atom/movable/screen/alert/status_effect/buff/matthios_smile
 	name = "Matthios' Grin"
-	desc = "I can feel The Gilded God smile upon me! It bends the very strings of fate to my favor!"
-	icon_state = "buff"
+	desc = "I can feel The Gilded God's smile upon me! It bends the very strings of fate to my favor!"
+	icon_state = "stressvg"
 
 /datum/status_effect/buff/matthios_smile
 	id = "matthios_smile"

--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -2181,14 +2181,3 @@
 /atom/movable/screen/alert/status_effect/buff/oath_ring
 	name = "Oathmarked"
 	desc = "The oath drives me forward, so long as the reminder is kept near."
-
-/atom/movable/screen/alert/status_effect/buff/matthios_smile
-	name = "Matthios' Grin"
-	desc = "I can feel The Gilded God's smile upon me! It bends the very strings of fate to my favor!"
-	icon_state = "stressvg"
-
-/datum/status_effect/buff/matthios_smile
-	id = "matthios_smile"
-	alert_type = /atom/movable/screen/alert/status_effect/buff/matthios_smile
-	effectedstats = list(STATKEY_LCK = 2)
-	duration = 40 MINUTES

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -516,3 +516,8 @@
 	timer = 5 MINUTES
 	stressadd = 1
 	desc = span_red("Xylix took pity upon me and saved me from the consequences of bad luck. I must do better!")
+
+/datum/stressevent/nobility_gone
+	timer = 15 MINUTES /// Major... but NOT permament, we want to punish the guy, not make him far travel.
+	stressadd = 6
+	desc = span_boldred("I have been stripped of my nobility! I have fallen from Astrata's grace!")

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -478,9 +478,9 @@
 /datum/stressevent/neutral_noblement
 	timer = 5 MINUTES
 	stressadd = -3
-	desc = span_green("I have been granted nobility! My blood runs blue!")
+	desc = span_green("I have been granted noble status! My blood runs blue!")
 
 /datum/stressevent/matthios_noblement
 	timer = 15 MINUTES
 	stressadd = -6
-	desc = span_green("I've fooled the Sun-Tyrant and her lackeys! I've stolen her gift, just as The Gilded God once did!")	
+	desc = span_green("I've fooled the Sun-Tyrant and her lackeys! I've stolen her gift, just as Matthios once did!")	

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -473,14 +473,14 @@
 /datum/stressevent/astrata_noblement
 	timer = 5 MINUTES
 	stressadd = -6
-	desc = span_green("The Sun-Tyrant has deemed me worthy! I am truly blessed!")
+	desc = span_boldgreen("The Sun-Tyrant has deemed me worthy! I am truly blessed!")
 
 /datum/stressevent/neutral_noblement
 	timer = 5 MINUTES
-	stressadd = -3
-	desc = span_green("I have been granted noble status! My blood runs blue!")
+	stressadd = -4
+	desc = span_boldgreen("I have been granted noble status! My blood runs blue!")
 
 /datum/stressevent/matthios_noblement
 	timer = 15 MINUTES
 	stressadd = -6
-	desc = span_green("I've fooled the Sun-Tyrant and her lackeys! I've stolen her gift, just as Matthios once did!")	
+	desc = span_boldgreen("I've fooled the Sun-Tyrant and her lackeys! I've stolen her gift, just as Matthios once did!")	

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -469,3 +469,18 @@
 	timer = 10 MINUTES
 	stressadd = -2
 	desc = span_green("Xylix spun the thread of fate in my favour! Truly, I am blessed!")
+
+/datum/stressevent/astrata_noblement
+	timer = 5 MINUTES
+	stressadd = -6
+	desc = span_green("The Sun-Tyrant has deemed me worthy! I am truly blessed!")
+
+/datum/stressevent/neutral_noblement
+	timer = 5 MINUTES
+	stressadd = -3
+	desc = span_green("I have been granted nobility! My blood runs blue!")
+
+/datum/stressevent/matthios_noblement
+	timer = 15 MINUTES
+	stressadd = -6
+	desc = span_green("I've fooled the Sun-Tyrant and her lackeys! I've stolen her gift, just as The Gilded God once did!")	

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -10,8 +10,7 @@
 	allowed_races = RACES_NO_CONSTRUCT
 	tutorial = "Picked out of your political value rather than likely any form of love, you have become the Grand Duke's most trusted confidant--and likely friend--throughout your marriage. Your loyalty and perhaps even your love will be tested this day... for the daggers that threaten your beloved are as equally pointed at your own throat."
 
-	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant,
-	/obj/effect/proc_holder/spell/self/grant_nobility)
+	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant)
 	outfit = /datum/outfit/job/roguetown/lady
 
 	display_order = JDO_LADY

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -18,7 +18,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		/obj/effect/proc_holder/spell/self/grant_title,
 		/obj/effect/proc_holder/spell/self/convertrole/servant,
 		/obj/effect/proc_holder/spell/self/convertrole/guard,
-		/obj/effect/proc_holder/spell/self/grant_nobility,
 		/obj/effect/proc_holder/spell/self/convertrole/bog
 	)
 	outfit = /datum/outfit/job/roguetown/lord
@@ -372,66 +371,6 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	REMOVE_TRAIT(recruit, TRAIT_OUTLANDER, ADVENTURER_TRAIT)
 	REMOVE_TRAIT(recruit, TRAIT_OUTLANDER, TRAIT_GENERIC)
 	GLOB.lord_titles[recruit.real_name] = granted_title
-	return TRUE
-
-/obj/effect/proc_holder/spell/self/grant_nobility
-	name = "Grant Nobility"
-	desc = "Make someone a noble, or strip them of their nobility."
-	overlay_state = "recruit_titlegrant"
-	antimagic_allowed = TRUE
-	recharge_time = 100
-	/// Maximum range for nobility granting
-	var/nobility_range = 3
-
-/obj/effect/proc_holder/spell/self/grant_nobility/cast(list/targets, mob/user = usr)
-	. = ..()
-	var/list/recruitment = list()
-	for(var/mob/living/carbon/human/village_idiot in (get_hearers_in_view(nobility_range, user) - user))
-		//not allowed
-		if(!can_nobility(village_idiot))
-			continue
-		recruitment[village_idiot.name] = village_idiot
-	if(!length(recruitment))
-		to_chat(user, span_warning("There are no potential honoraries in range."))
-		return
-	var/inputty = input(user, "Select an honorary!", "[name]") as anything in recruitment
-	if(inputty)
-		var/mob/living/carbon/human/recruit = recruitment[inputty]
-		if(!QDELETED(recruit) && (recruit in get_hearers_in_view(nobility_range, user)))
-			INVOKE_ASYNC(src, PROC_REF(grant_nobility), recruit, user)
-		else
-			to_chat(user, span_warning("Honorific failed!"))
-	else
-		to_chat(user, span_warning("Honorific cancelled."))
-
-/obj/effect/proc_holder/spell/self/grant_nobility/proc/can_nobility(mob/living/carbon/human/recruit)
-	//wtf
-	if(QDELETED(recruit))
-		return FALSE
-	//need a mind
-	if(!recruit.mind)
-		return FALSE
-	//need to see their damn face
-	if(!recruit.get_face_name(null))
-		return FALSE
-	if(HAS_TRAIT(recruit, TRAIT_DEFILED_NOBLE)) // Their lux was tainted by evil matthios rite. They are utterly fucked.
-		return FALSE
-	return TRUE
-
-/obj/effect/proc_holder/spell/self/grant_nobility/proc/grant_nobility(mob/living/carbon/human/recruit, mob/living/carbon/human/recruiter)
-	if(QDELETED(recruit) || QDELETED(recruiter))
-		return FALSE
-	if(HAS_TRAIT(recruit, TRAIT_NOBLE))
-		if(!(recruit.job in GLOB.foreign_positions))
-			recruiter.say("I HEREBY STRIP YOU, [uppertext(recruit.name)], OF NOBILITY!!")
-			REMOVE_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
-			REMOVE_TRAIT(recruit, TRAIT_NOBLE, TRAIT_VIRTUE)
-			return FALSE
-		else
-			to_chat(recruiter, span_warning("Their nobility is not mine to strip!"))
-			return FALSE
-	recruiter.say("I HEREBY GRANT YOU, [uppertext(recruit.name)], NOBILITY!")
-	ADD_TRAIT(recruit, TRAIT_NOBLE, TRAIT_GENERIC)
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/convertrole/servant

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -221,7 +221,6 @@
 	REMOVE_TRAIT(target, TRAIT_NOBLE, JOB_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_DEFILED_NOBLE, TRAIT_GENERIC)
 	REMOVE_TRAIT(target, TRAIT_DISGRACED_NOBLE, TRAIT_GENERIC) // Total TRAIT_NOBLE Death.
-	SET_SOCIAL_RANK(target, 1) // To dirt you go!
 	sleep(5)
 	to_chat(target, span_danger("YOU ARE UNWORTHY OF MY GRACE!"))
 	loc.visible_message(span_warning("[target] is set aflame by Astrata's wrath!"))

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -30,7 +30,7 @@
 	icon_state = "astrata_chalky" // the icon state, so, the sprite the runes use on the floor. As of making, we have 6, each needs an active/inactive state.
 	desc = "A Holy Rune of Astrata. Warmth irradiates from the rune." // description on examine
 	var/solarrites = list("Guiding Light") // This is important - This is the var which stores every ritual option available to a ritualist - Ideally, we'd have like, 3 for each God. Right now, just 1.
-	var/prelaterites = list("Ennoblement", "Abasement")
+	var/prelaterites = list("Elevation", "Abasement")
 
 /obj/structure/ritualcircle/astrata/attack_hand(mob/living/user)
 	if(!..())
@@ -76,7 +76,7 @@
 						user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
 						spawn(120)
 							icon_state = "astrata_chalky"
-		if("Ennoblement")
+		if("Elevation")
 			if(!Adjacent(user))
 				to_chat(user, span_smallred("I need to be closer to the rune to perform this ritual."))
 				return
@@ -123,7 +123,7 @@
 				return
 			user.say("AND GRANT THEM YOUR HIGHEST HONOR!")
 			icon_state = "astrata_active"
-			ennoblement(target, user)
+			elevation(target, user)
 			spawn(120)
 				icon_state = "astrata_chalky"
 		if("Abasement")
@@ -132,7 +132,7 @@
 				return
 			var/list/valids_on_rune = list()
 			for(var/mob/living/carbon/human/peep in range(0, loc))
-				if(!HAS_TRAIT(peep, TRAIT_NOBLE || TRAIT_DEFILED_NOBLE || TRAIT_DISGRACED_NOBLE))
+				if(!(HAS_TRAIT(peep, TRAIT_NOBLE) || HAS_TRAIT(peep, TRAIT_DEFILED_NOBLE) || HAS_TRAIT(peep, TRAIT_DISGRACED_NOBLE)))
 					continue
 				if(peep.changed_noble_status)
 					continue
@@ -160,23 +160,23 @@
 			spawn(120)
 				icon_state = "astrata_chalky"			
 
-/obj/structure/ritualcircle/astrata/proc/ennoblement(mob/living/carbon/human/target, mob/living/carbon/human/user)
+/obj/structure/ritualcircle/astrata/proc/elevation(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(!target || QDELETED(target) || target.loc != loc)
-		to_chat(user, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive Matthios' blessing.")
+		to_chat(user, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive Astrata's gift.")
 		return
 	var/prompt = alert(target, "Do you accept Astrata's gift?","Astrata demands an answer.", "I accept.", "I refuse.")
 	if(prompt == "I accept.")
 		playsound(loc, 'sound/magic/astrata_choir.ogg', 85, FALSE, -1)
 		to_chat(target, span_userdanger("I can feel the white-hot LUX make its way into my veins! My blood burnt out to be blue!"))
 		ADD_TRAIT(target, TRAIT_NOBLE, TRAIT_GENERIC)
-		loc.visible_message(span_cult("The LUX turns white-hot and enters their veins!"))
+		loc.visible_message(span_cult("The LUX turns white-hot and enters [target]'s veins!"))
 		target.Stun(60)
 		target.Knockdown(60)
 		to_chat(target, span_userdanger("UNIMAGINABLE PAIN!"))
 		target.apply_damage(15, BURN, BODY_ZONE_HEAD) // 'Unimaginable Pain'? Nae! Tis' but 15 burn.
 		target.flash_fullscreen("whiteflash")
-		sleep(20) // we don't want to nukespam the target's chat. Well we do it either way but like, I mean, this gives them breathing room.
-		priority_announce("[user.real_name] has elevated [target.real_name] into the blessed ranks of the Nobility! Their blood runs blue!", title = "Blessed Dae!", sound = 'sound/misc/bell.ogg')
+		sleep(5)
+		priority_announce("[user.real_name] has elevated [target.real_name] into the blessed ranks of the Nobility! Their blood runs blue!", title = "BLESSED DAE!", sound = 'sound/misc/bell.ogg')
 		if(target.patron?.type == /datum/patron/inhumen/matthios)
 			to_chat(target, span_cult("I can feel the smile of Matthios upon me..."))
 			target.apply_status_effect(/datum/status_effect/buff/matthios_smile)
@@ -187,16 +187,15 @@
 		else
 			to_chat(target, span_cult("I can feel the light of Astrata upon me..."))
 			target.add_stress(/datum/stressevent/neutral_noblement)
-		sleep(1 SECONDS)
 		switch(target.social_rank)
 			if(1)
-				to_chat(target, span_warning("I hav-e risen exponentially into the ranks of the Nobility! This is a grand TRIUMPH!"))
+				to_chat(target, span_boldnotice("I have risen exponentially into the ranks of the Nobility! This is a grand TRIUMPH!"))
 				target.adjust_triumphs(5)
 			if(2)
-				to_chat(target, span_warning("I have risen greatly into the ranks of the Nobility! This is a great TRIUMPH!"))
+				to_chat(target, span_boldnotice("I have risen greatly into the ranks of the Nobility! This is a great TRIUMPH!"))
 				target.adjust_triumphs(3)
 			if(3)
-				to_chat(target, span_warning("I have entered the ranks of the Nobility! This is a TRIUMPH!"))
+				to_chat(target, span_boldnotice("I have entered the ranks of the Nobility! This is a TRIUMPH!"))
 				target.adjust_triumphs(1)
 		user.apply_status_effect(/datum/status_effect/debuff/ritesexpended) // Rites expended only if the guy accepts, I feel it's only fair.
 		message_admins("PROMOTION: [user.real_name] ([user.ckey]) has granted nobility to [target.real_name] ([target.ckey])") 
@@ -204,14 +203,14 @@
 		target.changed_noble_status = TRUE // what if... you had ONE CHANCE, ONE OPPORTUNITY...
 
 	else if(prompt == "I refuse.")
-		loc.visible_message(span_cult("[target] refuses Astrata's gift. The light grows malignant...!"))
+		loc.visible_message(span_boldred("[target] refuses Astrata's gift. The light grows malignant...!"))
 		target.Stun(30)
 		target.Knockdown(30)
-		sleep(20)
-		to_chat(target, span_redtextbig("YOU DARE REJECT MY GIFT!? YOU SHALL BURN FOR YOUR INSOLENCE!"))
+		sleep(5)
+		to_chat(target, span_danger("YOU DARE REJECT MY GIFT!? YOU SHALL BURN FOR YOUR INSOLENCE!"))
 		target.adjustFireLoss(25)
 		target.fire_act(1,10)
-		to_chat(loc, span_warning("[target] is set ablaze by Astrata's wrath!"))
+		loc.visible_message(span_boldred("[target] is set aflame by Astrata's wrath!"))
 
 /obj/structure/ritualcircle/astrata/proc/abasement(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(!target || QDELETED(target) || target.loc != loc)
@@ -219,18 +218,23 @@
 		return
 	target.Stun(50)
 	target.Knockdown(50)
+	target.Jitter(50)
+	loc.visible_message(span_boldred("[target] shakes and thrashes around violently as yellow flames begin licking away at [target.p_their(TRUE)] skin!"))
 	REMOVE_TRAIT(target, TRAIT_NOBLE, TRAIT_GENERIC)
 	REMOVE_TRAIT(target, TRAIT_NOBLE, TRAIT_VIRTUE)
-	to_chat(target, span_warning("YOU ARE UNWORTHY OF MY GRACE!"))
+	REMOVE_TRAIT(target, TRAIT_NOBLE, JOB_TRAIT)
+	REMOVE_TRAIT(target, TRAIT_DEFILED_NOBLE, TRAIT_GENERIC)
+	REMOVE_TRAIT(target, TRAIT_DISGRACED_NOBLE, TRAIT_GENERIC) // Total TRAIT_NOBLE Death.
+	SET_SOCIAL_RANK(target, 1) // To dirt you go!
+	sleep(5)
+	to_chat(target, span_danger("YOU ARE UNWORTHY OF MY GRACE!"))
 	loc.visible_message(span_warning("[target] is set aflame by Astrata's wrath!"))
 	to_chat(target, span_userdanger("UNIMAGINABLE PAIN!"))
 	target.adjustFireLoss(25)
 	target.fire_act(1,10)
-	target.flash_fullscreen("whiteflash")
-	sleep(1 SECONDS)
-	priority_announce("[user.real_name] has stripped [target.real_name] of their nobility! They have fallen from Astrata's grace!", title = "Shameful Dae!", sound = 'sound/misc/excomm.ogg')
+	priority_announce("[user.real_name] has stripped [target.real_name] of their nobility! They have fallen from Astrata's grace!", title = "SHAMEFUL DAE!", sound = 'sound/misc/excomm.ogg')
 	message_admins("DEMOTION: [user.real_name] ([user.ckey]) has stripped nobility from [target.real_name] ([target.ckey])") // is it reeeally needed? unsure, but eh, worth it for the logs
-	log_game("DEMOTION: [user.real_name] ([user.ckey]) has stripped nobility from  [target.real_name] ([target.ckey])")	
+	log_game("DEMOTION: [user.real_name] ([user.ckey]) has stripped nobility from [target.real_name] ([target.ckey])")	
 	user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
 	target.changed_noble_status = TRUE // what if... you had ONE CHANCE, ONE OPPORTUNITY...
 

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -162,7 +162,7 @@
 	if(!target || QDELETED(target) || target.loc != loc)
 		to_chat(user, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive Astrata's gift.")
 		return
-	var/prompt = alert(target, "Do you accept Astrata's gift?","Astrata demands an answer.", "I accept.", "I refuse.")
+	var/prompt = alert(target, "Do you accept Astrata's gift?","ASTRATA DEMANDS YOUR ANSWER!", "I accept.", "I refuse.")
 	if(prompt == "I accept.")
 		playsound(loc, 'sound/magic/astrata_choir.ogg', 85, FALSE, -1)
 		to_chat(target, span_userdanger("I can feel the white-hot LUX make its way into my veins! My blood burnt out to be blue!"))

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -113,9 +113,7 @@
 				to_chat(target, span_cultsmall("I can feel someone's eyes upon me.."))
 			if(!do_after(user, 5 SECONDS))
 				return
-			user.say("MISTRESS OF ORDER! ARBITRATOR OF RIGHT!")
-			if(target.patron?.type == /datum/patron/inhumen/matthios)
-				to_chat(target, span_cultsmall("boring into the back of my head.."))			
+			user.say("MISTRESS OF ORDER! ARBITRATOR OF RIGHT!")		
 			if(!do_after(user, 5 SECONDS))
 				return
 			user.say("GAZE DOWN UPON THIS WORTHY ONE!")
@@ -178,8 +176,6 @@
 		sleep(5)
 		priority_announce("[user.real_name] has elevated [target.real_name] into the blessed ranks of the Nobility! Their blood runs blue!", title = "BLESSED DAE!", sound = 'sound/misc/bell.ogg')
 		if(target.patron?.type == /datum/patron/inhumen/matthios)
-			to_chat(target, span_cult("I can feel the smile of Matthios upon me..."))
-			target.apply_status_effect(/datum/status_effect/buff/matthios_smile)
 			target.add_stress(/datum/stressevent/matthios_noblement)
 		else if(target.patron?.type == /datum/patron/divine/astrata)
 			to_chat(target, span_cult("I can feel the warmth of Astrata upon me..."))

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -27,6 +27,7 @@
 	icon_state = "astrata_chalky" // the icon state, so, the sprite the runes use on the floor. As of making, we have 6, each needs an active/inactive state.
 	desc = "A Holy Rune of Astrata. Warmth irradiates from the rune." // description on examine
 	var/solarrites = list("Guiding Light") // This is important - This is the var which stores every ritual option available to a ritualist - Ideally, we'd have like, 3 for each God. Right now, just 1.
+	var/prelaterites = list("Ennoblement", "Abasement")
 
 /obj/structure/ritualcircle/astrata/attack_hand(mob/living/user)
 	if(!..())
@@ -40,7 +41,17 @@
 	if(user.has_status_effect(/datum/status_effect/debuff/ritesexpended))
 		to_chat(user,span_smallred("I have performed enough rituals for the day... I must rest before communing more.")) // If you have already done a ritual in the last 30 minutes, you cannot do another.
 		return
-	var/riteselection = input(user, "Rituals of the Sun", src) as null|anything in solarrites // When you use a open hand on a rune, It'll give you a selection of all the rites available from that rune
+
+	var/list/available_rites = list()
+
+	if(user.patron?.type == /datum/patron/divine/astrata)
+		available_rites += solarrites
+
+	if(HAS_TRAIT(user, TRAIT_CHOSEN))
+		available_rites += prelaterites
+
+
+	var/riteselection = input(user, "Rituals of the Sun", src) as null|anything in available_rites // When you use a open hand on a rune, It'll give you a selection of all the rites available from that rune
 	switch(riteselection) // rite selection goes in this section, try to do something fluffy. Presentation is most important here, truthfully.
 		if("Guiding Light") // User selects Guiding Light, begins the stuff for it
 			if(do_after(user, 50)) // just flavor stuff before activation
@@ -62,6 +73,96 @@
 						user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
 						spawn(120)
 							icon_state = "astrata_chalky"
+		if("Ennoblement")
+			if(!Adjacent(user))
+				to_chat(user, span_smallred("I need to be closer to the rune to perform this ritual."))
+				return
+			var/list/valids_on_rune = list()
+			for(var/mob/living/carbon/human/peep in range(0, loc))
+				if(HAS_TRAIT(peep, TRAIT_NOBLE))
+					continue
+				valids_on_rune += peep
+			if(!valids_on_rune.len)
+				to_chat(user, span_smallred("There are no valid targets on the rune."))
+				return
+			var/mob/living/carbon/human/target = input(user, "Choose a host")
+			if(!target || QDELETED(target) || target.loc != loc)
+				return
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("ASTRATA, SOVEREIGN OF THE WORLD!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("GAZE DOWN UPON THIS MORTAL!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("MISTRESS OF ORDER! ARBITRATOR OF RIGHT!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("GAZE DOWN UPON THIS ONE!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("AND GRANT THEM YOUR HIGHEST HONOR!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			icon_state = "astrata_active"
+			astratanobling(target)
+			spawn(120)
+				icon_state = "astrata_chalky"
+
+/obj/structure/ritualcircle/astrata/proc/astratanobling(mob/living/carbon/human/target)
+	if(!target || QDELETED(target) || target.loc != loc)
+		to_chat(usr, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive Matthios' blessing.")
+		return
+	if(HAS_TRAIT(target, TRAIT_NOBLE))
+		loc.visible_message(span_cult("This one is already of noble blood!"))
+		return
+	if(target.mind?.assigned_role in GLOB.church_positions)
+		loc.visible_message(span_cult("This one has already sworn themselves to the Church!"))
+		return
+	if(HAS_TRAIT(target, TRAIT_INQUISITION))
+		loc.visible_message(span_cult("This one's fervent and unshakable faith in The One prevents them from receiving Astrata's gift."))
+		return
+	if(target.name in GLOB.excommunicated_players || HAS_TRAIT(target, TRAIT_EXCOMMUNICATED))
+		loc.visible_message(span_cult("This one has been excommunicated from the Church!"))
+		return
+	if(target.name in GLOB.outlawed_players)
+		loc.visible_message(span_cult("Astrata shall not grant nobility to one who defies her decrees!"))
+	var/prompt = alert(target, "Do you accept Astrata's gift?", "I accept.", "I refuse.")
+	if(prompt == "I accept.")
+		ADD_TRAIT(target, TRAIT_NOBLE, "astrata_enoblement")
+		target.Stun(60)
+		target.Knockdown(60)
+		playsound(loc, 'sound/magic/astrata_choir.ogg', 85, FALSE, -1)
+		loc.visible_message(span_cult("The Light of Astrata shines down bright upon [target]! His blood runs blue!"))
+		if(target.patron?.type == /datum/patron/inhumen/matthios)
+			to_chat(target, span_cult("I can feel the smile of Matthios upon me..."))
+			target.apply_status_effect(/datum/status_effect/buff/matthios_smile)
+			target.add_stress(/datum/stressevent/matthios_noblement)
+		else if(target.patron?.type == /datum/patron/divine/astrata)
+			to_chat(target, span_cult("I can feel the warmth of Astrata upon me..."))
+			target.add_stress(/datum/stressevent/astrata_noblement)
+		else
+			to_chat(target, span_cult("I can feel the light of Astrata upon me..."))
+			target.add_stress(/datum/stressevent/neutral_noblement)
+		switch(target.social_rank)
+			if(1)
+				target.adjust_triumphs(5)
+				to_chat(target, span_cult("I have risen exponentially into the ranks of the Nobility! This is a true TRIUMPH!"))
+			if(2)
+				target.adjust_triumphs(3)
+				to_chat(target, span_cult("I have risen into the ranks of the Nobility! This is a TRIUMPH!"))
+			if(3)
+				target.adjust_triumphs(1)
+				to_chat(target, span_cult("I have entered the ranks of the Nobility! This is a TRIUMPH!"))
+		if(prompt == "I refuse.")
+			loc.visible_message(span_cult("[target] refuses Astrata's gift. The light grows malignant...!"))
+			target.Stun(30)
+			target.Knockdown(30)
+			to_chat(target, span_warning("YOU DARE REJECT MY GIFT!? YOU SHALL BURN FOR YOUR INSOLENCE!"))
+			target.adjustFireLoss(25)
+			target.fire_act(1,10)
+			to_chat(loc, span_warning("[target] is set ablaze by Astrata's wrath!"))
 
 /obj/structure/ritualcircle/astrata/proc/guidinglight(src)
 	var/ritualtargets = view(7, loc) // Range of 7 from the source, which is the rune
@@ -70,7 +171,6 @@
 		to_chat(target,span_cultsmall("Astrata's light guides me forward, drawn to me by the Ritualist's pyre!"))
 		playsound(target, 'sound/magic/holyshield.ogg', 80, FALSE, -1) // Cool sound!
 // If you want to review a more complicated one, Undermaiden's Bargain is probs the most complicated of the starting set. - Have fun! - Onutsio 🏳️‍⚧️
-
 
 /obj/structure/ritualcircle/noc
 	name = "Rune of the Moon"

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -1,3 +1,6 @@
+/mob/living/carbon/human
+	var/changed_noble_status = FALSE
+
 /obj/structure/ritualcircle
 	name = "ritual circle"
 	desc = ""
@@ -81,60 +84,99 @@
 			for(var/mob/living/carbon/human/peep in range(0, loc))
 				if(HAS_TRAIT(peep, TRAIT_NOBLE))
 					continue
+				if(peep.changed_noble_status)
+					continue
 				valids_on_rune += peep
 			if(!valids_on_rune.len)
 				to_chat(user, span_smallred("There are no valid targets on the rune."))
 				return
-			var/mob/living/carbon/human/target = input(user, "Choose a host")
+			var/mob/living/carbon/human/target = input(user, "Choose a host") as null|anything in valids_on_rune
 			if(!target || QDELETED(target) || target.loc != loc)
 				return
-			if(!do_after(user, 5 SECONDS))
+			if(!locate(/obj/item/reagent_containers/lux) in loc)
+				to_chat(user, span_red("The ritual needs a piece of LUX offered as a sacrifice.")) // Minor price, but something that at least makes the Prelate go 'hmm.. is this guy really worth it?'
+				return
+			if(target.mind?.assigned_role in GLOB.church_positions)
+				to_chat(user, span_red("This one has already sworn themselves to the Church!"))
+				return
+			if(HAS_TRAIT(target, TRAIT_PSYDONITE)) // no nobility for you, Psy-chud! This is so the Inquisition doesn't get nobled since I don't believe it makes sense, they are *kinda* clergy.
+				to_chat(user, span_red("This one's fervent and unshakable faith in The One prevents them from receiving Astrata's gift."))
+				return
+			if(target.name in GLOB.excommunicated_players || HAS_TRAIT(target, TRAIT_EXCOMMUNICATED))
+				to_chat(user, span_red("This one has been excommunicated from the Church!"))
+				return
+			if(target.name in GLOB.outlawed_players || HAS_TRAIT(target, TRAIT_OUTLAW))
+				to_chat(user, span_red("Astrata shall not grant nobility to anyone who defies her decrees!"))
 				return
 			user.say("ASTRATA, SOVEREIGN OF THE WORLD!")
-			if(!do_after(user, 5 SECONDS))
-				return
-			user.say("GAZE DOWN UPON THIS MORTAL!")
+			if(target.patron?.type == /datum/patron/inhumen/matthios)
+				to_chat(target, span_cultsmall("I can feel someone's eyes upon me.."))
 			if(!do_after(user, 5 SECONDS))
 				return
 			user.say("MISTRESS OF ORDER! ARBITRATOR OF RIGHT!")
+			if(target.patron?.type == /datum/patron/inhumen/matthios)
+				to_chat(target, span_cultsmall("boring into the back of my head.."))			
 			if(!do_after(user, 5 SECONDS))
 				return
-			user.say("GAZE DOWN UPON THIS ONE!")
+			user.say("GAZE DOWN UPON THIS WORTHY ONE!")
 			if(!do_after(user, 5 SECONDS))
 				return
 			user.say("AND GRANT THEM YOUR HIGHEST HONOR!")
+			icon_state = "astrata_active"
+			ennoblement(target, user)
+			spawn(120)
+				icon_state = "astrata_chalky"
+		if("Abasement")
+			if(!Adjacent(user))
+				to_chat(user, span_smallred("I need to be closer to the rune to perform this ritual."))
+				return
+			var/list/valids_on_rune = list()
+			for(var/mob/living/carbon/human/peep in range(0, loc))
+				if(!HAS_TRAIT(peep, TRAIT_NOBLE || TRAIT_DEFILED_NOBLE || TRAIT_DISGRACED_NOBLE))
+					continue
+				if(peep.changed_noble_status)
+					continue
+				valids_on_rune += peep
+			if(!valids_on_rune.len)
+				to_chat(user, span_smallred("There are no valid targets on the rune."))
+				return
+			var/mob/living/carbon/human/target = input(user, "Choose a host") as null|anything in valids_on_rune
+			if(!target || QDELETED(target) || target.loc != loc)
+				return
+			user.say("ASTRATA, SOVEREIGN OF THE WORLD!")
+			if(!do_after(user, 5 SECONDS))
+				return			
+			user.say("MISTRESS OF ORDER! ARBITRATOR OF RIGHT!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("WE BECKON! GAZE DOWN UPON THIS UNWORTHY ONE!")
+			if(!do_after(user, 5 SECONDS))
+				return
+			user.say("AND STRIP THEM OF THEIR UNDESERVED HONORS!")
 			if(!do_after(user, 5 SECONDS))
 				return
 			icon_state = "astrata_active"
-			astratanobling(target)
+			abasement(target, user)
 			spawn(120)
-				icon_state = "astrata_chalky"
+				icon_state = "astrata_chalky"			
 
-/obj/structure/ritualcircle/astrata/proc/astratanobling(mob/living/carbon/human/target)
+/obj/structure/ritualcircle/astrata/proc/ennoblement(mob/living/carbon/human/target, mob/living/carbon/human/user)
 	if(!target || QDELETED(target) || target.loc != loc)
-		to_chat(usr, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive Matthios' blessing.")
+		to_chat(user, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to receive Matthios' blessing.")
 		return
-	if(HAS_TRAIT(target, TRAIT_NOBLE))
-		loc.visible_message(span_cult("This one is already of noble blood!"))
-		return
-	if(target.mind?.assigned_role in GLOB.church_positions)
-		loc.visible_message(span_cult("This one has already sworn themselves to the Church!"))
-		return
-	if(HAS_TRAIT(target, TRAIT_INQUISITION))
-		loc.visible_message(span_cult("This one's fervent and unshakable faith in The One prevents them from receiving Astrata's gift."))
-		return
-	if(target.name in GLOB.excommunicated_players || HAS_TRAIT(target, TRAIT_EXCOMMUNICATED))
-		loc.visible_message(span_cult("This one has been excommunicated from the Church!"))
-		return
-	if(target.name in GLOB.outlawed_players)
-		loc.visible_message(span_cult("Astrata shall not grant nobility to one who defies her decrees!"))
-	var/prompt = alert(target, "Do you accept Astrata's gift?", "I accept.", "I refuse.")
+	var/prompt = alert(target, "Do you accept Astrata's gift?","Astrata demands an answer.", "I accept.", "I refuse.")
 	if(prompt == "I accept.")
-		ADD_TRAIT(target, TRAIT_NOBLE, "astrata_enoblement")
+		playsound(loc, 'sound/magic/astrata_choir.ogg', 85, FALSE, -1)
+		to_chat(target, span_userdanger("I can feel the white-hot LUX make its way into my veins! My blood burnt out to be blue!"))
+		ADD_TRAIT(target, TRAIT_NOBLE, TRAIT_GENERIC)
+		loc.visible_message(span_cult("The LUX turns white-hot and enters their veins!"))
 		target.Stun(60)
 		target.Knockdown(60)
-		playsound(loc, 'sound/magic/astrata_choir.ogg', 85, FALSE, -1)
-		loc.visible_message(span_cult("The Light of Astrata shines down bright upon [target]! His blood runs blue!"))
+		to_chat(target, span_userdanger("UNIMAGINABLE PAIN!"))
+		target.apply_damage(15, BURN, BODY_ZONE_HEAD) // 'Unimaginable Pain'? Nae! Tis' but 15 burn.
+		target.flash_fullscreen("whiteflash")
+		sleep(20) // we don't want to nukespam the target's chat. Well we do it either way but like, I mean, this gives them breathing room.
+		priority_announce("[user.real_name] has elevated [target.real_name] into the blessed ranks of the Nobility! Their blood runs blue!", title = "Blessed Dae!", sound = 'sound/misc/bell.ogg')
 		if(target.patron?.type == /datum/patron/inhumen/matthios)
 			to_chat(target, span_cult("I can feel the smile of Matthios upon me..."))
 			target.apply_status_effect(/datum/status_effect/buff/matthios_smile)
@@ -145,24 +187,52 @@
 		else
 			to_chat(target, span_cult("I can feel the light of Astrata upon me..."))
 			target.add_stress(/datum/stressevent/neutral_noblement)
+		sleep(1 SECONDS)
 		switch(target.social_rank)
 			if(1)
+				to_chat(target, span_warning("I hav-e risen exponentially into the ranks of the Nobility! This is a grand TRIUMPH!"))
 				target.adjust_triumphs(5)
-				to_chat(target, span_cult("I have risen exponentially into the ranks of the Nobility! This is a true TRIUMPH!"))
 			if(2)
+				to_chat(target, span_warning("I have risen greatly into the ranks of the Nobility! This is a great TRIUMPH!"))
 				target.adjust_triumphs(3)
-				to_chat(target, span_cult("I have risen into the ranks of the Nobility! This is a TRIUMPH!"))
 			if(3)
+				to_chat(target, span_warning("I have entered the ranks of the Nobility! This is a TRIUMPH!"))
 				target.adjust_triumphs(1)
-				to_chat(target, span_cult("I have entered the ranks of the Nobility! This is a TRIUMPH!"))
-		if(prompt == "I refuse.")
-			loc.visible_message(span_cult("[target] refuses Astrata's gift. The light grows malignant...!"))
-			target.Stun(30)
-			target.Knockdown(30)
-			to_chat(target, span_warning("YOU DARE REJECT MY GIFT!? YOU SHALL BURN FOR YOUR INSOLENCE!"))
-			target.adjustFireLoss(25)
-			target.fire_act(1,10)
-			to_chat(loc, span_warning("[target] is set ablaze by Astrata's wrath!"))
+		user.apply_status_effect(/datum/status_effect/debuff/ritesexpended) // Rites expended only if the guy accepts, I feel it's only fair.
+		message_admins("PROMOTION: [user.real_name] ([user.ckey]) has granted nobility to [target.real_name] ([target.ckey])") 
+		log_game("PROMOTION: [user.real_name] ([user.ckey]) has granted nobility to [target.real_name] ([target.ckey])")
+		target.changed_noble_status = TRUE // what if... you had ONE CHANCE, ONE OPPORTUNITY...
+
+	else if(prompt == "I refuse.")
+		loc.visible_message(span_cult("[target] refuses Astrata's gift. The light grows malignant...!"))
+		target.Stun(30)
+		target.Knockdown(30)
+		sleep(20)
+		to_chat(target, span_redtextbig("YOU DARE REJECT MY GIFT!? YOU SHALL BURN FOR YOUR INSOLENCE!"))
+		target.adjustFireLoss(25)
+		target.fire_act(1,10)
+		to_chat(loc, span_warning("[target] is set ablaze by Astrata's wrath!"))
+
+/obj/structure/ritualcircle/astrata/proc/abasement(mob/living/carbon/human/target, mob/living/carbon/human/user)
+	if(!target || QDELETED(target) || target.loc != loc)
+		to_chat(user, "Selected target is not on the rune! [target.p_they(TRUE)] must be directly on top of the rune to have their nobility stripped.")
+		return
+	target.Stun(50)
+	target.Knockdown(50)
+	REMOVE_TRAIT(target, TRAIT_NOBLE, TRAIT_GENERIC)
+	REMOVE_TRAIT(target, TRAIT_NOBLE, TRAIT_VIRTUE)
+	to_chat(target, span_warning("YOU ARE UNWORTHY OF MY GRACE!"))
+	loc.visible_message(span_warning("[target] is set aflame by Astrata's wrath!"))
+	to_chat(target, span_userdanger("UNIMAGINABLE PAIN!"))
+	target.adjustFireLoss(25)
+	target.fire_act(1,10)
+	target.flash_fullscreen("whiteflash")
+	sleep(1 SECONDS)
+	priority_announce("[user.real_name] has stripped [target.real_name] of their nobility! They have fallen from Astrata's grace!", title = "Shameful Dae!", sound = 'sound/misc/excomm.ogg')
+	message_admins("DEMOTION: [user.real_name] ([user.ckey]) has stripped nobility from [target.real_name] ([target.ckey])") // is it reeeally needed? unsure, but eh, worth it for the logs
+	log_game("DEMOTION: [user.real_name] ([user.ckey]) has stripped nobility from  [target.real_name] ([target.ckey])")	
+	user.apply_status_effect(/datum/status_effect/debuff/ritesexpended)
+	target.changed_noble_status = TRUE // what if... you had ONE CHANCE, ONE OPPORTUNITY...
 
 /obj/structure/ritualcircle/astrata/proc/guidinglight(src)
 	var/ritualtargets = view(7, loc) // Range of 7 from the source, which is the rune

--- a/modular_deserttown/jobs/desertjobs.dm
+++ b/modular_deserttown/jobs/desertjobs.dm
@@ -120,7 +120,6 @@
 		/obj/effect/proc_holder/spell/self/convertrole/azeb,
 		/obj/effect/proc_holder/spell/self/grant_title,
 		/obj/effect/proc_holder/spell/self/convertrole/guard,
-		/obj/effect/proc_holder/spell/self/grant_nobility,
 		)
 		cmode_music = 'sound/music/combat_desert2.ogg'
 	..()


### PR DESCRIPTION
## About The Pull Request

It's a bit silly that it is the Duke that has the ability to grant and take Nobility away while being a noble it is specifically an *Astratan* thing, no? Well I indeed thought so! So I decided to be the change in the world that I want to see (for the better, or for worse..)

As such, I have removed the 'Grant Nobility' spells from the Duke and the Consort, now if they want to go and make Gobbo the Evil-Ass Graggarite Goblin a noble, they must go to the Church and convince the Prelate first. The Prelate himself gets two new rites to perform, via the Rune of The Sun, the first one being:

'Elevation';
Elevation is a rite of granting someone a noble position. It has several stopgaps, and requirements.
-First of all, as a rite, it is by its nature somewhat costly as it locks the Prelate out of using any other runes for 30 minutes, this is so he actually *thinks* about whether he ought to do it, or not!
-Second of all, if the rite thing didn't yet occur to the Prelate, the 'Elevation' rite itself requires one pure LUX, this isn't exactly impossible to get if someone is really dedicated, but it is, again, meant to act as a stopgap, and to force the Prelate into pondering "Should I really waste a LUX just because the Duke wants to make Gobbo the Evil-Ass Graggarite Goblin into a minor noble?"
-Third of all, it has a few requirements all of it's own! Obviously, you can't noble a noble, so those already of blue-blood do not even show as targets. Second, Church and Inquisition members cannot be made into Nobles, as both have already dedicated their lyfes to their respective deities. 
-Fourth of all, the Excommunicated, the Heretics and the Outlaws obviously cannot be ascended into Nobility. Astrata doesn't like people who don't like her Order.

If all the requirements have been met, and the target itself is valid, the ritual will go through, the target will receive their sought-after TRAIT_NOBLE as well as TRIUMPHs, based on their social ranks, as a promotion from some dirt-level vagabond into the ranks of nobility is a grand achievement, they get 5 TRI, Peasants get 3, and Yeomen receive only 1. This is because, at least in my mind, the whole Elevation ritual is meant to be something of a big deal, with a large price, and generally a big IC moment for the receiver. The ritual will also be announced to the whole server, to ensure that everyone knows to treat Gobbo the Evil-Ass Graggarite Goblin the respect he **DESERVES.**

The target will also receive a substantial, and long moodbuff, a more powerful one if they are either Astratan or Matthosian, they were meant to receive also a statbuff *from* Matthios himself, but after consultation with our lore team, I decided to simply cut it to a bigger moodbuff.

'Abasement'

Abasement is a second rite now made available to the Prelate, it is the reverse of 'Elevation' as it removes Nobility from one, regardless if the Nobility comes from a job, virtue or a strange evil and mysterious third way that I don't know what is, it is gone, same as with Elevation, the stripping of the rank is broadcasted to the whole Duchy, and the target receives both a long-lasting mood penalty, as well as a moderate statpenalty 

The rites can only be performed once per person, so no promoting/demotion the same guy five times in a round. Make your minds up, people!

## Testing Evidence
Noble Virtue removal
<img width="1492" height="955" alt="Zrzut ekranu 2026-05-03 190114" src="https://github.com/user-attachments/assets/035a5668-08c0-464d-8b0f-71d63400df02" />
Job Noble trait removal
<img width="493" height="410" alt="Zrzut ekranu 2026-05-03 185813" src="https://github.com/user-attachments/assets/28b85dad-17a0-4307-ae88-93fa1275714a" />
Astrata-patron mood buff.
<img width="478" height="30" alt="Zrzut ekranu 2026-05-03 182201" src="https://github.com/user-attachments/assets/d5f368a6-ef4e-44bc-9993-9ca54ce0e017" />
Target-side chat view of Elevation succeeding + Announcement
<img width="489" height="281" alt="Zrzut ekranu 2026-05-03 182142" src="https://github.com/user-attachments/assets/88f24bcb-ad20-40f6-8b07-47543e9a6714" />
Prompt (you get burned if you refuse, obviously!)
<img width="636" height="291" alt="Zrzut ekranu 2026-05-03 182118" src="https://github.com/user-attachments/assets/857b71c3-33b2-4267-9afd-03ea8cdd3800" />
New rituals (Prelate)
<img width="642" height="528" alt="Zrzut ekranu 2026-05-03 181824" src="https://github.com/user-attachments/assets/fdb6c30f-f7ac-4286-bb2b-feec3bdae6c8" />
No new rituals (Acolyte)
<img width="1087" height="696" alt="Zrzut ekranu 2026-05-03 181806" src="https://github.com/user-attachments/assets/3bbb9058-402e-4e13-929c-7ce2712e0205" />
Matthios mood buff
<img width="495" height="45" alt="Zrzut ekranu 2026-05-03 141531" src="https://github.com/user-attachments/assets/23ce5a70-a247-445f-8645-5b9eb088c0c6" />

## Why It's Good For The Game

I feel turning elevation into a prelate-only ritual makes a lot of sense from IC lore standport, since he is, by (divine) law the highest representative of Astrata around, granting and taking nobility status away seems to be something that he, and really only he ought to be doing. 

Likewise, turning into an actual ritual, with a cost and consideration hopefully makes it so that Prelates don't just hand it out willy-nilly and instead actually ponder whether or not a given person actually deserves the status, and if they do, and if they go through with it, it actually carries notable IC and OOC boons, in the forms of mood and stat buffs and even TRIUMPHs, hopefully making the attainment of the status something worth striving for, for many IC-reasons, Astratans obviously would love to rise in the blessed hierarchy of Order, so they are certain to strive for it, Matthosians, on the other hate, for as much as they might hate nobility, certainly could see a reason in 'stealing' the gift of Nobility from Astrata and her lackeys.

If my writing doesn't seem on-par, or as (un)funny as usual, it is because I been camping and probably ingested the recommeneded weekly dose of smoke in like, two hours. DOESN'T MATTER.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: 'Elevation', 'Abasement' rituals to the Rune of the Sun
removal: 'Grant Nobility' from Grand Duke/Consort
add: 'astrata_noblement', 'neutral_noblement', 'matthios_noblement' positive moodbuffs. 
add: 'nobilitygone' negative moodbuffs
add: 'Lost Status' (FOR -1, PER -1, INT -1) debuff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
