### PR TITLE
mallet in the loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 
 /datum/loadout_item/mallet
 	name = "Wooden Mallet"
-	path = /obj/item/rogueweapon/hammer/wooden
+	path = /obj/item/rogueweapon/hammer/wood
 	triumph_cost = 3
 
 //ANCIENT TOOLS (Ancient Alloy)

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -146,6 +146,11 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	path = /obj/item/storage/roguebag
 	triumph_cost = 2
 
+/datum/loadout_item/mallet
+	name = "Wooden Mallet"
+	path = /obj/item/rogueweapon/hammer/wooden
+	triumph_cost = 3
+
 //ANCIENT TOOLS (Ancient Alloy)
 
 /datum/loadout_item/ancient_hammer


### PR DESCRIPTION
## About The Pull Request

Adds the wooden mallet as an available option in the loadout menu for 3 triumphs.

## Testing Evidence

TBA, also it's one line

## Why It's Good For The Game

An alternative to the ancient hammer with a different aesthetic, in case anybody dislikes it.

## Changelog

:cl:

qol: mallets are now available in the loadout menu

/:cl: