### PR TITLE
Very slight Grenzel Mercenary&Adventurer adjustment buffs!

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/grenzelhoft.dm
@@ -50,15 +50,25 @@
 		/obj/item/rogueweapon/scabbard/sheath = 1
 		)
 	if(H.mind)
-		var/grenzel_purpose = list("Zweihander","Halberd","Eagle's Beak")
+		var/grenzel_purpose = list("Zweihander","Hellebardier (Halberd)","Armbrustschütze (Crossbow + Messer)", "Eagle's Beak")
 		var/weapon_choice = input(H, "Choose your ALLY", "WOE THE CONTRACT") as anything in grenzel_purpose
 		switch(weapon_choice)
 			if("Zweihander")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 				r_hand = /obj/item/rogueweapon/greatsword/grenz
-			if("Halberd")
+			if("Hellebardier (Halberd)")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 				r_hand = /obj/item/rogueweapon/halberd
+			if("Armbrustschütze (Crossbow + Messer)")
+				H.adjust_skillrank_up_to(/datum/skill/combat/crossbows, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/tracking, 3, TRUE)
+				l_hand = /obj/item/rogueweapon/sword/long/kriegmesser
+				r_hand = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow
+				beltl = /obj/item/quiver/bolts
+				beltr = /obj/item/rogueweapon/scabbard
+				H.change_stat(STATKEY_STR, -1)
+				H.change_stat(STATKEY_PER, 2) // so the boy can aim his crossbow and see further, maintain +7 stats total.
 			if("Eagle's Beak")
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 				r_hand = /obj/item/rogueweapon/eaglebeak

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -150,7 +150,8 @@
 		/datum/skill/combat/crossbows = SKILL_LEVEL_MASTER,		//every combat class with a ranged weapon gets this . eat my jorts. They have no dodge expert.
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,  // as a treat? so they can go pick one up bc axes are dookie?
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT 	// >camps and makes defenses in the wild >doesnt know how to track
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,		// Make your energy count, little silly individual

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -154,7 +154,7 @@
 		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT, 	// >camps and makes defenses in the wild >doesnt know how to track
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,		// Make your energy count, little silly individual
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,		// Make your ene- no. The adventurer has better athletics, you're a trained mercenary.
 		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,		// meant to live off the land and set up camp.
 		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE,		// learn 2 maintain your uniform.
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,		// Just so you don't suck at cooking

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/grenzelhoft.dm
@@ -151,7 +151,7 @@
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,  // as a treat? so they can go pick one up bc axes are dookie?
-		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT 	// >camps and makes defenses in the wild >doesnt know how to track
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT, 	// >camps and makes defenses in the wild >doesnt know how to track
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,		// Make your energy count, little silly individual


### PR DESCRIPTION
## About The Pull Request

I'm dating a german girl and she told me that, historically speaking, none of these mercenaries existed in the real world and I was actually using the words wrong, so I figured why the hell not? These guys don't even get to enjoy sausages in the real world, so why not throw them a bone?

This PR is a shameless one up given to the Grenzel adventurers at someone's request, and brings their mercenary equivalent up to parity so that they don't end up being powercrept.

The Bluthund gains a new loadout option: **Crossbow + Messer**, which is similar to the existing Mercenary loadout of similar gear. They've lesser stats and crossbow skill, though, so... Still inferior? This also comes with **TRACKING** as a skill. So you can be the bluthund that blut hunds.
(My german girlfriend told me this means bloodhound, she's cool like that.)







(I don't actually have a german girlfriend. I lied.)

## Testing Evidence
<img width="298" height="259" alt="image" src="https://github.com/user-attachments/assets/4dc23fef-b758-4354-b685-c638c3fa227e" />
<img width="281" height="206" alt="image" src="https://github.com/user-attachments/assets/9d6a0aa3-0a7b-46ce-990d-d25fcbf5eece" />
## Why It's Good For The Game

Variety. It also pleases my nonexistent german girlfriend.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New loadout option for Foreigner Grenzelhoftian adventurer, including tracking skill and a crossbow.
balance: Armbrustschütze gains tracking skill, athletics and sword skill to maintain parity between the adventurer/mercenary counterpart.
/:cl: