### PR TITLE
Big Guys get Big Loads and Small Sheaths get Seen

### DIFF
--- a/code/datums/mob_descriptors/descriptors/other.dm
+++ b/code/datums/mob_descriptors/descriptors/other.dm
@@ -68,6 +68,8 @@
 			if(SHEATH_TYPE_NORMAL)
 				if(penis.penis_size == 3)
 					used_name = "a fat sheath"
+				else if(penis.penis_size == 1)
+					used_name = "a meager sheath"
 				else
 					used_name = "a sheath"
 			if(SHEATH_TYPE_SLIT)

--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -635,21 +635,29 @@
 			volume = 4
 		else
 			volume = 3
-	if(HAS_TRAIT(user, TRAIT_GOODLOVER))
-		volume = floor(volume * 1.5)
 
 	var/obj/item/organ/penis/shaft = user.getorganslot(ORGAN_SLOT_PENIS)
 	if(shaft?.penis_type in list(PENIS_TYPE_KNOTTED, PENIS_TYPE_EQUINE, PENIS_TYPE_EQUINE_KNOTTED, PENIS_TYPE_TAPERED_KNOTTED, PENIS_TYPE_TAPERED_DOUBLE_KNOTTED, PENIS_TYPE_BARBED_KNOTTED))
 		volume += 1
-		
-	return volume
+
+	if(HAS_TRAIT(user, TRAIT_GOODLOVER))
+		volume *= 1.5
+	if(HAS_TRAIT(user, TRAIT_BIGGUY))
+		volume *= 1.5
+	if(is_species(user, /datum/species/gnoll))
+		volume *= 1.5
+	return floor(volume)
 
 /datum/sex_controller/proc/get_max_loads()
 	var/con = user.STACON
 	var/loads = 2 + floor(clamp((con - 10) * 2, 0, 99) / 2)
 	if(HAS_TRAIT(user, TRAIT_GOODLOVER))
-		loads = floor(loads * 1.5)
-	return loads
+		loads *= 1.5
+	if(HAS_TRAIT(user, TRAIT_BIGGUY))
+		loads *= 1.5
+	if(is_species(user, /datum/species/gnoll))
+		loads *= 1.5
+	return floor(loads)
 
 /// Returns the max charge based on dynamic load count
 /datum/sex_controller/proc/get_max_charge()


### PR DESCRIPTION
## About The Pull Request

Adjusts the Dynamic Cum mechanics as per [#1525](https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1525)  to allow people with `TRAIT_BIGGUY` to get a multiplier to their cum volume and max loads as well as Gnolls (,who do not get either, typically)!

Also adds an examine descriptor for those with small sheaths (they previously had none).

## Testing Evidence

4 (Large Balls) + 1 (Knotted/Equine penis), then both `GOODLOVER` and `BIGGUY` traits *1.5 each for 11.25, rounded down to 11. Total loads formula remains unchanged, and accounts for the multipliers and rounds in the same way, so where appropriate, allows people who have both traits potentially more loads (accounting for their CON, of course). 

<img width="274" height="81" alt="image" src="https://github.com/user-attachments/assets/66667aea-ac0b-4b8c-a120-1a2936bc50fa" />
<img width="241" height="23" alt="dreamseeker_dEQZywlhQP" src="https://github.com/user-attachments/assets/5a315bb4-b751-45a6-9a1e-c7c209a7c9b6" />


## Why It's Good For The Game

A small tweak that makes big guys feel big! (And also lets small dicks feel seen?)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a cum volume/max loads multiplier to characters with the BIGGUY trait
add: Added a cum volume/max loads multiplier to gnolls
add: Added an examine descriptor for characters with small penises that would have sheaths
/:cl: