### PR TITLE
Soap adjustments

### DIFF
--- a/_maps/map_files/rockhill/rockhillOLD.dmm
+++ b/_maps/map_files/rockhill/rockhillOLD.dmm
@@ -12563,8 +12563,6 @@
 /area/rogue/indoors/town/shop)
 "myB" = (
 /obj/structure/closet/crate/chest/crafted,
-/obj/item/bath/soap,
-/obj/item/bath/soap,
 /turf/open/floor/rogue/ruinedwood{
 	icon_state = "weird1"
 	},

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -16,7 +16,7 @@
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && !victim.jumping && !victim.zfalling && isnull(victim.throwing))
+	if(istype(victim) && !victim.is_flying() && !victim.jumping && !victim.zfalling && isnull(victim.throwing) && victim.m_intent == MOVE_INTENT_RUN)
 		if(victim.slip(knockdown_time, parent, lube_flags, paralyze_time, force_drop_items) && callback)
 			callback.Invoke(victim)
 

--- a/code/game/objects/items/soap.dm
+++ b/code/game/objects/items/soap.dm
@@ -17,7 +17,7 @@
 
 /obj/item/soap/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, 10)
 
 /obj/item/soap/examine(mob/user)
 	. = ..()

--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -333,14 +333,4 @@
 
 /obj/item/soap/bath
 	name = "herbal soap"
-	desc = "A soap made from various herbs"
-	icon = 'icons/obj/items_and_weapons.dmi'
-	icon_state = "soap"
-	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
-	w_class = WEIGHT_CLASS_TINY
-	item_flags = NOBLUDGEON
-
-/obj/item/bath/soap/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	desc = "A soap made from various herbs."


### PR DESCRIPTION
## About The Pull Request

Does a few things, all largely related to soap.

Introduces a check to make sure the mover is sprinting before causing the slip itself, and the duration of the knockdown has been reduced from 8 seconds to 1.

Cleans up some old redundant code of herbal soap, child of regular soap, and deletes old vestigial code for a dummied out soap that had an improper item path.

...Also adds a period to the examine description for herbal soap. 

~~Edit: Apparently also nerfs Xylixian miracles (and ritual) related to slipping by extension.
I do not weep for Xylixians. Get better material!!~~

Edit 2: *Apparently*, I was mistaken, the Xylixian miracles related to slipping are untouched, actually, so slipsquare and grand slipsquare still make turfs inflict a 10s knockdown, and Ritual of Pratfall still retains its ability to force a knockdown (albeit 2 seconds) on any who step onto the laying down Xylixian in question (I guess this is fine?).
<sup>Woe...</sup>

## Testing Evidence
<img width="72" height="38" alt="dreamseeker_dJwoq6RG86" src="https://github.com/user-attachments/assets/cc2022a7-fb94-45c9-818e-47b8b870e79f" />
<img width="218" height="47" alt="dreamseeker_zaL86oihqU" src="https://github.com/user-attachments/assets/39a64e64-b7b4-47d2-8933-90a1f2a1be41" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Soap, while infrequently used, has a nasty punishment of inflicting an **Eight Second** hard knockdown, during which you cannot stand at all, and all you needed to do to inflict this upon someone is have them enter the tile it's on. No check, nothing. You could even grab ahold of someone, drop soap, and pull them into the tile to do so. Needless to say, this invites a very... *slippery* slope in terms of strategizing for combat, where people would just take soap for the sheer advantage it offers in making someone effectively crippled for eight full seconds, suffering reduced dodge and parry chances on the ground.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Deleted old code referencing an improper component initialization for a dummy item path
del: Removed redundant code from soap/bath item that was copied from soap itself
balance: Adding a sprinting check to soap to slip people
balance: Also by extension nerfs Xylixian miracles + rituals and the associated slip-granting sources
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
