### PR TITLE
Makes Deadened Characters Actually Emotionless

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -183,6 +183,7 @@
 // Generic
 #define TRAIT_BASHDOORS "Door Basher"
 #define TRAIT_NOMOOD "Moodless"
+#define TRAIT_DETACHED "Detached"
 #define TRAIT_BAD_MOOD "Bad Mood"
 #define TRAIT_NIGHT_OWL "Night Owl"
 #define TRAIT_BEAUTIFUL "Beautiful"
@@ -448,6 +449,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_RESIDENT = span_info("I've been granted a Nervelock account, and the ownership of a house in the vale."),
 	TRAIT_LIGHT_STEP = span_info("My steps are light and swift. I make less noise while sneaking, and can sneak much quicker."),
 	TRAIT_NOMOOD = span_info("I feel no sorrow, no joy, and no stress."),
+	TRAIT_DETACHED = span_info("Nothing could move me. Any emotion I show is a facade."),
 	TRAIT_AZURENATIVE = span_info("I've grown up and lived all my lyfe in these lands. I can only trigger ambushes if I sprint through them."),
 	TRAIT_SLEUTH = span_info("I can spot my tracked Mark's trail without needing to approach it, and can spot them at a distance. I can track more frequently, and the act is not impaired by movement. I can examine tracks right away."),
 	TRAIT_HARDSHELL = span_info("The bulk of this armor prevents me from parrying effectively, but I can still move out of the way."),

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -33,6 +33,7 @@
 	// If this is true, we skip setting the base runechat message and instead use whatever our at-emote-runtime message is. Useful for things like kiss/lick which change message based on conditions.
 	var/use_params_for_runechat = FALSE
 	var/is_animal = FALSE
+	var/needs_emotion = FALSE //If true, emote will check for detached trait and not run if the user has it and the emote wasn't intentional. Used for emotes that require emotional investment to make sense, like crying or laughing.
 
 /datum/emote/New()
 	if(!runechat_msg && !use_params_for_runechat)
@@ -286,7 +287,8 @@
 				return FALSE
 //			to_chat(user, span_warning("I cannot [key] while restrained!"))
 			return FALSE
-
+	if(needs_emotion && HAS_TRAIT(user, TRAIT_DETACHED) && !intentional)
+		return FALSE
 	if(intentional && HAS_TRAIT(user, TRAIT_EMOTEMUTE))
 		return FALSE
 

--- a/code/datums/sexcon/sexcon_knotting.dm
+++ b/code/datums/sexcon/sexcon_knotting.dm
@@ -258,7 +258,7 @@
 			top.Stun(15)
 	if(!btm.IsStun())
 		if(prob(5))
-			btm.emote("groan")
+			btm.emote("groan", forced = TRUE)
 			btm.sexcon.try_do_pain_effect(PAIN_MED_EFFECT, FALSE)
 			btm.Stun(15)
 		else if(prob(3))
@@ -321,7 +321,7 @@
 			return
 	if(!btm.IsStun())
 		if(prob(10))
-			btm.emote("groan")
+			btm.emote("groan", forced = TRUE)
 			btm.sexcon.try_do_pain_effect(PAIN_MED_EFFECT, FALSE)
 			btm.Stun(15)
 			if(top.sexcon.knotted_part_partner&SEX_PART_JAWS && btm.getOxyLoss() < 50) // if the current top knotted them orally

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -65,7 +65,7 @@
 	if(guaranteed_fail)
 		to_chat(HU, special_msg)
 		to_chat(HT, span_notice("I fooled [HU.p_them()]! I've regained my footing!"))
-		HU.emote("groan")
+		HU.emote("groan", forced = TRUE)
 		HU.stamina_add(HU.max_stamina * 0.2)
 		HT.bait_stacks = 0
 		HT.apply_status_effect(/datum/status_effect/debuff/baited)

--- a/code/modules/jobs/job_types/roguetown/church/martyr/martyr_items.dm
+++ b/code/modules/jobs/job_types/roguetown/church/martyr/martyr_items.dm
@@ -81,7 +81,7 @@
 			return FALSE
 		else	//Everyone else
 			to_chat(user, span_warning("A painful jolt across your entire body sends you to the ground. You cannot touch this thing."))
-			H.emote("groan")
+			H.emote("groan", forced = TRUE)
 			H.Stun(10)
 			return FALSE
 	else

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -6,6 +6,7 @@
 	key_third_person = "cries"
 	message = "cries."
 	emote_type = EMOTE_AUDIBLE
+	needs_emotion = TRUE
 
 /mob/living/carbon/human/verb/emote_cry()
 	set name = "Cry"
@@ -25,7 +26,7 @@
 	key = "sexmoanlight"
 	emote_type = EMOTE_AUDIBLE
 	nomsg = TRUE
-	only_forced_audio = TRUE
+	needs_emotion = TRUE
 
 /datum/emote/living/carbon/human/sexmoanlight/can_run_emote(mob/living/user, status_check = TRUE , intentional)
 	. = ..()
@@ -38,7 +39,7 @@
 	key = "sexmoanhvy"
 	emote_type = EMOTE_AUDIBLE
 	nomsg = TRUE
-	only_forced_audio = TRUE
+	needs_emotion = TRUE
 
 /datum/emote/living/carbon/human/sexmoanhvy/can_run_emote(mob/living/user, status_check = TRUE , intentional)
 	. = ..()

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -428,6 +428,7 @@
 	message_muffled = "makes a muffled groan."
 	emote_type = EMOTE_AUDIBLE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /mob/living/carbon/human/verb/emote_groan()
 	set name = "Groan"
@@ -776,6 +777,7 @@
 	message_muffled = "makes a muffled laugh."
 	emote_type = EMOTE_AUDIBLE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/laugh/can_run_emote(mob/living/user, status_check = TRUE , intentional)
 	. = ..()
@@ -854,6 +856,7 @@
 	message_muffled = "makes a muffled noise in attempt to scream!"
 	emote_type = EMOTE_AUDIBLE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /mob/living/carbon/human/verb/emote_scream()
 	set name = "Scream"
@@ -881,6 +884,7 @@
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/scream/painscream/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -906,6 +910,7 @@
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/scream/agony/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -924,6 +929,7 @@
 	emote_type = EMOTE_AUDIBLE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/scream/firescream/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -965,6 +971,7 @@
 	nomsg = TRUE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/drown
 	key = "drown"
@@ -980,6 +987,7 @@
 	nomsg = TRUE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/paincrit/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
@@ -998,6 +1006,7 @@
 	nomsg = TRUE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/painmoan
 	key = "painmoan"
@@ -1005,6 +1014,7 @@
 	nomsg = TRUE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/groin
 	key = "groin"
@@ -1012,6 +1022,7 @@
 	nomsg = TRUE
 	only_forced_audio = TRUE
 	show_runechat = FALSE
+	needs_emotion = TRUE
 
 /datum/emote/living/fatigue
 	key = "fatigue"

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -31,7 +31,7 @@
 /datum/virtue/utility/deadened
 	name = "Deadened"
 	desc = "Some terrible incident colours my past, and now, I feel nothing."
-	added_traits = list(TRAIT_NOMOOD)
+	added_traits = list(TRAIT_NOMOOD, TRAIT_DETACHED)
 
 /datum/virtue/utility/light_steps
 	name = "Light Steps"


### PR DESCRIPTION
## About The Pull Request

adds a second trait to the deadened virtue, Detached, that makes it so all forced emotes that would conceivably require a degree of emotion are instead nullified.
this includes moans, groans, cries, laughing, screams

this also allows sex moans to be used at any time, through *sexmoanlight and *sexmoanhvy

## Testing Evidence

i put deadened on my character. i  beat myself up a lot and fell to the ground in painstun without actually screaming. there were no grunts. i also started jerking my shiz crazy style. there were no moans.
<details>
  <summary>pic</summary>
<img width="451" height="472" alt="image" src="https://github.com/user-attachments/assets/d21ee34d-9626-48d3-94d4-5683d7fbda01" />

</details>
then i took it off and did did the same. and then there were screams, grunts and moans.
<details>
  <summary>pic</summary>
<img width="447" height="340" alt="image" src="https://github.com/user-attachments/assets/3440d0d2-d877-40df-bbd2-55edd5f40e03" />


</details>

## Why It's Good For The Game

characters with no mood are way, way too expressive even though they're meant to show no emotion at all.

this fixes that

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Characters with the deadened virtue will no longer unintentionally scream, groan, moan, or any other emote that would necessitate showing emotions.
add: Sex moans can be used at will through *sexmoanhvy and *sexmoanlight
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
