### PR TITLE
More crafting recipes for statues

### DIFF
--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -1029,7 +1029,7 @@
 	icon = 'icons/roguetown/misc/ay.dmi'
 	icon_state = "4"
 	pixel_x = -32
-	pixel_y = -16
+	// pixel_y = -16
 
 /obj/structure/fluff/statue/scare
 	name = "scarecrow"
@@ -1581,6 +1581,7 @@
 	desc = "Wisdom and calm."
 	icon_state = "noc"
 	icon = 'icons/roguetown/misc/statues/statue_noc.dmi'
+	pixel_x = -16
 
 /obj/structure/fluff/statue/noc/guard
 	name = "active noc statue"
@@ -1591,6 +1592,7 @@
 	desc = "Beauty and Charm"
 	icon_state = "eora"
 	icon = 'icons/roguetown/misc/statues/statue_eora.dmi'
+	pixel_x = -16
 
 /obj/structure/fluff/statue/zizo
 	name = "dubious statue"

--- a/code/modules/roguetown/roguecrafting/statues.dm
+++ b/code/modules/roguetown/roguecrafting/statues.dm
@@ -1,0 +1,96 @@
+
+// /datum/crafting_recipe/roguetown/structure
+// 	abstract_type = /datum/crafting_recipe/roguetown/structure
+// 	req_table = FALSE
+// 	subtype_reqs = TRUE
+// 	craftsound = 'sound/foley/Building-01.ogg'
+// 	verbage_simple = "construct"
+// 	verbage = "constructs"
+
+// /datum/crafting_recipe/roguetown/structure/TurfCheck(mob/user, turf/T)
+// 	if(istype(T,/turf/open/transparent/openspace))
+// 		return FALSE
+// 	if(istype(T, /turf/open/water))
+// 		return FALSE
+// 	return ..()
+
+/datum/crafting_recipe/roguetown/structure/statue
+	reqs = list(/obj/item/natural/stone = 4)
+	verbage_simple = "build"
+	verbage = "builds"
+	skillcraft = /datum/skill/craft/masonry
+	craftdiff = 4
+
+/datum/crafting_recipe/roguetown/structure/statue/woman
+	name = "statue (lady)"
+	result = /obj/structure/fluff/statue/femalestatue
+
+/datum/crafting_recipe/roguetown/structure/statue/woman
+	name = "statue (lady sitting)"
+	result = /obj/structure/fluff/statue/femalestatue2
+
+/datum/crafting_recipe/roguetown/structure/statue/aasimar
+	name = "statue (aasimar)"
+	result = /obj/structure/fluff/statue/aasimar
+
+/datum/crafting_recipe/roguetown/structure/statue/tiefling
+	name = "statue (tiefling)"
+	result = /obj/structure/fluff/statue/small
+	reqs = list(/obj/item/natural/stone = 2)
+
+/datum/crafting_recipe/roguetown/structure/statue/gargoyle
+	name = "statue (gargoyle)"
+	result = /obj/structure/fluff/statue/gargoyle
+	reqs = list(/obj/item/natural/stone = 2)
+
+/datum/crafting_recipe/roguetown/structure/statue/knight
+	name = "statue (knight, facing left)"
+	result = /obj/structure/fluff/statue/knight
+
+/datum/crafting_recipe/roguetown/structure/statue/knightr
+	name = "statue (knight, facing right)"
+	result = /obj/structure/fluff/statue/knight/r
+
+/datum/crafting_recipe/roguetown/structure/statue/knightalt
+	name = "statue (knight, tall, facing left)"
+	result = /obj/structure/fluff/statue/knightalt
+
+/datum/crafting_recipe/roguetown/structure/statue/knightaltr
+	name = "statue (knight, tall, facing right)"
+	result = /obj/structure/fluff/statue/knightalt/r
+
+/datum/crafting_recipe/roguetown/structure/statue/hooded
+	name = "statue (hooded)"
+	result = /obj/structure/fluff/statue
+	reqs = list(/obj/item/natural/stone = 3)
+
+/datum/crafting_recipe/roguetown/structure/statue/grand
+	reqs = list(/obj/item/natural/stone = 4, /obj/item/ingot/gold)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/structure/statue/grand/zizo
+	name = "statue (Zizo, grand)"
+	result = /obj/structure/fluff/statue/zizo
+
+/datum/crafting_recipe/roguetown/structure/statue/grand/astrata
+	name = "statue (Astrata, grand)"
+	result = /obj/structure/fluff/statue/astrata/gold
+
+/datum/crafting_recipe/roguetown/structure/statue/grand/eora
+	name = "statue (Eora, grand)"
+	result = /obj/structure/fluff/statue/eora
+
+/datum/crafting_recipe/roguetown/structure/statue/grand/noc
+	name = "statue (Noc, grand)"
+	result = /obj/structure/fluff/statue/noc
+
+/datum/crafting_recipe/roguetown/structure/statue/grand/abyssor
+	name = "statue (Abyssor, grand)"
+	result = /obj/structure/fluff/statue/abyssor
+	reqs = list(/obj/item/natural/stone = 5)
+	craftdiff = 5
+
+/datum/crafting_recipe/roguetown/structure/statue/grand/abyssor/dolomite
+	name = "statue (Abyssor, dolomite, grand)"
+	result = /obj/structure/fluff/statue/abyssor/dolomite
+

