### PR TITLE
eradicate ser

### DIFF
--- a/_maps/map_files/otherz/bandit_fortress.dmm
+++ b/_maps/map_files/otherz/bandit_fortress.dmm
@@ -1197,7 +1197,7 @@
 "DE" = (
 /obj/structure/table/wood/poor,
 /obj/item/reagent_containers/glass/cup/skull{
-	desc = "The skull of Ser Jebediah Gillie, prior commander of the wardens, hard to believe you're drinking from his skull.";
+	desc = "The skull of Sir Jebediah Gillie, prior commander of the wardens, hard to believe you're drinking from his skull.";
 	name = "Ser Jebediah Gillie"
 	},
 /turf/open/floor/rogue/twig,

--- a/code/datums/migrants/migrant_waves/czwarteki_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/czwarteki_noble_roles.dm
@@ -37,7 +37,7 @@
 			S.name = "Hussar's tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/code/datums/migrants/migrant_waves/heartfelt roles.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt roles.dm
@@ -36,7 +36,7 @@
 			S.name = "knight tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 			honorary = "Dame"
 		GLOB.chosen_names -= prev_real_name

--- a/code/datums/migrants/migrant_waves/knightly_journey_roles.dm
+++ b/code/datums/migrants/migrant_waves/knightly_journey_roles.dm
@@ -19,7 +19,7 @@
 			S.name = "knight tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1397,7 +1397,7 @@
 							if(!surname || !length(trim(surname)))
 								surname = thegroom.dna.species.random_surname()
 							priority_announce("[thegroom.real_name] has married [thebride.real_name]!", title = "Holy Union!", sound = 'sound/misc/bell.ogg')
-							var/list/titles = list("Sir", "Ser", "Dame", "Lord", "Lady", "Knight-Captain", "Duke", "Duchess", "Father", "Mother", "Brother", "Sister", "Prelate", "Devotee", "Votary")
+							var/list/titles = list("Sir", "Dame", "Lord", "Lady", "Knight-Captain", "Duke", "Duchess", "Father", "Mother", "Brother", "Sister", "Prelate", "Devotee", "Votary")
 							// Assign surname to groom
 							var/list/groom_name_parts = splittext(thegroom.real_name, " ")
 							var/title_found = (titles.Find(groom_name_parts[1]) != 0)

--- a/code/game/objects/structures/roguetown/sanctified_tree.dm
+++ b/code/game/objects/structures/roguetown/sanctified_tree.dm
@@ -1252,7 +1252,7 @@
 
 	priority_announce("[thegroom.real_name] and [thebride.real_name] have been wed beneath the Treefather's boughs!", title = "Nature's Union!", sound = 'sound/misc/bell.ogg')
 
-	var/list/titles = list("Sir", "Ser", "Dame", "Lord", "Lady", "Knight-Captain", "Duke", "Duchess", "Father", "Mother", "Brother", "Sister", "Prelate", "Devotee", "Votary")
+	var/list/titles = list("Sir", "Dame", "Lord", "Lady", "Knight-Captain", "Duke", "Duchess", "Father", "Mother", "Brother", "Sister", "Prelate", "Devotee", "Votary")
 
 	var/list/groom_name_parts = splittext(thegroom.real_name, " ")
 	var/title_found = (titles.Find(groom_name_parts[1]) != 0)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
@@ -28,7 +28,7 @@
 			S.name = "knight tabard ([index])"
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(H.pronouns == SHE_HER || H.pronouns == THEY_THEM_F)
 			honorary = "Dame"
 		GLOB.chosen_names -= prev_real_name

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
@@ -40,7 +40,7 @@
 		var/mob/living/carbon/human/H = L
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(should_wear_femme_clothes(H))
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -58,7 +58,7 @@
 			S.name = "Captain Tabard ([index])" //This doesn't even actually work but you know.
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(should_wear_femme_clothes(H))
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/modular_deserttown/jobs/garrison/cataphract.dm
+++ b/modular_deserttown/jobs/garrison/cataphract.dm
@@ -39,7 +39,7 @@
 		var/mob/living/carbon/human/H = L
 		var/prev_real_name = H.real_name
 		var/prev_name = H.name
-		var/honorary = "Ser"
+		var/honorary = "Sir"
 		if(should_wear_femme_clothes(H))
 			honorary = "Dame"
 		H.real_name = "[honorary] [prev_real_name]"

--- a/strings/accent_universal.json
+++ b/strings/accent_universal.json
@@ -2,7 +2,6 @@
     "universal": {
 		"life": "lyfe",
 		"lifestyle": "lyfestyle",
-		"sir": "ser",
 		"lantern": "lamptern",
 		"ERP": "bush whacking",
 	    "day": "dae",

--- a/strings/italian_replacement.json
+++ b/strings/italian_replacement.json
@@ -19,7 +19,6 @@
     "full": {
         "wine": "vino",
 		"thank you": "grazie",
-		"ser": "signore",
 		"sir": "signore",
 		"madam": "signora",
 		"madame": "signora",


### PR DESCRIPTION
## About The Pull Request

Eradicates ser from the game, replacing it with sir in the accents and honoraries

## Testing Evidence

TBA

## Why It's Good For The Game

Ser is the most agonizingly dumb thing ever. It's the grimshart poopdark modification of words for no reason, but now it's applied to a character's name, so you have to CALL SOMEBODY ser, instead of sir, and it makes everyone sound lame and stupid.

## Changelog

:cl:

del: Ser eradicated

/:cl: