### PR TITLE
[AI] Small tweaks for potential performance gains

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -60,6 +60,7 @@
 	var/next_full_seek
 	var/lazy_seek_interval = 4
 	var/full_seek_interval = 20
+	var/use_lazy_target_scan = TRUE
 
 	cmode = 1
 	setparrytime = 30
@@ -102,7 +103,7 @@
 	if(target)
 		possible_targets = ListTargets()
 	else
-		if(search_objects)
+		if(search_objects || !use_lazy_target_scan)
 			possible_targets = ListTargets()
 		else if(world.time >= next_seek)
 			next_seek = world.time + lazy_seek_interval

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -57,6 +57,9 @@
 	var/retreat_health
 
 	var/next_seek
+	var/next_full_seek
+	var/lazy_seek_interval = 4
+	var/full_seek_interval = 20
 
 	cmode = 1
 	setparrytime = 30
@@ -93,7 +96,31 @@
 		return 0
 	if(binded)
 		return FALSE
-	var/list/possible_targets = ListTargets() //we look around for potential targets and make it a list for later use.
+	var/list/possible_targets
+
+	// Untargeted hostiles are the common case in live rounds; keep scans cheap and infrequent.
+	if(target)
+		possible_targets = ListTargets()
+	else
+		if(search_objects)
+			possible_targets = ListTargets()
+		else if(world.time >= next_seek)
+			next_seek = world.time + lazy_seek_interval
+			var/turf/search_turf = get_turf(targets_from)
+			if(search_turf)
+				possible_targets = ListTargetsLazy(search_turf.z)
+
+		// Periodically run a full scan so object searches and non-player interactions still function.
+		if(world.time >= next_full_seek)
+			next_full_seek = world.time + full_seek_interval
+			var/list/full_targets = ListTargets()
+			if(possible_targets)
+				possible_targets |= full_targets
+			else
+				possible_targets = full_targets
+
+		if(!possible_targets)
+			possible_targets = list()
 
 	if(environment_smash)
 		EscapeConfinement()
@@ -156,12 +183,16 @@
 
 /mob/living/simple_animal/hostile/attacked_by(obj/item/I, mob/living/user)
 	if(stat == CONSCIOUS && !target && AIStatus != NPC_AI_OFF && !client && user)
+		next_seek = 0
+		next_full_seek = 0
 		FindTarget(list(user), 1)
 	return ..()
 
 /mob/living/simple_animal/hostile/bullet_act(obj/projectile/P)
 	if(stat == CONSCIOUS && !target && AIStatus != NPC_AI_OFF && !client)
 		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
+			next_seek = 0
+			next_full_seek = 0
 			FindTarget(list(P.firer), 1)
 		Goto(P.starting, move_to_delay, 3)
 	return ..()
@@ -400,6 +431,8 @@
 	if(target)
 		last_aggro_loss = world.time
 	target = null
+	next_seek = 0
+	next_full_seek = 0
 	approaching_target = FALSE
 	in_melee = FALSE
 	walk(src, 0)
@@ -576,7 +609,10 @@
 		if(AI_ON)
 			. = 1
 		if(AI_IDLE)
-			if(FindTarget(possible_targets, 1))
+			if(target && CanAttack(target))
+				. = 1
+				toggle_ai(AI_ON)
+			else if(FindTarget(possible_targets, 1))
 				. = 1
 				toggle_ai(AI_ON) //Wake up for more than one Life() cycle.
 			else
@@ -626,6 +662,6 @@
 	. = list()
 	for (var/I in SSmobs.clients_by_zlevel[_Z])
 		var/mob/M = I
-		if (get_dist(M, src) < vision_range)
+		if (get_dist(M, targets_from) <= vision_range)
 			if (isturf(M.loc))
 				. += M

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/retaliate.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/hostile/retaliate
 	var/list/enemies = list()
 	stop_automated_movement_when_pulled = TRUE
+	use_lazy_target_scan = FALSE
 
 /mob/living/simple_animal/hostile/retaliate/attack_hand(mob/living/carbon/human/M)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -1015,9 +1015,15 @@ GLOBAL_VAR_INIT(farm_animals, FALSE)
 		qdel(I)
 		food = max(food + 30, 100)
 
-/mob/living/simple_animal/Life()
+/mob/living/simple_animal/Life(seconds, times_fired)
 	if(!client && can_have_ai && (AIStatus == AI_Z_OFF || AIStatus == AI_OFF))
 		return
+	// AI_IDLE mobs have no players nearby and are not processing via SSnpcpool.
+	// Skip the expensive mob/living/Life() call 2/3 of ticks; status effects already
+	// run every 3rd tick for clientless mobs, so net frequency is unchanged.
+	// Return TRUE (alive) so hostile/Life() does not enter its "dead" path and call walk(src, 0).
+	if(!client && AIStatus == AI_IDLE && times_fired % 3 != 0)
+		return TRUE
 	. = ..()
 	if(.)
 		if(food > 0)


### PR DESCRIPTION
## About The Pull Request

The mobs subsystem is our primary source of server load right now, often exceeding even 70ms of block time (over 140% of the tick budget). 

This PR contains two relatively minor changes which SHOULDN'T have any noticeable impact in terms of gameplay, though I will preface this PR with saying I am NOT an engine coder and this may just be me entirely misunderstanding some of the logic here. Maints please take a close look and if you think i'm being stupid, I probably am. I just figured i'd have a crack at some things which seem to be fixable.

Firstly we now throttle target acquisition logic for hostile mobs who do not have a target. This lets us not need to rely on large numbers of 'idle' mobs calling the _hearers()_ proc EVERY tick, which is relatively intensive. Instead mobs who are idle will now do a cheap client-list scan most of the time, then performing a hearers check less often. If a mob is attacked or loses its target the timer resets so it should still react immediately. I cleared up a few logical changes like a mob losing a target and not immediately finding it, I also didn't realize how retaliate mobs were different but now do, so this should not affect gameplay noticeably, but hopefully help to start reduce load on the mob controller

Secondly simple_animals will now skip the life() proc for 2/3 of ticks IF idle. They were using this despite it not (afaik) being needed, Now it only fires alongside the status effect proc every 3 ticks. This should just help also reduce processing that is functionally entirely unneeded which making no change to gameplay.

## Testing Evidence

Tested on local, where mob behavior seems unchanged.  

## Why It's Good For The Game

TDI bad

## Changelog

:cl:
fix: boring AI proc stuff, should help with TDI
/:cl:

