### PR TITLE
Small bandit fix, Lawlessness update

### DIFF
--- a/code/datums/character_flaw/lawless.dm
+++ b/code/datums/character_flaw/lawless.dm
@@ -37,6 +37,12 @@
 	if (!my_crime)
 		my_crime = "crimes against the Crown"
 	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, bounty_total, FALSE, my_crime, bounty_poster)
+	if(HAS_TRAIT(H, TRAIT_NOBLE))
+		REMOVE_TRAIT(H, TRAIT_NOBLE, JOB_TRAIT)
+		REMOVE_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
+		REMOVE_TRAIT(H, TRAIT_NOBLE, ADVENTURER_TRAIT)
+		ADD_TRAIT(H, TRAIT_DISGRACED_NOBLE, TRAIT_GENERIC)
+		H.is_noble()
 	if (face_known == "They know my face")
 		if(bounty_poster == "The Justiciary of The Vale")
 			GLOB.outlawed_players += H.real_name

--- a/code/modules/client/vices_menu.dm
+++ b/code/modules/client/vices_menu.dm
@@ -118,12 +118,12 @@
 				if(show_message && user)
 					to_chat(user, span_warning("Unintelligible vice conflicts with Second Voice virtue!"))
 				return TRUE
-	// Lawless conflicts with: Nobility
+	// Lawless conflicts with: Nobility and High Society
 	if(vice_type == /datum/charflaw/lawless)
 		for(var/datum/virtue/virt in virtue_list)
-			if(virt && virt.type == /datum/virtue/utility/noble)
+			if(virt && virt.type == /datum/virtue/utility/noble || virt.type == /datum/virtue/pack/highsociety)
 				if(show_message && user)
-					to_chat(user, span_warning("Lawless vice conflicts with Nobility virtue - you can't be an outlaw and keep Astrata's grace!"))
+					to_chat(user, span_warning("Lawless vice conflicts with the Nobility and High Society virtues - you can't be an outlaw and keep Astrata's grace!"))
 				return TRUE
 
 	return FALSE

--- a/code/modules/client/vices_menu.dm
+++ b/code/modules/client/vices_menu.dm
@@ -118,7 +118,14 @@
 				if(show_message && user)
 					to_chat(user, span_warning("Unintelligible vice conflicts with Second Voice virtue!"))
 				return TRUE
-	
+	// Lawless conflicts with: Nobility
+	if(vice_type == /datum/charflaw/lawless)
+		for(var/datum/virtue/virt in virtue_list)
+			if(virt && virt.type == /datum/virtue/utility/noble)
+				if(show_message && user)
+					to_chat(user, span_warning("Lawless vice conflicts with Nobility virtue - you can't be an outlaw and keep Astrata's grace!"))
+				return TRUE
+
 	return FALSE
 
 /datum/preferences/proc/check_vice_vice_conflict(vice_type, list/selected_vices, show_message = FALSE, mob/user = null)

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -29,7 +29,7 @@
 	advjob_examine = TRUE
 	always_show_on_latechoices = TRUE
 	job_reopens_slots_on_death = FALSE //no endless stream of bandits, unless the migration waves deem it so
-	job_traits = list(TRAIT_SELF_SUSTENANCE, TRAIT_DEATHBYSNUSNU, TRAIT_STEELHEARTED, TRAIT_KNOWNCRIMINAL)
+	job_traits = list(TRAIT_SELF_SUSTENANCE, TRAIT_DEATHBYSNUSNU, TRAIT_STEELHEARTED)
 	same_job_respawn_delay = 1 MINUTES
 	cmode_music = 'sound/music/cmode/antag/combat_deadlyshadows.ogg'
 	job_subclasses = list(
@@ -66,10 +66,14 @@
 
 // Changed up proc from Wretch to suit bandits bit more
 /proc/bandit_select_bounty(mob/living/carbon/human/H)
-	var/wanted = input(H, "Are you wanted by the kingdom?", "You will be more skilled from your experience") as anything in list("Yes", "No")
-	if(wanted == "No") 
-		to_chat(H, span_warning("I am still relatively new to the gang. My crimes have gone unnoticed so far, but I lack experience."))
-		return null
+	var/wanted = list("Yes", "No")
+	var/wanted_choice = input(H, "Are you wanted by the kingdom?", "You will be more skilled from your experience") as anything in wanted
+	switch(wanted_choice)
+		if("Yes")
+			ADD_TRAIT(H, TRAIT_KNOWNCRIMINAL, TRAIT_GENERIC)
+		if("No") 
+			to_chat(H, span_warning("I am still relatively new to the gang. My crimes have gone unnoticed so far, but I lack experience."))
+			return null
 	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of Rotwood", "The Grenzelhoftian Holy See")
 	var/bounty_severity = input(H, "How notorious are you?", "Bounty Amount") as anything in list("Small Game", "Highwayman", "Vale Boogeyman")
 	var/race = H.dna.species


### PR DESCRIPTION
## About The Pull Request

Makes it so that you only have the OUTLAW! text if you say Yes to the question "Are you wanted by the kingdom?"

Kept hedge knights disgraced though, and also added parity to lawless that any noble role taking lawless is ALSO disgraced.

I couldn't get the nobility virtue and lawless vice to work together though, so I made them mutually exclusive.

## Testing Evidence
Adventurer Aristocrat with Lawless, and face known.
<img width="903" height="389" alt="image" src="https://github.com/user-attachments/assets/e87448b2-e12f-4568-bf09-b6a1138a0958" />

Heavy Knight, face NOT known
<img width="903" height="389" alt="image" src="https://github.com/user-attachments/assets/ebef1508-beeb-4da9-a53e-2c4cd513aa82" />

Hedge Knight, face NOT known
<img width="903" height="389" alt="image" src="https://github.com/user-attachments/assets/e65ba29c-6c78-416b-9c21-c01d9be988bc" />

Showing that the vice and virtue are mutually exclusive
<img width="537" height="100" alt="image" src="https://github.com/user-attachments/assets/68cafd21-8e06-44b2-b116-18b622595a6a" />


## Why It's Good For The Game

Bandits that choose to not be wanted by the keep do not get a bounty, and yet currently they still have the OUTLAW! examine, so they'll still be targeted by guards and mercenaries, and yet there'll be no payout if they try to put the bandit in the castifico.

Now, they can at least attempt some subterfuge, though hedge knights will need a good story for why they're disgraced (and probably be attacked anyway).

## Changelog

:cl:
balance: lawless now makes nobles disgraced.
fix: bandits that opt to not be wanted now are actually not wanted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
