### PR TITLE
New Hare/Rabbit/Cabbit Titles + Fixes Fancy Sandals

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -26,7 +26,7 @@
 	use_titles = TRUE
 	race_titles = list(
 	"Cat-Kin", "Dog-Kin", "Volf-Kin", "Lion-Kin", "Venard-Kin", "Tiger-Kin", "Sheep-Kin",
-	"Goat-Kin", "Rous-Kin", "Possum-Kin", "Pig-Kin", "Boar-Kin", "Rabbit-Kin", "Horse-Kin",
+	"Goat-Kin", "Rous-Kin", "Possum-Kin", "Pig-Kin", "Boar-Kin", "Rabbit-Kin", "Cabbit-Kin", "Hare-Kin", "Horse-Kin",
 	"Donkey-Kin", "Hyena-Kin", "Deer-Kin", "Bear-Kin", "Panda-Kin", "Coyote-Kin", "Moose-Kin",
 	"Jackal-Kin", "Panther-Kin", "Lynx-Kin", "Leopard-Kin", "Monkey-Kin", "Bird-Kin", "Seal-Kin", "Frog-Kin",
 	"Bat-Kin", "Otter-Kin", "Cow-Kin", "Bull-Kin", "Bee-Kin", "Lizard-Kin", "Insect-Kin", "Spider-Kin", "Monster-Kin", "Chimera"

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorphsmall.dm
@@ -16,7 +16,7 @@
 	use_titles = TRUE
 	race_titles = list(
 	"Catvolk", "Dogvolk", "Volfvolk", "Lionvolk", "Venardvolk", "Tigervolk", "Sheepvolk",
-	"Goatvolk", "Rousvolk", "Possumvolk", "Pigvolk", "Boarvolk", "Rabbitvolk", "Horsevolk",
+	"Goatvolk", "Rousvolk", "Possumvolk", "Pigvolk", "Boarvolk", "Rabbitvolk", "Cabbitvolk", "Harevolk", "Horsevolk",
 	"Donkeyvolk", "Hyenavolk", "Deervolk", "Bearvolk", "Pandavolk", "Coyotevolk", "Moosevolk",
 	"Jackalvolk", "Panthervolk", "Lynxvolk", "Leopardvolk", "Monkeyvolk", "Birdvolk", "Sealvolk", "Frogvolk",
 	"Batvolk", "Ottervolk", "Cowvolk", "Bullvolk", "Beevolk", "Monstervolk", "Chimeravolk"

--- a/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/demihuman.dm
@@ -31,7 +31,7 @@
 	race_titles = list(
 	"Half-Cat", "Half-Dog", "Half-Volf", "Half-Lion", "Half-Venard",
 	"Half-Tiger", "Half-Sheep", "Half-Goat", "Half-Rous", "Half-Possum",
-	"Half-Pig", "Half-Boar", "Half-Cabbit", "Half-Rabbit", "Half-Horse", "Half-Donkey",
+	"Half-Pig", "Half-Boar", "Half-Cabbit", "Half-Rabbit", "Half-Hare", "Half-Horse", "Half-Donkey",
 	"Half-Hyena", "Half-Deer", "Half-Bear", "Half-Panda", "Half-Coyote",
 	"Half-Moose", "Half-Jackal", "Half-Panther", "Half-Lynx", "Half-Leopard",
 	"Half-Monkey", "Half-Bird", "Half-Seal", "Half-Frog", "Half-Bat", "Half-Otter", "Half-Cow",

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -488,6 +488,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Sandals"
 	path = /obj/item/clothing/shoes/roguetown/sandals
 
+/datum/loadout_item/toga_sandals
+	name = "Fancy Sandals"
+	path = /obj/item/clothing/shoes/roguetown/sandals/toga_sandals
+
 /datum/loadout_item/shortboots
 	name = "Short Boots"
 	path = /obj/item/clothing/shoes/roguetown/shortboots

--- a/modular_rmh/code/modules/clothing/valentyi/toga_sandals.dm
+++ b/modular_rmh/code/modules/clothing/valentyi/toga_sandals.dm
@@ -12,7 +12,7 @@
 
 /datum/crafting_recipe/roguetown/leather/footwear/toga_sandals
 	name = "fancy sandals"
-	result = /obj/item/clothing/shoes/roguetown/sandals/
+	result = /obj/item/clothing/shoes/roguetown/sandals/toga_sandals
 	reqs = list(/obj/item/natural/hide/cured = 1)
 
 //SUPPLY PACKS
@@ -21,11 +21,11 @@
 	name = "Fancy Sandals"
 	cost = 15
 	contains = list(
-					/obj/item/clothing/shoes/roguetown/sandals/,
+					/obj/item/clothing/shoes/roguetown/sandals/toga_sandals,
 				)
 
 //LOADOUT
 
 /datum/loadout_item/toga_sandals
 	name = "Fancy Sandals"
-	path = /obj/item/clothing/shoes/roguetown/sandals/
+	path = /obj/item/clothing/shoes/roguetown/sandals/toga_sandals


### PR DESCRIPTION
## About The Pull Request
- Fixes the fancy sandals in the loadout to give the actual fancy sandals item (not the gladiator ones) and not the regular sandals. I had to change the filepaths so it wouldn't confuse it with regular sandals.
- Adds half-hare &  half-rabbit to half-kin race titles.
- Adds harevolk and cabbitvolk for critterkin's titles.
- Adds hare-kin and cabbit-kin for wildkin.

## Testing Evidence
<img width="1291" height="273" alt="titleandsandalspr" src="https://github.com/user-attachments/assets/559868ad-669e-40b5-b744-6263e29d7d4f" />

## Why It's Good For The Game
Broken stuff bad. Also, more title options are good. And yes, there is a difference between a cabbit, rabbit and a hare.

## Changelog
:cl:
fix: Fixes the fancy sandals in the loadout to give the actual fancy sandals item (not the gladiator ones) and not the regular sandals.
add: Adds half-hare &  half-rabbit to half-kin race titles.
add: Adds harevolk and cabbitvolk for critterkin's titles.
add: Adds hare-kin and cabbit-kin for wildkin.
/:cl: