### PR TITLE
Fixes Frostbolt cast breaking

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/frost_bolt.dm
@@ -32,7 +32,7 @@
 	xp_gain = TRUE
 	miracle = FALSE
 
-/obj/effect/proc_holder/spell/invoked/projectile/frostbolt/cast(mob/user = usr)
+/obj/effect/proc_holder/spell/invoked/projectile/frostbolt/cast(list/targets, mob/user = user)
 	var/mob/living/target = user
 	var/datum/intent/a_intent = target.a_intent
 	if(istype(a_intent, /datum/intent/special/magicarc))


### PR DESCRIPTION
I forgot to add list/targets parameter to the cast proc by mistake. This lets it cast properly again

## About The Pull Request
Fixes https://github.com/Rotwood-Vale/Ratwood-2.0/issues/1522
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="570" height="146" alt="image" src="https://github.com/user-attachments/assets/9b8f218a-36bf-4a99-9729-d34e43438e2a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
In my last PR, I fixed the frostbolt cast proc as it was under the wrong typepath. However, I forgot a parameter in the cast proc and managed to break it. I unfortunately was moving during the testmerge and didn't have a chance to fix it before it was merged. It's fixed now.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Frostbolt works again

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
