### PR TITLE
Fixes Sconce North Wall Crafting

### DIFF
--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -366,6 +366,10 @@
 	QDEL_NULL(torchy)
 	on = FALSE
 	set_light(0)
+	pixel_x = 0
+	pixel_y = 0
+	if(dirin == SOUTH)
+		pixel_y = 32
 	update_icon()
 
 	..(dirin, user)


### PR DESCRIPTION
## About The Pull Request
Previously, trying to craft a sconce on a wall north of the player would result in the sconce floating in front of the wall where the player was standing, rather than putting the icon of the sconce on the wall itself. This PR makes it so crafting the sconce causes it to sit on the wall itself, as (probably) originally intended.

## Testing Evidence
<img width="528" height="85" alt="Screenshot 2026-05-17 112839" src="https://github.com/user-attachments/assets/2ef8db5a-637a-4e38-9ff3-ded671e2815f" />
<img width="410" height="272" alt="Screenshot 2026-05-18 104859" src="https://github.com/user-attachments/assets/e19e52ee-ca20-43f3-9eca-dc8fa803642b" />
<img width="410" height="272" alt="Screenshot 2026-05-18 104912" src="https://github.com/user-attachments/assets/114dd796-77da-4b9f-b34d-f78a760ec761" />

## Why It's Good For The Game
Hopefully opens up more possibilities for sconce crafting, now that one of the four directions they can be crafted in isn't bugged.

## Changelog
🆑 
fix: crafting sconces on a north wall now properly puts the sconce on the wall itself
/:cl:
