### PR TITLE
Gives the veteran TRAIT_BADTRAINER

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -28,7 +28,7 @@
 		/datum/advclass/veteran/scout,
 		/datum/advclass/veteran/spy
 	)
-	job_traits = list(TRAIT_STEELHEARTED, TRAIT_COMBAT_AWARE)
+	job_traits = list(TRAIT_STEELHEARTED, TRAIT_COMBAT_AWARE, TRAIT_BADTRAINER)
 	virtue_restrictions = list(/datum/virtue/combat/combat_aware)//due to them having the trait by default
 
 /datum/job/roguetown/veteran/after_spawn(mob/living/L, mob/M, latejoin = TRUE)


### PR DESCRIPTION
## About The Pull Request
Gives the veteran TRAIT_BADTRAINER
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
They have the trait 👍 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This needs to be done.
We scale our antags and our counter-antags to fight based on certain combat stats that we give them.
If I give a guy level 4 in a weapon skill, and then give the antag level 5 weapon skill so they have a fighting chance, that's the expectation.

Veteran gets in the way of this because we have to assume that all the people who hunt down antags will have level 5 of any weapon skill purely because the veteran exists.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Veteran can no longer train people past combat skill 4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
