### PR TITLE
Helmet aesthetics storage is now aesthetics only. (AP port)

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -35,7 +35,7 @@
 
 /datum/component/storage/concrete/roguetown/hat/can_be_inserted(obj/item/storing, stop_messages, mob/user, worn_check = FALSE, params, storage_click = FALSE)
 	// we only want aesthetically head items, like flowercrowns, to be addable
-	if(!(storing.slot_flags & ITEM_SLOT_HEAD|ITEM_SLOT_MASK|ITEM_SLOT_NECK))
+	if(!(storing.slot_flags & (ITEM_SLOT_HEAD|ITEM_SLOT_MASK|ITEM_SLOT_NECK)))
 		return FALSE
 	// any sort of armoured item is forbidden, it's aesthetic only
 	if(storing.armor?.stab > 0 || storing.armor?.blunt > 0)


### PR DESCRIPTION
## About The Pull Request
see https://github.com/Azure-Peak/Azure-Peak/pull/6243

## Testing Evidence

see https://github.com/Azure-Peak/Azure-Peak/pull/6243

## Why It's Good For The Game
see https://github.com/Azure-Peak/Azure-Peak/pull/6243

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: WeNeedMorePhoron - ported by jam
fix: fixes helmet storage allowing non-clothing items
/:cl:
