### PR TITLE
Dying with critical weakness forces an emote

### DIFF
--- a/code/datums/wounds/_wound.dm
+++ b/code/datums/wounds/_wound.dm
@@ -242,6 +242,7 @@ GLOBAL_LIST_INIT(primordial_wounds, init_primordial_wounds())
 		werewolf_infection_timer = null
 		werewolf_infect_attempt()
 	if(mortal && HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
+		affected.emote("deathgurgle", forced = TRUE)
 		affected.death()
 	if(affected.hud_used?.zone_select)
 		affected.hud_used.zone_select.update_icon()

--- a/code/datums/wounds/types/fractures.dm
+++ b/code/datums/wounds/types/fractures.dm
@@ -233,6 +233,7 @@
 		var/mob/living/carbon/carbon_affected = affected
 		carbon_affected.update_disabled_bodyparts()
 	if(HAS_TRAIT(affected, TRAIT_CRITICAL_WEAKNESS))
+		affected.emote("deathgurgle", forced = TRUE)
 		affected.death()
 
 /datum/wound/fracture/neck/on_mob_loss(mob/living/affected)


### PR DESCRIPTION
## About The Pull Request
Makes dying with critical weakness force a death gurgle emote.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/811e556b-7e0d-4d63-85f4-e5dadd610531" />
Chopped head with the sword and it played the emote when I died 👍 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
It's super weird that when you die with critical weakness it's just completely silent.
This makes it where you at least force out an emote upon death.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Dying with critical weakness forces out an emote so that people can recognize you are no longer alive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
