### PR TITLE
Wretched Toiler again;

### DIFF
--- a/code/game/objects/items/rogueitems/gems.dm
+++ b/code/game/objects/items/rogueitems/gems.dm
@@ -82,6 +82,12 @@
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
+/obj/item/roguegem/houndgem
+	name = "houndstone gem"
+	icon_state = "topaz_cut"
+	sellprice = 0
+	desc = "A component to make a Houndstone, it looks like a topaz."
+
 /obj/item/roguegem/yellow
 	name = "toper"
 	icon_state = "topaz_cut"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
@@ -1,0 +1,119 @@
+/datum/advclass/wretch/vigilante
+	name = "Masked Lunatic"
+	tutorial = "You were a disenfranchised pauper, sickened by the rampant corruption of the garrison - or perhaps, just a crazed vagrant in a costume? Whether those brutalized 'thieves' were justified in their acts is up to YOU to decide, not them! You specialize in utilizing your various gadgets and thrown projectiles to dote out JUSTICE, however you see it fit."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/wretch/vigilante
+	cmode_music = 'sound/music/combatmaniac.ogg'
+	class_select_category = CLASS_CAT_ROGUE
+	category_tags = list(CTAG_WRETCH)
+	traits_applied = list(TRAIT_DECEIVING_MEEKNESS, TRAIT_PERFECT_TRACKER)
+	maximum_possible_slots = 1 // There can only be one.
+	extra_context = "This class is best experienced without preparation."
+	subclass_skills = list(
+		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT, //To make a clean getaway from the constables
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, // RUN BOY RUN
+		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT, // To escape grapplers, fuck you
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE, //To make your own costumes.
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //You WILL be getting neckstabbed A LOT.
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT, //SNIFF OUT JUSTICE.
+	)
+
+/datum/outfit/job/roguetown/wretch/vigilante/pre_equip(mob/living/carbon/human/H)
+	neck = /obj/item/clothing/neck/roguetown/chaincoif/ //So your skull isn't caved in if you decide to wear a cool hat.
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	backr = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/steel
+	gloves = /obj/item/clothing/gloves/roguetown/plate
+	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
+	backpack_contents = list(
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/rope/chain = 1,
+		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
+		)
+	if(H.mind)
+		var/classes = list("The Watchman", "The Gadgeteer", "I AM JUSTICE INCARNATE!!!")
+		var/classchoice = input(H, "Choose your archetypes", "Available archetypes") as anything in classes
+		switch(classchoice)
+			if("The Watchman") //Face-to-face CQC. No crit resist. Pure aura. Rorschach.
+				H.set_blindness(0)
+				watchman_equip(H)
+			if("The Gadgeteer") //Make gadgets, be precise and smart. Think ahead before you start swinging. Nite Owl.
+				H.set_blindness(0)
+				owl_equip(H)
+			if("I AM JUSTICE INCARNATE!!!") //THROW SHIT AT PEOPLE. RANDOM BULLSHIT GO!!!! MOON KNIGHT.
+				H.set_blindness(0)
+				bullshit_equip(H)
+
+/datum/outfit/job/roguetown/wretch/vigilante/proc/watchman_equip(mob/living/carbon/human/H)
+	H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE) //No civilized barbarian. Sorry chud. Go play Berserker if you want that.
+	H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 5, TRUE) //I can do this all day.
+	backl = /obj/item/storage/backpack/rogue/backpack/bagpack
+	beltl = /obj/item/rogueweapon/knuckles
+	beltr = /obj/item/rogueweapon/stoneaxe/hurlbat
+	head = /obj/item/clothing/head/roguetown/roguehood/shalal/heavyhood
+	cloak = /obj/item/clothing/cloak/thief_cloak
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket
+	H.change_stat(STATKEY_STR, 2)
+	H.change_stat(STATKEY_CON, 3)
+	H.change_stat(STATKEY_WIL, 3)
+	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC) //No crit resist - you can still get folded pretty easily if overwhelmed
+	wretch_select_bounty(H)
+
+/datum/outfit/job/roguetown/wretch/vigilante/proc/owl_equip(mob/living/carbon/human/H)
+	backl = /obj/item/rogueweapon/woodstaff/quarterstaff/steel //nonlethal takedowns
+	beltr = /obj/item/quiver/sling/iron
+	l_hand = /obj/item/grapplinghook
+	r_hand = /obj/item/bomb/smoke
+	beltl = /obj/item/bomb/smoke
+	cloak = /obj/item/clothing/cloak/cape/puritan
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+	mask = /obj/item/clothing/mask/rogue/duelmask
+	backpack_contents = list(
+		/obj/item/lockpickring/mundane = 1,
+		/obj/item/gun/ballistic/revolver/grenadelauncher/sling = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
+		/obj/item/rope/chain = 1,
+		)
+	H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, 4, TRUE) //Investigations
+	H.adjust_skillrank_up_to(/datum/skill/combat/slings, 4, TRUE) // Funny as shit to use.
+	H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE) //Last resort CQC. Enough def on a quarterstaff to fight defensively, not enough to be truly offensive.
+	H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE) //Nearly missed this while finishing up the staff-skill port.
+	H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 4, TRUE) //I lurk in the shadows...
+	H.adjust_skillrank_up_to(/datum/skill/craft/crafting, 4, TRUE) //Crafty
+	H.adjust_skillrank_up_to(/datum/skill/misc/climbing, 5, TRUE) // Escape routes
+	H.adjust_skillrank_up_to(/datum/skill/craft/engineering, 4, TRUE) //Make your own tinkering tools and smokebombs
+	H.adjust_skillrank_up_to(/datum/skill/craft/smelting, 3, TRUE) //Just so your smelted ingots aren't ruined
+	H.change_stat(STATKEY_CON, 1)
+	H.change_stat(STATKEY_INT, 2)
+	H.change_stat(STATKEY_WIL, 3)
+	H.change_stat(STATKEY_PER, 3)
+	wretch_select_bounty(H)
+
+/datum/outfit/job/roguetown/wretch/vigilante/proc/bullshit_equip(mob/living/carbon/human/H)
+	beltr = /obj/item/rogueweapon/stoneaxe/hurlbat
+	r_hand = /obj/item/rogueweapon/stoneaxe/hurlbat
+	l_hand = /obj/item/rogueweapon/stoneaxe/hurlbat
+	beltl = /obj/item/quiver/javelin/steel
+	backl = /obj/item/quiver/javelin/steel
+	cloak = /obj/item/clothing/cloak/cape
+	mask = /obj/item/clothing/mask/rogue/facemask
+	H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 1, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/misc/reading, 2, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 2, TRUE)
+	H.adjust_skillrank_up_to(/datum/skill/craft/cooking, 1, TRUE)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/magicians_brick) //Trust the plan.
+	ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC) // You LITERALLY get no weapon skills. You're throwing shit at enemies.
+	H.change_stat(STATKEY_SPD, 2)
+	H.change_stat(STATKEY_WIL, 1)
+	H.change_stat(STATKEY_INT, 4) //Hilarious
+	wretch_select_bounty(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
@@ -1,119 +1,162 @@
-/datum/advclass/wretch/vigilante
-	name = "Masked Lunatic"
-	tutorial = "You were a disenfranchised pauper, sickened by the rampant corruption of the garrison - or perhaps, just a crazed vagrant in a costume? Whether those brutalized 'thieves' were justified in their acts is up to YOU to decide, not them! You specialize in utilizing your various gadgets and thrown projectiles to dote out JUSTICE, however you see it fit."
+/datum/advclass/wretch/wretchedtoiler
+	name = "Wretched Toiler"
+	tutorial = "The wretched engine of evil churns ever onward - the gears pushed by wretched toilers such as yourself. And toil you shall - until the machinations of thine masters come to fruition."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
-	outfit = /datum/outfit/job/roguetown/wretch/vigilante
-	cmode_music = 'sound/music/combatmaniac.ogg'
-	class_select_category = CLASS_CAT_ROGUE
+	outfit = /datum/outfit/job/wretch/wretchedtoiler
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_DECEIVING_MEEKNESS, TRAIT_PERFECT_TRACKER)
-	maximum_possible_slots = 1 // There can only be one.
-	extra_context = "This class is best experienced without preparation."
-	subclass_skills = list(
-		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT, //To make a clean getaway from the constables
-		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, // RUN BOY RUN
-		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT, // To escape grapplers, fuck you
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/reading = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/sewing = SKILL_LEVEL_APPRENTICE, //To make your own costumes.
-		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE, //You WILL be getting neckstabbed A LOT.
-		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT, //SNIFF OUT JUSTICE.
+	traits_applied = list(TRAIT_RITUALIST, TRAIT_ARCYNE_T2, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT, TRAIT_SMITHING_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_HOMESTEAD_EXPERT) //This can always be nerfed or changed to a specialization choice.
+	cmode_music = 'sound/music/cmode/antag/combat_thrall.ogg' //We don't have the original .ogg and I'm lazy. You get thrall music now. Change it if you want.
+	class_select_category = CLASS_CAT_TRADER
+	extra_context = "Choose between 2 options: being an EVIL mastermind or a WRETCHED servant" //choose between master and servant
+	maximum_possible_slots = 5 // We can toil a LOT but if the entire wretch slot is just omnicrafters this will become problematic
+
+	// balance isn't real i picked these bc they're funny
+	subclass_stats = list(
+		STATKEY_STR = -1, //YOU ARE WRETCHED!!!
+		STATKEY_CON = -2, //AND YOU WILL +TOIL+!!!!!!!!!!!
+		STATKEY_INT = 2, //4 int so you can be a feintbeast with the master swordskill I'm giving yo-HAHAHAHAHA JUST KIDDING! GRIND EXPERT ALCHEMY, WORMS!!!
+		STATKEY_PER = 1, //i like looking into the distance
+		STATKEY_WIL = 1, //i want this to be lower because i like hearing the stamout sfx but i will allow you ONE point of END
 	)
 
-/datum/outfit/job/roguetown/wretch/vigilante/pre_equip(mob/living/carbon/human/H)
-	neck = /obj/item/clothing/neck/roguetown/chaincoif/ //So your skull isn't caved in if you decide to wear a cool hat.
-	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
-	backr = /obj/item/storage/backpack/rogue/satchel
-	belt = /obj/item/storage/belt/rogue/leather/knifebelt/black/steel
-	gloves = /obj/item/clothing/gloves/roguetown/plate
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor/iron
-	wrists = /obj/item/clothing/wrists/roguetown/bracers/jackchain
+	subclass_skills = list(
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_EXPERT, //You shall TOIL. You can TOIL most skills quite well.
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/smelting = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/engineering = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/sewing = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/crafting = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN, //So you can manhandle the princess for your dark master
+		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/tanning = SKILL_LEVEL_EXPERT,
+		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT, //summon monsters? I think?
+		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT, //miracle regen? I think?
+		/datum/skill/craft/alchemy = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT, // brotherhood order spells most importantly. But this fellas gonna run a lot to.
+		)
+
+// Hedge Mage on purpose has nearly the same fit as a Adv Mage / Mage Associate who cast conjure armor roundstart. Call it meta disguise.
+/datum/outfit/job/wretch/wretchedtoiler/pre_equip(mob/living/carbon/human/H)
+	//shared loadout
+	belt = /obj/item/storage/belt/rogue/leather
+	beltl = /obj/item/storage/magebag/associate
+	backl = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
 		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
 		/obj/item/rope/chain = 1,
-		/obj/item/reagent_containers/glass/bottle/alchemical/healthpot = 1,	//Small health vial
-		)
-	if(H.mind)
-		var/classes = list("The Watchman", "The Gadgeteer", "I AM JUSTICE INCARNATE!!!")
-		var/classchoice = input(H, "Choose your archetypes", "Available archetypes") as anything in classes
-		switch(classchoice)
-			if("The Watchman") //Face-to-face CQC. No crit resist. Pure aura. Rorschach.
-				H.set_blindness(0)
-				watchman_equip(H)
-			if("The Gadgeteer") //Make gadgets, be precise and smart. Think ahead before you start swinging. Nite Owl.
-				H.set_blindness(0)
-				owl_equip(H)
-			if("I AM JUSTICE INCARNATE!!!") //THROW SHIT AT PEOPLE. RANDOM BULLSHIT GO!!!! MOON KNIGHT.
-				H.set_blindness(0)
-				bullshit_equip(H)
+		/obj/item/ritechalk = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/rogueweapon/scabbard/sheath = 1,
+		/obj/item/recipe_book/magic,
+	)
+	H.dna.species.soundpack_m = new /datum/voicepack/male/wizard()	
+	//evil laughter/making fun of good guys (essential)
+	H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mockery)
+	//you get miracles, yay! not as peak as a dedicated miracle class, though
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_DEVOTEE, devotion_limit = CLERIC_REQ_2)
+	//give minion orders if they're a zizite
+	if (istype (H.patron, /datum/patron/inhumen/zizo))
+		if(H.mind)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/minion_order)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/gravemark)
+			H.mind.current.faction += "[H.name]_faction"
+	var/classes = list("MALICIOUS Mastermind","SNIVELLING servant")
+	var/classchoice = input(H, "Choose your archetypes", "Available archetypes") as anything in classes
+	switch(classchoice)
+		if("MALICIOUS Mastermind")
+			//stats
+			H.STAINT += 2
+			H.STAPER += 1
+			//orders and stuff. you're the MASTERMIND!
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/retreat)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/bolster)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/brotherhood)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/charge)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
+			//MINIONS! ATTACK!
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/call_to_slaughter)
+			//evil ass spells
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/eyebite)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)
+			//evil ass coordination stuff
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/mindlink)
+			//they get uhhh i think this is the hedgemage fit
+			mask = /obj/item/clothing/mask/rogue/eyepatch // Chuunibyou up to 11.
+			head = /obj/item/clothing/head/roguetown/roguehood/black
+			shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+			pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+			wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
+			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
+			if(should_wear_femme_clothes(H))
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/bikini
+			else
+				armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
+			gloves = /obj/item/clothing/gloves/roguetown/angle
+			cloak = /obj/item/clothing/suit/roguetown/shirt/robe/black
+			beltr = /obj/item/reagent_containers/glass/bottle/rogue/manapot
+			neck = /obj/item/clothing/neck/roguetown/leather // No iron gorget vs necro. They will have to acquire one in round.
+			r_hand = /obj/item/scrying //expert should give you good odds with this? if it breaks in one use, blame xylix, not me
+			//you get some spellpoints. if you really wanna take combat spells you can ig
+			H?.mind.adjust_spellpoints(12)
+			var/staffs = list(
+				"ronts-focused staff",
+				"blortz-focused staff",
+				"saffira-focused staff",
+				"gemerald-focused staff",
+				"amethyst-focused staff",
+				"toper-focused staff",
+			)
+			var/staffchoice = input(H, H, "Choose your staff", "Available staffs") as anything in staffs
+			switch(staffchoice)
+				if("ronts-focused staff")
+					backr = /obj/item/rogueweapon/woodstaff/ruby
+				if("blortz-focused staff")
+					backr = /obj/item/rogueweapon/woodstaff/quartz
+				if("saffira-focused staff")
+					backr = /obj/item/rogueweapon/woodstaff/sapphire
+				if("gemerald-focused staff")
+					backr = /obj/item/rogueweapon/woodstaff/emerald
+				if("amethyst-focused staff")
+					backr = /obj/item/rogueweapon/woodstaff/amethyst
+				if("toper-focused staff")
+					backr = /obj/item/rogueweapon/woodstaff/toper
 
-/datum/outfit/job/roguetown/wretch/vigilante/proc/watchman_equip(mob/living/carbon/human/H)
-	H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE) //No civilized barbarian. Sorry chud. Go play Berserker if you want that.
-	H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 5, TRUE) //I can do this all day.
-	backl = /obj/item/storage/backpack/rogue/backpack/bagpack
-	beltl = /obj/item/rogueweapon/knuckles
-	beltr = /obj/item/rogueweapon/stoneaxe/hurlbat
-	head = /obj/item/clothing/head/roguetown/roguehood/shalal/heavyhood
-	cloak = /obj/item/clothing/cloak/thief_cloak
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/jacket
-	H.change_stat(STATKEY_STR, 2)
-	H.change_stat(STATKEY_CON, 3)
-	H.change_stat(STATKEY_WIL, 3)
-	ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC) //No crit resist - you can still get folded pretty easily if overwhelmed
+		if("SNIVELLING servant")
+			//stats
+			H.STACON += 2
+			H.STAWIL += 1
+			//maximum TOIL!!!
+			H.adjust_skillrank_up_to(/datum/skill/labor/lumberjacking, SKILL_LEVEL_EXPERT, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/cooking, SKILL_LEVEL_EXPERT, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/misc/stealing, SKILL_LEVEL_EXPERT, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/labor/farming , SKILL_LEVEL_EXPERT, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/labor/mining, SKILL_LEVEL_EXPERT, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/masonry, SKILL_LEVEL_EXPERT, TRUE)
+			H.adjust_skillrank_up_to(/datum/skill/craft/carpentry, SKILL_LEVEL_EXPERT, TRUE)
+			//buffs. you better be snarling "GET THEM, MASTER!" while you cast these
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/fortitude)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/stoneskin)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/hawks_eyes)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/giants_strength)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/guidance)
+			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/haste)
+			//the fit. you ready to TOIL?
+			neck = /obj/item/clothing/neck/roguetown/gorget/cursed_collar //hey, relax. it's just an iron gorget that you can't take off and makes you look like someone's pet
+			armor = /obj/item/clothing/suit/roguetown/shirt/rags //toilmaxxing
+			//you get less spellpoints. enough for like slip or message or smth
+			H?.mind.adjust_spellpoints(6) 
 	wretch_select_bounty(H)
 
-/datum/outfit/job/roguetown/wretch/vigilante/proc/owl_equip(mob/living/carbon/human/H)
-	backl = /obj/item/rogueweapon/woodstaff/quarterstaff/steel //nonlethal takedowns
-	beltr = /obj/item/quiver/sling/iron
-	l_hand = /obj/item/grapplinghook
-	r_hand = /obj/item/bomb/smoke
-	beltl = /obj/item/bomb/smoke
-	cloak = /obj/item/clothing/cloak/cape/puritan
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded
-	mask = /obj/item/clothing/mask/rogue/duelmask
-	backpack_contents = list(
-		/obj/item/lockpickring/mundane = 1,
-		/obj/item/gun/ballistic/revolver/grenadelauncher/sling = 1,
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
-		/obj/item/flashlight/flare/torch/lantern/prelit = 1,
-		/obj/item/rope/chain = 1,
-		)
-	H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, 4, TRUE) //Investigations
-	H.adjust_skillrank_up_to(/datum/skill/combat/slings, 4, TRUE) // Funny as shit to use.
-	H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE) //Last resort CQC. Enough def on a quarterstaff to fight defensively, not enough to be truly offensive.
-	H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE) //Nearly missed this while finishing up the staff-skill port.
-	H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 4, TRUE) //I lurk in the shadows...
-	H.adjust_skillrank_up_to(/datum/skill/craft/crafting, 4, TRUE) //Crafty
-	H.adjust_skillrank_up_to(/datum/skill/misc/climbing, 5, TRUE) // Escape routes
-	H.adjust_skillrank_up_to(/datum/skill/craft/engineering, 4, TRUE) //Make your own tinkering tools and smokebombs
-	H.adjust_skillrank_up_to(/datum/skill/craft/smelting, 3, TRUE) //Just so your smelted ingots aren't ruined
-	H.change_stat(STATKEY_CON, 1)
-	H.change_stat(STATKEY_INT, 2)
-	H.change_stat(STATKEY_WIL, 3)
-	H.change_stat(STATKEY_PER, 3)
-	wretch_select_bounty(H)
-
-/datum/outfit/job/roguetown/wretch/vigilante/proc/bullshit_equip(mob/living/carbon/human/H)
-	beltr = /obj/item/rogueweapon/stoneaxe/hurlbat
-	r_hand = /obj/item/rogueweapon/stoneaxe/hurlbat
-	l_hand = /obj/item/rogueweapon/stoneaxe/hurlbat
-	beltl = /obj/item/quiver/javelin/steel
-	backl = /obj/item/quiver/javelin/steel
-	cloak = /obj/item/clothing/cloak/cape
-	mask = /obj/item/clothing/mask/rogue/facemask
-	H.adjust_skillrank_up_to(/datum/skill/magic/arcane, 1, TRUE)
-	H.adjust_skillrank_up_to(/datum/skill/misc/reading, 2, TRUE)
-	H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 2, TRUE)
-	H.adjust_skillrank_up_to(/datum/skill/craft/cooking, 1, TRUE)
-	H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/magicians_brick) //Trust the plan.
-	ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_DODGEEXPERT, TRAIT_GENERIC) // You LITERALLY get no weapon skills. You're throwing shit at enemies.
-	H.change_stat(STATKEY_SPD, 2)
-	H.change_stat(STATKEY_WIL, 1)
-	H.change_stat(STATKEY_INT, 4) //Hilarious
-	wretch_select_bounty(H)
+/obj/effect/proc_holder/spell/invoked/order //i think this has to be here
+	name = ""
+	range = 5

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
@@ -9,7 +9,7 @@
 	cmode_music = 'sound/music/cmode/antag/combat_thrall.ogg' //We don't have the original .ogg and I'm lazy. You get thrall music now. Change it if you want.
 	class_select_category = CLASS_CAT_TRADER
 	extra_context = "Choose between 2 options: being an EVIL mastermind or a WRETCHED servant" //choose between master and servant
-	maximum_possible_slots = 5 // We can toil a LOT but if the entire wretch slot is just omnicrafters this will become problematic
+	maximum_possible_slots = 1 
 
 	// balance isn't real i picked these bc they're funny
 	subclass_stats = list(
@@ -35,6 +35,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/tanning = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT, //summon monsters? I think?
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT, //miracle regen? I think?

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -48,6 +48,7 @@
 		/datum/advclass/wretch/vigilante,
 		/datum/advclass/wretch/blackoakwyrm,
 		/datum/advclass/wretch/antipope,
+		/datum/advclass/wretch/wretchedtoiler
 		/datum/advclass/wretch/ancientchampion,
 	)
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -48,7 +48,7 @@
 		/datum/advclass/wretch/vigilante,
 		/datum/advclass/wretch/blackoakwyrm,
 		/datum/advclass/wretch/antipope,
-		/datum/advclass/wretch/wretchedtoiler
+		/datum/advclass/wretch/wretchedtoiler,
 		/datum/advclass/wretch/ancientchampion,
 	)
 

--- a/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
+++ b/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
@@ -180,9 +180,9 @@
 	skill_level = 5
 
 /datum/artificer_recipe/contraptions/houndstone
-	name = "Houndstone (+1 cog, +1 Topar)"
+	name = "Houndstone (+1 cog, +1 Topar, +1 Houndstone Gem)"
 	required_item = /obj/item/ingot/steel
-	additional_items = list(/obj/item/roguegear/bronze, /obj/item/roguegem/yellow)
+	additional_items = list(/obj/item/roguegear/bronze, /obj/item/roguegem/yellow, /obj/item/roguegem/houndgem)
 	created_item = /obj/item/scomstone/bad/garrison
 	skill_level = 5
 

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -293,6 +293,21 @@
 	new /obj/item/roguebin(src)
 	new /obj/item/reagent_containers/glass/bucket(src)
 
+/datum/roguestock/import/houndstonegem
+	name = "Houndstone Gem Crate"
+	desc = "Gems needed for Houndstones."
+	item_type = /obj/structure/closet/crate/chest/steward/houndstonegem
+	export_price = 100
+	importexport_amt = 1
+
+/obj/structure/closet/crate/chest/steward/houndstonegem/Initialize(mapload)
+	. = ..()
+	new /obj/item/roguegem/houndgem(src)
+	new /obj/item/roguegem/houndgem(src)
+	new /obj/item/roguegem/houndgem(src)
+	new /obj/item/roguegem/houndgem(src)
+	new /obj/item/roguegem/houndgem(src)
+
 /datum/roguestock/import/craftsman
 	name = "Craftsman Crate"
 	desc = "Handsaw, chisel, hammer."

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1899,6 +1899,7 @@
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\wretch\poacher.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\wretch\pyromaniac.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\wretch\vigilante.dm"
+#include "code\modules\jobs\job_types\roguetown\adventurer\types\wretch\wretchedtoiler.dm"
 #include "code\modules\jobs\job_types\roguetown\byos\tribalchief.dm"
 #include "code\modules\jobs\job_types\roguetown\byos\tribalguard.dm"
 #include "code\modules\jobs\job_types\roguetown\byos\triballackey.dm"


### PR DESCRIPTION
## About The Pull Request

i'm going to copy paste what was said here as to why it was good and why it should happen:

I would actually interject and say support classes for wretches are quite useful. It enables wretches, especially when paired up with others, to do things that they normally cannot. For example, fortify the fort at the Bog, so it no longer becomes a death trap for the antagonists. You can actually have a focal point now that the wretches can use as a sort of forward operating base.

I think you're really quite missing out by disabling it by not realizing that there's some real potential here, especially with some of the players that we do have.

I strongly encourage you reconsider, as this class did have a positive impact on other servers. Furthermore, this is a roleplay server after all, not a TDM, so not every antagonist has to have insane combat power in order to create conflict or support it.

After all, Sawbones, for instance, have great utility and importance for Bandits. You wouldn't remove it, simply because it's not narrowly focused solely on combat.

## Testing Evidence

standby.

## Why It's Good For The Game

See above

## Changelog


:cl:
add: Ports Wretched Toilers from Scarlet Reach. Rejoice, minions! For you are WRETCHED! And you must TOIL!!
/:cl: