### PR TITLE
Bug fix/buff to Pestras T4 miracle

### DIFF
--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_status_effects.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_status_effects.dm
@@ -18,14 +18,14 @@
 	desc = "I have channeled too much of Pestra's power, and cannot harbor much of her divine infestation."
 	icon_state = "divine_exhaustion"
 
-// The healing of this is equivalent 3x pestra's heal, or 2x fortified pestra's heal. It wanes but lasts a long time.
+// The ultimate healing miracle
 /datum/status_effect/buff/divine_rebirth_healing
 	id = "divine_rebirth_healing"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/divine_rebirth_healing
 	duration = 30 SECONDS // Gradual healing
 	tick_interval = 3 SECONDS
 	var/time_left
-	var/healing_strength = 45 // Starts strong
+	var/healing_strength = 45
 	var/limbs_regenerated = 0
 	var/max_limbs_to_regenerate = 3
 	var/outline_colour = "#FFD700"
@@ -49,8 +49,6 @@
 /datum/status_effect/buff/divine_rebirth_healing/tick()
 	var/time_progress = (duration - time_left) / duration
 	time_left -= tick_interval
-	// This shouldn't ever dip below 5, but let's use MAX for safety anyways
-	healing_strength = max(5, healing_strength - (time_progress * (healing_strength - 5)))
 	var/obj/effect/temp_visual/heal/H = new /obj/effect/temp_visual/heal_rogue(get_turf(owner))
 	H.color = outline_colour
 	do_sprite_shake(owner, 3, 3, 15, 1)


### PR DESCRIPTION
## About The Pull Request

Fixed the bug with Pestras special T4 miracle whose healing is supposed to reduce over the course of working instead being stuck at minimal healing for entire duration by...
Removing the healing being reduced over time at all. This means the miracle heals a bit under 2 times the originally intended amount so it is straight buff, but as explained in why good for a game i don't think its an issue (i can always reduce the healing strength to bring it back in line if need be)

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

I would test it if i didn't get this error every time i try to compile the files:
=> Finished 'bun' in 0.254s
:: Skipping 'tgui' (up to date)
loading interface/skin.dmf
interface\stylesheet.dm:167:error: near 1500ms: invalid number: '1500ms'
roguetown.dmb - 0 errors, 0 warnings (5/15/26 2:58 pm)
Total time: 0:17
=> Target 'dm' failed in 18.029s, exit code: 255
=> Target 'build' failed

This also shows up on the main branch so its not error from my side. Its 4 lines of code deleted anyway, and i checked that there are no variables left hanging

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

To people who have never heard of T4 healing pestra miracle, its not weird
It needs:
A) Keeper doing his job and getting his ultimate research done
B) Pestra cleric with at least master in miracles (that's missionary, acolyte and keeper)
C) That cleric to gather 10 infestation charges
D) Same cleric deciding its worth to cripple himself for 20 minutes by reducing his max infestation charges to 1 to use the spell on you

It is supposed to be ultimate miracle for pestra, and even in bugged state fills the otherwise unfiled niche of being able to regrow limbs, but the cost is 20 minutes cooldown with is closer to 26 if we account for the need to gather 9 infestation stacks afterwards, the aforementioned setting of max infestation stacks to 1 for that 20 minute cooldown. Its quite possibly the single most expensive miracle a acolyte can cast, and it should be appropriately powerful. The bug setting the healing to 5 (aka normal pestra healing spell) has to be fixed, but i believe the 2 times over all healing my fix entails is not an issue given just how limited are the casting of this spell. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed Pestras ultimate miracle being stuck at lowest healing rate
balance: By removing lowering healing rate from it at all
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
