### PR TITLE
Head/Court Physician is a Noble

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/physician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/physician.dm
@@ -15,7 +15,7 @@
 	outfit = /datum/outfit/job/roguetown/physician
 	whitelist_req = TRUE
 	advclass_cat_rolls = list(CTAG_COURTPHYS = 2)
-	social_rank = SOCIAL_RANK_MINOR_NOBLE
+	social_rank = SOCIAL_RANK_NOBLE
 	give_bank_account = 30
 	min_pq = 3 //Please don't kill the duke by operating on strong intent. Play apothecary until you're deserving of the great white beak of doom
 	max_pq = null
@@ -23,7 +23,7 @@
 
 	cmode_music = 'sound/music/combat_physician.ogg'
 
-	job_traits = list(TRAIT_MEDICINE_EXPERT, TRAIT_ALCHEMY_EXPERT, TRAIT_NOSTINK, TRAIT_EMPATH)
+	job_traits = list(TRAIT_MEDICINE_EXPERT, TRAIT_ALCHEMY_EXPERT, TRAIT_NOSTINK, TRAIT_EMPATH, TRAIT_NOBLE)
 	job_subclasses = list(
 		/datum/advclass/physician
 	)


### PR DESCRIPTION
## About The Pull Request

As described

Would make it so that the 'Head Physician' of dunworld is more of a Yeoman and the 'Court Physician' of rockhill more a noble but idk how to code that.

## Testing Evidence
<img width="1231" height="457" alt="image" src="https://github.com/user-attachments/assets/bec716bd-b243-4309-bc4c-995b1f662be9" />

## Why It's Good For The Game

Something that was the case in RW1 and we never got around to changing it back after inheriting AP code.

## Changelog
:cl:
add: Court Physician is once more a Noble
/:cl: