### PR TITLE
delete duplicate status effects that did nothing

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -477,7 +477,23 @@
 
 	msg_stage++
 
+//---- Feint
+/datum/status_effect/debuff/feintcd
+	id = "feintcd"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/feintcd
+	duration = 15 SECONDS
 
+/datum/status_effect/debuff/feintcd/on_creation(mob/living/new_owner, new_dur)
+	if(new_dur)
+		duration = new_dur
+	return ..()
+
+/atom/movable/screen/alert/status_effect/debuff/feintcd
+	name = "Feint Cooldown"
+	desc = "I used it. I must wait, or risk a lower chance of success."
+	icon_state = "feintcd"
+
+//---- Bait
 /datum/status_effect/debuff/baited
 	id = "bait"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/baited
@@ -498,12 +514,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/baitedcd
 	duration = 30 SECONDS
 
-/atom/movable/screen/alert/status_effect/debuff/feintcd
-	name = "Feint Cooldown"
-	desc = "I used it. I must wait, or risk a lower chance of success."
-	icon_state = "feintcd"
-
-
+//---- Clash
 /atom/movable/screen/alert/status_effect/debuff/clashcd
 	name = "Guard Cooldown"
 	desc = "I used it. I must wait."
@@ -514,6 +525,12 @@
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/clashcd
 	duration = 30 SECONDS
 
+/atom/movable/screen/alert/status_effect/debuff/clashcd
+	name = "Riposte / Guard Cooldown"
+	desc = "I used it. I must wait."
+	icon_state = "guardcd"
+
+//---- Exposed
 /atom/movable/screen/alert/status_effect/debuff/exposed
 	name = "Exposed"
 	desc = "My defenses are exposed. I can be hit through my parry and dodge!"
@@ -523,22 +540,21 @@
 	id = "nofeint"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/exposed
 	duration = 10 SECONDS
+	mob_effect_icon = 'icons/mob/mob_effects.dmi'
+	mob_effect_icon_state = "eff_exposed"
+	mob_effect_layer = MOB_EFFECT_LAYER_EXPOSED
 
 /datum/status_effect/debuff/exposed/on_creation(mob/living/new_owner, new_dur)
 	if(new_dur)
 		duration = new_dur
 	return ..()
 
-/datum/status_effect/debuff/feintcd
-	id = "feintcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/feintcd
-	duration = 30 SECONDS
-
-//Unused
+//---- Riposted
 /datum/status_effect/debuff/riposted
 	id = "riposted"
 	duration = 3 SECONDS
 
+//---- Click cd
 /datum/status_effect/debuff/clickcd
 	id = "clickcd"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/clickcd
@@ -554,6 +570,33 @@
 	name = "Action Delayed"
 	desc = "I cannot take another action."
 	icon_state = "clickcd"
+
+//---- Strike cd
+/datum/status_effect/debuff/strikecd
+	id = "strikecd"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/precisestrikecd
+	duration = 30 SECONDS
+
+/atom/movable/screen/alert/status_effect/debuff/precisestrikecd
+	name = "Precise Strike Cooldown"
+	desc = "I used it. I must wait."
+	icon_state = "strikecd"
+
+//---- Special CD
+/datum/status_effect/debuff/specialcd
+	id = "specialcd"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/specialcd
+	duration = 30 SECONDS
+
+/datum/status_effect/debuff/specialcd/on_creation(mob/living/new_owner, new_dur)
+	if(new_dur)
+		duration = new_dur
+	return ..()
+
+/atom/movable/screen/alert/status_effect/debuff/specialcd
+	name = "Precise Strike Cooldown"
+	desc = "I used it. I must wait."
+	icon_state = "strikecd"
 
 // Magical mishaps
 // Victim loses common, their default language, or a random language (in order of preference) for the duration
@@ -857,188 +900,7 @@
 	owner.confused = max(owner.confused - confusion_amount, 0)
 	..()
 
-/atom/movable/screen/alert/status_effect/debuff/feintcd
-	name = "Feint Cooldown"
-	desc = "I used it. I must wait, or risk a lower chance of success."
-	icon_state = "feintcd"
-
-
-/atom/movable/screen/alert/status_effect/debuff/clashcd
-	name = "Guard Cooldown"
-	desc = "I used it. I must wait."
-	icon_state = "guardcd"
-
-/datum/status_effect/debuff/strikecd
-	id = "strikecd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/precisestrikecd
-	duration = 30 SECONDS
-
-/atom/movable/screen/alert/status_effect/debuff/precisestrikecd
-	name = "Precise Strike Cooldown"
-	desc = "I used it. I must wait."
-	icon_state = "strikecd"
-
-/datum/status_effect/debuff/clashcd
-	id = "clashcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/clashcd
-	duration = 30 SECONDS
-
-/datum/status_effect/debuff/specialcd
-	id = "specialcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/specialcd
-	duration = 30 SECONDS
-
-/datum/status_effect/debuff/specialcd/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	return ..()
-
-/atom/movable/screen/alert/status_effect/debuff/specialcd
-	name = "Precise Strike Cooldown"
-	desc = "I used it. I must wait."
-	icon_state = "strikecd"
-
-/atom/movable/screen/alert/status_effect/debuff/exposed
-	name = "Exposed"
-	desc = "My defenses are exposed. I can be hit through my parry and dodge!"
-	icon_state = "exposed"
-
-/datum/status_effect/debuff/exposed
-	id = "nofeint"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/exposed
-	duration = 10 SECONDS
-	mob_effect_icon = 'icons/mob/mob_effects.dmi'
-	mob_effect_icon_state = "eff_exposed"
-	mob_effect_layer = MOB_EFFECT_LAYER_EXPOSED
-
-/datum/status_effect/debuff/exposed/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	return ..()
-
-/datum/status_effect/debuff/feintcd
-	id = "feintcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/feintcd
-	duration = 15 SECONDS
-
-/datum/status_effect/debuff/feintcd/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	return ..()
-
-//Unused
-/datum/status_effect/debuff/riposted
-	id = "riposted"
-	duration = 3 SECONDS
-
-/datum/status_effect/debuff/clickcd
-	id = "clickcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/clickcd
-	duration = 3 SECONDS
-
-/datum/status_effect/debuff/clickcd/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	new_owner.changeNext_move(duration)
-	return ..()
-
-/atom/movable/screen/alert/status_effect/debuff/clickcd
-	name = "Action Delayed"
-	desc = "I cannot take another action."
-	icon_state = "clickcd"
-
-/datum/status_effect/debuff/crit_resistance_cd
-
-/atom/movable/screen/alert/status_effect/debuff/feintcd
-	name = "Feint Cool down"
-	desc = "I used it. I must wait, or risk a lower chance of success."
-	icon_state = "feintcd"
-
-
-/atom/movable/screen/alert/status_effect/debuff/clashcd
-	name = "Riposte / Guard Cooldown"
-	desc = "I used it. I must wait."
-	icon_state = "guardcd"
-
-/datum/status_effect/debuff/strikecd
-	id = "strikecd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/precisestrikecd
-	duration = 30 SECONDS
-
-/atom/movable/screen/alert/status_effect/debuff/precisestrikecd
-	name = "Precise Strike Cooldown"
-	desc = "I used it. I must wait."
-	icon_state = "strikecd"
-
-/datum/status_effect/debuff/clashcd
-	id = "clashcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/clashcd
-	duration = 30 SECONDS
-
-/datum/status_effect/debuff/specialcd
-	id = "specialcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/specialcd
-	duration = 30 SECONDS
-
-/datum/status_effect/debuff/specialcd/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	return ..()
-
-/atom/movable/screen/alert/status_effect/debuff/specialcd
-	name = "Precise Strike Cooldown"
-	desc = "I used it. I must wait."
-	icon_state = "strikecd"
-
-/atom/movable/screen/alert/status_effect/debuff/exposed
-	name = "Exposed"
-	desc = "My defenses are exposed. I can be hit through my parry and dodge!"
-	icon_state = "exposed"
-
-/datum/status_effect/debuff/exposed
-	id = "nofeint"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/exposed
-	duration = 10 SECONDS
-	mob_effect_icon = 'icons/mob/mob_effects.dmi'
-	mob_effect_icon_state = "eff_exposed"
-	mob_effect_layer = MOB_EFFECT_LAYER_EXPOSED
-
-/datum/status_effect/debuff/exposed/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	return ..()
-
-/datum/status_effect/debuff/feintcd
-	id = "feintcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/feintcd
-	duration = 15 SECONDS
-
-/datum/status_effect/debuff/feintcd/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	return ..()
-
-//Unused
-/datum/status_effect/debuff/riposted
-	id = "riposted"
-	duration = 3 SECONDS
-
-/datum/status_effect/debuff/clickcd
-	id = "clickcd"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/clickcd
-	duration = 3 SECONDS
-
-/datum/status_effect/debuff/clickcd/on_creation(mob/living/new_owner, new_dur)
-	if(new_dur)
-		duration = new_dur
-	new_owner.changeNext_move(duration)
-	return ..()
-
-/atom/movable/screen/alert/status_effect/debuff/clickcd
-	name = "Action Delayed"
-	desc = "I cannot take another action."
-	icon_state = "clickcd"
-
+//---- Crit resistance cd
 /datum/status_effect/debuff/crit_resistance_cd
 	id = "crit_resist_cd"
 	duration = CRIT_RESISTANCE_TIMER_CD


### PR DESCRIPTION
## About The Pull Request
Cleans up code in debuffs.dm
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
compiles
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
code fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Delete duplicate debuffs that did nothing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
