### PR TITLE
Athleticism & Knights

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_foot.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_foot.dm
@@ -22,7 +22,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
@@ -23,7 +23,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
 	)

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
@@ -26,7 +26,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 	)

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
@@ -26,7 +26,7 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 	)


### PR DESCRIPTION
## About The Pull Request

Upgrades the Journeyman Athletics on Foot Knight, Heavy Knight, and Mounted Knight to Expert. 

## Testing Evidence

Psydon strike me down if this doesn't work, this is a very very simple change.

## Why It's Good For The Game

Probably due to some powercreep long ago, these two knight subclasses have ended up with lower athleticism than 75% of the garrison. These are supposed to be elite warriors and guardians of the Crown... why would they not be trained to a higher or equivalent standard.

In-game, it'll just make it so that the constant running around and fighting that knights have to do will not be as draining. This will make them a bit better of fighters, but it shouldn't really make a massive impact.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: gave heavy knight, foot knight, and mounted knight expert athletics
/:cl: