### PR TITLE
Fixes player-made books being blank.

### DIFF
--- a/code/game/objects/items/rogueitems/books.dm
+++ b/code/game/objects/items/rogueitems/books.dm
@@ -501,7 +501,7 @@
 	base_icon_state = "basic_book"
 	override_find_book = TRUE
 
-/obj/item/book/rogue/playerbook/Initialize(mapload, loc, in_round_player_generated, mob/living/in_round_player_mob, text)
+/obj/item/book/rogue/playerbook/Initialize(mapload, in_round_player_generated, mob/living/in_round_player_mob, text)
 	. = ..()
 	is_in_round_player_generated = in_round_player_generated
 	if(is_in_round_player_generated)


### PR DESCRIPTION
## About The Pull Request

Removes a `loc` argument from `playerbook/initialize` that was misaligned, resulting in playermade books being blank and not using defined settings.

## Testing Evidence

<img width="312" height="117" alt="dreamseeker_DkMMBTzSZj" src="https://github.com/user-attachments/assets/0ccde53c-a3fa-4d76-b117-4e96396a4c8d" />
<img width="194" height="137" alt="YCLnixtBYY" src="https://github.com/user-attachments/assets/d29b5ddd-408c-4c2a-8c03-3e762a841296" />
<img width="249" height="83" alt="dreamseeker_1gKooT8F9k" src="https://github.com/user-attachments/assets/31b868de-ca56-4be2-adb3-7d1177997296" />
<img width="280" height="174" alt="IR5B28d2Yl" src="https://github.com/user-attachments/assets/950014ed-d260-4702-9a02-515b99043b0a" />


## Why It's Good For The Game

Fixes (and returns) the ability for players to pen their own books!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed player-made books being blank
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