--- a/code/modules/roguetown/roguecrafting/statues.dm
+++ b/code/modules/roguetown/roguecrafting/statues.dm
@@ -69,28 +69,28 @@
 	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/structure/statue/grand/zizo
-	name = "statue (Zizo, grand)"
+	name = "statue (grand, Zizo)"
 	result = /obj/structure/fluff/statue/zizo
 
 /datum/crafting_recipe/roguetown/structure/statue/grand/astrata
-	name = "statue (Astrata, grand)"
+	name = "statue (grand, Astrata)"
 	result = /obj/structure/fluff/statue/astrata/gold
 
 /datum/crafting_recipe/roguetown/structure/statue/grand/eora
-	name = "statue (Eora, grand)"
+	name = "statue (grand, Eora)"
 	result = /obj/structure/fluff/statue/eora
 
 /datum/crafting_recipe/roguetown/structure/statue/grand/noc
-	name = "statue (Noc, grand)"
+	name = "statue (grand, Noc)"
 	result = /obj/structure/fluff/statue/noc
 
 /datum/crafting_recipe/roguetown/structure/statue/grand/abyssor
-	name = "statue (Abyssor, grand)"
+	name = "statue (grand, Abyssor)"
 	result = /obj/structure/fluff/statue/abyssor
 	reqs = list(/obj/item/natural/stone = 5)
 	craftdiff = 5
 
 /datum/crafting_recipe/roguetown/structure/statue/grand/abyssor/dolomite
-	name = "statue (Abyssor, dolomite, grand)"
+	name = "statue (grand, Abyssor (dolomite))"
 	result = /obj/structure/fluff/statue/abyssor/dolomite
 

--- a/code/modules/roguetown/roguecrafting/structure.dm
+++ b/code/modules/roguetown/roguecrafting/structure.dm
@@ -920,15 +920,6 @@
 	wallcraft = TRUE
 	craftdiff = 2
 
-/datum/crafting_recipe/roguetown/structure/statue
-	name = "statue"
-	result = /obj/structure/fluff/statue/femalestatue //TODO: Add sculpting
-	reqs = list(/obj/item/natural/stone = 3)
-	verbage_simple = "build"
-	verbage = "builds"
-	skillcraft = /datum/skill/craft/masonry
-	craftdiff = 3
-
 // SCOM is not constructable, only the receive only version is constructable to prevent unactionable sneeding.
 /datum/crafting_recipe/roguetown/structure/rcom
 	name = "RCOM"

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2508,6 +2508,7 @@
 #include "code\modules\roguetown\roguecrafting\items.dm"
 #include "code\modules\roguetown\roguecrafting\runes.dm"
 #include "code\modules\roguetown\roguecrafting\sewing.dm"
+#include "code\modules\roguetown\roguecrafting\statues.dm"
 #include "code\modules\roguetown\roguecrafting\structure.dm"
 #include "code\modules\roguetown\roguecrafting\tallow.dm"
 #include "code\modules\roguetown\roguecrafting\turfs.dm"


### PR DESCRIPTION
## About The Pull Request

Can build most kinds of statue now with expert masonry and a lot of rocks. Also the fancy gold-plated big god statues - albeit with master masonry, a lot of rocks, and a gold ingot.

One bit of weirdness I found with craftable statues is that they're crafted with a Direction, which changes where it blocks movement from; normally they always only block movement north to south... I'ts a little weird but probably not the end of the world.

## Testing Evidence

<img width="854" height="710" alt="image" src="https://github.com/user-attachments/assets/2c2cd37f-266b-4047-b693-0d7788619c2c" />

## Why It's Good For The Game

It's nice to be able to build things! And the gold-plated god statues are a nice special ability for those with master masonry.

## Changelog

:cl:
add: more crafting recipes for statues
/:cl:
