### PR TITLE
Optimize progress bars

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -8,7 +8,6 @@
 	var/shown = 0
 	var/mob/user
 	var/listindex
-	var/list/tracked_clients
 
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
@@ -31,12 +30,10 @@
 	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
 /datum/progressbar/proc/update(progress)
-	if(!tracked_clients)
-		tracked_clients = list()
-	for(var/mob/M in viewers(user, null))
-		if(M.client)
-			M.client.images |= bar
-			tracked_clients |= M.client
+	for(var/mob/M in get_hearers_in_view(world.view, src, RECURSIVE_CONTENTS_CLIENT_MOBS))
+		if(!M.client) // still need to check just in case
+			continue
+		M.client.images += bar // no need for |=, images is deduplicated engine-side which is far faster
 
 	progress = CLAMP(progress, 0, goal)
 	last_progress = progress
@@ -64,14 +61,11 @@
 		LAZYREMOVE(user.progressbars, bar.loc)
 
 	animate(bar, alpha = 0, time = PROGRESSBAR_ANIMATION_TIME)
-	addtimer(CALLBACK(src, PROC_REF(remove_from_client)), PROGRESSBAR_ANIMATION_TIME, TIMER_CLIENT_TIME)
+	addtimer(CALLBACK(src, PROC_REF(remove_from_clients)), PROGRESSBAR_ANIMATION_TIME, TIMER_CLIENT_TIME)
 	return ..()
 
-/datum/progressbar/proc/remove_from_client()
-	for(var/client/C in tracked_clients)
-		C.images -= bar
-	bar = null
-	tracked_clients = null
+/datum/progressbar/proc/remove_from_clients()
+	QDEL_NULL(bar) // deleting an image clears it from all clients
 
 #undef PROGRESSBAR_ANIMATION_TIME
 #undef PROGRESSBAR_HEIGHT


### PR DESCRIPTION
## About The Pull Request
Makes progress bars use the spatial grid for cliented mobs, to hopefully avoid having to filter out clientless mobs from viewers().

Removes unnecessary client tracking for progress bars. Per the DM ref for `client.images` (emphasis mine):

> This is a list of images that are displayed to the user. The output operator is one way to add entries to this list. **Deleting an image object will automatically remove it from the display,** but if you want to retain an image (so other people can still see it), it can be removed by directly modifying this list. 

Now we just qdel it when we set it to null, instead of just nulling it and letting it softdel.

## Testing Evidence
Uh, not yet :)

## Why It's Good For The Game
Alternative to #1488. Will hopefully make progress bars faster and have them show to nearby mobs with clients even if they aren't directly on turfs.