### PR TITLE
Makes rontz ring (and scomstone)(and the crown) unusable (while restrained and/or incapacitated)

### DIFF
--- a/code/modules/roguetown/roguemachine/scomm/rontzring.dm
+++ b/code/modules/roguetown/roguemachine/scomm/rontzring.dm
@@ -85,6 +85,9 @@
 	if(user.restrained() || user.incapacitated())
 		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
 		return
+	if(!get_location_accessible(user, BODY_ZONE_PRECISE_MOUTH, grabs = TRUE))
+		to_chat(user, span_warning("My mouth is covered!"))
+		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(input_text)

--- a/code/modules/roguetown/roguemachine/scomm/rontzring.dm
+++ b/code/modules/roguetown/roguemachine/scomm/rontzring.dm
@@ -48,6 +48,9 @@
 /obj/item/mattcoin/attack_self(mob/living/user)
 	. = ..()
 
+	if(user.restrained() || user.incapacitated())
+		return FALSE
+
 	if(disguised)
 		if(alert(user, "Revert disguise?", "Disguise", "Yes", "No") == "Yes")
 			name = "rontz ring"
@@ -78,6 +81,9 @@
 	update_icon()
 
 /obj/item/mattcoin/attack_right(mob/living/carbon/human/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
 	var/input_text = input(user, "Enter your message:", "Message")
 	if(input_text)
@@ -92,6 +98,9 @@
 
 /obj/item/mattcoin/MiddleClick(mob/user)
 	if(.)
+		return
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
 		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
 	playsound(loc, 'sound/misc/coindispense.ogg', 100, FALSE, -1)

--- a/code/modules/roguetown/roguemachine/scomm/rontzring.dm
+++ b/code/modules/roguetown/roguemachine/scomm/rontzring.dm
@@ -49,6 +49,7 @@
 	. = ..()
 
 	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
 		return FALSE
 
 	if(disguised)

--- a/code/modules/roguetown/roguemachine/scomm/scomstone.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomstone.dm
@@ -30,6 +30,9 @@
 	grid_height = 32
 
 /obj/item/scomstone/attack_right(mob/living/carbon/human/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	if(on_cooldown)
 		to_chat(user, span_warning("The gemstone inside the ring radiates heat. It's still cooling down from its last use."))
 		playsound(loc, 'sound/misc/machineno.ogg', 100, FALSE, -1)
@@ -68,6 +71,9 @@
 	on_cooldown = FALSE
 
 /obj/item/scomstone/MiddleClick(mob/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	if(.)
 		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
@@ -149,6 +155,9 @@
 	sellprice = 100
 
 /obj/item/scomstone/garrison/attack_right(mob/living/carbon/human/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)
 	if(on_cooldown)
 		to_chat(user, span_warning("The gemstone inside the ring radiates heat. It's still cooling down from its last use."))
@@ -200,6 +209,9 @@
 	addtimer(CALLBACK(src, PROC_REF(reset_cooldown)), cooldown)
 
 /obj/item/scomstone/garrison/attack_self(mob/living/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	if(.)
 		return
 	user.changeNext_move(CLICK_CD_INTENTCAP)

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -36,6 +36,9 @@
 	qdel(src) //Anti-stall
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/attack_right(mob/living/carbon/human/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	user.changeNext_move(CLICK_CD_MELEE)
 	visible_message(span_notice ("[user] presses their hands against their crown."))
 	var/input_text = input(user, "Enter your ducal message:", "Crown SCOM")
@@ -71,6 +74,9 @@
 					S.repeat_message(input_text, src, usedcolor)
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/attack_self(mob/living/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	if(.)
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -79,6 +85,9 @@
 	to_chat(user, span_info("I [garrisonline ? "connect the crown to the garrison SCOMline" : "connect the crown to the general SCOMline"]"))
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/MiddleClick(mob/user)
+	if(user.restrained() || user.incapacitated())
+		to_chat(user, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
 	if(.)
 		return
 	user.changeNext_move(CLICK_CD_MELEE)


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that if a user is either incapacitated (stuned, paralysed, asleep (I think..)) or restrained by (chain, in hand) they can no longer use the rontz ring/scomstone/crown.

## Testing Evidence

<img width="1861" height="637" alt="Zrzut ekranu 2026-05-16 005331" src="https://github.com/user-attachments/assets/11be067d-68a9-4b18-b79c-95a39330ad9a" />

## Why It's Good For The Game

Consequences... good? Yes I do indeed believe that if you fucked up big-time as antag you should not actually be permitted to just PSY-BLAST every last one of your non-erping buddies your exact coordinates, how many people are guarding you, what they are armed with, and also what they had for breakfast that morning. You fucked up. You are chained, you are at the mercy of your captor.

Don't want to not be able to call your buddies for backup? Do want to be able to talk with them? Play better. Don't get caught. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Rontz Ring is now no longer usable when the user is restrained or incapacitated
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
