### PR TITLE
Inquisitorial duster 

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -1814,7 +1814,7 @@
 
 /atom/movable/screen/alert/status_effect/buff/psydonic_endurance
 	name = "Psydonic Endurance"
-	desc = "I am protected by blessed Psydonian plate armor."
+	desc = "I am protected by blessed Psydonian armor."
 	icon_state = "buff"
 
 #undef BLOODRAGE_FILTER

--- a/code/modules/clothing/rogueclothes/armor/plate.dm
+++ b/code/modules/clothing/rogueclothes/armor/plate.dm
@@ -614,6 +614,15 @@
 			user.visible_message(span_warning("[user] stops fitting [W] inside the [src]."))
 		return
 
+/obj/item/clothing/suit/roguetown/armor/plate/scale/inqcoat/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot == SLOT_ARMOR)
+		user.apply_status_effect(/datum/status_effect/buff/psydonic_endurance)
+
+/obj/item/clothing/suit/roguetown/armor/plate/scale/inqcoat/dropped(mob/living/carbon/human/user)
+	. = ..()
+	if(istype(user) && user?.wear_armor == src)
+		user.remove_status_effect(/datum/status_effect/buff/psydonic_endurance)
 
 /obj/item/clothing/suit/roguetown/armor/plate/scale/inqcoat/armored
 	slot_flags = ITEM_SLOT_ARMOR


### PR DESCRIPTION
## About The Pull Request

The Inquisitorial Duster (light armor) now also provides the PSYDONIC ENDURANCE buff, like its medium and heavy armor counterparts.

## Testing Evidence
<img width="1679" height="998" alt="image" src="https://github.com/user-attachments/assets/5bbac762-f4ce-46f9-bebc-e013f97b8f51" />
No armor
<img width="1679" height="1000" alt="image" src="https://github.com/user-attachments/assets/ba2ea8cc-e724-4ce5-bc96-d3b43100f88d" />
With armor 

## Why It's Good For The Game
Grants the same buff as other inquisitorial armor counterparts

## Changelog
:cl:
balance: added psydonic endurance to inquisitorial leather duster
code: changed some code
/ :cl:

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
