### PR TITLE
Fixes Reformist cross icon

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -568,7 +568,7 @@
 	name = "reformist psycross"
 	desc = "A psycross with its prongs bent inward. God is dead, but this world HE left is beautiful and worth of loving. ENDURE with every broken bone in your body."
 	sellprice = 0
-	icon_state = "psycross_reform"
+	icon_state = "reformistcross"
 
 /obj/item/clothing/neck/roguetown/psicross/pearl //put it as a psycross so it can be used for miracles
 	name = "pearl amulet"


### PR DESCRIPTION
## About The Pull Request

Reformist crosses were borked, this unborks them. I suspect it had something to do with the recent Amulets PR renaming the icon states

## Testing Evidence
<img width="695" height="457" alt="image" src="https://github.com/user-attachments/assets/92a13719-84c9-4546-a491-15f0826cc551" />

## Why It's Good For The Game

Fix

## Changelog

:cl:
fix: fixes reformist crosses being invisible
/:cl: