### PR TITLE
Fickle Lyfe

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -352,46 +352,184 @@
 /datum/status_effect/debuff/necras_touched
 	id = "necras_touched"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/necras_touched
-	effectedstats = list(STATKEY_STR = -1, STATKEY_WIL = -1, STATKEY_PER = -1, STATKEY_INT = -1, STATKEY_SPD = -3,  STATKEY_CON = -4, STATKEY_LCK = -6)
-	duration = 15 MINUTES
-	//I think luck nuke and con nuke will be more impactful and more flavrful, i mean, you just got back from the dead, your body is in shambles and your soul is rattled. You should feel it HARD. This is the "I just got back from the dead" debuff, and it should feel like it.
+	duration = 20 MINUTES
+	tick_interval = 1 MINUTES
+	var/list/raw_penalties
+	var/recovery_progress = 0
+	var/recovery_goal = 300
+
 /datum/status_effect/debuff/necras_touched/on_apply()
+	raw_penalties = list(STATKEY_STR = -10, STATKEY_CON = -10, STATKEY_WIL = -10, STATKEY_LCK = -10, STATKEY_PER = -10, STATKEY_INT = -10, STATKEY_SPD = -10)
+	effectedstats = raw_penalties.Copy()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
 
+/datum/status_effect/debuff/necras_touched/proc/get_recovery_points()
+	var/points = 5
+	var/is_hungry = owner.has_status_effect("hungryt1") || owner.has_status_effect("hungryt2") || owner.has_status_effect("hungryt3")
+	var/is_thirsty = owner.has_status_effect("thirsty1") || owner.has_status_effect("thirsty2") || owner.has_status_effect("thirsty3")
+	var/well_fed = !is_hungry && !is_thirsty && (owner.has_status_effect("meal") || owner.has_status_effect("greatmeal") || owner.has_status_effect("snack") || owner.has_status_effect("greatsnack"))
+	if(well_fed)
+		points += 5
+	if(owner.has_status_effect("vigorized"))
+		points += 5
+	if(owner.IsSleeping())
+		points += 20
+	return points
+
+/datum/status_effect/debuff/necras_touched/tick()
+	recovery_progress = min(recovery_progress + get_recovery_points(), recovery_goal)
+	var/target_penalty = round(-10 * (1 - recovery_progress / recovery_goal))
+	var/list/to_remove = list()
+	for(var/S in raw_penalties)
+		var/current_penalty = raw_penalties[S]
+		var/delta = target_penalty - current_penalty
+		if(delta > 0 && effectedstats[S])
+			var/actual = min(delta, -effectedstats[S])
+			if(actual > 0)
+				owner.change_stat(S, actual)
+				effectedstats[S] += actual
+			if(effectedstats[S] >= 0)
+				effectedstats -= S
+		raw_penalties[S] = target_penalty
+		if(target_penalty >= 0)
+			to_remove += S
+	for(var/S in to_remove)
+		raw_penalties -= S
+	if(recovery_progress >= recovery_goal)
+		owner.remove_status_effect(src)
+
 /datum/status_effect/debuff/necras_touched/on_remove()
-	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
+	. = ..()
 
 /datum/status_effect/debuff/necras_touched/lux
 	duration = 5 MINUTES
+	recovery_goal = 75
 
 /atom/movable/screen/alert/status_effect/debuff/necras_touched
 	name = "Necra's Touch"
 	desc = "Necra's cold grasp lingers on my body. My body falters, and I am vulnerable to grievous wounds."
 	icon_state = "revived"
 
+/atom/movable/screen/alert/status_effect/debuff/necras_touched/examine_ui(mob/user)
+	var/datum/status_effect/debuff/necras_touched/E = attached_effect
+	var/list/inspec = list("----------------------")
+	inspec += "<br><span class='notice'><b>[name]</b></span>"
+	inspec += "<br>[desc]"
+	for(var/S in E?.effectedstats)
+		if(E.effectedstats[S] < 0)
+			var/newnum = E.effectedstats[S] * -1
+			inspec += "<br><span class='danger'>[S]</span> \Roman [newnum]"
+	inspec += "<br>----------------------"
+	if(E?.owner)
+		var/mob/living/M = E.owner
+		inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b>"
+		var/is_hungry = M.has_status_effect("hungryt1") || M.has_status_effect("hungryt2") || M.has_status_effect("hungryt3")
+		var/is_thirsty = M.has_status_effect("thirsty1") || M.has_status_effect("thirsty2") || M.has_status_effect("thirsty3")
+		var/well_fed = !is_hungry && !is_thirsty && (M.has_status_effect("meal") || M.has_status_effect("greatmeal") || M.has_status_effect("snack") || M.has_status_effect("greatsnack"))
+		var/has_drink_buff = M.has_status_effect("vigorized")
+		var/sleeping = M.IsSleeping()
+		var/points_this_tick = E.get_recovery_points()
+		inspec += "<br>Gaining <b>[points_this_tick]</b> recovery per minute."
+		if(sleeping)
+			inspec += "<br><span class='green'>Sleeping (+20)</span>"
+		else
+			inspec += "<br><span class='danger'>Not sleeping — rest to recover faster.</span>"
+		if(well_fed && has_drink_buff)
+			inspec += "<br><span class='green'>Well-fed and vigorized (+10)</span>"
+		else if(well_fed)
+			inspec += "<br><span class='green'>Well-fed (+5)</span>"
+		else if(has_drink_buff)
+			inspec += "<br><span class='green'>Vigorized (+5)</span>"
+		else
+			inspec += "<br><span class='danger'>Eat a hearty meal and drink coffee or tea (+5 each).</span>"
+		if(is_hungry)
+			inspec += "<br><span class='danger'>Hunger prevents the meal bonus.</span>"
+		if(is_thirsty)
+			inspec += "<br><span class='danger'>Thirst prevents the meal bonus.</span>"
+	inspec += "<br>----------------------"
+	to_chat(user, "[inspec.Join()]")
+
 //For revive - Necra's Claim. Her mark rests upon you - you cannot be brought back from death until it fades.
 /datum/status_effect/debuff/necras_claim
 	id = "necras_claim"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/necras_claim
-	duration = 25 MINUTES
+	duration = 30 MINUTES
+	tick_interval = 1 MINUTES
+	needs_processing = TRUE
+	var/recovery_progress = 0
+	var/recovery_goal = 300
 
 /datum/status_effect/debuff/necras_claim/on_apply()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_DNR, id)
+
+/datum/status_effect/debuff/necras_claim/proc/get_recovery_points()
+	var/points = 5
+	var/is_hungry = owner.has_status_effect("hungryt1") || owner.has_status_effect("hungryt2") || owner.has_status_effect("hungryt3")
+	var/is_thirsty = owner.has_status_effect("thirsty1") || owner.has_status_effect("thirsty2") || owner.has_status_effect("thirsty3")
+	var/well_fed = !is_hungry && !is_thirsty && (owner.has_status_effect("meal") || owner.has_status_effect("greatmeal") || owner.has_status_effect("snack") || owner.has_status_effect("greatsnack"))
+	if(well_fed)
+		points += 5
+	if(owner.has_status_effect("vigorized"))
+		points += 5
+	if(owner.IsSleeping())
+		points += 20
+	return points
+
+/datum/status_effect/debuff/necras_claim/tick()
+	recovery_progress = min(recovery_progress + get_recovery_points(), recovery_goal)
+	if(recovery_progress >= recovery_goal)
+		owner.remove_status_effect(src)
 
 /datum/status_effect/debuff/necras_claim/on_remove()
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_DNR, id)
 
 /datum/status_effect/debuff/necras_claim/lux
-	duration = 10 MINUTES
+	duration = 15 MINUTES
+	recovery_goal = 75
 
 /atom/movable/screen/alert/status_effect/debuff/necras_claim
 	name = "Necra's Claim"
 	desc = "Necra has marked me as Her own. Should I die again while my lux regains their vitality, no power can drag me back from Her embrace."
 	icon_state = "rotted_body"
+
+/atom/movable/screen/alert/status_effect/debuff/necras_claim/examine_ui(mob/user)
+	var/datum/status_effect/debuff/necras_claim/E = attached_effect
+	var/list/inspec = list("----------------------")
+	inspec += "<br><span class='notice'><b>[name]</b></span>"
+	inspec += "<br>[desc]"
+	inspec += "<br>----------------------"
+	if(E?.owner)
+		var/mob/living/M = E.owner
+		inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b>"
+		var/is_hungry = M.has_status_effect("hungryt1") || M.has_status_effect("hungryt2") || M.has_status_effect("hungryt3")
+		var/is_thirsty = M.has_status_effect("thirsty1") || M.has_status_effect("thirsty2") || M.has_status_effect("thirsty3")
+		var/well_fed = !is_hungry && !is_thirsty && (M.has_status_effect("meal") || M.has_status_effect("greatmeal") || M.has_status_effect("snack") || M.has_status_effect("greatsnack"))
+		var/has_drink_buff = M.has_status_effect("vigorized")
+		var/sleeping = M.IsSleeping()
+		var/points_this_tick = E.get_recovery_points()
+		inspec += "<br>Gaining <b>[points_this_tick]</b> recovery per minute."
+		if(sleeping)
+			inspec += "<br><span class='green'>Sleeping (+20)</span>"
+		else
+			inspec += "<br><span class='danger'>Not sleeping — rest to recover faster.</span>"
+		if(well_fed && has_drink_buff)
+			inspec += "<br><span class='green'>Well-fed and vigorized (+10)</span>"
+		else if(well_fed)
+			inspec += "<br><span class='green'>Well-fed (+5)</span>"
+		else if(has_drink_buff)
+			inspec += "<br><span class='green'>Vigorized (+5)</span>"
+		else
+			inspec += "<br><span class='danger'>Eat a hearty meal and drink coffee or tea (+5 each).</span>"
+		if(is_hungry)
+			inspec += "<br><span class='danger'>Hunger prevents the meal bonus.</span>"
+		if(is_thirsty)
+			inspec += "<br><span class='danger'>Thirst prevents the meal bonus.</span>"
+	inspec += "<br>----------------------"
+	to_chat(user, "[inspec.Join()]")
 
 //For de-rot - your body ROTTED. Harsher penalty for longer, can be fully off-set with a cure-rot potion.
 /datum/status_effect/debuff/rotted

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -349,17 +349,49 @@
 	desc = "A putrid rotting scent fills your nose as Graggar's call for slaughter rattles you to your core.."
 	icon_state = "call_to_slaughter"
 
-//For revive - your body DIDN'T rot, but it did suffer damage. Unlike being rotted, this one is only timed. Not forever.
-/datum/status_effect/debuff/revived
-	id = "revived"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/revived
-	effectedstats = list(STATKEY_STR = -1, STATKEY_PER = -1, STATKEY_INT = -1, STATKEY_WIL = -1, STATKEY_CON = -1, STATKEY_SPD = -1, STATKEY_LCK = -1)
-	duration = 15 MINUTES		//Should be long enough to stop someone from running back into battle. Plus, this stacks with body-rot debuff. RIP.
+/datum/status_effect/debuff/necras_touched
+	id = "necras_touched"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/necras_touched
+	effectedstats = list(STATKEY_STR = -2, STATKEY_CON = -2, STATKEY_WIL = -2, STATKEY_LCK = -2)
+	duration = 15 MINUTES
 
-/atom/movable/screen/alert/status_effect/debuff/revived
-	name = "Revival Sickness"
-	desc = "You felt lyfe itself course through you, restoring your lux and your essance. You.. live - but your body aches. It still needs time to recover.."
+/datum/status_effect/debuff/necras_touched/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
+
+/datum/status_effect/debuff/necras_touched/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
+
+/datum/status_effect/debuff/necras_touched/lux
+	duration = 5 MINUTES
+
+/atom/movable/screen/alert/status_effect/debuff/necras_touched
+	name = "Necra's Touch"
+	desc = "Necra's cold grasp lingers on my body. My body falters, and I am vulnerable to grievous wounds."
 	icon_state = "revived"
+
+//For revive - Necra's Claim. Her mark rests upon you - you cannot be brought back from death until it fades.
+/datum/status_effect/debuff/necras_claim
+	id = "necras_claim"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/necras_claim
+	duration = 25 MINUTES
+
+/datum/status_effect/debuff/necras_claim/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_DNR, id)
+
+/datum/status_effect/debuff/necras_claim/on_remove()
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_DNR, id)
+
+/datum/status_effect/debuff/necras_claim/lux
+	duration = 10 MINUTES
+
+/atom/movable/screen/alert/status_effect/debuff/necras_claim
+	name = "Necra's Claim"
+	desc = "Necra has marked me as Her own. Should I die again while my lux regains their vitality, no power can drag me back from Her embrace."
+	icon_state = "rotted_body"
 
 //For de-rot - your body ROTTED. Harsher penalty for longer, can be fully off-set with a cure-rot potion.
 /datum/status_effect/debuff/rotted

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -352,9 +352,9 @@
 /datum/status_effect/debuff/necras_touched
 	id = "necras_touched"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/necras_touched
-	effectedstats = list(STATKEY_STR = -2, STATKEY_CON = -2, STATKEY_WIL = -2, STATKEY_LCK = -2)
+	effectedstats = list(STATKEY_STR = -1, STATKEY_WIL = -1, STATKEY_PER = -1, STATKEY_INT = -1, STATKEY_SPD = -3,  STATKEY_CON = -4, STATKEY_LCK = -6)
 	duration = 15 MINUTES
-
+	//I think luck nuke and con nuke will be more impactful and more flavrful, i mean, you just got back from the dead, your body is in shambles and your soul is rattled. You should feel it HARD. This is the "I just got back from the dead" debuff, and it should feel like it.
 /datum/status_effect/debuff/necras_touched/on_apply()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -357,12 +357,12 @@
 	var/list/raw_penalties
 	var/recovery_progress = 0
 	var/recovery_goal = 300
+	var/ticks_elapsed = 0
 
 /datum/status_effect/debuff/necras_touched/on_apply()
 	raw_penalties = list(STATKEY_STR = -5, STATKEY_CON = -5, STATKEY_WIL = -5, STATKEY_LCK = -5, STATKEY_PER = -5, STATKEY_INT = -5, STATKEY_SPD = -5)
 	effectedstats = raw_penalties.Copy()
 	. = ..()
-	ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
 
 /datum/status_effect/debuff/necras_touched/proc/get_recovery_points()
 	var/points = 5
@@ -378,6 +378,13 @@
 	return points
 
 /datum/status_effect/debuff/necras_touched/tick()
+	ticks_elapsed++
+	if(ticks_elapsed == 1)
+		ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
+		ADD_TRAIT(owner, TRAIT_DNR, id)
+	else if(ticks_elapsed == 11)
+		REMOVE_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
+		REMOVE_TRAIT(owner, TRAIT_DNR, id)
 	recovery_progress = min(recovery_progress + get_recovery_points(), recovery_goal)
 	var/target_penalty
 	if(recovery_progress < recovery_goal * 0.5)
@@ -406,6 +413,7 @@
 
 /datum/status_effect/debuff/necras_touched/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
+	REMOVE_TRAIT(owner, TRAIT_DNR, id)
 	. = ..()
 
 /datum/status_effect/debuff/necras_touched/lux
@@ -438,6 +446,10 @@
 			inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b> <span class='danger'>(Stats locked until [halfway])</span>"
 		else
 			inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b> <span class='green'>(Stats recovering)</span>"
+		if(E.ticks_elapsed >= 1 && E.ticks_elapsed < 11)
+			inspec += "<br><span class='danger'>Death mark active — cannot be revived. ([11 - E.ticks_elapsed] min remaining)</span>"
+		else if(E.ticks_elapsed < 1)
+			inspec += "<br><span class='warning'>Death mark activates in 1 minute.</span>"
 		var/is_hungry = M.has_status_effect("hungryt1") || M.has_status_effect("hungryt2") || M.has_status_effect("hungryt3")
 		var/is_thirsty = M.has_status_effect("thirsty1") || M.has_status_effect("thirsty2") || M.has_status_effect("thirsty3")
 		var/well_fed = !is_hungry && !is_thirsty && (M.has_status_effect("meal") || M.has_status_effect("greatmeal") || M.has_status_effect("snack") || M.has_status_effect("greatsnack"))

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -359,7 +359,7 @@
 	var/recovery_goal = 300
 
 /datum/status_effect/debuff/necras_touched/on_apply()
-	raw_penalties = list(STATKEY_STR = -10, STATKEY_CON = -10, STATKEY_WIL = -10, STATKEY_LCK = -10, STATKEY_PER = -10, STATKEY_INT = -10, STATKEY_SPD = -10)
+	raw_penalties = list(STATKEY_STR = -5, STATKEY_CON = -5, STATKEY_WIL = -5, STATKEY_LCK = -5, STATKEY_PER = -5, STATKEY_INT = -5, STATKEY_SPD = -5)
 	effectedstats = raw_penalties.Copy()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_CRITICAL_WEAKNESS, id)
@@ -373,13 +373,18 @@
 		points += 5
 	if(owner.has_status_effect("vigorized"))
 		points += 5
-	if(owner.IsSleeping())
+	if(owner.buckled && (istype(owner.buckled, /obj/structure/bed) || istype(owner.buckled, /obj/structure/chair)))
 		points += 20
 	return points
 
 /datum/status_effect/debuff/necras_touched/tick()
 	recovery_progress = min(recovery_progress + get_recovery_points(), recovery_goal)
-	var/target_penalty = round(-10 * (1 - recovery_progress / recovery_goal))
+	var/target_penalty
+	if(recovery_progress < recovery_goal * 0.5)
+		target_penalty = -5
+	else
+		var/second_half_progress = (recovery_progress - recovery_goal * 0.5) / (recovery_goal * 0.5)
+		target_penalty = round(-5 * (1 - second_half_progress))
 	var/list/to_remove = list()
 	for(var/S in raw_penalties)
 		var/current_penalty = raw_penalties[S]
@@ -407,6 +412,10 @@
 	duration = 5 MINUTES
 	recovery_goal = 75
 
+/datum/status_effect/debuff/necras_touched/frankenstein
+	duration = 3 MINUTES
+	recovery_goal = 25
+
 /atom/movable/screen/alert/status_effect/debuff/necras_touched
 	name = "Necra's Touch"
 	desc = "Necra's cold grasp lingers on my body. My body falters, and I am vulnerable to grievous wounds."
@@ -424,98 +433,22 @@
 	inspec += "<br>----------------------"
 	if(E?.owner)
 		var/mob/living/M = E.owner
-		inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b>"
+		var/halfway = E.recovery_goal * 0.5
+		if(E.recovery_progress < halfway)
+			inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b> <span class='danger'>(Stats locked until [halfway])</span>"
+		else
+			inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b> <span class='green'>(Stats recovering)</span>"
 		var/is_hungry = M.has_status_effect("hungryt1") || M.has_status_effect("hungryt2") || M.has_status_effect("hungryt3")
 		var/is_thirsty = M.has_status_effect("thirsty1") || M.has_status_effect("thirsty2") || M.has_status_effect("thirsty3")
 		var/well_fed = !is_hungry && !is_thirsty && (M.has_status_effect("meal") || M.has_status_effect("greatmeal") || M.has_status_effect("snack") || M.has_status_effect("greatsnack"))
 		var/has_drink_buff = M.has_status_effect("vigorized")
-		var/sleeping = M.IsSleeping()
+		var/resting = M.buckled && (istype(M.buckled, /obj/structure/bed) || istype(M.buckled, /obj/structure/chair))
 		var/points_this_tick = E.get_recovery_points()
 		inspec += "<br>Gaining <b>[points_this_tick]</b> recovery per minute."
-		if(sleeping)
-			inspec += "<br><span class='green'>Sleeping (+20)</span>"
+		if(resting)
+			inspec += "<br><span class='green'>Resting (+20)</span>"
 		else
-			inspec += "<br><span class='danger'>Not sleeping — rest to recover faster.</span>"
-		if(well_fed && has_drink_buff)
-			inspec += "<br><span class='green'>Well-fed and vigorized (+10)</span>"
-		else if(well_fed)
-			inspec += "<br><span class='green'>Well-fed (+5)</span>"
-		else if(has_drink_buff)
-			inspec += "<br><span class='green'>Vigorized (+5)</span>"
-		else
-			inspec += "<br><span class='danger'>Eat a hearty meal and drink coffee or tea (+5 each).</span>"
-		if(is_hungry)
-			inspec += "<br><span class='danger'>Hunger prevents the meal bonus.</span>"
-		if(is_thirsty)
-			inspec += "<br><span class='danger'>Thirst prevents the meal bonus.</span>"
-	inspec += "<br>----------------------"
-	to_chat(user, "[inspec.Join()]")
-
-//For revive - Necra's Claim. Her mark rests upon you - you cannot be brought back from death until it fades.
-/datum/status_effect/debuff/necras_claim
-	id = "necras_claim"
-	alert_type = /atom/movable/screen/alert/status_effect/debuff/necras_claim
-	duration = 30 MINUTES
-	tick_interval = 1 MINUTES
-	needs_processing = TRUE
-	var/recovery_progress = 0
-	var/recovery_goal = 300
-
-/datum/status_effect/debuff/necras_claim/on_apply()
-	. = ..()
-	ADD_TRAIT(owner, TRAIT_DNR, id)
-
-/datum/status_effect/debuff/necras_claim/proc/get_recovery_points()
-	var/points = 5
-	var/is_hungry = owner.has_status_effect("hungryt1") || owner.has_status_effect("hungryt2") || owner.has_status_effect("hungryt3")
-	var/is_thirsty = owner.has_status_effect("thirsty1") || owner.has_status_effect("thirsty2") || owner.has_status_effect("thirsty3")
-	var/well_fed = !is_hungry && !is_thirsty && (owner.has_status_effect("meal") || owner.has_status_effect("greatmeal") || owner.has_status_effect("snack") || owner.has_status_effect("greatsnack"))
-	if(well_fed)
-		points += 5
-	if(owner.has_status_effect("vigorized"))
-		points += 5
-	if(owner.IsSleeping())
-		points += 20
-	return points
-
-/datum/status_effect/debuff/necras_claim/tick()
-	recovery_progress = min(recovery_progress + get_recovery_points(), recovery_goal)
-	if(recovery_progress >= recovery_goal)
-		owner.remove_status_effect(src)
-
-/datum/status_effect/debuff/necras_claim/on_remove()
-	. = ..()
-	REMOVE_TRAIT(owner, TRAIT_DNR, id)
-
-/datum/status_effect/debuff/necras_claim/lux
-	duration = 15 MINUTES
-	recovery_goal = 75
-
-/atom/movable/screen/alert/status_effect/debuff/necras_claim
-	name = "Necra's Claim"
-	desc = "Necra has marked me as Her own. Should I die again while my lux regains their vitality, no power can drag me back from Her embrace."
-	icon_state = "rotted_body"
-
-/atom/movable/screen/alert/status_effect/debuff/necras_claim/examine_ui(mob/user)
-	var/datum/status_effect/debuff/necras_claim/E = attached_effect
-	var/list/inspec = list("----------------------")
-	inspec += "<br><span class='notice'><b>[name]</b></span>"
-	inspec += "<br>[desc]"
-	inspec += "<br>----------------------"
-	if(E?.owner)
-		var/mob/living/M = E.owner
-		inspec += "<br><b>Recovery: [E.recovery_progress] / [E.recovery_goal]</b>"
-		var/is_hungry = M.has_status_effect("hungryt1") || M.has_status_effect("hungryt2") || M.has_status_effect("hungryt3")
-		var/is_thirsty = M.has_status_effect("thirsty1") || M.has_status_effect("thirsty2") || M.has_status_effect("thirsty3")
-		var/well_fed = !is_hungry && !is_thirsty && (M.has_status_effect("meal") || M.has_status_effect("greatmeal") || M.has_status_effect("snack") || M.has_status_effect("greatsnack"))
-		var/has_drink_buff = M.has_status_effect("vigorized")
-		var/sleeping = M.IsSleeping()
-		var/points_this_tick = E.get_recovery_points()
-		inspec += "<br>Gaining <b>[points_this_tick]</b> recovery per minute."
-		if(sleeping)
-			inspec += "<br><span class='green'>Sleeping (+20)</span>"
-		else
-			inspec += "<br><span class='danger'>Not sleeping — rest to recover faster.</span>"
+			inspec += "<br><span class='danger'>Not resting — sit or lie down to recover faster.</span>"
 		if(well_fed && has_drink_buff)
 			inspec += "<br><span class='green'>Well-fed and vigorized (+10)</span>"
 		else if(well_fed)

--- a/code/modules/mob/living/misc.dm
+++ b/code/modules/mob/living/misc.dm
@@ -1,3 +1,13 @@
+/mob/living/proc/apply_necras_revival(grace_seconds = 2 MINUTES, touched_type = /datum/status_effect/debuff/necras_touched, claim_type = /datum/status_effect/debuff/necras_claim)
+	apply_status_effect(touched_type)
+	addtimer(CALLBACK(src, PROC_REF(apply_necras_claim_if_alive), claim_type), grace_seconds)
+
+/mob/living/proc/apply_necras_claim_if_alive(claim_type = /datum/status_effect/debuff/necras_claim)
+	if(stat == DEAD)
+		return
+	apply_status_effect(claim_type)
+	to_chat(src, span_danger("Necra's mark settles upon me. Should I fall again too soon, no power can drag me back from Her embrace."))
+
 /mob/proc/food_tempted(/obj/item/W, mob/user)
 	return
 

--- a/code/modules/mob/living/misc.dm
+++ b/code/modules/mob/living/misc.dm
@@ -1,12 +1,5 @@
-/mob/living/proc/apply_necras_revival(grace_seconds = 2 MINUTES, touched_type = /datum/status_effect/debuff/necras_touched, claim_type = /datum/status_effect/debuff/necras_claim)
+/mob/living/proc/apply_necras_revival(touched_type = /datum/status_effect/debuff/necras_touched)
 	apply_status_effect(touched_type)
-	addtimer(CALLBACK(src, PROC_REF(apply_necras_claim_if_alive), claim_type), grace_seconds)
-
-/mob/living/proc/apply_necras_claim_if_alive(claim_type = /datum/status_effect/debuff/necras_claim)
-	if(stat == DEAD)
-		return
-	apply_status_effect(claim_type)
-	to_chat(src, span_danger("Necra's mark settles upon me. Should I fall again too soon, no power can drag me back from Her embrace."))
 
 /mob/proc/food_tempted(/obj/item/W, mob/user)
 	return

--- a/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/fleshcrafting/flesh_tick.dm
@@ -168,7 +168,7 @@
 	if(!parent)
 		return
 	var/mob/living/L = parent
-	if(!L.has_status_effect(/datum/status_effect/debuff/devitalised) && !L.has_status_effect(/datum/status_effect/debuff/revived) && !L.has_status_effect(/datum/status_effect/debuff/leech_schizophrenia))
+	if(!L.has_status_effect(/datum/status_effect/debuff/devitalised) && !L.has_status_effect(/datum/status_effect/debuff/necras_touched	) && !L.has_status_effect(/datum/status_effect/debuff/leech_schizophrenia))
 		L.visible_message(span_notice("The leech tick falls off of [L], looking full and satisfied."))
 		new full_leechtick_type(get_turf(L))
 		L.apply_status_effect(/datum/status_effect/debuff/devitalised)

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -159,7 +159,7 @@
 		ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.mind.remove_antag_datum(/datum/antagonist/zombie)
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-	target.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	target.apply_necras_revival()
 	return TRUE
 
 /obj/effect/proc_holder/spell/invoked/revive/cast_check(skipcharge = 0,mob/user = usr)

--- a/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
+++ b/code/modules/spells/roguetown/acolyte/eora/eora_status_effects.dm
@@ -189,7 +189,7 @@
 		M.visible_message(span_notice("[M] is dragged back from Necra's hold!"), span_green("I awake from the void."))
 
 		M.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)
-		M.apply_status_effect(/datum/status_effect/debuff/revived)
+		M.apply_necras_revival()
 		M.remove_status_effect(src)
 
 #define POM_FILTER "pom_aura"

--- a/code/modules/spells/roguetown/acolyte/resurrect.dm
+++ b/code/modules/spells/roguetown/acolyte/resurrect.dm
@@ -21,7 +21,7 @@
 	var/required_items = list(/obj/item/clothing/neck/roguetown/psicross = 1)
 	var/alt_required_items = list(/obj/item/clothing/neck/roguetown/psicross = 1)
 	var/item_radius = 1
-	var/debuff_type = /datum/status_effect/debuff/revived
+	var/debuff_type = null
 	var/structure_range = 1
 	var/harms_undead = TRUE
 	priest_excluded = TRUE
@@ -99,7 +99,7 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 		target.mind.remove_antag_datum(/datum/antagonist/zombie)
 		target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-		target.apply_status_effect(debuff_type)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+		target.apply_necras_revival()
 		//Due to an increased cost and cooldown, these revival types heal quite a bit.
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
 		consume_items(target)
@@ -350,7 +350,7 @@
 
 /datum/status_effect/debuff/random_revival/proc/apply_random_debuff()
 	var/static/list/possible_debuffs = list(
-		/datum/status_effect/debuff/revived,
+		/datum/status_effect/debuff/necras_touched,
 		/datum/status_effect/debuff/dreamfiend_curse,
 		/datum/status_effect/debuff/metabolic_acceleration,
 		/datum/status_effect/debuff/malum_revival,

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -361,7 +361,7 @@
 		H.visible_message(span_notice("[H] is ABSOLVED!"), span_green("I awake from the void."))
 		H.mind.remove_antag_datum(/datum/antagonist/zombie)
 		H.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-		H.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+		H.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
 		return TRUE
 
 	// Transfer afflictions from the target to the caster

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -361,7 +361,7 @@
 		H.visible_message(span_notice("[H] is ABSOLVED!"), span_green("I awake from the void."))
 		H.mind.remove_antag_datum(/datum/antagonist/zombie)
 		H.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-		H.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
+		H.apply_necras_revival(/datum/status_effect/debuff/necras_touched/lux)
 		return TRUE
 
 	// Transfer afflictions from the target to the caster

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -313,6 +313,6 @@
 		update_icon()
 
 		// Apply debuffs
-		occupant.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
+		occupant.apply_necras_revival(/datum/status_effect/debuff/necras_touched/frankenstein)
 
 	return TRUE

--- a/code/modules/surgery/revive_chair.dm
+++ b/code/modules/surgery/revive_chair.dm
@@ -313,6 +313,6 @@
 		update_icon()
 
 		// Apply debuffs
-		occupant.apply_status_effect(/atom/movable/screen/alert/status_effect/debuff/revived)
+		occupant.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
 
 	return TRUE

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -97,7 +97,7 @@
 			adjust_playerquality(revive_pq, user.ckey)
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-	target.apply_status_effect(/datum/status_effect/debuff/revived)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	target.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
 	return TRUE
 
 /datum/surgery_step/infuse_lux/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -97,7 +97,7 @@
 			adjust_playerquality(revive_pq, user.ckey)
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-	target.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
+	target.apply_necras_revival(/datum/status_effect/debuff/necras_touched/lux)
 	return TRUE
 
 /datum/surgery_step/infuse_lux/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
+++ b/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
@@ -77,7 +77,8 @@
 			adjust_playerquality(revive_pq, user.ckey)
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-	target.apply_status_effect(/datum/status_effect/debuff/leech_schizophrenia)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+	target.apply_status_effect(/datum/status_effect/debuff/leech_schizophrenia)
+	target.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
 	return TRUE
 
 /datum/surgery_step/infuse_tick/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
+++ b/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
@@ -78,7 +78,7 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
 	target.apply_status_effect(/datum/status_effect/debuff/leech_schizophrenia)
-	target.apply_necras_revival(2 MINUTES, /datum/status_effect/debuff/necras_touched/lux, /datum/status_effect/debuff/necras_claim/lux)
+	target.apply_necras_revival(/datum/status_effect/debuff/necras_touched/lux)
 	return TRUE
 
 /datum/surgery_step/infuse_tick/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/intent/intent, success_prob)

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -1113,7 +1113,7 @@
 		ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 	target.mind.remove_antag_datum(/datum/antagonist/zombie)
 	target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)
-	target.apply_status_effect(/datum/status_effect/debuff/revived)
+	target.apply_necras_revival()
 	target.apply_status_effect(/datum/status_effect/buff/healing, 14)
 	target.add_stress(/datum/stressevent/necrarevive)
 	src.coinslot -= 1 // -1 coin, please insert more coins.

--- a/modular_azurepeak/code/modules/reagents/reagent_containers/rotcure.dm
+++ b/modular_azurepeak/code/modules/reagents/reagent_containers/rotcure.dm
@@ -20,5 +20,4 @@
 	if(volume > 8)	//Roughly 1 sip from vial.
 		M.remove_status_effect(/datum/status_effect/debuff/rotted)	//Removes de-rot debuff, which is otherwise perminant.
 		M.remove_status_effect(/datum/status_effect/debuff/necras_touched)
-		M.remove_status_effect(/datum/status_effect/debuff/necras_claim)
-	..()
+		..()

--- a/modular_azurepeak/code/modules/reagents/reagent_containers/rotcure.dm
+++ b/modular_azurepeak/code/modules/reagents/reagent_containers/rotcure.dm
@@ -19,5 +19,6 @@
 /datum/reagent/rotcure/on_mob_life(mob/living/carbon/M)
 	if(volume > 8)	//Roughly 1 sip from vial.
 		M.remove_status_effect(/datum/status_effect/debuff/rotted)	//Removes de-rot debuff, which is otherwise perminant.
-		M.remove_status_effect(/datum/status_effect/debuff/revived)	//Removes the 15-minute temp revive debuff
+		M.remove_status_effect(/datum/status_effect/debuff/necras_touched)
+		M.remove_status_effect(/datum/status_effect/debuff/necras_claim)
 	..()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/zizo.dm
@@ -482,7 +482,7 @@
 	var/required_items = list(/obj/item/organ/heart = 1)
 	var/alt_required_items = list(/obj/item/organ/heart = 1)
 	var/item_radius = 1
-	var/debuff_type = /datum/status_effect/debuff/revived
+	var/debuff_type = null
 	var/structure_range = 1
 
 /obj/effect/proc_holder/spell/invoked/evil_resurrect/start_recharge()
@@ -555,7 +555,7 @@
 			ADD_TRAIT(target, TRAIT_IWASREVIVED, "[type]")
 		target.mind.remove_antag_datum(/datum/antagonist/zombie)
 		target.remove_status_effect(/datum/status_effect/debuff/rotted_zombie)	//Removes the rotted-zombie debuff if they have it - Failsafe for it.
-		target.apply_status_effect(debuff_type)	//Temp debuff on revive, your stats get hit temporarily. Doubly so if having rotted.
+		target.apply_necras_revival()
 		//Due to an increased cost and cooldown, these revival types heal quite a bit.
 		target.apply_status_effect(/datum/status_effect/buff/healing, 14)
 		consume_items(target)


### PR DESCRIPTION
## About The Pull Request
https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1447 (I used the timer code for brief safety period of revivals from this PR)
Essentially this but in a more balanced(?) way.

Reworks death penalties to be more balanced and fair-feeling.

When you get revived (by Anastasis, a god spell, or whatever), you take -5 to every stat (STR, CON, WIL, LCK, PER, INT, SPD) and after the first minute, you also get Critical Weakness and DNR applied to you. Both of those last 10 minutes, so from minute 1 to minute 11 after revival. After that they fall off on their own.

The stat penalty itself recovers over time, but it stays fully locked at -5 for the first half of your recovery before it starts lifting — so you can't just instantly shake it off. You recover faster if you're resting on a bed or chair (+20 recovery per minute), well-fed (+5), and/or vigorized (+5). So there's real incentive to actually sit down and recover instead of rushing back into combat.

This is essentially a "you died, take a break" system. You can still walk around, talk, do crafting, whatever — you just can't meaningfully fight or be saved again for a little while. If you go pick a fight while on DNR that's kind of on you at that point.

Lux revival (surgery, court physician, etc.) is explicitly better. The debuff only lasts 5 minutes and recovery happens faster, so you're back to normal sooner. This makes working with a surgeon or apothecary actually worthwhile vs just getting a cheap church rez.

The Fulmenor revival chair gives the fastest recovery of all — 3 minute debuff, quick recovery goal. That's the reward for having one available.

## Testing Evidence
I still have yet to test it, due to needing two clients. But the code is simple enough to work. I will post pictures of here later when i managed to run two instances.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Death should sting without being permanent grief unless you're actually playing recklessly. The old flat DNR felt punishing for reasons outside the player's control — getting ganked once and losing all revival chances permanently is rough. This way, dying still matters (you're weak and unrevivable for a bit), but if it was a stupid death through no real fault of yours, you can sit it out and recover. If you die and then immediately charge back into a fight while on DNR... well, that's genuinely your fault.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Reworked revival penalties. Dying now applies a -5 to all stats with Critical Weakness and DNR kicking in after the first minute, lasting 10 minutes. Stats recover over time, faster if you're resting, well-fed, or vigorized. Lux revival (surgery/physicians) gives a shorter and milder version of the debuff. The Fulmenor revival chair gives the fastest recovery.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
