### PR TITLE
Inquisition minor skill buffs

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/adjudicator.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/adjudicator.dm
@@ -28,7 +28,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/arbalist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/arbalist.dm
@@ -26,7 +26,7 @@
 		/datum/skill/misc/tracking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/confessor.dm
@@ -33,6 +33,7 @@
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 	)
 	subclass_stashed_items = list(
 		"Tome of Psydon" = /obj/item/book/rogue/bibble/psy


### PR DESCRIPTION


## About The Pull Request

Buffs athletics to expert in adjudicator and arbalist (they have journeyman)

Plus adds apprentice swimming in confessor. (Has none)

## Testing Evidence

trust me, it works.

## Why It's Good For The Game

It's beyond me that adjudicator and arbalist, the specialized combat classes have less than expert in athletics, which they need in order to keep up and not be outstammed.

+ Swimming to confessor because, why the guy that's supposed to infiltrate shit doesn't know how to swim atleast a bit?

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
