### PR TITLE
Clamps now reduce bloodloss again.

### DIFF
--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -125,10 +125,9 @@
 		bleed_rate *= grab.bleed_suppressing
 	bleed_rate = max(round(bleed_rate, 0.1), 0)
 
-	// temporarily disabling below because it is niche use and a LOT of performance drain
-	/*var/surgery_flags = get_surgery_flags()
+	var/surgery_flags = get_surgery_flags()
 	if(surgery_flags & SURGERY_CLAMPED)
-		return min(bleed_rate, 0.5)*/
+		return min(bleed_rate, 0.5)
 	return bleed_rate
 
 /// Called after a bodypart is attacked so that wounds and critical effects can be applied


### PR DESCRIPTION
## About The Pull Request

A optimization port from SR disabled this

## Testing Evidence

https://github.com/user-attachments/assets/0e160688-c929-46a1-bcef-e53e3594e9c5

https://github.com/user-attachments/assets/1f303e27-5486-4aa4-a259-480d893c60e0

## Why It's Good For The Game

Currently opening somone's ribcage with a saw knocks down a lot of blood if you work fast, any mad science roleplay like replacing limbs is a HEAVY bloodloss effect for doing so, with this you can probably do all that crazy stuff without draining your patient dry in seconds.

## Changelog

:cl:
balance: Clamps now actually reduce bloodloss on attached limbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
