### PR TITLE
Adds Longstrider Trait to Specific Taur Bodies

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -778,6 +778,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				return FALSE
 			if(is_inhumen || is_lamia || is_harpy)
 				return FALSE
+			var/obj/item/bodypart/taur/taur_part = H.get_taur_tail()
+			if(taur_part?.grants_longstrider)
+				return FALSE
 			if( !(I.slot_flags & ITEM_SLOT_SHOES) )
 				return FALSE
 			if(num_legs < 1)

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -470,6 +470,8 @@
 /obj/item/bodypart/taur/drop_limb(special) //copypasta
 	var/mob/living/carbon/C = owner
 	. = ..()
+	if(C && grants_longstrider)
+		REMOVE_TRAIT(C, TRAIT_LONGSTRIDER, BODY_ZONE_TAUR)
 	if(C && !special)
 		if(HAS_TRAIT_FROM(C, TRAIT_PONYGIRL_RIDEABLE, BODY_ZONE_TAUR))
 			REMOVE_TRAIT(C, TRAIT_PONYGIRL_RIDEABLE, BODY_ZONE_TAUR)
@@ -582,6 +584,13 @@
 	C.queue_icon_update(PENDING_UPDATE_BODY | PENDING_UPDATE_HAIR | PENDING_UPDATE_DAMAGE)	
 	C.update_mobility()
 	return TRUE
+
+/obj/item/bodypart/taur/attach_limb(mob/living/carbon/C, special)
+	. = ..()
+	if(. && grants_longstrider)
+		ADD_TRAIT(C, TRAIT_LONGSTRIDER, BODY_ZONE_TAUR)
+		if(C.shoes)
+			C.dropItemToGround(C.shoes, force = TRUE)
 
 /obj/item/bodypart/head/attach_limb(mob/living/carbon/C, special)
 	//Transfer some head appearance vars over

--- a/code/modules/surgery/bodyparts/taur.dm
+++ b/code/modules/surgery/bodyparts/taur.dm
@@ -39,6 +39,8 @@
 	// "d" = deer
 	// null = no taur-specific clothing support
 	var/taur_clothing_category = null
+	// If TRUE, grants TRAIT_LONGSTRIDER on attach and prevents wearing shoes (like harpies)
+	var/grants_longstrider = FALSE
 	// Customizable colors for plate tasset overlays (like detail_color on clothing)
 	var/tasset1_color = null
 	var/tasset2_color = null
@@ -226,6 +228,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	offset_x = -16
 	taur_icon_state = "saiga_s"
 	clip_mask_state = "clip_mask_saiga"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -236,6 +239,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	taur_icon_state = "deer_s"
 	taur_clothing_category = "d"
 	taur_markings_state = "deer_markings"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -247,6 +251,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	taur_markings_state = "goat_markings"
 	clip_mask_state = null
 	clip_mask_legs_state = "clip_mask_goat"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -325,6 +330,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	taur_icon_state = "spider_s"
 	taur_markings_state = "spider_markings"
 	taur_tertiary_state = "spider_markings_2"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -335,6 +341,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	taur_icon_state = "centipede_s"
 	taur_markings_state = "centipede_markings"
 	taur_tertiary_state = "centipede_markings_2"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -354,6 +361,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	offset_x = -16
 	taur_icon_state = "ant_s"
 	taur_markings_state = "ant_markings"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -363,6 +371,7 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	offset_x = -16
 	taur_icon_state = "wasp_s"
 	taur_markings_state = "wasp_markings"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE
 
@@ -373,5 +382,6 @@ GLOBAL_LIST_INIT(taur_types, subtypesof(/obj/item/bodypart/taur))
 	taur_icon_state = "insect_s"
 	taur_markings_state = "insect_markings"
 	taur_tertiary_state = "insect_markings_2"
+	grants_longstrider = TRUE
 
 	has_taur_color = TRUE


### PR DESCRIPTION
## About The Pull Request
- Makes it so that if a player has a certain taur body type, it gives them the longstrider trait. In exchange, they cannot wear shoes like harpies. Others not in the following list will be as usual. The taur body types getting the trait are: saiga body, goat legs, deer body, ant body, centipede body, insect body, spider body, wasp body.

## Testing Evidence
<img width="1454" height="421" alt="longstride" src="https://github.com/user-attachments/assets/aaeaba1e-507b-4fd2-bca9-d75b0d727351" />

## Why It's Good For The Game
I always found it strange that certain taur body types or many legged taur body types did not have innate longstrider, despite being mount capable. Even if they were mountable, they weren't exactly useful as a mount since their speed as a mount was reliant on their speed stat. Traversing difficult terrain on a saiga or goat for example is a way better option.

Now, riding centaurs or just having cloven hoofs or more than four legs (insect types) give a small boon to traversing terrain. Not many people play taurs anyway, but for those who do, they will get the biological benefit of an easier time traversing terrain.

The cost of having this benefit is not wearing shoes though. We don't have horseshoes yet but maybe in the future we will. Anyway, I think it is a fair tradeoff since it is also kinda silly to me that those with horse bodies and the like could wear shoes over their hoofs anyway. This will give them a blatant weak spot for combatants to target in exchange for better mobility on rough ground.

## Changelog
:cl:
add: Makes it so that if a player has a certain taur body type, it gives them the longstrider trait. In exchange, they cannot wear shoes like harpies. Others not in the following list will be as usual. The taur body types getting the trait are: saiga body, goat legs, deer body, ant body, centipede body, insect body, spider body, wasp body.
/:cl:
