### PR TITLE
Speeds up the Deadite timer

### DIFF
--- a/code/datums/components/rotting.dm
+++ b/code/datums/components/rotting.dm
@@ -1,5 +1,5 @@
-#define DEAD_TO_ZOMBIE_TIME 7 MINUTES	//Time before death -> raised as zombie (when outside of the city)
-										//(This isn't exact time. Extended 5 -> 7 because only takes 2-3 min in testing at 5.)
+#define DEAD_TO_ZOMBIE_TIME 5 MINUTES	//Time before death -> raised as zombie (when outside of the city)
+										//(This might not be the exact time)
 
 /datum/component/rot
 	var/amount = 0


### PR DESCRIPTION
## About The Pull Request

Changes the deadite timer time from 7 minutes to 5 minutes

## Testing Evidence

Killed m'self. seemed a good two-minutes or so quicker than usual!
<img width="1995" height="1075" alt="image" src="https://github.com/user-attachments/assets/a1db640b-48bf-4ba0-ba92-9a6010649b8c" />


## Why It's Good For The Game

Zombies are fun, and waiting is boooooriiiing. Feels like we don't really see The Rot in action very often.

## Changelog

:cl:
balance: the 'deadite rot timer' is reduced from 7 minutes to 5 minutes
/:cl:
