### PR TITLE
Psydonian miracle changes (arbiter buff)

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -212,13 +212,13 @@
 		//This and necra's vow need a better way of handling this. But I'm too lazy to do that.
 		if(M.has_status_effect(/datum/status_effect/buff/inviolability))
 			if(isnull(user.mind))
-				user.adjust_fire_stacks(1)
+				user.adjust_fire_stacks(3, /datum/status_effect/fire_handler/fire_stacks/sunder)
 				user.ignite_mob()
 			else
 				if(prob(30))
 					to_chat(M, span_warning("Some matter of force harms us!"))
-			user.adjust_blurriness(2)
-			user.adjustBruteLoss(rand(10, 15))
+			user.adjust_blurriness(3)
+			user.adjustBruteLoss(rand(15, 30))
 
 	//Niche signal for post-swingdelay attacks when we want to care about those.
 	_attacker_signal = null

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1301,13 +1301,13 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(user.mob_biotypes & MOB_UNDEAD)//This and necra's vow need a better way of handling this. But I'm too lazy to do that.
 			if(target.has_status_effect(/datum/status_effect/buff/inviolability))
 				if(isnull(user.mind))
-					user.adjust_fire_stacks(1)
+					user.adjust_fire_stacks(3, /datum/status_effect/fire_handler/fire_stacks/sunder)
 					user.ignite_mob()
 				else
 					if(prob(30))
 						to_chat(user, span_warning("Some matter of force harms us!"))
-				user.adjust_blurriness(2)
-				user.adjustBruteLoss(rand(10, 15))
+				user.adjust_blurriness(3)
+				user.adjustBruteLoss(rand(15, 30))
 
 /*		var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases
 		if(user.dna.species.punchdamagelow)

--- a/code/modules/spells/roguetown/oldgod_martial.dm
+++ b/code/modules/spells/roguetown/oldgod_martial.dm
@@ -119,7 +119,7 @@ Given the nature of Psydon, two of these are INTENDED to be refluffed Tennite sp
 	devotion_cost = 60
 
 /obj/effect/proc_holder/spell/self/psydonic_inspire/cast(list/targets,mob/living/user = usr)
-	user.blood_volume = max(user.blood_volume-200, 0)//It's a mass AoE for an already powerful faction.
+	user.blood_volume = max(user.blood_volume-100, 0)//It's a mass AoE for an already powerful faction.
 	user.handle_blood()
 	new /obj/effect/decal/cleanable/blood/puddle(user.loc)
 	for(var/mob/living/carbon/target in view(6, get_turf(user)))
@@ -164,14 +164,14 @@ Given the nature of Psydon, two of these are INTENDED to be refluffed Tennite sp
 	invocation_type = "shout"
 	antimagic_allowed = TRUE
 	miracle = TRUE
-	devotion_cost = 80
+	devotion_cost = 60
 
 /obj/effect/proc_holder/spell/self/psydonic_sacrosanctity/cast(mob/living/carbon/human/user)
 	if(!isliving(user))
 		return FALSE
 	user.blood_volume = max(user.blood_volume+200, 0)
 	user.handle_blood()
-	user.apply_damage(200, BRUTE, spread_damage = TRUE)//Try to beat a bleedout? A point of damage for each point of blood.
+	user.apply_damage(100, BRUTE, spread_damage = TRUE)//Try to beat a bleedout? A point of damage for each point of blood.
 	return TRUE
 
 //Inviolability. A shield around the user, harming any undead who strike them.
@@ -181,7 +181,7 @@ Given the nature of Psydon, two of these are INTENDED to be refluffed Tennite sp
 	Any undead striking you are harmed in turn. \
 	<small><span class='bloody'>A greater miracle.</span></small>"
 	overlay_state = "psy_invio"
-	recharge_time = 6 MINUTES
+	recharge_time = 4 MINUTES
 	movement_interrupt = FALSE
 	chargedrain = 0
 	chargetime = 1 SECONDS
@@ -194,15 +194,15 @@ Given the nature of Psydon, two of these are INTENDED to be refluffed Tennite sp
 	invocation_type = "shout"
 	antimagic_allowed = TRUE
 	miracle = TRUE
-	devotion_cost = 100
+	devotion_cost = 80
 
 /obj/effect/proc_holder/spell/self/psydonic_inviolability/cast(mob/living/carbon/human/user)
 	if(!isliving(user))
 		return FALSE
-	user.blood_volume = max(user.blood_volume-300, 0)//RAAAA!!!!
+	user.blood_volume = max(user.blood_volume-100, 0)//RAAAA!!!!
 	user.handle_blood()
 	new /obj/effect/decal/cleanable/blood/puddle(user.loc)
-	user.apply_damage(300, BRUTE, spread_damage = TRUE)
+	user.apply_damage(100, BRUTE, spread_damage = TRUE)
 	user.apply_status_effect(/datum/status_effect/buff/inviolability)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Lowers the absurdly high self-damage and blood costs for Psydonic miracles so casting them isn't an instant death sentence, and adds the recoil effect against undead for Inviolability.

Tweaks:
Inspire: Blood cost 200 -> 100
Sacrosanctity: Devotion 80 -> 60, Brute self-damage 200 -> 100
Inviolability: Cooldown 6m -> 4m, Devotion 100 -> 80, Blood/Brute self-damage 300 -> 100
Inviolability Buff: Now properly punishes undead attackers by igniting them with sunder fire (along with brute damage and blurriness) when they strike the user.
## Testing Evidence
Cast Inspire, Sacrosanctity, and Inviolability. Verified the new costs apply.
<img width="1051" height="586" alt="image" src="https://github.com/user-attachments/assets/58ada0f6-2d7c-495b-9dc7-81be356fe800" />
Sacrosanctity
<img width="1129" height="696" alt="image" src="https://github.com/user-attachments/assets/0ed89a29-6d20-4fa8-b89a-8d0b2f42a077" />
for the one as you can see only -100 blood
<img width="952" height="583" alt="image" src="https://github.com/user-attachments/assets/09062a10-ed59-40ff-a858-b0dd06d1a3e6" />
Inviolability applies sunderfire and deals damage to the skeleton

## Why It's Good For The Game

The old 300 blood/brute cost was practically a death sentence. Cutting it to 100 keeps the heavy sacrifice but makes the miracle actually usable. Also, Inviolability now burns undead attackers with sunder fire.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Lowered the blood, brute, and devotion costs for Psydonic Inspire, Sacrosanctity, and Inviolability so they are no longer instantly lethal to cast.
balance: Reduced the cooldown of Psydonic Inviolability from 6 minutes to 4 minutes.
add: Psydonic Inviolability now burns undead attackers with sunder fire, dealing brute damage, and causing blurriness.
/:cl:

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
