### PR TITLE
[Performance Test, Test Merge Only!] Temporarily Disable Spectator Mode & Filter AI Wake-Up 

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -54,8 +54,8 @@
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
 /atom/proc/attack_ghost(mob/dead/observer/user)
-	if(is_hidden_from_ghosts(src, user))
-		return TRUE
+	// if(is_hidden_from_ghosts(src, user))
+	// 	return TRUE
 	if(SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_GHOST, user) & COMPONENT_NO_ATTACK_HAND)
 		return TRUE
 	if(user.client)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -227,7 +227,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 	if(!can_idle)
 		return FALSE
 	for(var/datum/spatial_grid_cell/grid as anything in our_cells.member_cells)
-		if(length(grid.client_contents))
+		for(var/mob/living/M in grid.client_contents)
 			return FALSE
 	return TRUE
 
@@ -237,12 +237,17 @@ have ways of interacting with a specific atom and control it. They posses a blac
 	if(should_idle())
 		set_ai_status(AI_STATUS_OFF)
 
-/datum/ai_controller/proc/on_client_enter(datum/source, atom/target)
+/datum/ai_controller/proc/on_client_enter(datum/source, list/entering_clients)
 	SIGNAL_HANDLER
-	if(ai_status == AI_STATUS_OFF || ai_status == AI_STATUS_IDLE)
-		set_ai_status(get_expected_ai_status())
 
-/datum/ai_controller/proc/on_client_exit(datum/source, datum/exited)
+	if(ai_status != AI_STATUS_OFF && ai_status != AI_STATUS_IDLE)
+		return
+		
+	for(var/mob/living/M in entering_clients)
+		set_ai_status(get_expected_ai_status())
+		return
+
+/datum/ai_controller/proc/on_client_exit(datum/source, list/exited_clients)
 	SIGNAL_HANDLER
 	recalculate_idle()
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -131,12 +131,12 @@
 			msg = "<span style='color:#[human.voice_color];text-shadow:-1px -1px 0 #000,1px -1px 0 #000,-1px 1px 0 #000,1px 1px 0 #000;'><b>[emotelocation]</b></span> " + msg
 		else
 			msg = "<b>[emotelocation]</b> " + msg
-		var/list/hidden_ghosts = get_hidden_ghosts_for_target(user)
+		// hidden_ghosts = get_hidden_ghosts_for_target(user)
 		for(var/mob/M in GLOB.dead_mob_list)
 			if(!M.client || isnewplayer(M))
 				continue
-			if(M in hidden_ghosts)
-				continue
+			// if(M in hidden_ghosts)
+			// 	continue
 			var/T = get_turf(emotelocation)
 			if(M.stat == DEAD && M.client && (M.client.prefs?.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
 				M.show_message(msg)
@@ -144,9 +144,11 @@
 		if(show_runechat)
 			runechat_msg_to_use = runechat_msg ? runechat_msg : pre_color_msg
 		if(emote_type == EMOTE_AUDIBLE)
-			emotelocation.audible_message(msg, runechat_message = runechat_msg_to_use, log_seen = SEEN_LOG_EMOTE, ignored_mobs = hidden_ghosts)
+			// emotelocation.audible_message(msg, runechat_message = runechat_msg_to_use, log_seen = SEEN_LOG_EMOTE, ignored_mobs = hidden_ghosts)
+			emotelocation.audible_message(msg, runechat_message = runechat_msg_to_use, log_seen = SEEN_LOG_EMOTE)
 		else
-			emotelocation.visible_message(msg, runechat_message = runechat_msg_to_use, log_seen = SEEN_LOG_EMOTE, ignored_mobs = hidden_ghosts)
+			// emotelocation.visible_message(msg, runechat_message = runechat_msg_to_use, log_seen = SEEN_LOG_EMOTE, ignored_mobs = hidden_ghosts)
+			emotelocation.visible_message(msg, runechat_message = runechat_msg_to_use, log_seen = SEEN_LOG_EMOTE)
 
 /mob/living/proc/get_emote_pitch()
 	return clamp(voice_pitch, 0.5, 2)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2930,10 +2930,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					return
 
 				if("observe")
-					// SPECTATE DISABLED for testing — show notice instead of routing to make_me_an_observer
+					// SPECTATE DISABLED for testing... Showing the notice, sure, but might need to make the text bigger, lmao
 					// var/mob/dead/new_player/P = user
 					// P.make_me_an_observer()
-					to_chat(user, span_notice("Spectate disabled currently for testing purposes."))
+					to_chat(user, span_bignotice("Spectate disabled currently for testing purposes."))
 					return
 
 				if("finished")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2930,8 +2930,10 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					return
 
 				if("observe")
-					var/mob/dead/new_player/P = user
-					P.make_me_an_observer()
+					// SPECTATE DISABLED for testing — show notice instead of routing to make_me_an_observer
+					// var/mob/dead/new_player/P = user
+					// P.make_me_an_observer()
+					to_chat(user, span_notice("Spectate disabled currently for testing purposes."))
 					return
 
 				if("finished")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -615,16 +615,16 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 
 	usr << browse(policytext.Join(""),"window=policy")
 
-/client/verb/toggle_ghost_protection()
-	set name = "Toggle Ghost Protection"
-	set category = "OOC"
-	set desc = "Permit or forbid ghosts from orbiting or seeing you."
-	if(!mob)
-		return
-	// Flip preference
-	prefs.ghost_protection = !prefs.ghost_protection
-	prefs.save_preferences()
-	to_chat(src, span_notice("Ghost protection is now [prefs.ghost_protection ? "ENABLED (Ghosts can no longer see or orbit you)" : "DISABLED (Ghosts can now see and orbit you)"]."))
+// /client/verb/toggle_ghost_protection()
+// 	set name = "Toggle Ghost Protection"
+// 	set category = "OOC"
+// 	set desc = "Permit or forbid ghosts from orbiting or seeing you."
+// 	if(!mob)
+// 		return
+// 	// Flip preference
+// 	prefs.ghost_protection = !prefs.ghost_protection
+// 	prefs.save_preferences()
+// 	to_chat(src, span_notice("Ghost protection is now [prefs.ghost_protection ? "ENABLED (Ghosts can no longer see or orbit you)" : "DISABLED (Ghosts can now see and orbit you)"]."))
 
 // Currently ghost sprite not displaying
 // Can't return to afterlife or use for teleporting 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -188,11 +188,11 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			if(ready != tready)
 				ready = tready
 		//if it's post initialisation and they're trying to observe we do the needful
-		
-		if(!SSticker.current_state < GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
-			ready = tready
-			make_me_an_observer()
-			return
+
+		// if(!SSticker.current_state < GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
+		// 	ready = tready
+		// 	make_me_an_observer()
+		// 	return
 
 	if(href_list["refresh"])
 		winshow(src, "preferencess_window", FALSE)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -608,23 +608,21 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set desc = ""
 	set hidden = 1
 	var/list/all_mobs = getpois(mobs_only=1,skip_mindless=1)
-	var/list/allowed_mobs = list()
 
-	// admins can see everybody, i think thats fair
-	if(!check_rights(R_ADMIN, FALSE))
-		for(var/current_name in all_mobs)
-			var/mob/current_mob = all_mobs[current_name]
+	// GHOST PROTECTION DISABLED — restore unfiltered orbit list
+	// var/list/allowed_mobs = list()
+	// if(!check_rights(R_ADMIN, FALSE))
+	// 	for(var/current_name in all_mobs)
+	// 		var/mob/current_mob = all_mobs[current_name]
+	// 		if(current_mob.client)
+	// 			var/datum/preferences/current_prefs = current_mob.client.prefs
+	// 			if(!current_prefs.ghost_protection)
+	// 				allowed_mobs[current_name] = current_mob
+	// else
+	// 	allowed_mobs += all_mobs
 
-			if(current_mob.client)
-				// check if the player is has ghost protection
-				var/datum/preferences/current_prefs = current_mob.client.prefs
-				if(!current_prefs.ghost_protection)
-					allowed_mobs[current_name] = current_mob
-	else
-		allowed_mobs += all_mobs
-
-	var/input = input("Who?!", "Haunt", null, null) as null|anything in allowed_mobs
-	var/mob/target = allowed_mobs[input]
+	var/input = input("Who?!", "Haunt", null, null) as null|anything in all_mobs
+	var/mob/target = all_mobs[input]
 
 	ManualFollow(target)
 
@@ -635,8 +633,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/proc/ManualFollow(atom/movable/target)
 	if (!istype(target))
 		return
-	if(is_hidden_from_ghosts(target, src))
-		return
+	// GHOST PROTECTION DISABLED
+	// if(is_hidden_from_ghosts(target, src))
+	// 	return
 
 	var/icon/I = icon(target.icon,target.icon_state,target.dir)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -609,7 +609,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set hidden = 1
 	var/list/all_mobs = getpois(mobs_only=1,skip_mindless=1)
 
-	// GHOST PROTECTION DISABLED — restore unfiltered orbit list
+	// GHOST PROTECTION DISABLED: This may need to be particularly looked into as noted in a discussion.
 	// var/list/allowed_mobs = list()
 	// if(!check_rights(R_ADMIN, FALSE))
 	// 	for(var/current_name in all_mobs)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -947,15 +947,15 @@
 	else
 		return FALSE
 
-/mob/living/carbon/human/proc/on_client_enter(datum/source, atom/target)
+/mob/living/carbon/human/proc/on_client_enter(datum/source, list/entering_clients)
 	SIGNAL_HANDLER
-	if(mode == NPC_AI_OFF)
+	if(mode != NPC_AI_SLEEP)
+		return
+	for(var/mob/living/M in entering_clients)
+		mode = NPC_AI_IDLE
 		return
 
-	if(mode == NPC_AI_SLEEP)
-		mode = NPC_AI_IDLE
-
-/mob/living/carbon/human/proc/on_client_exit(datum/source, datum/exited)
+/mob/living/carbon/human/proc/on_client_exit(datum/source, list/exited_clients)
 	SIGNAL_HANDLER
 	if(mode == NPC_AI_OFF)
 		return
@@ -988,7 +988,7 @@
 		return
 
 	for(var/datum/spatial_grid_cell/grid as anything in our_cells.member_cells)
-		if(length(grid.client_contents))
+		for(var/mob/living/M in grid.client_contents)
 			if(mode != NPC_AI_SLEEP && mode != NPC_AI_IDLE)
 				return TRUE
 			mode = NPC_AI_IDLE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -295,13 +295,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			continue
 		listening |= M
 		the_dead[M] = TRUE
-	var/list/hidden_ghosts = null
-	if(has_ghost_protection(src))
-		hidden_ghosts = get_hidden_ghosts_for_target(src)
-		for(var/mob/dead/observer/ghost in hidden_ghosts)
-			if(ghost in listening)
-				listening -= ghost
-				the_dead -= ghost
+	// GHOST PROTECTION DISABLED
+	// if(has_ghost_protection(src))
+	// 	hidden_ghosts = get_hidden_ghosts_for_target(src)
+	// 	for(var/mob/dead/observer/ghost in hidden_ghosts)
+	// 		if(ghost in listening)
+	// 			listening -= ghost
+	// 			the_dead -= ghost
 	log_seen(src, null, listening, original_message, SEEN_LOG_SAY)
 
 	var/eavesdropping
@@ -347,10 +347,12 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		var/mob/living/carbon/human/H = src
 		mob_color = H.voice_color
 	var/chatmsg = "<font color = #[mob_color]><b>[src]</b></font> " + sign_verb + "."
-	var/list/ignored_mobs = understanders.Copy()
-	if(length(hidden_ghosts))
-		ignored_mobs += hidden_ghosts
-	visible_message(chatmsg, runechat_message = sign_verb, log_seen = SEEN_LOG_EMOTE, ignored_mobs = ignored_mobs)
+	// GHOST PROTECTION DISABLED
+	// var/list/ignored_mobs = understanders.Copy()
+	// if(length(hidden_ghosts))
+	// 	ignored_mobs += hidden_ghosts
+	// visible_message(chatmsg, runechat_message = sign_verb, log_seen = SEEN_LOG_EMOTE, ignored_mobs = ignored_mobs)
+	visible_message(chatmsg, runechat_message = sign_verb, log_seen = SEEN_LOG_EMOTE, ignored_mobs = understanders)
 
 	//speech bubble
 	var/list/speech_bubble_recipients = list()
@@ -455,7 +457,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	// AZURE EDIT END
 	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source)
 	var/list/the_dead = list()
-	var/list/hidden_ghosts = null
 //	var/list/yellareas	//CIT CHANGE - adds the ability for yelling to penetrate walls and echo throughout areas
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
@@ -490,12 +491,13 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			continue
 		listening |= M
 		the_dead[M] = TRUE
-	if(has_ghost_protection(src))
-		hidden_ghosts = get_hidden_ghosts_for_target(src)
-		for(var/mob/dead/observer/ghost in hidden_ghosts)
-			if(ghost in listening)
-				listening -= ghost
-				the_dead -= ghost
+	// GHOST PROTECTION DISABLED
+	// if(has_ghost_protection(src))
+	// 	hidden_ghosts = get_hidden_ghosts_for_target(src)
+	// 	for(var/mob/dead/observer/ghost in hidden_ghosts)
+	// 		if(ghost in listening)
+	// 			listening -= ghost
+	// 			the_dead -= ghost
 	log_seen(src, null, listening, original_message, SEEN_LOG_SAY)
 
 	var/eavesdropping

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -613,15 +613,6 @@
 		value = initial(search_objects)
 	search_objects = value
 
-/mob/living/simple_animal/hostile/consider_wakeup()
-	for(var/datum/spatial_grid_cell/grid as anything in our_cells.member_cells)
-		if(length(grid.client_contents))
-			toggle_ai(AI_ON)
-			return TRUE
-
-	toggle_ai(AI_IDLE)
-	return TRUE
-
 /mob/living/simple_animal/hostile/proc/ListTargetsLazy(_Z)//Step 1, find out what we can see
 	. = list()
 	for (var/I in SSmobs.clients_by_zlevel[_Z])

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -981,7 +981,7 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 
 /mob/living/simple_animal/proc/consider_wakeup()
 	for(var/datum/spatial_grid_cell/grid as anything in our_cells.member_cells)
-		if(length(grid.client_contents))
+		for(var/mob/living/M in grid.client_contents)
 			toggle_ai(AI_ON)
 			return TRUE
 
@@ -1035,12 +1035,15 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 			playsound(src, "fart", 100, TRUE)
 			new pooptype(loc)
 
-/mob/living/simple_animal/proc/on_client_enter(datum/source, atom/target)
+/mob/living/simple_animal/proc/on_client_enter(datum/source, list/entering_clients)
 	SIGNAL_HANDLER
-	if(AIStatus == AI_IDLE)
+	if(AIStatus != AI_IDLE)
+		return
+	for(var/mob/living/M in entering_clients)
 		toggle_ai(AI_ON)
+		return
 
-/mob/living/simple_animal/proc/on_client_exit(datum/source, datum/exited)
+/mob/living/simple_animal/proc/on_client_exit(datum/source, list/exited_clients)
 	SIGNAL_HANDLER
 	consider_wakeup()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -192,11 +192,10 @@ GLOBAL_VAR_INIT(mobids, 1)
 		return
 	if(!islist(ignored_mobs))
 		ignored_mobs = list(ignored_mobs)
-	var/list/hidden_ghosts = null
-	if(has_ghost_protection(src))
-		hidden_ghosts = get_hidden_ghosts_for_target(src)
-		if(length(hidden_ghosts))
-			ignored_mobs += hidden_ghosts
+	// if(has_ghost_protection(src))
+	// 	hidden_ghosts = get_hidden_ghosts_for_target(src)
+	// 	if(length(hidden_ghosts))
+	// 		ignored_mobs += hidden_ghosts
 	var/list/hearers = get_hearers_in_view(vision_distance, src) //caches the hearers and then removes ignored mobs.
 	hearers -= ignored_mobs
 	if(self_message)

--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -77,5 +77,6 @@
 		var/list/embeds = departing_mob.get_embedded_objects()
 		for(var/thing in embeds)
 			QDEL_NULL(thing)
+	departing_mob.returntolobby()
 	QDEL_NULL(departing_mob)
 


### PR DESCRIPTION
## About The Pull Request

**Do not merge.**

This is purely for testing and observation as of this moment.

This PR is different from #1546. In fact, some aspects of that PR covers some areas that this one does not in regards to CanAttack. However, I haven't really reviewed in full.

For one, in this PR, we temporarily disable spectate to begin with. After a discussion with a maintainer, this PR along with the temperature/weather PR (I asked Radiant if they could make turning it on and off a configurable option) both seem to coincidence around the time when time dilation ballooned significantly, i.e. late March. Although it may not be either of those PRs necessarily.

Why are we temporarily disabling spectate? This is to gauge performance differences properly. A significant number of players did notice an increase in performance when observe was disabled. However, not all of its features were fully disabled. This is to see the full effects of the spectator removal on performance.

We will then see if there is any appreciable effects of ghost protection as well separately later on performance. **There is some wonkiness to it as noted by Ketrai in the original PR.**

This adds filtering for only mob/living when it comes to reviewing over eligible clients and in regards to what triggers them waking up. This is to see if it prevents ghosts and aghosts from causing lag spikes as demonstrated from video examples shown by a staff member.

**Some notes:**
~~for(var/mob/living/M in grid.client_contents) may be an entirely too big of a list at times. I don't know how DM works under the hood when filtered through a loop like this. Suggestion was made to make a special category for non-ghost mobs? Either ways, could be reverted back if it's a concern.~~

After further review, I believe that spatial grid search is already being called to begin with anyways. Furthermore, from what I also understand, it only checks for any mobs with a client. So, the list should not be that big. So, it should be fine. Again, someone can double-check me. But I believe this should be good to go.

Ghost harddel is a major issue as well in regards to performance. Not really touched here.

## Testing Evidence
<img width="429" height="110" alt="compile" src="https://github.com/user-attachments/assets/a4bf577c-f1cb-4501-b864-b306d9b5043b" />

## Why It's Good For The Game

Testing.

## Changelog

**Not to be merged!**