### PR TITLE
Pontifex Pontifixes (And giving it the Vizier treatment)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -93,7 +93,7 @@
 
 /datum/advclass/mercenary/warscholar/pontifex
 	name = "Naledi Pontifex"
-	tutorial = "You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Though your abilities in magical fields are lacking, you are far more dangerous than other magi in a straight fight. You manifest your calm, practiced skill into a killing intent that takes the shape of an arcyne blade."
+	tutorial = "You are a Naledi Pontifex, a warrior trained into a hybridized style of movement-controlling magic and hand-to-hand combat. Your chosen Path determines your specialization, though you'll never match another mage in pure magical power. Instead, you manifest an imitation of a shard of PSYDON's blade and rely on trickery and battlefield control."
 	outfit = /datum/outfit/job/roguetown/mercenary/warscholar_pontifex
 	subclass_languages = list(/datum/language/celestial)
 	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_CIVILIZEDBARBARIAN, TRAIT_ARCYNE_T1)
@@ -117,7 +117,7 @@
 		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_JOURNEYMAN,
 	)
-	subclass_spellpoints = 0 // Override inheritance lol
+	subclass_spellpoints = 4 // Override inheritance
 
 /datum/outfit/job/roguetown/mercenary/warscholar_pontifex
 	var/detailcolor
@@ -144,11 +144,31 @@
 		detailcolor = input("Choose a color.", "NALEDIAN COLORPLEX") as anything in naledicolors
 		detailcolor = naledicolors[detailcolor]
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch) // In an attempt to make them less Possibly Wildly OP, they can't freely pick their spells. Casts at apprentice level, but doesn't get the spellbuy points it'd provide.
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/ensnare)
-		H.mind.AddSpell(new/obj/effect/proc_holder/spell/invoked/projectile/repel)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/summonrogueweapon/bladeofpsydon)
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/shadowstep)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/fetch)
+		H.mind.AddSpell(new/obj/effect/proc_holder/spell/invoked/projectile/repel)
+	if(H.mind)
+		var/weapons = list("Path of War","Path of Control","Path of Shadows","Path of Survival")
+		var/weapon_choice = input(H, "Choose your path.", "WHAT PATH DO YOU WALK?") as anything in weapons
+		switch(weapon_choice)
+			if("Path of War")//Weak combat stuff only
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/airblade)//longer CD than arcane bolt but more versatile
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
+			if("Path of Control")//Battlefield control, minimal damage dealing
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/ensnare)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/forcewall/greater)
+			if("Path of Shadows")//Sneaky trickster punchmage
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/lesserknock)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/invisibility)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/blindness/warscholar)
+			if("Path of Survival")//Trade magic for skills
+				H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/cooking, 3, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, 2, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/misc/swimming, 3, TRUE)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/diagnose/secular)//as a bodyguard it can be REALLY important to find where the bleed is.
 
 	head = /obj/item/clothing/head/roguetown/roguehood/pontifex
 	gloves = /obj/item/clothing/gloves/roguetown/angle/pontifex

--- a/code/modules/spells/roguetown/acolyte/noc.dm
+++ b/code/modules/spells/roguetown/acolyte/noc.dm
@@ -24,6 +24,16 @@
 	miracle = TRUE
 	cost = 3
 
+/obj/effect/proc_holder/spell/invoked/blindness/warscholar // Be very careful who this is given out to, Blindness can be surprisingly strong.
+	name = "Arcyne Blindness"
+	desc = "Direct a mote of living darkness to temporarily blind another. This imperfect replica of divine magick requires a Naledian Psycross to function."
+	invocations = list("Visus discede!")
+	devotion_cost = 0
+	recharge_time = 25 SECONDS // +10 because improper Naledi imitation
+	miracle = FALSE
+	req_items = list (/obj/item/clothing/neck/roguetown/psicross/naledi)
+	associated_skill = /datum/skill/magic/arcane
+
 /obj/effect/proc_holder/spell/invoked/blindness/cast(list/targets, mob/user = usr)
 	if(isliving(targets[1]))
 		var/mob/living/target = targets[1]

--- a/modular_azurepeak/code/modules/spells/warscholar.dm
+++ b/modular_azurepeak/code/modules/spells/warscholar.dm
@@ -4,11 +4,11 @@
 
 /obj/effect/proc_holder/spell/targeted/touch/summonrogueweapon/bladeofpsydon
 	name = "Blade of Psydon"
-	desc = "The manifestation of the higher concept of a blade itself. Said to be drawn upon from Noc's tresury of wisdom, each casting a poor facsimile of the perfect weapon They hold."
+	desc = "The manifestation of the higher concept of a blade itself. Said to be drawn upon from Noc's treasury of wisdom, each casting a poor facsimile of the perfect weapon He once held. This spell requires a Warscholar's mask to be cast."
 	clothes_req = FALSE
-	drawmessage = "I imagine the perfect weapon, forged by arcyne knowledge, it's edge flawless. \
+	drawmessage = "I imagine the perfect weapon, forged by arcyne knowledge, its edge flawless. \
 	I feel it in my mind's eye -- but it's just out of reach. I pull away it's shadow, a bad copy, and yet it is one of a great weapon nonetheless... "
-	dropmessage = "Letting go, I watch the blade lose it's form, unable to stay stable without my energy rooting it to this world..."
+	dropmessage = "Letting go, I watch the blade lose its form, unable to stay stable without my energy rooting it to this world..."
 	overlay_state = "boundkatar"
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane
@@ -17,18 +17,18 @@
 
 /obj/item/melee/touch_attack/rogueweapon/bladeofpsydon
 	name = "\improper arcyne push dagger"
-	desc = "This blade throbs, translucent and iridiscent, blueish arcyne energies running through it's translucent surface..."
+	desc = "This blade throbs, translucent and iridiscent, blueish arcyne energies running through its semi-transparent surface..."
 	catchphrase = null
 	icon = 'icons/mob/actions/roguespells.dmi'
 	icon_state = "katar_bound"
-	charges = 20
 	force = 24
+	charges = 999
 	possible_item_intents = list(/datum/intent/katar/cut, /datum/intent/katar/thrust)
 	gripsprite = FALSE
 	wlength = WLENGTH_SHORT
 	w_class = WEIGHT_CLASS_HUGE
 	parrysound = list('sound/combat/parry/bladed/bladedsmall (1).ogg','sound/combat/parry/bladed/bladedsmall (2).ogg','sound/combat/parry/bladed/bladedsmall (3).ogg')
-	max_blade_int = 999
+	max_blade_int = 500
 	max_integrity = 50
 	swingsound = list('sound/combat/wooshes/bladed/wooshsmall (1).ogg','sound/combat/wooshes/bladed/wooshsmall (2).ogg','sound/combat/wooshes/bladed/wooshsmall (3).ogg')
 	associated_skill = /datum/skill/combat/unarmed


### PR DESCRIPTION
## About The Pull Request

Pontifex, at some point in the distant past, got nerfed despite it being only pretty okay so far as unarmed classes go. I'd even argue that, as it is on live, it's worse than _Arcane Trickster_, an Adventurer class. This brings it... Not quite up to par with Hierophant, but at least to a point I'd call it a solid pick again.

Also just fixes some common complaints I've heard about it, cleaned up the grammar here and there, and made its unique spell(s) have more clear descriptions about their requirements.

## Testing Evidence

<img width="1920" height="1080" alt="proof01" src="https://github.com/user-attachments/assets/dd03d3c5-16ef-4df6-bb01-87a79a38ee56" />

(I know I should probably have more but like... It's really tedious loading up every subclass, especially when I had to fix some spaghetti)

## Why It's Good For The Game

The Bugfixes: I really shouldn't have to explain why this is a good thing. Easier to read, less obfuscation for noobs, etc etc.

The Balance Stuff: Pontifex, on live, isn't... Great? Your punch dagger having only 20 strikes before it vanishes is certainly... _A_ decision of all time. Really, I _should_ make it a variant of Conjure Weapon but having be a literally unremovable weapon is a novel feature so... It just lasts a LOT of hits. It shouldn't just vanish mid-fight anymore, at least. Also, you get 4 spellpoints with your T1 spells. Really tight budget even for cantrips, but it's similar to what they used to have. Due to the Paths giving them spells they didn't originally have access to, the SP is low.

Pontifex as it is, and was, is a weird one in that it's a dedicated unarmed build but doesn't have the stats normally needed to make it work and instead has really useful magic. Less good on their own but amazing as bodyguards, rogues, and in teamfights. So I decided to lean into that with their Paths.

Path of War: Air Blade is criminally underused as it's pretty much exclusive to the Adventurer Spellsword, despite being a side/downgrade to Arcane Bolt. And it's really hard to go wrong with Enchant Weapon, though you can't apply it to your conjured weapon... It also has a 1.3 damage mod intent so it doesn't really need it. Goes amazing well with a pair of knucks, however.

Path of Control: Ensnare was moved here and you get Greater Forcewall. This lets Pontifexes who choose this path dictate the flow of battle. This is just returns you to the original intent of Pontifex where you're an annoying shit who stops people from running and/or chasing you.

Path of Shadows: The name says it all, but it embraces the theme of you using the secrets of Noc to your advantage. Lesser Knock because sneakthief, invis because shadows, and Blindess... Because shadows. Are you noticing a theme? If you use it right, this is probably the strongest Path out of the three though with your Apprentice (or Journeyman, with AP) Arcane, Blindness shouldn't be _too_ oppressive. That and your Blind is on a whopping 25 second cooldown, which should further make the other Paths more appealing.

Path of Survival: Because you think Pontifex is good as it is, but could just use a _little_ more in terms of skills to shine. Mostly a sovl pick, but still valid due to the +1 athletics and +2 swimming/medicine. Diagnosis is there for the rare Pontifex bodyguard main.

## Changelog

:cl:
add: Arcyne Blindness - A variant of Blindness that scales on Arcane skill. Longer CD, requires a Naledian psycross to use.
fix: Adjusted some text regarding the Pontifex. Makes some of what they need clearer and it should read better.
balance: Pontifex now has 4 Spellpoints but still only T1 spells.
balance: Pontifex no longer has Ensnare by default.
balance: Pontifex now has 4 'Paths' (subclasses) to choose from.
add: Path of War - Air Blade (sidegrade to Arcane Bolt) and Enchant Weapon. Enchant Weapon can't be used on your Push Dagger, but is deadly if applied to a pair of knuckles.
add: Path of Control - Ensnare and Greater Forcewall. Heavy focus on CC and battlefield control.
add: Path of Shadows - Lesser Knock, Invisibility, and Arcane Blindness. Heavy focus on trickery and shadows.
add: Path of Survival - Increases your Medicine, Cooking, Athletics, and Swimming skills. Also gives you Secular Diagnosis. Sovl and lets you bodyguard or run around like a punch-dagger wielding maniac better.
/:cl:
