### PR TITLE
gives necromancer wretch the "Raise Deadite" spell

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -66,6 +66,7 @@
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/tame_undead)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead_formation/necromancer)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_undead_guard)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/raise_deadite)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/lacrima/free)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/convert_heretic)
 		wretch_select_bounty(H)


### PR DESCRIPTION
## About The Pull Request
what it says on the tin
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
works on my localhost
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Personally I think it doesn't make sense that the necromancer is only able to raise long-dead corpses (skeletons) and not the people he's just killed as deadites.

It hurts a bit that I have to use arcyne potential just to feel like I can afford something that I should thematically have by default already, when I really wish I could use my virtue to drink murky water and raw meat so it fits more my character. 3 points isn't a lot but on a class that only has 16 spellpoints it ends up hurting.

Also lets the necromancer let people who've died to him actually play the game (by biting and scratching people as a deadite). Not only does it fit the zizite/necromancer fantasy but deadites are pretty weak and usually end up getting killed/restrained for rotcuring, which means you don't have to do the awkward "I drop this corpse in a public spot so they can be revived because I don't want to full RR this guy". Win win for both sides.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: necromancer wretch gets raise deadite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
