### PR TITLE
Mage Associate Overhaul, Sorcerer Overhaul, Missionary Tweaks

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -555,7 +555,7 @@
 
 /datum/advclass/cleric/missionary
 	name = "Missionary"
-	tutorial = "You are a devout worshipper of the divine with a strong connection to your patron god. You've spent years studying scriptures and serving your deity - now you wander into foreign lands, spreading the word of your faith."
+	tutorial = "You are a devout worshipper of the divine with a strong connection to your patron god. You've spent years studying scriptures and serving your deity - now you wander into foreign lands, spreading the word of your faith. Preachers focus on homesteading while Shepards preach through example and protecting their would-be flock."
 	outfit = /datum/outfit/job/roguetown/adventurer/missionary
 	traits_applied = list(TRAIT_EMPATH)
 	subclass_stats = list(
@@ -568,13 +568,18 @@
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,//just enough to reattach limbs, same as acolytes
+		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/carpentry = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/lumberjacking = SKILL_LEVEL_NOVICE,
 	)
 	subclass_stashed_items = list(
 		"The Verses and Acts of the Ten" = /obj/item/book/rogue/bibble,
@@ -647,14 +652,20 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_3)//Only T4 NOT to start maxed, with a devotion cap.
 	C.update_devotion(C.max_devotion / 4 - 50, C.max_devotion / 4 - 50, silent = TRUE) // Start at ~25% of devotion cap
 	if(H.mind)
-		var/weapons = list("Woodstaff", "Quarterstaff")
-		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		var/weapons = list("Path of the Preacher", "Path of the Shepard")
+		var/weapon_choice = input(H, "Choose your path.", "CHOOSE YOUR DISCIPLINE.") as anything in weapons
 		switch(weapon_choice)
-			if("Woodstaff")
-				backr = /obj/item/rogueweapon/woodstaff
-			if("Quarterstaff")
+			if("Path of the Preacher")//Discount homesteader. No trait so you can't level these skills up, nor do you have starting tools.
+				r_hand = /obj/item/rogueweapon/woodstaff
+				H.adjust_skillrank_up_to(/datum/skill/craft/cooking, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/carpentry, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/masonry, 1, TRUE)//just so you can make pretty floors easier
+				H.adjust_skillrank_up_to(/datum/skill/craft/sewing, 3, TRUE)
+			if("Path of the Shepard")//The "combat" variant. The core stat spread should keep this class from ever overshadowing the others, but it's worth keeping an eye out anyway.
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
-				l_hand = /obj/item/rogueweapon/scabbard/gwstrap
+				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 4, TRUE)//Staves are pretty mediocre. Mostly just makes it really hard to get past their wielded parry.
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)//Good luck fighting like a monk without monk stats or Dodge Expert.
 
 	if(istype(H.patron, /datum/patron/divine))
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -1,29 +1,32 @@
 /datum/advclass/mage
 	name = "Sorcerer"
-	tutorial = "You are a learned mage and a scholar, having spent your life studying the arcane and its ways."
+	tutorial = "Spellslingers are mages that focus on more potent spells, greater athleticism, and the art of the staff. Arcane Alchemists instead turned their studies to mixing magic and alchemy, the basics of medicine, and rely on creativity instead of arcane might."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/adventurer/mage
 	class_select_category = CLASS_CAT_MAGE
 	subclass_social_rank = SOCIAL_RANK_YEOMAN
 	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
-	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2)
 	subclass_stats = list(
 		STATKEY_INT = 3,
-		STATKEY_PER = 2,
 		STATKEY_SPD = 1,
 	)
 	subclass_spellpoints = 18
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
+		/datum/skill/labor/butchering = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/roguetown/adventurer/mage/pre_equip(mob/living/carbon/human/H)
@@ -50,12 +53,34 @@
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()
 	if(H.age == AGE_OLD)
-		H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_EXPERT, TRUE)
 		H.mind?.adjust_spellpoints(6)
 	H.cmode_music = 'sound/music/cmode/adventurer/combat_outlander4.ogg'
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
+	if(H.mind)
+		var/weapons = list("Spellslinger","Arcane Alchemist")
+		var/weapon_choice = input(H, "Choose your path.", "WHO ARE YOU?") as anything in weapons
+		switch(weapon_choice)
+			if("Arcane Alchemist")
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/aerosolize)
+				H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/sewing, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/labor/butchering, 2, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/labor/farming, 2, TRUE)
+				H.change_stat("perception", 1)
+				H.change_stat("intelligence", 1)
+				ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
+				ADD_TRAIT(H, TRAIT_SEEDKNOW, TRAIT_GENERIC)
+			if("Spellslinger")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 2, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 4, TRUE)
+				H.mind?.adjust_spellpoints(3)
+				ADD_TRAIT(H, TRAIT_ARCYNE_T3, TRAIT_GENERIC)
+				H.change_stat("willpower", 2)
 
 /datum/advclass/mage/spellblade
 	name = "Spellblade"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/mage.dm
@@ -12,7 +12,7 @@
 		STATKEY_INT = 3,
 		STATKEY_SPD = 1,
 	)
-	subclass_spellpoints = 18
+	subclass_spellpoints = 15
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
@@ -78,7 +78,7 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 2, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 4, TRUE)
-				H.mind?.adjust_spellpoints(3)
+				H.mind?.adjust_spellpoints(6)
 				ADD_TRAIT(H, TRAIT_ARCYNE_T3, TRAIT_GENERIC)
 				H.change_stat("willpower", 2)
 

--- a/code/modules/jobs/job_types/roguetown/courtier/mage_associate.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/mage_associate.dm
@@ -50,7 +50,7 @@
 	subclass_stats = list(
 		STATKEY_INT = 3,
 		STATKEY_CON = 1,
-		STATKEY_WIL = 2,
+		STATKEY_WIL = 1,
 		STATKEY_SPD = 1
 	)
 	subclass_spellpoints = 21

--- a/code/modules/jobs/job_types/roguetown/courtier/mage_associate.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/mage_associate.dm
@@ -23,7 +23,7 @@
 	cmode_music = 'sound/music/cmode/nobility/combat_courtmage.ogg'
 	advjob_examine = TRUE // So that Court Magicians can know if they're teachin' a Apprentice or if someone's a bit more advanced of a player. Just makes the title show up as the advjob's name.
 	social_rank = SOCIAL_RANK_YEOMAN
-	job_traits = list(TRAIT_ALCHEMY_EXPERT, TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3)
+	job_traits = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2)
 	job_subclasses = list(
 		/datum/advclass/wapprentice/associate,
 		/datum/advclass/wapprentice/alchemist,
@@ -33,6 +33,7 @@
 /datum/outfit/job/roguetown/wapprentice
 	shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 	pants = /obj/item/clothing/under/roguetown/tights/random
+	neck = /obj/item/storage/belt/rogue/pouch/coins/poor
 	belt = /obj/item/storage/belt/rogue/leather
 	beltr = /obj/item/storage/keyring/mageapprentice
 	backl = /obj/item/storage/backpack/rogue/satchel
@@ -45,21 +46,23 @@
 	outfit = /datum/outfit/job/roguetown/wapprentice/associate
 
 	category_tags = list(CTAG_WASSOCIATE)
+	traits_applied = list(TRAIT_ARCYNE_T3)
 	subclass_stats = list(
 		STATKEY_INT = 3,
-		STATKEY_PER = 2,
+		STATKEY_CON = 1,
+		STATKEY_WIL = 2,
 		STATKEY_SPD = 1
 	)
 	subclass_spellpoints = 21
 	subclass_skills = list(
-		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
@@ -93,28 +96,30 @@
 	outfit = /datum/outfit/job/roguetown/wapprentice/alchemist
 
 	category_tags = list(CTAG_WASSOCIATE)
-	traits_applied = list(TRAIT_SEEDKNOW)
+	traits_applied = list(TRAIT_SEEDKNOW, TRAIT_ALCHEMY_EXPERT)
 	subclass_stats = list(
-		STATKEY_INT = 3,
-		STATKEY_PER = 3,
+		STATKEY_INT = 4,
+		STATKEY_PER = 2,
 		STATKEY_WIL = 1
 	)
 	subclass_spellpoints = 18
 	subclass_skills = list(
-		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/mining = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/fishing = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 	)
 
 /datum/outfit/job/roguetown/wapprentice/alchemist/pre_equip(mob/living/carbon/human/H)
@@ -135,9 +140,21 @@
 		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
 		H.change_stat(STATKEY_PER, -1)
 		H.change_stat(STATKEY_INT, 1)
+		H.mind?.adjust_spellpoints(3)//split studies, less magic
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'
+	if(H.mind)
+		var/weapons = list("Applied Alchemy","Magical Medicine")
+		var/weapon_choice = input(H, "Choose your tools.", "CHOOSE YOUR DISCIPLINE.") as anything in weapons
+		switch(weapon_choice)
+			if("Applied Alchemy")
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/aerosolize)
+				H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 4, TRUE)
+			if("Magical Medicine")
+				l_hand = /obj/item/storage/belt/rogue/surgery_bag
+				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 4, TRUE)
+
 
 /datum/advclass/wapprentice/apprentice
 	name = "Magician Apprentice"
@@ -145,19 +162,26 @@
 	outfit = /datum/outfit/job/roguetown/wapprentice/apprentice
 
 	category_tags = list(CTAG_WASSOCIATE)
+	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)//emphasizing the "serve" part of their description
 	subclass_stats = list(
 		STATKEY_INT = 4,
-		STATKEY_WIL = 1,
+		STATKEY_WIL = 2,
 		STATKEY_SPD = 1,
-		STATKEY_LCK = 1 // this is just a carrot for the folk who are mad enough to take this role...
 	)
 	subclass_spellpoints = 18
 	subclass_skills = list(
-		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/polearms = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/farming = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
+		/datum/skill/labor/butchering = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_NOVICE,//running around for errands
 	)
 
 /datum/outfit/job/roguetown/wapprentice/apprentice/pre_equip(mob/living/carbon/human/H)
@@ -169,12 +193,6 @@
 		/obj/item/spellbook_unfinished/pre_arcyne = 1,
 		/obj/item/chalk = 1,
 		)
-	if(H.age == AGE_OLD)
-		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
-		H.adjust_skillrank(/datum/skill/magic/arcane, 1, TRUE)
-		H.change_stat(STATKEY_SPD, -1)
-		H.change_stat(STATKEY_INT, 1)
-		H.mind?.adjust_spellpoints(3)
 	switch(H.patron?.type)
 		if(/datum/patron/inhumen/zizo)
 			H.cmode_music = 'sound/music/combat_heretic.ogg'

--- a/code/modules/jobs/job_types/roguetown/courtier/mage_associate.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/mage_associate.dm
@@ -170,7 +170,7 @@
 	)
 	subclass_spellpoints = 18
 	subclass_skills = list(
-		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,


### PR DESCRIPTION
## About The Pull Request

Mage Associate: Makes the three classes actually distinct and fill their own niches. Associates focus on flinging spells, Alchemists do alchemy, and Apprentices actually apprentice.

Adventurer Sorcerer: Splits the two styles of Mage into two subclasses within Sorcerer. Not enough differences to justify whole-ass classes so you get a loadout split.

Missionary: Makes them more like actual Missionaries, and a little closer to Acolytes. Mostly some life skills baseline to emphasize your noncombat nature and a choice between better life skills or weapon skills on a class without the stats to use them.

## Testing Evidence

<img width="1920" height="1080" alt="proof03" src="https://github.com/user-attachments/assets/4702d6f9-3526-49aa-a028-1b9a8f7cba04" />
<img width="1920" height="1080" alt="proof01" src="https://github.com/user-attachments/assets/b710e136-2365-4d04-aadd-98d8eb4664bd" />
<img width="1920" height="1080" alt="proof02" src="https://github.com/user-attachments/assets/bd883206-2fdc-46f4-8003-624180360bc7" />


## Why It's Good For The Game

So, this applies to all 'mage' classes in this, but: I replaced Unarmed with Knife-fighting. Why? Literally none of these guys have strength. None of them start with unarmed weapons. You know what most mage classes spawn with? _A knife._ You know what two weapons mages are typically associated with culturally? Staves and daggers.

So yeah, you get apprentice knife-fighting now. Or novice. Probably technically a nerf since unarmed is pretty much just objectively better than knife-fighting outside of a few niche cases but I think it's more flavorful _and_ it means your starting knives serve as potential backup weapons.

Plus, like, if you're _really_ dedicated to punch mage? Just go hit a dummy. Or take the virtue. Or go play Pontifex.

[===]

Mage Associate: So, on live, there's... Not any real difference between the three subclasses of Associate? Associate proper had 21 spellpoints and decent skills, Alchemist had _slightly_ better alchemy-related skills but 18 spellpoints, and Apprentice had no skills and 18 spellpoints... But a marginally better stat spread than Associate.

Now the role you choose actually determines your specialization. Also, their stats have been normalized.

Associates focus more on combat and casting with their (now exclusive) T3 spells, 3 more free spellpoints, and more sustain-focused stats/skills. Probably not going to see garrison mages because even with this, getting a Houndstone is probably going to be eternally like pulling teeth but now you're not a liability trying to keep up with a running battle. However, you're _hard_ locked out of the ability (unless you spend your virtue on it) to level alchemy, so now you physically cannot make Strong Red since it's Expert locked now. You also can't transmute cycle!

Alchemists focus, as you might have guessed it, on alchemy. Your stats and skills are also less focused on direct combat so - combined with the recent Feint changes - there's less chance someone tries to discount spellblade as this subclass. You also have a choice between a higher starting alchemy (and Aerosolize as an innate spell. USE THOSE POTIONS AND POISONS!) or medicine (the objectively worse choice, but sovlful for anyone wanting to be a mad scientist-mage) and a surgical kit. Doesn't give you the surgeon trait, though, so you'll still never replace the court physician unless they're truly awful.

Apprentices now _actually_ apprentice! You lack T3 spells, have generally worse skills than everyone else, and... Your stats are normalized! You're basically the housekeeper of the tower, especially as you have Homesteader Expert now. This lets you level a LOT of skills but most of them you don't have any starting levels in, so you'll be doing it from scratch. Plus, unless you're a Malumite mage, good luck leveling more than one or two past Jman in a round.

Oh, and I FINALLY gave mages a purse with a few coins. They were lacking this for _so_ long.

[===]

Adventurer Sorcerer: Second verse, same as the first. Mostly. Weighted stat totals are the same, just 2 points are based on your specialization.

Baseline they have a few skills that make sense for a mage, presumably, used to living on the road. Basic cooking so they can cook meat on magic campfires, basic sewing so they fix holes in their robes slightly faster, and basic butchering because reagents. Nothing too impactful, honestly, as it's either for flavor or just fixing a weird mechanical hole.

Arcane Alchemist is _sort of_ a mix of both MA Alchemist variants in that you get both improved medicine and alchemy skill, but you lack the MA Alchemist's home base and security. And you don't get a surgeon's bag and you're stuck with T2 spells just like the MA Alchemist. You do get innate Aerosolize, but you have less SP than a Spellslinger. You do get +1 Perception and +1 Intelligence at least!

Spellslinger is basically just MA Associate, but as an adventurer. +3 spellpoints over the Alchemist (+6 technically but Aerosolize is a 3 point spell), T3 spells, +2 Willpower, and better combat-focused skills.

[===]

Missionary: Surely I won't do the same thing three times in a row. Right?

... Right?

Okay so I maybe did the same thing again. Though the baseline is definitely a bit more of a step up compared to the last ones. Missionaries now have skills to actually do _missionary_ things. Cook, craft, sew, basic woodwork and woodcutting. Plus you have _just_ enough medicine skill to reattach limbs, but not enough to do lux stuff. Still gotta grind out that level if you wanna be a surgeon.

Path of the Preacher: Focuses on household skills. You don't get any traits, just base levels so you still need specialists to go all out. Or to spend your virtue on it. You get the shittier wood staff too, to indicate you prefer a more peaceful way of things. The only real skill of note here is Masonry 1 and that's solely so you can make stone floors without the incredibly annoying stone skill grind.

Path of the Shepard: The... _Dubiously_ useful combat path for Missionary. You even get the better staff! Lorewise you take a more active approach to spreading the faith, presumably by protecting the people you preach to. Or by hitting them until they listen to you. Mechanically, it just makes you a REALLY bad imitation of a monk. Expert staves, jman wrestling, and jman unarmed? Heck yeah! No strength stats? No dodge expert, or crit resistance? Ruh roh.

Really, if you ever _intend_ to pick this to fight, you're probably better off going Paladin or Monk, but hey. Maybe someone just really wants to show off their Steel Quarterstaff game and this'll help with that.



## Changelog


:cl:
fix: Magician's Associate (MA) three subclasses now has a coinpurse with coins in it. Finally.
fix: MA's three subclasses now have normalized stats.
balance: Overhauled Magician's Associate's subclasses to have distinct roles.
add: Added Subclasses to the Sorcerer (Spellslinger, Arcane Alchemist) and Missionary (Preacher, Shepard) adventurer classes.
add: Added Subclasses (sort of) to MA Alchemist.
balance: MA Associate - Focuses on combat and spellcasting. T3 spells, more spellpoints, slightly better combat skills, stats suited for combat. Lost Alchemy Expert in turn. No more Strong Red for you.
balance: MA Alchemist - Focuses on alchemy or medicine. Stats are more sovl focused, but still useful if you're clever. Also useful if you want to harvest reagents and there's no farmers/hunters around. You have T2 spells because of the Alchemy, though.
balance: MA Apprentice - Focuses on being an apprentice and actually feeling like one, instead of a sleeper power pick. Or you can just be a magical maid. Take your pick. Has Homesteading Expert and mediocre base skills. Also, apprentices are locked to T2 spells so newcomers are less overwhelmed with choice.
balance: Sorcerer Spellslinger - Diet MA Associate. More combat-focused stat spread, skills, +3 spellpoints, T3 spells
balance: Sorcerer Arcane Alchemist - Diet MA Alchemist. More utility focused stat spread, skills. Locked to T2 spells. Gets Alchemy Expert and Seed Knowledge to make up for it.
balance: Missionary Preacher - Diet Acolyte. Improved housekeeping and housemaking skills, but you're not a Homesteader. You've got the skills but no tools and you can't really improve your skills.
balance: Missionary Shepard - Diet... Monk? Expert Staves and better Wrestling/Unarmed. A little sovl, as a treat, for our few Missionary mains.
balance: Old MA Apprentices are no longer objectively better than Old MA Associates. In fact, now you get nothing as an Old MA Apprentice. Either drop out or go be an Associate/Alchemist.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
