### PR TITLE
fixes candles in the dungeon-generator rooms

### DIFF
--- a/_maps/dungeon_generator/hallway/Malphpiece3.dmm
+++ b/_maps/dungeon_generator/hallway/Malphpiece3.dmm
@@ -16,7 +16,7 @@
 /area/rogue/under/tomb/cave)
 "aj" = (
 /obj/structure/fluff/walldeco/vinez/l,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
 "ak" = (
@@ -28,7 +28,7 @@
 /area/rogue/under/tomb/cave)
 "au" = (
 /obj/structure/fluff/walldeco/vinez/l,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /obj/item/reagent_containers/glass/bottle/rogue/whitewine,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
@@ -67,12 +67,12 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/cave)
 "aM" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
 "aN" = (
 /obj/structure/fluff/walldeco/vinez/r,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
 "aP" = (
@@ -89,7 +89,7 @@
 /area/rogue/under/tomb/cave)
 "aT" = (
 /obj/structure/fluff/walldeco/vinez/r,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/item/rogue/instrument/flute,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
@@ -103,7 +103,7 @@
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/tomb/cave)
 "aX" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/effect/dungeon_directional_helper/north,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/cave)
@@ -130,7 +130,7 @@
 /area/rogue/under/tomb/cave)
 "ij" = (
 /obj/structure/spider/stickyweb,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/cave)
 "pm" = (
@@ -146,7 +146,7 @@
 /area/rogue/under/tomb/cave)
 "ue" = (
 /obj/structure/spider/stickyweb,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/cave)
 "Fr" = (

--- a/_maps/dungeon_generator/hallway/Malphpiece5.dmm
+++ b/_maps/dungeon_generator/hallway/Malphpiece5.dmm
@@ -8,7 +8,7 @@
 /turf/open/floor/rogue/volcanic,
 /area/rogue/under/tomb/cave)
 "d" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/rogue/herringbone,
@@ -20,7 +20,7 @@
 /turf/open/floor/rogue/volcanic,
 /area/rogue/under/tomb/cave)
 "i" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/cave)
 "j" = (
@@ -48,7 +48,7 @@
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/under/tomb/cave)
 "t" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/tomb/cave)
 "v" = (
@@ -125,7 +125,7 @@
 /turf/open/floor/rogue/volcanic,
 /area/rogue/under/tomb/cave)
 "Z" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/cave)
 

--- a/_maps/dungeon_generator/hallway/Malphpiece8.dmm
+++ b/_maps/dungeon_generator/hallway/Malphpiece8.dmm
@@ -50,7 +50,7 @@
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/cave)
 "nq" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/cave)
 "oX" = (
@@ -90,7 +90,7 @@
 /turf/open/floor/rogue/blocks/paving/vert,
 /area/rogue/under/tomb/cave)
 "sI" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/cave)
 "sS" = (
@@ -144,7 +144,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/cave)
 "EA" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/cave)
@@ -157,7 +157,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/tomb/cave)
 "FE" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/cave)
@@ -191,7 +191,7 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/tomb/cave)
 "Ng" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/cave)
 "Oz" = (
@@ -224,7 +224,7 @@
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/under/tomb/cave)
 "Xd" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/cave)
 "Yk" = (

--- a/_maps/dungeon_generator/hallway/Malphpiece9.dmm
+++ b/_maps/dungeon_generator/hallway/Malphpiece9.dmm
@@ -4,7 +4,7 @@
 /area/rogue/under/tomb/cave)
 "b" = (
 /obj/structure/fluff/walldeco/vinez/l,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/drip,
@@ -18,7 +18,7 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/tomb/cave)
 "d" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/tomb/cave)
 "f" = (
@@ -28,7 +28,7 @@
 /area/rogue/under/tomb/cave)
 "g" = (
 /obj/structure/fluff/walldeco/vinez/r,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/puddle,
 /turf/open/floor/rogue/carpet/lord/right,
@@ -119,7 +119,7 @@
 /area/rogue/under/tomb/cave)
 "A" = (
 /obj/structure/fluff/walldeco/vinez/l,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/rogue/carpet/lord/left,
@@ -157,7 +157,7 @@
 /area/rogue/under/tomb/cave)
 "H" = (
 /obj/structure/fluff/walldeco/vinez/r,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/blood/puddle,
@@ -195,7 +195,7 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/tomb/cave)
 "O" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/tomb/cave)
 "P" = (

--- a/_maps/dungeon_generator/hallway/Puzzle Trap Large.dmm
+++ b/_maps/dungeon_generator/hallway/Puzzle Trap Large.dmm
@@ -67,7 +67,7 @@
 /area/rogue/under/tomb)
 "jC" = (
 /obj/structure/spider/stickyweb,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "jP" = (
@@ -117,7 +117,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "oa" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/fluff/walldeco/vinez,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb)
@@ -162,7 +162,7 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb)
 "rD" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "rQ" = (
@@ -279,7 +279,7 @@
 /area/rogue/under/tomb)
 "zQ" = (
 /obj/structure/mineral_door/bars,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/fluff/walldeco/vinez,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
@@ -299,11 +299,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "Db" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb)
 "Ee" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "EL" = (
@@ -331,7 +331,7 @@
 /area/rogue/under/tomb)
 "Is" = (
 /obj/structure/mineral_door/bars,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "Iu" = (
@@ -386,7 +386,7 @@
 "LG" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/spider/stickyweb,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "MC" = (
@@ -522,7 +522,7 @@
 /area/rogue/under/tomb)
 "Yg" = (
 /obj/structure/mineral_door/bars,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "YT" = (

--- a/_maps/dungeon_generator/hallway/Puzzle Trap Small.dmm
+++ b/_maps/dungeon_generator/hallway/Puzzle Trap Small.dmm
@@ -17,7 +17,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "f" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "g" = (
@@ -31,7 +31,7 @@
 /area/rogue/under/tomb)
 "i" = (
 /obj/structure/fluff/walldeco/vinez,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/mineral/rogue,
 /area/rogue/under/tomb)
 "j" = (
@@ -68,16 +68,16 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "s" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/mineral/rogue,
 /area/rogue/under/tomb)
 "w" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "y" = (
 /obj/structure/fluff/walldeco/vinez,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb)
 "B" = (

--- a/_maps/dungeon_generator/rest/Malphpiece1.dmm
+++ b/_maps/dungeon_generator/rest/Malphpiece1.dmm
@@ -29,7 +29,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/tomb)
 "av" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "aw" = (
@@ -80,7 +80,7 @@
 /area/rogue/under/tomb)
 "aZ" = (
 /obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /obj/item/reagent_containers/food/snacks/rogue/cheddar/aged,
 /obj/item/reagent_containers/glass/cup/skull,
 /turf/open/floor/rogue/cobblerock,
@@ -120,7 +120,7 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "zA" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "HU" = (
@@ -137,7 +137,7 @@
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "TY" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)

--- a/_maps/dungeon_generator/room/AcidMageTower.dmm
+++ b/_maps/dungeon_generator/room/AcidMageTower.dmm
@@ -16,11 +16,11 @@
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "aK" = (
-/obj/machinery/light/rogue/wallfire,
+/obj/machinery/light/rogue/campfire/fireplace,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/tomb/indoors/magic)
 "aN" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/fluff/walldeco/painting/skull,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/tomb/indoors/magic)
@@ -99,7 +99,7 @@
 /turf/open/floor/rogue/carpet/lord/right,
 /area/rogue/under/tomb/indoors/magic)
 "eT" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "eX" = (
@@ -276,7 +276,7 @@
 /obj/structure/spider/stickyweb{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/magic)
 "mb" = (
@@ -367,7 +367,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/tomb/indoors/magic)
 "qc" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/tomb/indoors/magic)
 "qd" = (
@@ -474,7 +474,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/tomb/indoors/magic)
 "tl" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/trap/wall_projectile/acidsplash{
 	dir = 4
 	},
@@ -610,19 +610,19 @@
 /area/rogue/under/tomb/indoors/magic)
 "xc" = (
 /obj/structure/forcefield_weak,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/lava/acid,
 /area/rogue/under/tomb/cave/wet)
 "xo" = (
 /obj/structure/bed/rogue/inn/wooldouble,
 /obj/item/bedsheet/rogue/fabric_double,
 /obj/item/clothing/ring/gold,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/magic)
 "xG" = (
 /obj/structure/roguewindow/stained/silver,
-/obj/structure/curtain/bounty,
+/obj/structure/curtain,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors/magic)
 "ys" = (
@@ -706,7 +706,7 @@
 "Bk" = (
 /obj/structure/table/wood,
 /obj/item/millstone,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/under/tomb/indoors/magic)
 "BC" = (
@@ -756,14 +756,14 @@
 "CH" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /obj/structure/spider/cocoon,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/magic)
 "CI" = (
 /obj/structure/toilet,
 /obj/item/natural/poo,
 /obj/item/natural/poo/horse,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors/magic)
 "CL" = (
@@ -786,7 +786,7 @@
 /area/rogue/under/tomb/indoors/magic)
 "Dl" = (
 /obj/structure/closet/crate/drawer/inn,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/tomb/indoors/magic)
 "DH" = (
@@ -826,7 +826,7 @@
 /area/rogue/under/tomb/indoors/magic)
 "Fc" = (
 /obj/structure/toilet,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors/magic)
 "Fr" = (
@@ -984,7 +984,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/magic)
 "MY" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/magic)
@@ -1002,7 +1002,7 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/tomb/indoors/magic)
 "NW" = (
@@ -1029,7 +1029,7 @@
 "Ow" = (
 /obj/structure/roguewindow/stained/silver,
 /obj/structure/curtain,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors/magic)
 "Ox" = (
@@ -1101,7 +1101,7 @@
 "PU" = (
 /obj/structure/bookcase,
 /obj/item/natural/wood/plank,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors/magic)
 "Qf" = (
@@ -1252,7 +1252,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "TP" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/magic)
 "TW" = (
@@ -1278,7 +1278,7 @@
 /area/rogue/under/tomb/indoors/magic)
 "Vf" = (
 /obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors/magic)
 "Vo" = (
@@ -1294,11 +1294,11 @@
 /area/rogue/under/tomb/indoors/magic)
 "Wi" = (
 /obj/structure/forcefield_weak,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb/cave/wet)
 "Wj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "WD" = (
@@ -1321,7 +1321,7 @@
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/under/tomb/indoors/magic)
 "XV" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/tomb/indoors/magic)
 "Ya" = (
@@ -1363,7 +1363,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/magic)
 "Zg" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/water/swamp,
 /area/rogue/under/tomb/indoors/magic)
 "Zk" = (

--- a/_maps/dungeon_generator/room/Bathhouse Dungeon.dmm
+++ b/_maps/dungeon_generator/room/Bathhouse Dungeon.dmm
@@ -9,7 +9,7 @@
 /area/rogue/under/tomb/indoors/royal)
 "aj" = (
 /obj/structure/closet/crate/drawer/random,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/carpet,
@@ -24,12 +24,12 @@
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/tomb/indoors/magic)
 "ay" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/tomb/indoors/royal)
 "az" = (
 /obj/structure/fluff/walldeco/vinez,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb)
 "aH" = (
@@ -57,7 +57,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors)
 "bj" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb)
 "bn" = (
@@ -154,7 +154,7 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/under/tomb)
 "do" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/sewer)
 "dw" = (
@@ -218,7 +218,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)
 "eJ" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "eM" = (
@@ -227,7 +227,7 @@
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors)
 "eN" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/sewer)
 "eR" = (
@@ -251,7 +251,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)
 "fe" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/church,
 /area/rogue/under/tomb/indoors)
@@ -333,7 +333,7 @@
 /area/rogue/under/tomb/wilds)
 "hv" = (
 /obj/structure/fluff/walldeco/rpainting/crown,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors/royal)
 "hy" = (
@@ -402,7 +402,7 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb/sewer)
 "is" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
@@ -414,7 +414,7 @@
 /area/rogue/under/tomb/indoors)
 "iv" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
@@ -475,7 +475,7 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/under/tomb/indoors/royal)
 "jQ" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors)
 "jR" = (
@@ -542,7 +542,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/tomb/indoors/royal)
 "le" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/metal,
 /area/rogue/under/tomb/indoors)
 "lh" = (
@@ -563,7 +563,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "lN" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/tomb/indoors/magic)
 "lS" = (
@@ -577,11 +577,11 @@
 /turf/open/water,
 /area/rogue/under/tomb/sewer)
 "mq" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/royal)
 "ms" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/tomb/indoors)
 "mu" = (
@@ -623,7 +623,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)
 "ob" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/tomb)
 "od" = (
@@ -642,7 +642,7 @@
 /area/rogue/under/tomb)
 "oy" = (
 /obj/structure/fluff/walldeco/vinez,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/tomb/indoors/magic)
 "oC" = (
@@ -661,7 +661,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "oY" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors/royal)
 "oZ" = (
@@ -871,7 +871,7 @@
 /area/rogue/under/tomb/indoors/royal)
 "sT" = (
 /obj/structure/flora/roguegrass/water,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/water/bath,
 /area/rogue/under/tomb)
 "sW" = (
@@ -882,7 +882,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "sZ" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/tomb)
 "te" = (
@@ -966,7 +966,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "uo" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/structure/closet/crate/chest/lootbox,
 /obj/effect/spawner/lootdrop/general_loot_hi,
 /turf/open/floor/rogue/blocks,
@@ -1043,7 +1043,7 @@
 /area/rogue/under/tomb/indoors/royal)
 "vB" = (
 /obj/structure/fluff/walldeco/stone,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/sewer)
 "vF" = (
@@ -1090,13 +1090,13 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/sewer)
 "wl" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/tomb)
 "wu" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "wA" = (
@@ -1127,7 +1127,7 @@
 /area/rogue/under/tomb/sewer)
 "xe" = (
 /obj/structure/fluff/walldeco/vinez,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/tomb/indoors)
 "xD" = (
@@ -1154,7 +1154,7 @@
 /area/rogue/under/tomb/sewer)
 "yh" = (
 /obj/item/millstone,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
@@ -1166,7 +1166,7 @@
 "yu" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/roguegrass/pyroclasticflowers,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "yH" = (
@@ -1176,7 +1176,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/royal)
 "yM" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/under/tomb/indoors/royal)
@@ -1197,11 +1197,11 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/tomb/indoors)
 "yX" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors)
 "zb" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/under/tomb)
 "zi" = (
@@ -1263,7 +1263,7 @@
 /area/rogue/under/tomb/indoors)
 "Au" = (
 /obj/structure/mineral_door/bars,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/structure/trap/saw_blades,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
@@ -1484,7 +1484,7 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb)
 "Ey" = (
-/obj/machinery/light/rogue/wallfire,
+/obj/machinery/light/rogue/campfire/fireplace,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb)
 "EB" = (
@@ -1529,7 +1529,7 @@
 "FM" = (
 /obj/structure/fluff/statue/small,
 /obj/structure/flora/roguegrass/water,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/water/bath,
 /area/rogue/under/tomb)
 "FR" = (
@@ -1552,7 +1552,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "Gk" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/tomb/indoors)
 "Gm" = (
@@ -1724,7 +1724,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "JD" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/water/bath,
 /area/rogue/under/tomb)
 "JQ" = (
@@ -1750,7 +1750,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/royal)
 "Kg" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb/indoors)
 "Ku" = (
@@ -1857,12 +1857,12 @@
 /obj/structure/stairs{
 	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/tomb/indoors/royal)
 "Ms" = (
 /obj/item/reagent_containers/glass/cup/wooden,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/structure/table/wood{
 	icon_state = "longtable_mid"
 	},
@@ -1891,7 +1891,7 @@
 /area/rogue/under/tomb/wilds)
 "Np" = (
 /obj/structure/fluff/walldeco/vinez,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb/indoors/magic)
 "Nu" = (
@@ -1957,7 +1957,7 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/sewer)
 "PP" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/closed/wall/mineral/rogue/stone,
 /area/rogue/under/tomb/indoors/royal)
 "PS" = (
@@ -1969,7 +1969,7 @@
 /turf/open/water/bath,
 /area/rogue/under/tomb)
 "Qg" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb)
 "Qj" = (
@@ -1981,7 +1981,7 @@
 /area/rogue/under/tomb/indoors)
 "Qt" = (
 /obj/structure/roguewindow/stained/silver,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/wilds)
 "Qu" = (
@@ -2077,11 +2077,11 @@
 /turf/open/water/bath,
 /area/rogue/under/tomb)
 "Ti" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/tomb/indoors)
 "TC" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors)
 "TJ" = (
@@ -2116,7 +2116,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/royal)
 "UF" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/blocks/green,
 /area/rogue/under/tomb/indoors)
@@ -2210,7 +2210,7 @@
 "Wh" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/misc,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "Wy" = (
@@ -2343,7 +2343,7 @@
 "Zo" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /obj/structure/flora/roguegrass/water,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/water/bath,
 /area/rogue/under/tomb)
 "Zu" = (
@@ -2367,7 +2367,7 @@
 /area/rogue/under/tomb/indoors)
 "ZZ" = (
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/under/tomb/indoors/magic)
 

--- a/_maps/dungeon_generator/room/ForgottenInn.dmm
+++ b/_maps/dungeon_generator/room/ForgottenInn.dmm
@@ -355,7 +355,7 @@
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb/indoors)
 "MK" = (
-/obj/machinery/light/rogue/wallfire{
+/obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = 16
 	},
 /turf/closed/wall/mineral/rogue/decowood/vert,

--- a/_maps/dungeon_generator/room/GoblinInfestedJoint.dmm
+++ b/_maps/dungeon_generator/room/GoblinInfestedJoint.dmm
@@ -393,7 +393,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb)
 "mt" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/tomb/indoors)
@@ -482,7 +482,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb)
 "qe" = (
-/obj/machinery/light/rogue/wallfire,
+/obj/machinery/light/rogue/campfire/fireplace,
 /turf/closed/wall/mineral/rogue/wooddark/vertical,
 /area/rogue/under/tomb/indoors)
 "qf" = (

--- a/_maps/dungeon_generator/room/Goonies.dmm
+++ b/_maps/dungeon_generator/room/Goonies.dmm
@@ -242,7 +242,7 @@
 "fU" = (
 /obj/structure/table/wood/crafted,
 /obj/item/rogueweapon/surgery/retractor,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "fW" = (
@@ -527,7 +527,7 @@
 /area/rogue/under/tomb/indoors)
 "ob" = (
 /obj/item/roguebin/water/gross,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "og" = (
@@ -677,7 +677,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "sS" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/tomb/indoors)
 "tj" = (
@@ -1006,7 +1006,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/tomb/cave)
 "Cu" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/tomb/indoors)
 "Cx" = (
@@ -1051,7 +1051,7 @@
 /area/rogue/under/tomb/indoors)
 "DZ" = (
 /obj/structure/table/optable,
-/obj/structure/curtain/bounty,
+/obj/structure/curtain,
 /obj/item/rogueweapon/surgery/scalpel,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
@@ -1072,7 +1072,7 @@
 /area/rogue/under/tomb/lake)
 "Fa" = (
 /obj/structure/mineral_door/wood,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/tomb/indoors)
 "Fk" = (
@@ -1233,7 +1233,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "Jh" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "Jr" = (
@@ -1336,7 +1336,7 @@
 /obj/structure/stairs{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "MK" = (
@@ -1508,7 +1508,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "PS" = (
@@ -1522,7 +1522,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "Ql" = (
@@ -1862,7 +1862,7 @@
 "Zp" = (
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/effect/spawner/lootdrop/general_loot_mid,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "Zx" = (

--- a/_maps/dungeon_generator/room/Malphpiece4.dmm
+++ b/_maps/dungeon_generator/room/Malphpiece4.dmm
@@ -4,7 +4,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/tomb/wilds/bog)
 "bh" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/indoors/royal)
 "bE" = (
@@ -38,7 +38,7 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/tomb/wilds/bog)
 "dV" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /obj/structure/fluff/statue/knight/interior,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/indoors/royal)
@@ -91,7 +91,7 @@
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/indoors/royal)
 "pC" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/indoors/royal)
 "pK" = (
@@ -132,7 +132,7 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/tomb/wilds/bog)
 "wo" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /obj/structure/fluff/statue/knight/interior/r,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/under/tomb/indoors/royal)
@@ -162,7 +162,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)
 "Eu" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)
 "Hc" = (
@@ -188,7 +188,7 @@
 /turf/open/floor/rogue/dirt/ambush,
 /area/rogue/under/tomb/wilds/bog)
 "Lx" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/royal)
 "Ly" = (

--- a/_maps/dungeon_generator/room/SpiralLibraryIteration2.dmm
+++ b/_maps/dungeon_generator/room/SpiralLibraryIteration2.dmm
@@ -239,7 +239,7 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors/magic)
 "Fr" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb/indoors/magic)
 "FF" = (
@@ -317,7 +317,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "Tb" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/effect/decal/cleanable/debris/stony,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors/magic)

--- a/_maps/dungeon_generator/room/SteamCastle.dmm
+++ b/_maps/dungeon_generator/room/SteamCastle.dmm
@@ -99,12 +99,12 @@
 /area/rogue/under/tomb/indoors/royal)
 "bm" = (
 /obj/structure/mineral_door/wood/violet,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "bn" = (
 /obj/structure/closet/crate/roguecloset/crafted,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/tomb/indoors)
 "bv" = (
@@ -215,7 +215,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/tomb/indoors)
 "cS" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors)
 "cU" = (
@@ -249,7 +249,7 @@
 /area/rogue/under/tomb/indoors/royal)
 "dq" = (
 /obj/structure/fermentation_keg/random/water,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "du" = (
@@ -286,7 +286,7 @@
 /area/rogue/under/tomb)
 "dU" = (
 /obj/structure/bookcase,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "ea" = (
@@ -383,7 +383,7 @@
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors)
 "fc" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/chair/bench/couchablack,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/royal)
@@ -496,7 +496,7 @@
 /area/rogue/under/tomb/indoors)
 "gG" = (
 /obj/structure/roguewindow/stained/silver,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors)
 "gH" = (
@@ -585,7 +585,7 @@
 /turf/closed/mineral,
 /area/rogue/under/tomb)
 "hK" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb/indoors)
 "hM" = (
@@ -611,7 +611,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb/wilds)
 "hV" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/under/tomb/indoors/royal)
 "hW" = (
@@ -740,7 +740,7 @@
 /area/rogue/under/tomb/indoors)
 "jm" = (
 /obj/structure/bookcase/random,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
@@ -894,11 +894,11 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "ll" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/closed/wall/mineral/rogue/pipe,
 /area/rogue/under/tomb/indoors)
 "lm" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/royal)
 "ln" = (
@@ -983,14 +983,14 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb/wilds)
 "mi" = (
 /obj/structure/bars/pipe{
 	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb)
 "mj" = (
@@ -1165,7 +1165,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 10
 	},
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "nL" = (
@@ -1363,7 +1363,7 @@
 "qg" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/under/tomb/indoors/magic)
 "qp" = (
@@ -1423,7 +1423,7 @@
 /area/rogue/under/tomb)
 "rh" = (
 /obj/structure/flora/roguegrass/bush,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/wilds)
 "ri" = (
@@ -1599,7 +1599,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/wilds)
 "tZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/trap/curse/hidden,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
@@ -1733,7 +1733,7 @@
 /area/rogue/under/tomb/wilds)
 "vL" = (
 /obj/structure/fermentation_keg,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb/indoors)
 "vR" = (
@@ -1856,7 +1856,7 @@
 /area/rogue/under/tomb/indoors)
 "xf" = (
 /obj/structure/bars,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors)
 "xh" = (
@@ -1943,7 +1943,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb/indoors)
 "xZ" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors)
 "ya" = (
@@ -1952,7 +1952,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "yb" = (
-/obj/machinery/light/rogue/wallfire,
+/obj/machinery/light/rogue/campfire/fireplace,
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/under/tomb/indoors)
 "yh" = (
@@ -1964,7 +1964,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "yj" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/wilds)
 "yk" = (
@@ -2151,7 +2151,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb)
 "An" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/tomb/indoors)
 "Ap" = (
@@ -2168,13 +2168,13 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb)
 "Aq" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/trap/saw_blades,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "Ar" = (
 /obj/structure/fluff/railing/border,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors)
 "As" = (
@@ -2211,7 +2211,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/tomb/indoors)
 "AM" = (
-/obj/machinery/light/rogue/wallfire{
+/obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = -32;
 	pixel_y = 3
 	},
@@ -2459,12 +2459,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/tomb/indoors)
 "Di" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/tomb/indoors)
 "Dp" = (
 /obj/structure/bars,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/wilds)
 "Dq" = (
@@ -2484,7 +2484,7 @@
 /area/rogue/under/tomb/wilds)
 "DM" = (
 /obj/structure/roguewindow/stained/silver,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors)
 "DY" = (
@@ -2566,7 +2566,7 @@
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors)
 "EY" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb)
 "EZ" = (
@@ -2592,7 +2592,7 @@
 /area/rogue/under/tomb)
 "Fk" = (
 /obj/structure/table/wood/fancy/purple,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/item/reagent_containers/glass/cup/golden,
 /turf/open/floor/carpet/purple,
 /area/rogue/under/tomb/indoors)
@@ -2636,7 +2636,7 @@
 	pixel_x = 5;
 	pixel_y = 1
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb)
 "Ga" = (
@@ -2851,7 +2851,7 @@
 /area/rogue/under/tomb/indoors)
 "HY" = (
 /obj/structure/flora/roguegrass/bush/wall/tall,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/wilds)
 "HZ" = (
@@ -2908,7 +2908,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors)
 "Iv" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/tomb/indoors)
 "Iy" = (
@@ -2933,7 +2933,7 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/item/roguestatue/gold/loot,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
@@ -2955,7 +2955,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors)
 "IX" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/trap/shock,
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors)
@@ -2992,7 +2992,7 @@
 /area/rogue/under/tomb/indoors)
 "JJ" = (
 /obj/structure/flora/roguegrass/bush,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/tomb/wilds)
 "JP" = (
@@ -3000,7 +3000,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb)
 "JS" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb/indoors)
 "JW" = (
@@ -3059,7 +3059,7 @@
 /area/rogue/under/tomb/indoors)
 "KT" = (
 /obj/structure/rack/rogue/shelf/big,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb/indoors)
 "La" = (
@@ -3230,7 +3230,7 @@
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/under/tomb/indoors/royal)
 "Nk" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/tomb/indoors/royal)
 "Nm" = (
@@ -3298,7 +3298,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "NY" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "Ok" = (
@@ -3327,7 +3327,7 @@
 /turf/open/floor/rogue/twig,
 /area/rogue/under/tomb/indoors)
 "OB" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/chair/bench/coucha/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/under/tomb/indoors/royal)
@@ -3344,7 +3344,7 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors/royal)
 "OM" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/tomb)
 "OO" = (
@@ -3518,7 +3518,7 @@
 "QA" = (
 /obj/structure/roguewindow/stained/silver,
 /obj/structure/bars,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/tomb/indoors)
 "QD" = (
@@ -3722,7 +3722,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "Ts" = (
-/obj/machinery/light/rogue/wallfire{
+/obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = -32;
 	pixel_y = 1
 	},
@@ -3758,7 +3758,7 @@
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/under/tomb/indoors)
 "TM" = (
-/obj/machinery/light/rogue/wallfire{
+/obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = 0;
 	pixel_y = 31
 	},
@@ -4081,7 +4081,7 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/tomb/indoors/royal)
 "Xa" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/tile/masonic/spiral,
 /area/rogue/under/tomb/indoors)
@@ -4143,7 +4143,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/wilds)
 "XQ" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/trap/chill,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
@@ -4160,7 +4160,7 @@
 /area/rogue/under/tomb/wilds)
 "Yp" = (
 /obj/structure/closet/crate/chest/crate,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/effect/spawner/lootdrop/general_loot_low,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/tomb/indoors)
@@ -4218,7 +4218,7 @@
 /turf/open/floor/rogue/tile/masonic/single,
 /area/rogue/under/tomb/indoors/magic)
 "YZ" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/wilds)
 "Za" = (

--- a/_maps/dungeon_generator/room/TownRuins.dmm
+++ b/_maps/dungeon_generator/room/TownRuins.dmm
@@ -1310,7 +1310,7 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/under/tomb)
 "AC" = (
-/obj/machinery/light/rogue/wallfire,
+/obj/machinery/light/rogue/campfire/fireplace,
 /turf/closed/wall/mineral/rogue/wooddark/end,
 /area/rogue/under/tomb/indoors)
 "AF" = (
@@ -1696,7 +1696,7 @@
 	pixel_y = 5;
 	pixel_x = -9
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/under/tomb/indoors)
 "HW" = (

--- a/_maps/dungeon_generator/room/drugden.dmm
+++ b/_maps/dungeon_generator/room/drugden.dmm
@@ -8,14 +8,14 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "dx" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/table/vtable,
 /obj/item/storage/belt/rogue/pouch,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "eS" = (
 /obj/effect/decal/cleanable/sigil/N,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "fo" = (
@@ -43,7 +43,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "hA" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "hL" = (
@@ -103,7 +103,7 @@
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors)
 "kQ" = (
-/obj/machinery/light/rogue/wallfire{
+/obj/machinery/light/rogue/campfire/fireplace{
 	pixel_y = 32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -115,7 +115,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "mv" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors)
 "oo" = (
@@ -251,7 +251,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "yB" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "yX" = (
@@ -265,7 +265,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "AD" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
@@ -372,7 +372,7 @@
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors)
 "Kf" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/closet/crate/drawer/inn,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
@@ -395,7 +395,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "Nh" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/closet/crate/drawer/inn,
 /obj/item/roguegem/blue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -468,7 +468,7 @@
 /turf/open/water/swamp/deep,
 /area/rogue/under/tomb/cave/wet)
 "Zk" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/structure/rack/rogue/shelf/big,
 /obj/item/perfume/random{
 	pixel_y = 25
@@ -497,7 +497,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "ZQ" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors)
 

--- a/_maps/dungeon_generator/room/goblincamp.dmm
+++ b/_maps/dungeon_generator/room/goblincamp.dmm
@@ -259,7 +259,7 @@
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/flashlight/flare/torch/lantern/bronzelamptern,
 /obj/item/flashlight/flare/torch/lantern/bronzelamptern,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/indoors)
 "CQ" = (
@@ -417,7 +417,7 @@
 /area/rogue/under/tomb/cave)
 "Yd" = (
 /obj/structure/closet/crate/chest/wicker,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/item/roguegem/random,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/indoors)

--- a/_maps/dungeon_generator/room/hctomb1.dmm
+++ b/_maps/dungeon_generator/room/hctomb1.dmm
@@ -81,7 +81,7 @@
 /obj/structure/stairs{
 	dir = 4
 	},
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "eF" = (
@@ -159,7 +159,7 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/tomb/cave)
 "ie" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb/indoors)
 "iA" = (
@@ -316,7 +316,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "tK" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /obj/structure/table/wood,
 /obj/item/clothing/mask/rogue/skullmask,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -452,7 +452,7 @@
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/tomb/cave)
 "zM" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 9
 	},
@@ -528,7 +528,7 @@
 /area/rogue/under/tomb)
 "Dz" = (
 /obj/structure/table/wood/crafted,
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/tomb/indoors)
 "DA" = (
@@ -671,7 +671,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb/cave)
 "OL" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/tomb/indoors)

--- a/_maps/dungeon_generator/room/hctomb3.dmm
+++ b/_maps/dungeon_generator/room/hctomb3.dmm
@@ -118,7 +118,7 @@
 /area/rogue/under/tomb/cave/spider)
 "dn" = (
 /obj/machinery/anvil,
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/cave/spider)
 "do" = (
@@ -139,7 +139,7 @@
 /area/rogue/under/tomb/indoors)
 "dK" = (
 /obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -385,7 +385,7 @@
 	pixel_y = -3
 	},
 /obj/structure/closet/crate/chest,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/cobweb/cobweb2,
@@ -459,7 +459,7 @@
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/indoors)
 "rS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/cave/spider)
@@ -788,7 +788,7 @@
 /turf/open/floor/rogue/church,
 /area/rogue/under/tomb/cave/spider)
 "CS" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/cave/spider)
@@ -1242,7 +1242,7 @@
 /area/rogue/under/tomb/indoors)
 "PA" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/mimic,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/natural/rock/random_ore,
 /turf/open/floor/rogue/church,
@@ -1380,7 +1380,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/spider/stickyweb,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/closet/crate/chest/lootbox,
 /obj/item/clothing/gloves/roguetown/plate/dwarven,
 /turf/open/floor/rogue/blocks/stonered/tiny,
@@ -1388,7 +1388,7 @@
 "Vz" = (
 /obj/machinery/anvil,
 /obj/item/rogueweapon/mace/warhammer/steel,
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/tomb/cave/spider)
 "VL" = (

--- a/_maps/dungeon_generator/room/hctomb4.dmm
+++ b/_maps/dungeon_generator/room/hctomb4.dmm
@@ -4,7 +4,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/magic)
 "ax" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "aN" = (
@@ -32,7 +32,7 @@
 /area/rogue/under/tomb/indoors)
 "bc" = (
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/tomb/indoors)
 "bw" = (
@@ -155,13 +155,13 @@
 	dir = 1
 	},
 /mob/living/carbon/human/species/skeleton/npc/mediumspread,
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors)
 "gp" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors)
 "gr" = (
@@ -343,12 +343,12 @@
 	pixel_y = -4
 	},
 /obj/effect/decal/cleanable/blood/gibs/body,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "nk" = (
 /obj/effect/decal/cleanable/vomit/old,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors)
 "nl" = (
@@ -379,7 +379,7 @@
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/tomb/indoors/magic)
 "nM" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/under/tomb/indoors)
 "od" = (
@@ -459,7 +459,7 @@
 /area/rogue/under/tomb/indoors)
 "pC" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/under/tomb/indoors/magic)
 "pH" = (
@@ -522,7 +522,7 @@
 /obj/structure/stairs{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "tl" = (
@@ -597,7 +597,7 @@
 /area/rogue/under/tomb/indoors/magic)
 "vu" = (
 /obj/structure/stairs,
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors)
 "vv" = (
@@ -654,7 +654,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors)
 "yP" = (
@@ -876,13 +876,13 @@
 /area/rogue/under/tomb/indoors)
 "Hq" = (
 /obj/item/chair/rogue,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors)
 "HG" = (
 /obj/structure/chair/stool/rogue,
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/tomb/indoors)
 "HM" = (
@@ -942,7 +942,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/tomb/cave)
 "LR" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/under/tomb/indoors)
 "Ma" = (
@@ -965,7 +965,7 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors)
 "Mv" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/carpet,
@@ -1030,7 +1030,7 @@
 /turf/open/floor/rogue/blocks/newstone/alt,
 /area/rogue/under/tomb/indoors)
 "OZ" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /obj/structure/table/wood{
 	dir = 8;
 	icon_state = "largetable"
@@ -1056,7 +1056,7 @@
 "Qt" = (
 /obj/structure/bonepile,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/carpet,
 /area/rogue/under/tomb/indoors/magic)
 "Qy" = (
@@ -1117,7 +1117,7 @@
 /obj/item/natural/cloth,
 /obj/item/natural/cloth,
 /obj/structure/closet/crate/roguecloset/crafted,
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /obj/item/broom,
@@ -1167,7 +1167,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb)
 "Uf" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb/indoors)
 "Ul" = (

--- a/_maps/dungeon_generator/room/hctomb5.dmm
+++ b/_maps/dungeon_generator/room/hctomb5.dmm
@@ -13,7 +13,7 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/under/tomb/indoors/rest)
 "aS" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /obj/structure/mannequin/male/female,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/tomb/indoors)
@@ -75,7 +75,7 @@
 /area/rogue/under/tomb)
 "hz" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/wood,
 /area/rogue/under/tomb/indoors/rest)
 "ic" = (
@@ -441,7 +441,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/tomb/indoors/rest)
 "SB" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/tomb/indoors)
 "Ul" = (
@@ -461,7 +461,7 @@
 /area/rogue/under/tomb/indoors/rest)
 "WJ" = (
 /obj/structure/stairs/stone,
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/tomb/indoors/rest)
 "WK" = (
@@ -501,7 +501,7 @@
 /turf/open/transparent/openspace,
 /area/rogue/under/tomb)
 "Zz" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/wool,
 /turf/open/floor/carpet/royalblack,

--- a/_maps/dungeon_generator/room/lavafort.dmm
+++ b/_maps/dungeon_generator/room/lavafort.dmm
@@ -147,7 +147,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/cave/lava)
 "lv" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_x = 32;
 	pixel_y = 0
 	},
@@ -237,7 +237,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/tomb/cave/lava)
 "oU" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/tomb/indoors)
 "ph" = (
@@ -300,7 +300,7 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "sY" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "tJ" = (
@@ -378,11 +378,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/cave/lava)
 "yN" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/tomb/cave/lava)
 "zk" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /mob/living/carbon/human/species/skeleton/npc/bogguard,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/under/tomb/indoors)
@@ -418,7 +418,7 @@
 /turf/open/lava,
 /area/rogue/under/tomb/cave/lava)
 "AH" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -566,11 +566,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/cave/lava)
 "KC" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/magic)
 "Lo" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_x = -32;
 	pixel_y = 0
 	},
@@ -597,7 +597,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors)
 "OE" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_x = 32;
 	pixel_y = 0
 	},
@@ -686,7 +686,7 @@
 /turf/open/floor/rogue/metal,
 /area/rogue/under/tomb/cave/lava)
 "TU" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/hexstone,
@@ -700,7 +700,7 @@
 /turf/open/floor/rogue/grassred,
 /area/rogue/under/tomb/cave/lava)
 "Uv" = (
-/obj/machinery/light/rogue/wallfire/candle/blue{
+/obj/machinery/light/rogue/candle/blue{
 	pixel_y = -32
 	},
 /mob/living/carbon/human/species/skeleton/npc/mediumspread,

--- a/_maps/dungeon_generator/room/queensretreat.dmm
+++ b/_maps/dungeon_generator/room/queensretreat.dmm
@@ -22,7 +22,7 @@
 	},
 /area/rogue/under/tomb/indoors/royal)
 "ax" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/water/bath,
 /area/rogue/under/tomb/indoors/royal)
 "bh" = (
@@ -73,7 +73,7 @@
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/under/tomb/indoors/royal)
 "bO" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /obj/structure/fluff/railing/border{
 	dir = 6
 	},
@@ -106,7 +106,7 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/tomb/indoors/royal)
 "dh" = (
-/obj/machinery/light/rogue/wallfire/candle/weak{
+/obj/machinery/light/rogue/candle/weak{
 	pixel_y = -32
 	},
 /obj/item/clothing/head/peaceflower,
@@ -125,7 +125,7 @@
 /area/rogue/under/tomb)
 "dI" = (
 /obj/effect/decal/cleanable/food/mess,
-/obj/machinery/light/rogue/wallfire/candle/weak/r,
+/obj/machinery/light/rogue/candle/weak/r,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors/royal)
 "dQ" = (
@@ -133,13 +133,13 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/tomb/wilds)
 "dW" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/r,
+/obj/machinery/light/rogue/candle/weak/r,
 /turf/open/floor/rogue/carpet/lord/right{
 	dir = 1
 	},
 /area/rogue/under/tomb/indoors/royal)
 "ed" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/royal)
 "es" = (
@@ -198,7 +198,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb)
 "hw" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/tomb/wilds)
 "hx" = (
@@ -248,7 +248,7 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/tomb/indoors/royal)
 "iX" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
@@ -316,12 +316,12 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/tomb/indoors/royal)
 "mb" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/under/tomb/indoors/royal)
 "mc" = (
 /obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle/weak/r,
+/obj/machinery/light/rogue/candle/weak/r,
 /obj/effect/spawner/lootdrop/general_loot_mid,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/royal)
@@ -359,7 +359,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "nW" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/tile/checker,
 /area/rogue/under/tomb/indoors/royal)
 "ok" = (
@@ -416,7 +416,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "qr" = (
-/obj/machinery/light/rogue/wallfire{
+/obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = -32
 	},
 /obj/structure/table/wood{
@@ -454,14 +454,14 @@
 /turf/open/floor/carpet/red,
 /area/rogue/under/tomb/indoors/royal)
 "qX" = (
-/obj/machinery/light/rogue/wallfire/candle/weak{
+/obj/machinery/light/rogue/candle/weak{
 	pixel_y = -32
 	},
 /obj/structure/fluff/clock,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/royal)
 "rE" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors/royal)
 "so" = (
@@ -470,7 +470,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "sL" = (
-/obj/machinery/light/rogue/wallfire/candle/weak{
+/obj/machinery/light/rogue/candle/weak{
 	pixel_y = -32
 	},
 /obj/item/rogue/instrument/harp,
@@ -547,7 +547,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/wilds)
 "uP" = (
-/obj/machinery/light/rogue/wallfire/candle/weak{
+/obj/machinery/light/rogue/candle/weak{
 	pixel_y = -32
 	},
 /obj/structure/table/wood,
@@ -557,7 +557,7 @@
 /area/rogue/under/tomb/indoors/royal)
 "vK" = (
 /obj/structure/bookcase/random,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/royal)
 "wt" = (
@@ -640,7 +640,7 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb/wilds)
 "BG" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors/royal)
 "BM" = (
@@ -701,7 +701,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "DU" = (
-/obj/machinery/light/rogue/wallfire/candle/weak{
+/obj/machinery/light/rogue/candle/weak{
 	pixel_y = -32
 	},
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -771,7 +771,7 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/under/tomb/indoors/royal)
 "GY" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/l,
+/obj/machinery/light/rogue/candle/weak/l,
 /mob/living/carbon/human/species/skeleton/npc/hardspread,
 /turf/open/floor/rogue/carpet/lord/left{
 	dir = 1
@@ -800,7 +800,7 @@
 /area/rogue/under/tomb/indoors/royal)
 "HT" = (
 /obj/structure/closet/crate/chest/crate,
-/obj/machinery/light/rogue/wallfire/candle/weak/r,
+/obj/machinery/light/rogue/candle/weak/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/indoors/royal)
 "HU" = (
@@ -841,13 +841,13 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/tomb/indoors/royal)
 "Ja" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/carpet/lord/right{
 	dir = 1
 	},
 /area/rogue/under/tomb/indoors/royal)
 "Jv" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/r,
+/obj/machinery/light/rogue/candle/weak/r,
 /turf/open/floor/rogue/carpet/lord/left{
 	dir = 1
 	},
@@ -958,7 +958,7 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/under/tomb/wilds)
 "Pd" = (
-/obj/machinery/light/rogue/wallfire/candle/weak/r,
+/obj/machinery/light/rogue/candle/weak/r,
 /obj/structure/closet/crate/roguecloset/crafted,
 /obj/item/clothing/neck/roguetown/psicross/noc,
 /obj/item/book/rogue/noc,
@@ -1008,7 +1008,7 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/tomb/wilds)
 "Qt" = (
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/carpet/red,
 /area/rogue/under/tomb/indoors/royal)
 "QB" = (
@@ -1112,7 +1112,7 @@
 /obj/item/millstone{
 	pixel_y = 7
 	},
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /obj/structure/table/wood{
 	icon_state = "longtable"
 	},
@@ -1205,7 +1205,7 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/rogueweapon/huntingknife/cleaver,
 /obj/item/kitchen/rollingpin,
-/obj/machinery/light/rogue/wallfire/candle/weak,
+/obj/machinery/light/rogue/candle/weak,
 /turf/open/floor/rogue/tile,
 /area/rogue/under/tomb/indoors/royal)
 "ZN" = (

--- a/_maps/dungeon_generator/stairs/Malphpiece6.dmm
+++ b/_maps/dungeon_generator/stairs/Malphpiece6.dmm
@@ -3,22 +3,22 @@
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "d" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "m" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/l,
+/obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "n" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/tomb)
 "v" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "w" = (
-/obj/machinery/light/rogue/wallfire/candle/blue/r,
+/obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/tomb)
 "M" = (

--- a/_maps/dungeon_generator/unusable/Malphpiece7.dmm
+++ b/_maps/dungeon_generator/unusable/Malphpiece7.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/machinery/light/rogue/wallfire/candle/r,
+/obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/cave)
 "b" = (
@@ -54,7 +54,7 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/cave)
 "D" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /obj/item/natural/stone,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/cave)
@@ -74,7 +74,7 @@
 /turf/open/floor/rogue/blocks/paving/vert,
 /area/rogue/under/tomb/sewer)
 "O" = (
-/obj/machinery/light/rogue/wallfire/candle/l,
+/obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/tomb/cave)
 "Q" = (

--- a/_maps/map_files/templates/sewers/sewers_bottomright_1.dmm
+++ b/_maps/map_files/templates/sewers/sewers_bottomright_1.dmm
@@ -28,7 +28,7 @@
 /area/rogue/under/town/sewer)
 "h" = (
 /obj/structure/table/wood,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/item/needle/thorn,
 /obj/item/needle/thorn,
 /obj/item/needle/thorn,
@@ -37,7 +37,7 @@
 "i" = (
 /obj/structure/table/church,
 /obj/structure/table/church/m,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/effect/spawner/lootdrop/roguetown/sewers,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
@@ -82,7 +82,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "t" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "u" = (

--- a/_maps/map_files/templates/sewers/sewers_bottomright_2.dmm
+++ b/_maps/map_files/templates/sewers/sewers_bottomright_2.dmm
@@ -22,7 +22,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "p" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "q" = (
@@ -69,7 +69,7 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "P" = (
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)

--- a/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
+++ b/_maps/map_files/templates/sewers/sewers_topleft_3.dmm
@@ -37,7 +37,7 @@
 /area/rogue/under/town/sewer)
 "g" = (
 /obj/structure/bed/rogue/shit,
-/obj/machinery/light/rogue/wallfire/candle,
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/town/sewer)
 "h" = (

--- a/_maps/map_files/templates/smalldungeons/smalldungeon1.dmm
+++ b/_maps/map_files/templates/smalldungeons/smalldungeon1.dmm
@@ -71,8 +71,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "bn" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /mob/living/carbon/human/species/skeleton/npc/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
@@ -93,7 +93,7 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave/dungeon1)
 "bv" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "bC" = (
@@ -959,7 +959,7 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)
 "vN" = (
-/obj/machinery/light/rogue/wallfire/candle/blue,
+/obj/machinery/light/rogue/candle/blue,
 /mob/living/carbon/human/species/skeleton/npc/medium,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/dungeon1)


### PR DESCRIPTION
## About The Pull Request

Since candles got repath'd in the weather update the changes didn't get carried over to the random generator rooms.

## Testing Evidence

loaded it up and there were candles. Simple enough change.

## Why It's Good For The Game

Fixes missing things

## Changelog

:cl:
fix: missing candles in the random dungeon generator
/:cl: