### PR TITLE
Padded + Studded Hood to Tailor Silverface | Slot Adjustments | Mask FoV Bugfix

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
@@ -31,6 +31,11 @@
 	cost = 25
 	contains = list(/obj/item/clothing/neck/roguetown/bevor/iron)
 
+/datum/supply_pack/rogue/armor_iron/studded_leather_hood
+	name = "Studded Leather Hood"
+	cost = 45
+	contains = list(/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced)
+
 /datum/supply_pack/rogue/armor_iron/breastplate_iron
 	name = "Breastplate"
 	cost = 35

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_iron.dm
@@ -31,11 +31,6 @@
 	cost = 25
 	contains = list(/obj/item/clothing/neck/roguetown/bevor/iron)
 
-/datum/supply_pack/rogue/armor_iron/studded_leather_hood
-	name = "Studded Leather Hood"
-	cost = 45
-	contains = list(/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced)
-
 /datum/supply_pack/rogue/armor_iron/breastplate_iron
 	name = "Breastplate"
 	cost = 35

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -63,9 +63,15 @@
 
 /datum/supply_pack/rogue/light_armor/reinforced_hood
 	name = "Reinforced Hood"
-	cost = 40 //It's armour. Quite good, given layering, too. Someone else can adjust this. EDIT: I'm someone else. If it's such good armor, let's make it as expensive as the other good armor in its class, like the padded gambeson. Steel mask is probably better, you're buying this if you want swag.
+	cost = 40 // The mage hood type, in a sense. This is the one that fits on the face or head but not the neck.
 	contains = list(
-					/obj/item/clothing/head/roguetown/roguehood/reinforced,
+					/obj/item/clothing/head/roguetown/roguehood/reinforced)
+
+/datum/supply_pack/rogue/light_armor/padded_leather_hood
+	name = "Padded Leather Hood" // The newer version of the hood that fits around the neck like a coif.
+	cost = 40
+	contains = list(
+					/obj/item/clothing/head/roguetown/helmet/leather/armorhood,
 				)
 
 // Exotic import stuff goes here. Should probably be a little pricier than normal stuff. 2x average? Be sure to name the purchase option so it relates to the actual item, but also what slot it fills.

--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -71,8 +71,12 @@
 	name = "Padded Leather Hood" // The newer version of the hood that fits around the neck like a coif.
 	cost = 40
 	contains = list(
-					/obj/item/clothing/head/roguetown/helmet/leather/armorhood,
-				)
+					/obj/item/clothing/head/roguetown/helmet/leather/armorhood)
+
+/datum/supply_pack/rogue/light_armor/studded_leather_hood
+	name = "Studded Leather Hood"
+	cost = 50
+	contains = list(/obj/item/clothing/head/roguetown/helmet/leather/armorhood/advanced,)
 
 // Exotic import stuff goes here. Should probably be a little pricier than normal stuff. 2x average? Be sure to name the purchase option so it relates to the actual item, but also what slot it fills.
 

--- a/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
@@ -183,7 +183,7 @@
 	icon_state = "studhood"
 	item_state = "studhood"
 	flags_inv =	HIDEHAIR|HIDEEARS|HIDEFACE
-	slot_flags = ITEM_SLOT_HEAD
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_NECK|ITEM_SLOT_MASK
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|NECK
 	//Something between leather and metal helmet, worse than metal helmet by far.
 	armor = list("blunt" = 70, "slash" = 65, "stab" = 60, "piercing" = 20, "fire" = 0, "acid" = 0)
@@ -199,6 +199,7 @@
 	desc = "A thick studded leather hood with buckles."
 	icon_state = "studhood" //make into new sprite
 	item_state = "studhood"
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_NECK|ITEM_SLOT_MASK
 	max_integrity = 280
 	//closer to metal helmet but still quite behind, same blunt resist of hardened leather helmet though.
 	armor = ARMOR_LEATHER_STUDDED
@@ -217,6 +218,7 @@
 				var/mob/living/carbon/H = user
 				H.update_inv_head()
 				H.update_inv_neck()
+				H.update_inv_wear_mask()
 		else if(adjustable == CADJUSTED)
 			ResetAdjust(user)
 			if(user)
@@ -224,3 +226,4 @@
 					var/mob/living/carbon/H = user
 					H.update_inv_head()
 					H.update_inv_neck()
+					H.update_inv_wear_mask()

--- a/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
@@ -183,7 +183,7 @@
 	icon_state = "studhood"
 	item_state = "studhood"
 	flags_inv =	HIDEHAIR|HIDEEARS|HIDEFACE
-	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_NECK|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_NECK
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES|NECK
 	//Something between leather and metal helmet, worse than metal helmet by far.
 	armor = list("blunt" = 70, "slash" = 65, "stab" = 60, "piercing" = 20, "fire" = 0, "acid" = 0)
@@ -199,7 +199,7 @@
 	desc = "A thick studded leather hood with buckles."
 	icon_state = "studhood" //make into new sprite
 	item_state = "studhood"
-	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_NECK|ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_HEAD|ITEM_SLOT_NECK
 	max_integrity = 280
 	//closer to metal helmet but still quite behind, same blunt resist of hardened leather helmet though.
 	armor = ARMOR_LEATHER_STUDDED

--- a/code/modules/clothing/rogueclothes/headwear/otherhoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/otherhoods.dm
@@ -178,3 +178,5 @@
 	else
 		flags_inv |= HIDE_HEADTOP
 	user.update_inv_head()
+	user.update_fov_angles()
+	user.update_vision_cone()

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -356,6 +356,16 @@
 	smeltresult = /obj/item/ingot/iron
 	sewrepair = FALSE
 
+/obj/item/clothing/mask/rogue/facemask/equipped(mob/user, slot)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.update_fov_angles()
+
+/obj/item/clothing/mask/rogue/facemask/dropped(mob/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.update_fov_angles()
+
 /obj/item/clothing/mask/rogue/facemask/shadowfacemask
 	name = "spider rider's mask"
 	desc = "A metal mask adorned with arachnid iconography. A grim visage crafted by a grim race."
@@ -862,7 +872,14 @@
 	next_honk = world.time + 1 SECONDS
 	playsound(src, 'sound/misc/honkmask.ogg', 70, TRUE)
 	to_chat(user, span_notice("The mask's nose is squeezed! It emits a squeaky honk."))
-
+/obj/item/clothing/mask/rogue/xylixmask/dropped(mob/user)
+	..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		hide_identity = initial(hide_identity)
+		block2add = initial(block2add)
+		H.update_fov_angles()
+		H.update_vision_cone()
 /obj/item/clothing/mask/rogue/xylixmask/MiddleClick(mob/user, params)
 	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, ismonkey(user)))
 		return

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -357,11 +357,13 @@
 	sewrepair = FALSE
 
 /obj/item/clothing/mask/rogue/facemask/equipped(mob/user, slot)
+	..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.update_fov_angles()
 
 /obj/item/clothing/mask/rogue/facemask/dropped(mob/user)
+	..()
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.update_fov_angles()


### PR DESCRIPTION
## About The Pull Request
- Adds the padded and studded hood to the tailor silverface.
- Adds studded hood to the merchant goldface.
- Allows the hoods to be worn on the neck slot (not just the head).

Bonus:
- Fixes a FoV issue with certain masks like the jester, oni and kitsune ones not updating the FoV at times when they were removed. Now it force updates your FoV to the smaller cone when taking it off instead of ruining your FoV like you had a mask still on.

## Testing Evidence
<img width="966" height="545" alt="hoodsgoldface" src="https://github.com/user-attachments/assets/ef55e7e8-f294-4550-bd32-0b6d5ac1640e" />

## Why It's Good For The Game
Currently you could only buy the padded hood from the merchant. The tailor was lacking them. I also made them wearable on neck since it was like that on SR. If necessary, I can bump their prices up more but they're pretty expensive at the moment anyway.

Also, the FoV bug has been bugging me for a while so I got that fixed.

## Changelog
:cl:
add: Adds the padded and studded hood to the tailor silverface.
add: Adds studded hood to the merchant goldface.
add: Allows the hoods to be worn on the neck slot (not just the head).
fix: Fixes a FoV issue with certain masks like the jester, oni and kitsune ones not updating the FoV at times when they were removed.
/:cl:
