### PR TITLE
Essence of Lumber Fix + QoLs

### DIFF
--- a/code/game/objects/items/rogueitems/natural/wood.dm
+++ b/code/game/objects/items/rogueitems/natural/wood.dm
@@ -64,6 +64,8 @@
 			new /obj/item/grown/log/tree/small(get_turf(src.loc))
 			if(prob(skill_level + user.goodluck(2)))	// when sawing instead of essence you get extra small log
 				new /obj/item/grown/log/tree/small(get_turf(src.loc))
+			if(prob(skill_level + user.goodluck(2)))	// same rate as chopping for lumber essence
+				new /obj/item/grown/log/tree/small/essence(get_turf(src.loc))
 			if(user.is_holding(src))
 				user.dropItemToGround(src)
 			user.mind.add_sleep_experience(/datum/skill/labor/lumberjacking, (user.STAINT*0.5))
@@ -84,7 +86,7 @@
 			new lumber(get_turf(src))
 				// Scaling is less steep than tanning as lumberjacking is easier to level and get
 			if(prob(skill_level + user.goodluck(2)))
-				new /obj/item/natural/cured/essence(get_turf(user))
+				new /obj/item/grown/log/tree/small/essence(get_turf(user))
 				if(!sound_played)
 					sound_played = TRUE
 					to_chat(user, span_warning("Dendor weeps..."))
@@ -192,6 +194,11 @@
 				user.dropItemToGround(src)
 			for(var/i=1, i<=woodtotal, ++i)
 				new /obj/item/natural/wood/plank(get_turf(src.loc))
+			var/lumber_skill = user.get_skill_level(/datum/skill/labor/lumberjacking)
+			if(prob(lumber_skill + user.goodluck(2)))
+				new /obj/item/grown/log/tree/small/essence(get_turf(src.loc))
+				to_chat(user, span_warning("Dendor weeps..."))
+				playsound(src, pick('sound/items/gem.ogg'), 100, FALSE)
 			user.mind.add_sleep_experience(/datum/skill/craft/carpentry, (user.STAINT*0.5))
 			new /obj/effect/decal/cleanable/debris/woody(get_turf(src))
 			qdel(src)

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -304,6 +304,17 @@
 	icon_state = "t[rand(1,4)]stump"
 
 /obj/structure/flora/roguetree/stump/attackby(obj/item/I, mob/living/user)
+	if(istype(I, /obj/item/rogueweapon/shovel))
+		var/skill_level = user.get_skill_level(/datum/skill/labor/lumberjacking)
+		var/dig_time = (120 - (skill_level * 15)) / 2
+		playsound(src, 'sound/items/dig_shovel.ogg', 80, TRUE)
+		if(!do_after(user, dig_time, target = user))
+			return
+		to_chat(user, span_notice("I dig up [src]."))
+		new lumber(get_turf(src))
+		playsound(src, destroy_sound, 100, TRUE)
+		qdel(src)
+		return TRUE
 	if(user.used_intent.blade_class == BCLASS_CHOP && lumber_amount)
 		var/skill_level = user.get_skill_level(/datum/skill/labor/lumberjacking)
 		var/lumber_time = (120 - (skill_level * 15))


### PR DESCRIPTION
## About The Pull Request
Someone requested to fix it so I did.
- Essence of lumber spawns when chopping wood instead of wilderness.
- You can get it from sawing into planks as well.
- Shovels now dig up stumps twice as fast as using an axe does.

## Testing Evidence
<img width="467" height="660" alt="woodessence" src="https://github.com/user-attachments/assets/8d4cd7fe-ba5d-44cd-ac20-b8ba23fd0ed5" />

## Why It's Good For The Game
Bug fixes good. Also, I was tired of waiting forever to chop stumps away.

## Changelog
:cl:
fix: Essence of lumber spawning from logs now spawns instead of the wilderness kind.
add: You can get essence of lumber from sawing logs into planks now.
qol: Shovels dig up stumps twice as fast as chopping with an axe does.
/:cl: