### PR TITLE
Artificer Improvements & More!

### DIFF
--- a/code/modules/roguetown/roguecrafting/engineering.dm
+++ b/code/modules/roguetown/roguecrafting/engineering.dm
@@ -42,6 +42,60 @@
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 2
 
+/datum/crafting_recipe/roguetown/engineering/ore2bronze
+	name = "Ore to Bronze"
+	result = /obj/item/ingot/bronze
+	reqs = list(/obj/item/rogueore/copper = 1) // 1 to 1 conversion rate
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4 // Bread and butter for artificers
+
+/datum/crafting_recipe/roguetown/engineering/ore2firedust
+	name = "Ore to Fire Essentia"
+	result = /obj/item/alch/firedust
+	reqs = list(/obj/item/rogueore/copper = 1) // 1 to 1 conversion rate
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4 // Bread and butter for artificers
+
+/datum/crafting_recipe/roguetown/engineering/ore2airdust
+	name = "Ore to Air Essentia"
+	result = /obj/item/alch/airdust
+	reqs = list(/obj/item/rogueore/copper = 1) // 1 to 1 conversion rate
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4 // Bread and butter for artificers
+
+/datum/crafting_recipe/roguetown/engineering/ore2airdust
+	name = "Ore to Earth Essentia"
+	result = /obj/item/alch/earthdust
+	reqs = list(/obj/item/rogueore/copper = 1) // 1 to 1 conversion rate
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4 // Bread and butter for artificers
+
+/datum/crafting_recipe/roguetown/engineering/ore2airdust
+	name = "Ore to Water Essentia"
+	result = /obj/item/alch/waterdust
+	reqs = list(/obj/item/rogueore/copper = 1) // 1 to 1 conversion rate
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 4 // Bread and butter for artificers
+
+/datum/crafting_recipe/roguetown/engineering/ore2airdust
+	name = "Arcyne Power Meld"
+	result = /obj/item/magic/melded/t1 
+	reqs = list(/obj/item/alch/magicdust = 1, /obj/item/alch/manabloompowder = 4)   // this might be much. Lets try it, will absolutely require interaction with alchemists
+	verbage_simple = "engineer"
+	verbage = "engineers"
+	skillcraft = /datum/skill/craft/engineering
+	craftdiff = 5 // Arguably will need high int for this. Might swap to 6
+
 /datum/crafting_recipe/roguetown/engineering/bars
 	name = "metal bars"
 	result = /obj/structure/bars
@@ -167,7 +221,7 @@
 	name = "pyroclastic bolt"
 	result = /obj/item/ammo_casing/caseless/rogue/bolt/pyro
 	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 1,
-				/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1)
+				/obj/item/alch/firedust = 1)
 	structurecraft = /obj/machinery/artificer_table
 	craftdiff = 1
 	skillcraft = /datum/skill/craft/engineering
@@ -182,7 +236,7 @@
 				/obj/item/ammo_casing/caseless/rogue/bolt/pyro
 				)
 	reqs = list(/obj/item/ammo_casing/caseless/rogue/bolt = 5,
-				/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 5)
+				/obj/item/alch/firedust = 5)
 	structurecraft = /obj/machinery/artificer_table
 	craftdiff = 1
 	skillcraft = /datum/skill/craft/engineering
@@ -191,7 +245,7 @@
 	name = "pyroclastic arrow"
 	result = /obj/item/ammo_casing/caseless/rogue/arrow/pyro
 	reqs = list(/obj/item/ammo_casing/caseless/rogue/arrow/iron = 1,
-				/obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1)
+				/obj/item/alch/firedust = 1)
 	structurecraft = /obj/machinery/artificer_table
 	craftdiff = 1
 	skillcraft = /datum/skill/craft/engineering
@@ -390,7 +444,7 @@
 	name = "blastsand sticks"
 	category = "Explosives"
 	result = /obj/item/tntstick
-	reqs = list(/obj/item/paper = 2, /obj/item/alch/coaldust = 2, /obj/item/compost = 1, /obj/item/natural/fibers = 1)
+	reqs = list(/obj/item/paper = 2, /obj/item/alch/coaldust = 2, /obj/item/alch/firedust = 1)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -411,7 +465,7 @@
 	result = list(/obj/item/impact_grenade/explosion,
 				  /obj/item/impact_grenade/explosion,
 				  /obj/item/impact_grenade/explosion)
-	reqs = list(/obj/item/natural/clay = 1, /obj/item/paper = 1, /obj/item/alch/coaldust = 1, /obj/item/alch/firedust = 1, /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius = 1)
+	reqs = list(/obj/item/natural/clay = 1, /obj/item/paper = 1, /obj/item/alch/coaldust = 1, /obj/item/alch/firedust = 1)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -422,7 +476,7 @@
 	result = list(/obj/item/impact_grenade/smoke, 
 				  /obj/item/impact_grenade/smoke,
 				  /obj/item/impact_grenade/smoke,)
-	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/ash = 1, /datum/reagent/water = 48)
+	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /datum/reagent/water = 48)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -433,7 +487,7 @@
 	result = list(/obj/item/impact_grenade/smoke/poison_gas,
 				  /obj/item/impact_grenade/smoke/poison_gas,
 				  /obj/item/impact_grenade/smoke/poison_gas)
-	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/ash = 1, /datum/reagent/berrypoison = 5, /obj/item/alch/airdust = 1, /datum/reagent/water = 48)
+	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /datum/reagent/berrypoison = 5, /obj/item/alch/airdust = 1, /datum/reagent/water = 48)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -444,7 +498,7 @@
 	result = list(/obj/item/impact_grenade/smoke/fire_gas,
 				  /obj/item/impact_grenade/smoke/fire_gas,
 				  /obj/item/impact_grenade/smoke/fire_gas)
-	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 2, /obj/item/ash = 1, /obj/item/alch/firedust = 1, /obj/item/alch/solardust = 1, /datum/reagent/water = 48)
+	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 2, /obj/item/alch/firedust = 1)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -455,7 +509,7 @@
 	result = list(/obj/item/impact_grenade/smoke/blind_gas,
 				  /obj/item/impact_grenade/smoke/blind_gas,
 				  /obj/item/impact_grenade/smoke/blind_gas)
-	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/ash = 1, /obj/item/reagent_containers/food/snacks/rogue/veg/onion_sliced = 1, /obj/item/natural/dirtclod = 1, /datum/reagent/water = 48)
+	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/alch/firedust = 1)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -466,7 +520,7 @@
 	result = list(/obj/item/impact_grenade/smoke/mute_gas,
 				  /obj/item/impact_grenade/smoke/mute_gas,
 				  /obj/item/impact_grenade/smoke/mute_gas)
-	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/ash = 1, /obj/item/alch/irondust = 1, /obj/item/rogueore/cinnabar = 1, /datum/reagent/water = 48)
+	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/alch/irondust = 1, /obj/item/rogueore/cinnabar = 1, /datum/reagent/water = 48)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4
@@ -477,7 +531,7 @@
 	result = list(/obj/item/impact_grenade/smoke/healing_gas,
 				  /obj/item/impact_grenade/smoke/healing_gas,
 				  /obj/item/impact_grenade/smoke/healing_gas)
-	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/ash = 1, /obj/item/alch/viscera = 1, /obj/item/alch/bonemeal = 1, /datum/reagent/water = 48)
+	reqs =  list(/obj/item/smokeshell = 3, /obj/item/alch/coaldust = 1, /obj/item/alch/viscera = 1, /obj/item/alch/bonemeal = 1, /datum/reagent/water = 48)
 	structurecraft = /obj/machinery/artificer_table
 	skillcraft = /datum/skill/craft/engineering
 	craftdiff = 4 

--- a/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
+++ b/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
@@ -161,10 +161,10 @@
 	additional_items = list(/obj/item/reagent_containers/glass/bottle/waterskin)
 
 /datum/artificer_recipe/bronze/tools/grappler
-	name = "Grappler (+1 ironpick)(+2 bronze gears)(+1 rope)"
+	name = "Grappler (+2 bronze gears)(+1 rope)"
 	required_item = /obj/item/ingot/bronze
 	created_item = /obj/item/grapplinghook
-	additional_items = list(/obj/item/rogueweapon/pick, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/rope)
+	additional_items = list(/obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/rope)
 	skill_level = 4
 
 // --------- Contraptions -----------
@@ -290,9 +290,9 @@
 	skill_level = 3
 
 /datum/artificer_recipe/contraptions/artificerarmor
-	name = "Artificer armor (+3 ancient alloy ingot)(+2 Bronze gear)"
+	name = "Artificer armor (1 purified alloy, 2 bronze ingots, 2 bronze gear)"
 	required_item = /obj/item/ingot/purifiedaalloy
-	additional_items = list(/obj/item/ingot/purifiedaalloy,/obj/item/ingot/purifiedaalloy, /obj/item/roguegear/bronze,/obj/item/roguegear/bronze)
+	additional_items = list(/obj/item/ingot/bronze, /obj/item/ingot/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze)
 	created_item = /obj/item/clothing/suit/roguetown/armor/plate/paalloy/artificer
 	hammers_per_item = 12
 	skill_level = 4
@@ -319,6 +319,15 @@
 	created_item = /obj/item/clothing/neck/roguetown/cursed_collar
 	hammers_per_item = 14
 	skill_level = 5
+
+/datum/artificer_recipe/contraptions/nochadeglasses // A new goodie for artificers
+	name = "Noc Shade (+1 Bronze Ingot)"
+	required_item = /obj/item/clothing/mask/rogue/spectacles
+	additional_items = list(/obj/item/roguegear/bronze, /obj/item/ingot/bronze)
+	created_item = /obj/item/clothing/mask/rogue/spectacles/inq
+	hammers_per_item = 14
+	skill_level = 5
+
 // --------- WEAPON -----------
 
 /datum/artificer_recipe/wood/weapons //Again, a bit silly, but is important
@@ -448,9 +457,9 @@
 	skill_level = 2
 
 /datum/artificer_recipe/ammunition/pyrobolt_five
-	name = "pyroclastic bolt x5 (+1 iron) (+1 fyritius)"
+	name = "pyroclastic bolt x5 (+1 iron) (+1 fire essentia)"
 	required_item = /obj/item/natural/wood/plank
-	additional_items = list(/obj/item/ingot/iron, /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius)
+	additional_items = list(/obj/item/ingot/iron, /obj/item/alch/firedust)
 	created_item = list(
 				/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
 				/obj/item/ammo_casing/caseless/rogue/bolt/pyro,
@@ -461,11 +470,10 @@
 	hammers_per_item = 6
 	skill_level = 2
 
-
 /datum/artificer_recipe/ammunition/pyroarrow_five
-	name = "pyroclastic arrow x5 (+1 iron) (+1 fyritius)"
+	name = "pyroclastic arrow x5 (+1 iron) (+1 fire essentia)"
 	required_item = /obj/item/natural/wood/plank
-	additional_items = list(/obj/item/ingot/iron, /obj/item/reagent_containers/food/snacks/grown/rogue/fyritius)
+	additional_items = list(/obj/item/ingot/iron, /obj/item/alch/firedust)
 	created_item = list(
 				/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
 				/obj/item/ammo_casing/caseless/rogue/arrow/pyro,
@@ -475,6 +483,30 @@
 				)
 	hammers_per_item = 6
 	skill_level = 2
+
+/datum/artificer_recipe/ammunition/lead_ball_pouch
+	name = "lead ball pouch"
+	required_item = /obj/item/natural/hide/cured
+	additional_items = list(/obj/item/natural/hide/cured, /obj/item/alch/firedust) // we dont want too many of these entering circulation
+	created_item = /obj/item/quiver/bullet
+	hammers_per_item = 2
+	skill_level = 1 // your just putting it together
+
+/datum/artificer_recipe/ammunition/powderflask
+	name = "Powder Flask (+2 firedust, +1 cured leather)"
+	required_item = /obj/item/natural/hide/cured
+	additional_items = list(/obj/item/alch/firedust, /obj/item/alch/firedust, /obj/item/natural/hide/cured) 
+	created_item = /obj/item/powderflask
+	hammers_per_item = 2
+	skill_level = 4  // We want professionals to be making this.
+
+/datum/artificer_recipe/ammunition/ramrod
+	name = "Rifle Ramrod (+1 bronze ingot,  +2 tallow)" // tallow is actually quite historically accurate
+	required_item = /obj/item/ingot/bronze
+	additional_items = list(/obj/item/ingot/bronze, /obj/item/reagent_containers/food/snacks/tallow, /obj/item/reagent_containers/food/snacks/tallow) 
+	created_item = /obj/item/powderflask
+	hammers_per_item = 2
+	skill_level = 4  // We want professionals to be making this.
 
 /datum/artificer_recipe/ammunition/lead_ball
 	name = "lead ball x8 (+2 iron)"
@@ -596,14 +628,11 @@
 
 
 /datum/artificer_recipe/general/tntbomb
-	name = "Gun powder sticks"
+	name = "Gun powder sticks (+1 scroll, +1 coal dust, +1 air essentia, +1 fire essentia)"
 	required_item = /obj/item/rogueore/coal
 	additional_items = list(/obj/item/paper/scroll,
 							/obj/item/alch/coaldust,
-							/obj/item/alch/coaldust,
 							/obj/item/alch/airdust,
-							/obj/item/alch/airdust,
-							/obj/item/alch/firedust,
 							/obj/item/alch/firedust)
 	created_item = /obj/item/tntstick
 	hammers_per_item = 5


### PR DESCRIPTION
## About The Pull Request

I spoke to several people about this and I personally agree with them so I've made this PR after reaching out to artificer players and some guildies too.

The following PR has been made after several requests to make Artificer more bearable and encourage interaction between artificers and the Mages Guild in an effort to make crafts within the Guild a not-so-miserable experience. Furthermore, this pr as a whole touches (and even adds) several recipes and MORE eventually once ideas start rolling in here. The PR also allows those with engineering skills to make items that relate to ensure firearms transition from being a gimmick to something uniquq and distinct.

This PR does NOT give anyone a firearms skill; It purely makes certain items craftable.

## Testing Evidence

When its no longer a draft pr.

## Why It's Good For The Game

Firearms, in my opinion, will be one way to differentiate ourselves from other servers; they were here during RW1 and they should be here as well and not feel so gimped after rebase, where firearms had little to no care.. Along with that, with imps (and other mobs from the Mage loop) dropping essentia on death, this allows artificers to interact with mages and alchemists for essentias so they can make their stuff.

## Changelog

:cl:
add: all essentia's to be made by artificers
add: bronze ingot recipe (might need to be removed, idk)
add: EMPTY lead ball pouch recipe
add:  powder flask recipe
add: ramrod recipe
changed: Pyro bolt recipes
changed: replace fyritus with fire essentia in several recipes
changed: Arcane meld (a power source for artificer armor) makeable by  1 pure essentia and 4 manabloom dusts
TODO add: mageloop mobs dropping essentias
TODO add: Craftable spectacles
remove: Pick requirement from grapples
remove: Adjusts the artificer plate to be moderately less expensive
/:cl:

If I missed anything in the change log, mention it but this is a heavy draft.