### PR TITLE
Removes reference to Azure Peak in gnolls

### DIFF
--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -22,4 +22,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, gnolls flock to Azuria."))
+			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the vale."))


### PR DESCRIPTION
Removes "Azuria"

## About The Pull Request

Single word change. Replaces "Azuria" with "The vale."

## Testing Evidence

Single word change. The word changes.

## Why It's Good For The Game

The location is not called Azuria.

## Changelog
:cl:
fix: Single word change. Replaces "Azuria" with "The vale."
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
