### PR TITLE
Noc Acolyte Fixes

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1257,7 +1257,7 @@
 
 /datum/status_effect/buff/moonlightdance/on_remove()
 	. = ..()
-	to_chat(owner, span_warning("Noc's silver leaves my"))
+	to_chat(owner, span_warning("Noc's silver light leaves my sight."))
 	REMOVE_TRAIT(owner, TRAIT_DARKVISION, MAGIC_TRAIT)
 
 

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -86,7 +86,7 @@
 	name = "Arcyne Affinity"
 	desc = "Allows you to learn a spell or two of a certain type once every cycle."
 	miracle = TRUE
-	devotion_cost = 200
+	devotion_cost = 250
 	recharge_time = 40 MINUTES
 	chargetime = 0
 	chargedrain = 0

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -87,12 +87,12 @@
 	desc = "Allows you to learn a spell or two of a certain type once every cycle."
 	miracle = TRUE
 	devotion_cost = 200
-	recharge_time = 50 MINUTES
+	recharge_time = 40 MINUTES
 	chargetime = 0
 	chargedrain = 0
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	associated_skill = /datum/skill/magic/holy
-	var/chosen_bundle
+	var/list/chosen_bundles = list() // Tracks which categories have already been granted
 	var/list/utility_bundle = list(	//Utility means exactly that. Nothing offensive and nothing that can affect another person negatively, 11 spellpoints total. (Barring Fetch, and technically Create Campfire)
 		/obj/effect/proc_holder/spell/self/message,
 		/obj/effect/proc_holder/spell/invoked/leap,
@@ -123,13 +123,18 @@
 	if(!user || !user.mind)
 		revert_cast()
 		return FALSE
-	var/choice = chosen_bundle
-	if(!chosen_bundle)
-		choice = alert(user, "What type of spells has Noc blessed you with?", "CHOOSE PATH", "Utility", "Offense", "Buffs")
-		if(!choice)
-			revert_cast()
-			return FALSE
-		chosen_bundle = choice
+	var/list/available_choices = list("Utility", "Offense", "Buffs")
+	for(var/already in chosen_bundles)
+		available_choices.Remove(already)
+	if(!available_choices.len)
+		user.mind.RemoveSpell(src)
+		to_chat(user, span_notice("The arcyne knowledge granted by Noc has been fully bestowed."))
+		return TRUE
+	var/choice = input(user, "What type of spells has Noc blessed you with?", "CHOOSE PATH") as null|anything in available_choices
+	if(!choice)
+		revert_cast()
+		return FALSE
+	chosen_bundles += choice
 	switch(choice)
 		if("Utility")
 			if(!user.mind?.has_spell(/obj/effect/proc_holder/spell/invoked/diagnose/secular))
@@ -142,9 +147,9 @@
 		if("Buffs")
 			add_spells(user, buff_bundle, choice_count = 4)
 			ADD_TRAIT(user, TRAIT_MAGEARMOR, TRAIT_MIRACLE)
-		else
-			revert_cast()
-			return FALSE
+	if(chosen_bundles.len >= 3)
+		user.mind.RemoveSpell(src)
+		to_chat(user, span_notice("The arcyne knowledge granted by Noc has been fully bestowed."))
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/noc_spell_bundle/proc/add_spells(mob/user, list/spells, choice_count = 1, grant_all = FALSE)

--- a/code/modules/spells/spell_types/wizard/misc/enchant_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/misc/enchant_weapon.dm
@@ -57,7 +57,8 @@
 			to_chat(user, "I consumes the [sacrifice] to enchant [I] permanently.")
 		if(I.GetComponent(/datum/component/enchanted_weapon))
 			qdel(I.GetComponent(/datum/component/enchanted_weapon))
-		I.AddComponent(/datum/component/enchanted_weapon, enchant_duration, TRUE, /datum/skill/magic/arcane, enchant_type)
+		var/refresh_skill = user.get_skill_level(/datum/skill/magic/arcane) ? /datum/skill/magic/arcane : /datum/skill/magic/holy
+		I.AddComponent(/datum/component/enchanted_weapon, enchant_duration, TRUE, refresh_skill, enchant_type)
 		user.visible_message("[user] enchants the [I], enveloping it in a magical glow.")
 		return TRUE
 	else


### PR DESCRIPTION
## About The Pull Request
Adjusted arcyne affinity to be better and less jank. 
- 50 minute CD -> 40 minute CD.
- Devotion adjustment 200 -> 250.
- Doesn't go on cooldown if you hit cancel.
- Removes the category from the chosen list once you cast it again. Actually lets you pick a new category instead of not being able to once you cast it again. This means you can get more spells to your arsenal.
- You can't get all the buff spells though. Also, once you have selected all 3 categories (if you choose to), the spell will remove itself from your spell bar to make more room.

I also fixed the ritual's text when it ends to not look like it cut off mid sentence.

Noc acolytes / missionaries qualify for the weapon enchanting refresh now. It was really annoying they would get the spell, but it wouldn't detect them as a magic user to auto-refresh the enchant for their weapon.

## Testing Evidence
<img width="1410" height="189" alt="arcyneaffnity" src="https://github.com/user-attachments/assets/6d7a33cc-05ba-420f-8cdf-9eeeae1d6d2a" />

## Why It's Good For The Game
It's more fun to play and feels better. Fixes are good, too.

## Changelog
:cl:
fix: Arcyne affinity is less jank. Lower CD, slightly higher devotion cost. Lets you pick multiple categories over time now.
fix: Noc acolytes & missionaries qualify for the weapon enchant spell's auto refresh.
fix: Noc ritual text when it ends. It used to just look like it cut off mid sentence.
/:cl: