### PR TITLE
Gives (some) witches the ritualist trait

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -73,11 +73,12 @@
 			H.mind?.adjust_spellpoints(9) // twelve if you pick arcyne potential
 			neck = null
 		if("Godsblood")
-			//miracle witch: capped at t2 miracles. cannot pray to regain devo, but has high innate regen because of it (2 instead of 1 from major)
+			//miracle witch: capped at t2 miracles. cannot pray to regain devo, but has high innate regen because of it (2 instead of 1 from major)TRAIT_RITUALIST
 			var/datum/devotion/D = new /datum/devotion/(H, H.patron)
 			H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 			D.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WITCH, devotion_limit = CLERIC_REQ_2)
 			D.max_devotion *= 0.5
+			ADD_TRAIT(TRAIT_RITUALIST, TRAIT_GENERIC)
 			switch(H.patron?.type)
 				if(/datum/patron/divine/astrata)
 					neck = /obj/item/clothing/neck/roguetown/psicross/astrata
@@ -112,6 +113,7 @@
 			D.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
 			D.max_devotion *= 0.5
 			ADD_TRAIT(H, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
+			ADD_TRAIT(TRAIT_RITUALIST, TRAIT_GENERIC)
 			H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.mind?.adjust_spellpoints(6) // twelve if you pick arcyne potential
 			switch(H.patron?.type)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/witch.dm
@@ -78,7 +78,7 @@
 			H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 			D.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WITCH, devotion_limit = CLERIC_REQ_2)
 			D.max_devotion *= 0.5
-			ADD_TRAIT(TRAIT_RITUALIST, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 			switch(H.patron?.type)
 				if(/datum/patron/divine/astrata)
 					neck = /obj/item/clothing/neck/roguetown/psicross/astrata
@@ -113,7 +113,7 @@
 			D.grant_miracles(H, cleric_tier = CLERIC_T1, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_1)
 			D.max_devotion *= 0.5
 			ADD_TRAIT(H, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
-			ADD_TRAIT(TRAIT_RITUALIST, TRAIT_GENERIC)
+			ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
 			H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
 			H.mind?.adjust_spellpoints(6) // twelve if you pick arcyne potential
 			switch(H.patron?.type)


### PR DESCRIPTION
## About The Pull Request

Godsblood and Mystagogue witches get the ritualist trait. I noticed that the prisoner witch had it and it feels like an oversight that at least one of the regular witches should also have it. It's a pretty scarce trait, only really available to antags and the church, but similarly rare is divine brand ritual chalk which the witch would have to find somewhere. 


## Why It's Good For The Game

Gives more differentiation between the subclasses and gives the class something to organically seek and find from either wretches or the church, emphasizing their place as a bridge between the town and bog. They can make deals with hags or suck up to the church or both and the reward is fluffy and mechanically interesting.

## Changelog

:cl:
add: Godsblood and Mystagogue witches get the ritualist trait but no chalk.
/:cl: