### PR TITLE
Adds a ARMORLESS Grenzelhoft Plume Hat to loadout so it can be worn on helmets.

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -593,7 +593,7 @@
 // The exact same as the Grenzelhoft hat w/ the cap, but capless; no armor stats. Allows for drip with the helmet aesthetic PR
 /obj/item/clothing/head/roguetown/caplessgrenzelhofthat
 	name = "capless grenzelhoft plume hat"
-	desc = "Whether it's monsters or fair maidens, a true Grenzelhoftian slays both."
+	desc = "Whether it's monsters or fair maidens, a true Grenzelhoftian slays both. This one lacks any protection beneath."
 	icon_state = "grenzelhat"
 	item_state = "grenzelhat"
 	icon = 'icons/roguetown/clothing/head.dmi'

--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -591,7 +591,7 @@
 	user.update_inv_head()
 
 // The exact same as the Grenzelhoft hat w/ the cap, but capless; no armor stats. Allows for drip with the helmet aesthetic PR
-/obj/item/clothing/head/roguetown/grenzelhofthat
+/obj/item/clothing/head/roguetown/caplessgrenzelhofthat
 	name = "capless grenzelhoft plume hat"
 	desc = "Whether it's monsters or fair maidens, a true Grenzelhoftian slays both."
 	icon_state = "grenzelhat"

--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -589,3 +589,21 @@
 		alternate_worn_layer = BACK_LAYER //Above Hair Layer
 	user.update_inv_wear_mask()
 	user.update_inv_head()
+
+// The exact same as the Grenzelhoft hat w/ the cap, but capless; no armor stats. Allows for drip with the helmet aesthetic PR
+/obj/item/clothing/head/roguetown/grenzelhofthat
+	name = "capless grenzelhoft plume hat"
+	desc = "Whether it's monsters or fair maidens, a true Grenzelhoftian slays both."
+	icon_state = "grenzelhat"
+	item_state = "grenzelhat"
+	icon = 'icons/roguetown/clothing/head.dmi'
+	sleeved = 'icons/roguetown/clothing/onmob/helpers/stonekeep_merc.dmi'
+	slot_flags = ITEM_SLOT_HEAD
+	detail_tag = "_detail"
+	altdetail_tag = "_detailalt"
+	dynamic_hair_suffix = ""
+	resistance_flags = FIRE_PROOF //doesnt spawn, only a cosmetic loadout item. Keep the swag.
+	color = "#262927"
+	detail_color = "#FFFFFF"
+	altdetail_color = "#9c2525"
+	

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -332,7 +332,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 
 /datum/loadout_item/tri_grenzelhoft_hat_capless
 	name = "Capless Grenzelhoft Hat"
-	path = /obj/item/clothing/head/roguetown/grenzelhofthat
+	path = /obj/item/clothing/head/roguetown/caplessgrenzelhofthat
 	
 //CLOAKS
 /datum/loadout_item/tabard

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -330,6 +330,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Salvia Crown"
 	path = /obj/item/flowercrown/salvia
 
+/datum/loadout_item/tri_grenzelhoft_hat_capless
+	name = "Capless Grenzelhoft Hat"
+	path = /obj/item/clothing/head/roguetown/grenzelhofthat
+	
 //CLOAKS
 /datum/loadout_item/tabard
 	name = "Tabard"


### PR DESCRIPTION
## About The Pull Request

as it says on the tin.

DO YOU WANT SWAG!!!!!!!!!!!!!!!?????????? I DO!!!!!!!!!

this PR GIVES YOU IT!!!!!!!

now you're able to take a plume hat from the loadout (NO ARMOR VALUES) and put it on ANY FUCKING HELMET YOU WANT!!!!!

didnt change anything w/ the OG grenzel hat -- that still costs 3 points and has armor and whatnot. This is purely cosmetic and 4 swag

its a no point no armor item.

## Testing Evidence

Built this bitch in webdev then tested it on local. It works. Add it plzz

<img width="1730" height="707" alt="image" src="https://github.com/user-attachments/assets/eb4d370d-59fa-474f-bfc0-fe834f3efa14" />
<img width="391" height="231" alt="image" src="https://github.com/user-attachments/assets/3c4d3464-5960-478c-897f-353eaa56c7a1" />

## Why It's Good For The Game

allows further customization for grenzel appearances. More swag. More money. More Harlots 2 slay.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Adds a Grenzelhoft plumehat w/ no armor values so it may be worn over helmets.

/:cl:
