### PR TITLE
Massively simplify hostile mob ListTargets

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -224,8 +224,6 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/returntolobby,
 	/client/proc/set_tod_override,
 	/client/proc/stresstest_chat,
-	/client/proc/cmd_admin_show_hostile_ai_metrics,
-	/client/proc/cmd_admin_reset_hostile_ai_metrics,
 	/client/proc/performance_stress_test, // Uncomment these if you tick the performance stress test .dm file
 	/client/proc/cleanup_stress_test_mobs
 	)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -15,44 +15,6 @@
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Toggle Debug Two") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_show_hostile_ai_metrics()
-	set category = "Debug"
-	set name = "Show Hostile AI Metrics"
-	if(!check_rights(R_DEBUG))
-		return
-
-	var/list/metrics = get_hostile_ai_targeting_metrics()
-	var/listtargets_calls = metrics["listtargets_calls"]
-	var/candidates_scanned = metrics["candidates_scanned"]
-	var/observer_candidates_filtered = metrics["observer_candidates_filtered"]
-	var/newplayer_candidates_filtered = metrics["newplayer_candidates_filtered"]
-	var/canattack_calls = metrics["canattack_calls"]
-	var/canattack_observer_rejects = metrics["canattack_observer_rejects"]
-	var/canattack_newplayer_rejects = metrics["canattack_newplayer_rejects"]
-
-	var/ghost_filtered_total = observer_candidates_filtered + newplayer_candidates_filtered
-	var/ghost_filtered_pct = candidates_scanned ? round((ghost_filtered_total * 100) / candidates_scanned, 0.01) : 0
-	var/avg_candidates_per_call = listtargets_calls ? round(candidates_scanned / listtargets_calls, 0.01) : 0
-	var/canattack_ghost_reject_total = canattack_observer_rejects + canattack_newplayer_rejects
-	var/canattack_ghost_reject_pct = canattack_calls ? round((canattack_ghost_reject_total * 100) / canattack_calls, 0.01) : 0
-
-	to_chat(src, span_notice("--- Hostile AI Targeting Metrics ---"))
-	to_chat(src, span_notice("NPC scans run: [listtargets_calls] | Mobs found by hearers(): [candidates_scanned] | Avg mobs per scan: [avg_candidates_per_call]"))
-	to_chat(src, span_notice("Ghosts stripped BEFORE targeting loop -> spectators: [observer_candidates_filtered], lobby players: [newplayer_candidates_filtered] | Total ghost waste avoided: [ghost_filtered_total] ([ghost_filtered_pct]% of all candidates)"))
-	to_chat(src, span_notice("CanAttack() calls: [canattack_calls] | Ghosts reaching CanAttack (should be ~0): spectators: [canattack_observer_rejects], lobby players: [canattack_newplayer_rejects] | Ghost leak rate: [canattack_ghost_reject_pct]%"))
-
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Hostile AI Metrics")
-
-/client/proc/cmd_admin_reset_hostile_ai_metrics()
-	set category = "Debug"
-	set name = "Reset Hostile AI Metrics"
-	if(!check_rights(R_DEBUG))
-		return
-
-	reset_hostile_ai_targeting_metrics()
-	to_chat(src, span_notice("Hostile AI targeting metrics reset."))
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Reset Hostile AI Metrics")
-
 
 
 /* 21st Sept 2010

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -2,6 +2,7 @@
 	var/poison_per_bite = 0
 	var/poison_type = /datum/reagent/toxin
 
+// todo: envenomated component that registerse to COMSIG_HOSTILE_ATTACKINGTARGET?
 /mob/living/simple_animal/hostile/retaliate/poison/AttackingTarget()
 	. = ..()
 	if(. && isliving(target))
@@ -11,56 +12,53 @@
 		return .
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake
-		name = "snake"
-		desc = ""
-		icon_state = "snake"
-		icon_living = "snake"
-		icon_dead = "snake_dead"
-		speak_emote = list("hisses")
-		health = 20
-		maxHealth = 20
-		attack_verb_continuous = "bites"
-		attack_verb_simple = "bite"
-		melee_damage_lower = 5
-		melee_damage_upper = 6
-		response_help_continuous = "pets"
-		response_help_simple = "pet"
-		response_disarm_continuous = "shoos"
-		response_disarm_simple = "shoo"
-		response_harm_continuous = "steps on"
-		response_harm_simple = "step on"
-		faction = list("hostile")
-		ventcrawler = VENTCRAWLER_ALWAYS
-		density = FALSE
-		pass_flags = PASSTABLE | PASSMOB
-		mob_size = MOB_SIZE_SMALL
-		mob_biotypes = MOB_ORGANIC|MOB_BEAST|MOB_REPTILE
-		gold_core_spawnable = FRIENDLY_SPAWN
-		obj_damage = 0
-		environment_smash = ENVIRONMENT_SMASH_NONE
+	name = "snake"
+	desc = ""
+	icon_state = "snake"
+	icon_living = "snake"
+	icon_dead = "snake_dead"
+	speak_emote = list("hisses")
+	health = 20
+	maxHealth = 20
+	attack_verb_continuous = "bites"
+	attack_verb_simple = "bite"
+	melee_damage_lower = 5
+	melee_damage_upper = 6
+	response_help_continuous = "pets"
+	response_help_simple = "pet"
+	response_disarm_continuous = "shoos"
+	response_disarm_simple = "shoo"
+	response_harm_continuous = "steps on"
+	response_harm_simple = "step on"
+	faction = list("hostile")
+	ventcrawler = VENTCRAWLER_ALWAYS
+	density = FALSE
+	pass_flags = PASSTABLE | PASSMOB
+	mob_size = MOB_SIZE_SMALL
+	mob_biotypes = MOB_ORGANIC|MOB_BEAST|MOB_REPTILE
+	gold_core_spawnable = FRIENDLY_SPAWN
+	obj_damage = 0
+	environment_smash = ENVIRONMENT_SMASH_NONE
 
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake/ListTargets(atom/the_target)
-	. = oview(vision_range, targets_from) //get list of things in vision range
-	var/list/living_mobs = list()
+	var/old_aggressive = aggressive
+	aggressive = TRUE // so we target all mice in view, not just enemies
+	. = ..() //get list of things in vision range
+	aggressive = old_aggressive
 	var/list/mice = list()
-	for (var/HM in .)
-		//Yum a tasty mouse
-		if(istype(HM, /mob/living/simple_animal/mouse))
-			mice += HM
-		if(isliving(HM))
-			living_mobs += HM
-
-	// if no tasty mice to chase, lets chase any living mob enemies in our vision range
-	if(length(mice) == 0)
-		//Filter living mobs (in range mobs) by those we consider enemies (retaliate behaviour)
-		return  living_mobs & enemies
-	return mice
+	for(var/mob/living/simple_animal/mouse/mouse in .)
+		mice += mouse
+	//Yum a tasty mouse
+	if(length(mice))
+		return mice
+	// if no tasty mice to chase, lets chase any enemies in our vision range
+	return . & enemies
 
 /mob/living/simple_animal/hostile/retaliate/poison/snake/AttackingTarget()
-		if(istype(target, /mob/living/simple_animal/mouse))
-				visible_message(span_notice("[name] consumes [target] in a single gulp!"), span_notice("I consume [target] in a single gulp!"))
-				QDEL_NULL(target)
-				adjustBruteLoss(-2)
-		else
-				return ..()
+	if(istype(target, /mob/living/simple_animal/mouse))
+		visible_message(span_notice("[name] consumes [target] in a single gulp!"), span_notice("I consume [target] in a single gulp!"))
+		QDEL_NULL(target)
+		adjustBruteLoss(-2)
+	else
+		return ..()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -230,23 +230,13 @@ GLOBAL_VAR_INIT(hostile_ai_canattack_newplayer_rejects, 0)
 
 /mob/living/simple_animal/hostile/proc/ListTargets() //Step 1, find out what we can see
 	GLOB.hostile_ai_listtargets_calls++
-	if(!search_objects)
-		. = hearers(vision_range, targets_from) - src //Remove self, so we don't suicide
-		GLOB.hostile_ai_candidates_scanned += length(.)
-		for(var/mob/dead/observer/O in .)
-			. -= O
-			GLOB.hostile_ai_observer_candidates_filtered++
-		for(var/mob/dead/new_player/N in .)
-			. -= N
-			GLOB.hostile_ai_newplayer_candidates_filtered++
-
-		var/static/hostile_machines = typecacheof(list())
-
-		for(var/HM in typecache_filter_list(range(vision_range, targets_from), hostile_machines))
-			if(can_see(targets_from, HM, vision_range))
-				. += HM
+	if(search_objects)
+		. = view(vision_range, targets_from)
 	else
-		. = oview(vision_range, targets_from)
+		. = viewers(vision_range, targets_from) // todo: check if this should be changed back to hearers() like it was before
+		// if you want to make certain non-mobs get targeted, PLEASE make a spatial grid channel for it
+		// do not add any kind of range() or view() or typecache or etc checking here, that is ludicrously expensive
+	. -= src
 
 /mob/living/simple_animal/hostile/proc/FindTarget(list/possible_targets, HasTargetsList = 0)//Step 2, filter down possible targets to things we actually care about
 	. = list()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -231,9 +231,9 @@ GLOBAL_VAR_INIT(hostile_ai_canattack_newplayer_rejects, 0)
 /mob/living/simple_animal/hostile/proc/ListTargets() //Step 1, find out what we can see
 	GLOB.hostile_ai_listtargets_calls++
 	if(search_objects)
-		. = view(vision_range, targets_from)
+		. = view(vision_range, targets_from) // todo: does this need to be dview to ensure they have darkvision like with hearers()?
 	else
-		. = viewers(vision_range, targets_from) // todo: check if this should be changed back to hearers() like it was before
+		. = hearers(vision_range, targets_from) // hearers so they have darkvision. todo: make this controllable via a var
 		// if you want to make certain non-mobs get targeted, PLEASE make a spatial grid channel for it
 		// do not add any kind of range() or view() or typecache or etc checking here, that is ludicrously expensive
 	. -= src

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,31 +1,3 @@
-GLOBAL_VAR_INIT(hostile_ai_listtargets_calls, 0)
-GLOBAL_VAR_INIT(hostile_ai_candidates_scanned, 0)
-GLOBAL_VAR_INIT(hostile_ai_observer_candidates_filtered, 0)
-GLOBAL_VAR_INIT(hostile_ai_newplayer_candidates_filtered, 0)
-GLOBAL_VAR_INIT(hostile_ai_canattack_calls, 0)
-GLOBAL_VAR_INIT(hostile_ai_canattack_observer_rejects, 0)
-GLOBAL_VAR_INIT(hostile_ai_canattack_newplayer_rejects, 0)
-
-/proc/get_hostile_ai_targeting_metrics()
-	return list(
-		"listtargets_calls" = GLOB.hostile_ai_listtargets_calls,
-		"candidates_scanned" = GLOB.hostile_ai_candidates_scanned,
-		"observer_candidates_filtered" = GLOB.hostile_ai_observer_candidates_filtered,
-		"newplayer_candidates_filtered" = GLOB.hostile_ai_newplayer_candidates_filtered,
-		"canattack_calls" = GLOB.hostile_ai_canattack_calls,
-		"canattack_observer_rejects" = GLOB.hostile_ai_canattack_observer_rejects,
-		"canattack_newplayer_rejects" = GLOB.hostile_ai_canattack_newplayer_rejects,
-	)
-
-/proc/reset_hostile_ai_targeting_metrics()
-	GLOB.hostile_ai_listtargets_calls = 0
-	GLOB.hostile_ai_candidates_scanned = 0
-	GLOB.hostile_ai_observer_candidates_filtered = 0
-	GLOB.hostile_ai_newplayer_candidates_filtered = 0
-	GLOB.hostile_ai_canattack_calls = 0
-	GLOB.hostile_ai_canattack_observer_rejects = 0
-	GLOB.hostile_ai_canattack_newplayer_rejects = 0
-
 /mob/living/simple_animal/hostile
 	faction = list("hostile")
 	stop_automated_movement_when_pulled = 0
@@ -229,7 +201,6 @@ GLOBAL_VAR_INIT(hostile_ai_canattack_newplayer_rejects, 0)
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 
 /mob/living/simple_animal/hostile/proc/ListTargets() //Step 1, find out what we can see
-	GLOB.hostile_ai_listtargets_calls++
 	if(search_objects)
 		. = view(vision_range, targets_from) // todo: does this need to be dview to ensure they have darkvision like with hearers()?
 	else
@@ -293,14 +264,7 @@ GLOBAL_VAR_INIT(hostile_ai_canattack_newplayer_rejects, 0)
 
 // Please do not add one-off mob AIs here, but override this function for your mob
 /mob/living/simple_animal/hostile/CanAttack(atom/the_target)//Can we actually attack a possible target?
-	GLOB.hostile_ai_canattack_calls++
 	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids
-		return FALSE
-	if(isobserver(the_target))
-		GLOB.hostile_ai_canattack_observer_rejects++
-		return FALSE
-	if(isnewplayer(the_target))
-		GLOB.hostile_ai_canattack_newplayer_rejects++
 		return FALSE
 
 	if(binded)


### PR DESCRIPTION
## About The Pull Request
Removes dead code in ListTargets that was making hostile mobs far more expensive than necessary.

Small note for maints: ~~instead of `hearers() - src` and `oview()` it now uses `viewers() - src` and `view() - src`. This should make object-targeting mobs able to target things on their own tile, and make sure mobs (by default) take visibility into account. If that's not desirable I can change it back to hearers().~~ It now uses `hearers() - src` and `view() - src`. I'm not sure if that `view()` needs to be `dview()` or not.

also removes a useless optimization and associated bookkeeping. skipping newplayers is pointless because those should never be on the map, and observers will fail either the invisibility or isliving checks.

## Testing Evidence
A volf and skeleton both targeted and attacked me normally. They didn't notice me while I was sneaking with max sneak skill, until I stopped sneaking and I was attacked. Woo.

## Why It's Good For The Game

I mentioned it on #1555. This removes dead code and simplifies the checks a lot. This PR means we will likely be able to check much more frequently with less lag, or at least less lag at the current check frequency, so there will be more responsiveness.