### PR TITLE
Stat flaws

### DIFF
--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -46,6 +46,11 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Wood Arm (L) (+1 TRI)"=/datum/charflaw/limbloss/arm_l,
 	"Wood Arm (R) (+1 TRI)"=/datum/charflaw/limbloss/arm_r,
 	"Hemophage (+1 TRI)"=/datum/charflaw/hemophage,
+	"Feeble-bodied"=/datum/charflaw/weak,
+	"Frail"=/datum/charflaw/frail,
+	"Doddering"=/datum/charflaw/slow,
+	"Nimrodded"=/datum/charflaw/dull,
+	"Unlucky"=/datum/charflaw/unlucky,
 	))
 
 /datum/charflaw
@@ -840,3 +845,54 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	..()
 	REMOVE_TRAIT(user, TRAIT_HEMOPHAGE, TRAIT_GENERIC)
 	REMOVE_TRAIT(user, TRAIT_VAMPBITE, TRAIT_GENERIC)
+
+
+/datum/charflaw/weak
+	name = "Feeble-bodied"
+	desc = "Limp-wristed and ineffectual, I am not as physically strong as most. <br>\
+	<small>-4 to Strength.</small>"
+
+/datum/charflaw/weak/apply_post_equipment(mob/user)
+	var/mob/living/carbon/human/H = user
+	to_chat(user, "You are weaker than most")
+	H.change_stat(STATKEY_STR, -4)
+
+/datum/charflaw/frail
+	name = "Frail"
+	desc = "Prone to bruising as well as coughs and sneezes, I am more easily injured than most. <br>\
+	<small>-4 to Constitution.</small>"
+
+/datum/charflaw/frail/apply_post_equipment(mob/user)
+	var/mob/living/carbon/human/H = user
+	to_chat(user, "You are more vulnerable than most")
+	H.change_stat(STATKEY_CON, -4)
+
+/datum/charflaw/slow
+	name = "Doddering"
+	desc = "Slow and Steady, you say to yourself. Perhaps a torn ankle, or perhaps it is simply your nature. You are slower than most. <br>\
+	<small>-4 to Speed.</small>"
+
+/datum/charflaw/slow/apply_post_equipment(mob/user)
+	var/mob/living/carbon/human/H = user
+	to_chat(user, "You are slower than most")
+	H.change_stat(STATKEY_SPD, -4)
+
+/datum/charflaw/dull
+	name = "Nimrodded"
+	desc = "Everyone keeps saying fancy words around you but you've never been able to figure out why... You are less intellectual than most. <br>\
+	<small>- 4 to Intellect.</small>"
+
+/datum/charflaw/dull/apply_post_equipment(mob/user)
+	var/mob/living/carbon/human/H = user
+	to_chat(user, "You are duller than most")
+	H.change_stat(STATKEY_INT, -4)
+
+/datum/charflaw/unlucky
+	name = "Unlucky"
+	desc = "Perhaps it is the glass mirror you cracked, or the black cat that follows you, or a curse of the gods. You just feel... off. <br>\
+	<small>-4 to Luck.</small>"
+
+/datum/charflaw/unlucky/apply_post_equipment(mob/user)
+	var/mob/living/carbon/human/H = user
+	to_chat(user, "You are unluckier than most")
+	H.change_stat(STATKEY_LCK, -4)


### PR DESCRIPTION
## About The Pull Request

Introduces a number of very simple flaws that tank specific stats
You have Feeble, which penalises Strength
Frail, which penalises Constitution,
Doddering, which penalises Speed
Nimrodded, which penalises Intelligence,
and Unlucky, which penalises Luck

## Testing Evidence
<img width="733" height="387" alt="image" src="https://github.com/user-attachments/assets/0b2bd2d0-6d24-4820-b252-35aaafc077c9" />

<img width="717" height="219" alt="image" src="https://github.com/user-attachments/assets/dec0640d-542f-4751-a923-b90c388eaab1" />

<img width="145" height="209" alt="image" src="https://github.com/user-attachments/assets/f146ff45-3f78-4a27-8f41-c85d59fd2268" />
This is with the +1 STR/-3 CON/-3 WIL/-4 INT of the beggar subclass, and the +1 INT and WIL of human

## Why It's Good For The Game
I often want to take Wretched but I don't want EVERY stat penalised - there are some characters who I want to be really weak but not stupid, and some characters that I want to be stupid but not weak, or characters that I want to be frail but not slow

## Changelog

:cl:
add: Adds a series of stat-penalty vices
/:cl: