### PR TITLE
Voice Descriptors When Speaking

### DIFF
--- a/code/datums/mob_descriptors/descriptors/voice.dm
+++ b/code/datums/mob_descriptors/descriptors/voice.dm
@@ -5,6 +5,10 @@
 	prefix = "a"
 	suffix = "voice"
 	show_obscured = TRUE
+	var/voice_string
+
+/datum/mob_descriptor/voice/proc/get_speaking_name(var/voice_gender)
+	return "[voice_string ? voice_string : name] [voice_gender]"
 
 /datum/mob_descriptor/voice/ordinary
 	name = "Ordinary"
@@ -88,6 +92,7 @@
 
 /datum/mob_descriptor/voice/smoker
 	name = "Smoker's"
+	voice_string = "Smoker"
 
 /datum/mob_descriptor/voice/venomous
 	name = "Venomous"

--- a/code/datums/mob_descriptors/descriptors/voice.dm
+++ b/code/datums/mob_descriptors/descriptors/voice.dm
@@ -7,7 +7,7 @@
 	show_obscured = TRUE
 	var/voice_string
 
-/datum/mob_descriptor/voice/proc/get_speaking_name(var/voice_gender)
+/datum/mob_descriptor/voice/proc/get_speaking_name(voice_gender)
 	return "[voice_string ? voice_string : name] [voice_gender]"
 
 /datum/mob_descriptor/voice/ordinary

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -140,7 +140,10 @@ GLOBAL_LIST_INIT(freqtospan, list(
 			else
 				hidden = TRUE
 			if(hidden)
-				if(istype(speaker, /mob/living))
+				if(ishuman(speaker))
+					var/mob/living/carbon/human/human = speaker
+					namepart = human.get_alt_name(TRUE)
+				else if(istype(speaker, /mob/living))
 					var/mob/living/L = speaker
 					namepart = "Unknown [(L.gender == FEMALE) ? "Woman" : "Man"]"
 				else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -53,15 +53,22 @@
 
 	return 0
 
-/mob/living/carbon/human/get_alt_name()
-	if(name != GetVoice())
+/mob/living/carbon/human/get_alt_name(var/force = FALSE)
+	if(force || name != GetVoice())
+		var/datum/mob_descriptor/voice/voice_descriptor = get_descriptor_type(/datum/mob_descriptor/voice)
+		if(!voice_descriptor)
+			return "Unknown Person"
+
+		var/voice_gender = "Person"
 		switch(voice_type)
 			if(VOICE_TYPE_FEM)
-				return "Unknown Woman"
+				voice_gender = "Woman"
 			if(VOICE_TYPE_MASC)
-				return "Unknown Man"
+				voice_gender = "Man"
 			if(VOICE_TYPE_ANDR)
-				return "Unknown Person"
+				voice_gender = "Person"
+
+		return voice_descriptor.get_speaking_name(voice_gender)
 	
 /mob/living/carbon/human/proc/forcesay(list/append) //this proc is at the bottom of the file because quote fuckery makes notepad++ cri
 	if(stat == CONSCIOUS)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -53,7 +53,7 @@
 
 	return 0
 
-/mob/living/carbon/human/get_alt_name(var/force = FALSE)
+/mob/living/carbon/human/get_alt_name(force = FALSE)
 	if(force || name != GetVoice())
 		var/datum/mob_descriptor/voice/voice_descriptor = get_descriptor_type(/datum/mob_descriptor/voice)
 		if(!voice_descriptor)

--- a/code/modules/mob/living/living_descriptors.dm
+++ b/code/modules/mob/living/living_descriptors.dm
@@ -12,6 +12,11 @@
 	if(!length(mob_descriptors))
 		mob_descriptors = null
 
+/mob/living/proc/get_descriptor_type(var/desired_type)
+	for(var/datum/mob_descriptor/descriptor as anything in mob_descriptors)
+		if(ispath(descriptor, desired_type))
+			return MOB_DESCRIPTOR(descriptor)
+
 /mob/living/proc/clear_mob_descriptors()
 	mob_descriptors = null
 

--- a/code/modules/mob/living/living_descriptors.dm
+++ b/code/modules/mob/living/living_descriptors.dm
@@ -12,7 +12,7 @@
 	if(!length(mob_descriptors))
 		mob_descriptors = null
 
-/mob/living/proc/get_descriptor_type(var/desired_type)
+/mob/living/proc/get_descriptor_type(desired_type)
 	for(var/datum/mob_descriptor/descriptor as anything in mob_descriptors)
 		if(ispath(descriptor, desired_type))
 			return MOB_DESCRIPTOR(descriptor)


### PR DESCRIPTION
## About The Pull Request

the game will use your voice descriptor when you talk, when masked or when out of view.

ported from azure

also fixes the issue where characters with fembodies will always be refered to as Woman when speaking out of view

## Testing Evidence

<img width="224" height="34" alt="image" src="https://github.com/user-attachments/assets/647dc497-6ec2-4c6b-8c1c-e730623146c6" />


## Why It's Good For The Game

good things are good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Your voice descriptor will prefix your voice identity on speaking when masked or out of view.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
