### PR TITLE
Various fixes to mountable and riding harpies

### DIFF
--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -49,7 +49,7 @@
 	M.updating_glide_size = FALSE
 	if(!driver || QDELETED(driver))
 		driver = M
-	handle_vehicle_offsets()
+	handle_vehicle_offsets(M)
 
 /datum/component/riding/proc/handle_vehicle_layer()
 	var/atom/movable/AM = parent
@@ -91,7 +91,7 @@
 				riding_xp_move_counter = 0
 		else
 			riding_xp_move_counter = 0 //reset counter if not running
-	handle_vehicle_offsets()
+	handle_vehicle_offsets(rider)
 	handle_vehicle_layer()
 
 /datum/component/riding/proc/ride_check(mob/living/M)
@@ -107,7 +107,7 @@
 	var/atom/movable/AM = parent
 	AM.unbuckle_mob(M)
 
-/datum/component/riding/proc/handle_vehicle_offsets()
+/datum/component/riding/proc/handle_vehicle_offsets(mob/living/driver)
 	var/atom/movable/AM = parent
 	var/AM_dir = "[AM.dir]"
 	var/passindex = 0
@@ -120,7 +120,7 @@
 					has_fixedeye = TRUE
 			passindex++
 			var/mob/living/buckled_mob = m
-			var/list/offsets = get_offsets(passindex)
+			var/list/offsets = get_offsets(passindex, driver)
 			var/rider_dir = get_rider_dir(passindex)
 			if(!has_fixedeye)
 				buckled_mob.setDir(rider_dir)
@@ -292,7 +292,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = parent
 	var/amt2use = HUMAN_CARRY_SLOWDOWN
-	var/reqstrength = 10
+	var/reqstrength = HAS_TRAIT(H, TRAIT_PONYGIRL_RIDEABLE) ? 0 : 10
 	if(H.r_grab && H.l_grab)
 		if(H.r_grab.grabbed == M)
 			if(H.l_grab.grabbed == M)
@@ -324,13 +324,13 @@
 	else
 		AM.layer = MOB_LAYER
 
-/datum/component/riding/human/get_offsets(pass_index)
+/datum/component/riding/human/get_offsets(pass_index, mob/living/driver)
 	var/mob/living/carbon/human/H = parent
 	if(H.buckle_lying)
 		return list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(0, 6), TEXT_WEST = list(0, 6))
 	else if(istype(parent, /mob/living/carbon/human/species/wildshape)) //Snowflake druid travel
 		return list(TEXT_NORTH = list(8, 6), TEXT_SOUTH = list(8, 6), TEXT_EAST = list(8, 6), TEXT_WEST = list(8, 6))
-	else if(H.has_status_effect(/datum/status_effect/debuff/harpy_flight))
+	else if(H.has_status_effect(/datum/status_effect/debuff/harpy_flight) && driver?.has_status_effect(/datum/status_effect/debuff/harpy_passenger))
 		return list(TEXT_NORTH = list(0, -24), TEXT_SOUTH = list(0, -24), TEXT_EAST = list(0, -24), TEXT_WEST = list(0, -24))
 	else
 		return list(TEXT_NORTH = list(0, 6), TEXT_SOUTH = list(0, 6), TEXT_EAST = list(-6, 4), TEXT_WEST = list(6, 4))

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -67,10 +67,11 @@
 /datum/component/riding/proc/vehicle_moved(datum/source)
 	var/atom/movable/AM = parent
 	AM.set_glide_size(DELAY_TO_GLIDE_SIZE(vehicle_move_delay))
+	var/mob/living/rider
 	for(var/mob/M in AM.buckled_mobs)
 		if(!istype(M, /mob/living))
 			continue
-		var/mob/living/rider = M
+		rider = M
 		ride_check(M)
 		M.set_glide_size(AM.glide_size)
 		// Award riding XP if the RIDER is in run intent while moving on mount

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -768,6 +768,8 @@
 	var/mob/living/carbon/human/passenger
 	var/stamcost = 9
 	var/obj/item/organ/wings/harpy/harpy_wings
+	/// Buckled mob if someone decides to mount the flying harpy
+	var/datum/weakref/buckled_mob
 
 /datum/status_effect/debuff/harpy_flight/on_creation(mob/living/new_owner, new_stamcost)
 	stamcost = new_stamcost
@@ -792,6 +794,10 @@
 	ADD_TRAIT(harpy, TRAIT_SPELLCOCKBLOCK, ORGAN_TRAIT)
 	harpy.flying = TRUE
 	init_signals()
+	var/mob/buckled_rider = harpy.buckled_mobs[1]
+	if(!isnull(buckled_rider))
+		buckled_mob = WEAKREF(buckled_rider)
+		buckled_rider.movement_type |= FLYING
 
 /datum/status_effect/debuff/harpy_flight/tick()
 	. = ..()
@@ -837,6 +843,10 @@
 		for(var/obj/item/rogueweapon/huntingknife/idagger/harpy_talons/talons in harpy.held_items)
 			harpy.dropItemToGround(talons, TRUE)
 			return
+	var/mob/buckled_rider = buckled_mob.resolve()
+	if(!isnull(buckled_rider))
+		buckled_rider.movement_type &= ~FLYING
+	buckled_mob = null
 
 /atom/movable/screen/alert/status_effect/debuff/harpy_flight
 	name = "Flying..."
@@ -867,6 +877,8 @@
 /datum/status_effect/debuff/harpy_flight/proc/init_signals()
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(check_movement))
 	RegisterSignal(owner, COMSIG_LIVING_UPDATE_TURF_MOVESPEED, PROC_REF(on_turf_movespeed_update))
+	RegisterSignal(owner, COMSIG_MOVABLE_BUCKLE, PROC_REF(harpy_mob_buckled))
+	RegisterSignal(owner, COMSIG_MOVABLE_UNBUCKLE, PROC_REF(harpy_mob_unbuckle))
 
 /datum/status_effect/debuff/harpy_flight/proc/check_movement(datum/source) // rewritten by @tmyqlfpir
 	SIGNAL_HANDLER
@@ -887,10 +899,32 @@
 	SIGNAL_HANDLER
 	return TURF_MOVESPEED_BLOCKED // Flying harpies do not get slowed down from turfs
 
+/// Updates flight when a mob is buckled as a harpy is already in flight
+/datum/status_effect/debuff/harpy_flight/proc/harpy_mob_buckled(datum/source, mob/living/M, force = FALSE)
+	SIGNAL_HANDLER
+	if(isnull(M))
+		return
+	buckled_mob = WEAKREF(M)
+	M.movement_type |= FLYING
+
+/// Updates flight when a mob is unbuckled as a harpy is already in flight
+/datum/status_effect/debuff/harpy_flight/proc/harpy_mob_unbuckle(datum/source, mob/living/M, force = FALSE)
+	SIGNAL_HANDLER
+	var/mob/living/unbuckling_mob = buckled_mob.resolve()
+	if(!unbuckling_mob && isnull(M))
+		buckled_mob = null
+		return
+	unbuckling_mob.movement_type &= ~FLYING
+	var/turf/tile_under_rider = get_turf(unbuckling_mob)
+	tile_under_rider.zFall(unbuckling_mob)
+	buckled_mob = null
+
 /datum/status_effect/debuff/harpy_flight/proc/remove_signals()
 	UnregisterSignal(owner, list(
 		COMSIG_MOVABLE_MOVED,
 		COMSIG_LIVING_UPDATE_TURF_MOVESPEED,
+		COMSIG_MOVABLE_BUCKLE,
+		COMSIG_MOVABLE_UNBUCKLE,
 	))
 	QDEL_NULL(shadow)
 

--- a/code/modules/surgery/organs/feature_organs/wings.dm
+++ b/code/modules/surgery/organs/feature_organs/wings.dm
@@ -98,37 +98,42 @@
 
 /obj/effect/proc_holder/spell/self/harpy_flight/cast(mob/living/carbon/human/user)
 	var/harpy_AC = user.highest_ac_worn()
-	if(harpy_AC == ARMOR_CLASS_NONE)
-		if(!user.buckled)
-			if(!user.pulledby)
-				if(!user.has_status_effect(/datum/status_effect/debuff/harpy_flight))
-					if(user.mobility_flags & MOBILITY_STAND)
-						if(!user.restrained(ignore_grab = FALSE))
-							if(HAS_TRAIT(user, TRAIT_INFINITE_STAMINA))
-								to_chat(user, span_bloody("I am too energetic to control my flight!</br>AGHH!!"))
-								user.Knockdown(10)
-							else
-								user.visible_message(span_notice("[user] prepares to take flight."))
-								if(do_after(user, 3 SECONDS))
-									var/athletics_skill = max(user.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
-									var/stamina_cost_final = round((baseline_stamina_cost - athletics_skill), 1)
-									user.apply_status_effect(/datum/status_effect/debuff/harpy_flight, stamina_cost_final)
-									playsound(user, pick(swoop_sound), 100)
-									user.emote("wingsfly", forced = TRUE)
-									if(prob(1)) // somebody, call saint jiub!!
-										playsound(user, 'sound/foley/footsteps/flight_sounds/cliffracer.ogg', 100)
-						else
-							to_chat(user, span_bloody("The chains are restricting my freedom!!"))
-					else
-						to_chat(user, span_bloody("I can't fly while imbalanced like this! AGHH!!"))
-				else
-					to_chat(user, span_bloody("Wah, back on the ground! How... quaint!!")) // sad emoji
-					user.remove_status_effect(/datum/status_effect/debuff/harpy_flight)
-					playsound(user, pick(swoop_sound), 100)
-					user.emote("wingsfly", forced = TRUE)
-			else
-				to_chat(user, span_bloody("SOMEONE'S <b>HOLDING ME</b>, I CAN'T GET OFF THE GROUND LIKE THIS! </br> THE CRUELTY!!"))
-		else
-			to_chat(user, span_bloody("I CAN'T GET OFF THE GROUND WHILE... STUCK LIKE THIS!!"))
-	else
+	if(harpy_AC != ARMOR_CLASS_NONE)
 		to_chat(user, span_bloody("THE ARMOR WEIGHS ME DOWN!!")) // LIGHT ON YO FEET SOULJA
+		return
+	if(user.buckled)
+		to_chat(user, span_bloody("I CAN'T GET OFF THE GROUND WHILE... STUCK LIKE THIS!!"))
+		return
+	if(user.pulledby)
+		to_chat(user, span_bloody("SOMEONE'S <b>HOLDING ME</b>, I CAN'T GET OFF THE GROUND LIKE THIS! </br> THE CRUELTY!!"))
+		return
+
+	if(user.has_status_effect(/datum/status_effect/debuff/harpy_flight))
+		to_chat(user, span_bloody("Wah, back on the ground! How... quaint!!")) // sad emoji
+		user.remove_status_effect(/datum/status_effect/debuff/harpy_flight)
+		playsound(user, pick(swoop_sound), 100)
+		user.emote("wingsfly", forced = TRUE)
+		return
+
+	if(!(user.mobility_flags & MOBILITY_STAND))
+		to_chat(user, span_bloody("I can't fly while imbalanced like this! AGHH!!"))
+		return
+	if(user.restrained(ignore_grab = FALSE))
+		to_chat(user, span_bloody("The chains are restricting my freedom!!"))
+
+	if(HAS_TRAIT(user, TRAIT_INFINITE_STAMINA))
+		to_chat(user, span_bloody("I am too energetic to control my flight!</br>AGHH!!"))
+		user.Knockdown(10)
+		return
+
+	user.visible_message(span_notice("[user] prepares to take flight."))
+	if(!do_after(user, 3 SECONDS))
+		return
+
+	var/athletics_skill = max(user.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
+	var/stamina_cost_final = round((baseline_stamina_cost - athletics_skill), 1)
+	user.apply_status_effect(/datum/status_effect/debuff/harpy_flight, stamina_cost_final)
+	playsound(user, pick(swoop_sound), 100)
+	user.emote("wingsfly", forced = TRUE)
+	if(prob(1)) // somebody, call saint jiub!!
+		playsound(user, 'sound/foley/footsteps/flight_sounds/cliffracer.ogg', 100)


### PR DESCRIPTION
## About The Pull Request
- Fixes https://github.com/Rotwood-Vale/Ratwood-2.0/issues/1428
- Buffs mountable virtue. Having mountable removes the strength requirement of having a rider
- Cleans some of the harpy flight code
- Differentiates the offsets of mounting a harpy vs being grabbed by a flying harpy.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested on local
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I think mountable is cool, but it sucks.
Removing the str requirement means that it actually feels good as a virtue.

I also fixed the harpy bug that just kills u and the offsets so it looks nicer.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Riding a mountable harpy flying no longer kills you
fix: Fixed the offsets of riding a flying harpy
balance: Mountable virtue has been buffed to no longer require strength as a mount
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
