### PR TITLE
Disable Wretch and Bandit

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -256,8 +256,8 @@ SUBSYSTEM_DEF(migrants)
 
 	SSticker.minds += character.mind
 	GLOB.joined_player_list += character.ckey
-	update_wretch_slots()
-	update_bandit_slots()
+	//update_wretch_slots()
+	//update_bandit_slots()
 	if(character.client)
 		character.client.update_ooc_verb_visibility()
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -478,8 +478,8 @@ SUBSYSTEM_DEF(ticker)
 			continue
 		if(player.ready == PLAYER_READY_TO_PLAY)
 			GLOB.joined_player_list += player.ckey
-			update_wretch_slots()
-			update_bandit_slots()
+		//	update_wretch_slots()
+		//	update_bandit_slots()
 			player.create_character(FALSE)
 		else
 			player.new_player_panel()

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -3,8 +3,8 @@
 	flag = BANDIT
 	department_flag = WANDERERS
 	faction = "Station"
-	total_positions = 5	//bare minimum of five on round start, regardless of garrison/holywarrior count
-	spawn_positions = 5
+	total_positions = 0	//bare minimum of five on round start, regardless of garrison/holywarrior count
+	spawn_positions = 0
 	antag_job = TRUE
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "At some point in your lyfe, you'd fallen to the wrong side of the carriage. Whether by butchery or finesse, you're known throughout the land. \
@@ -71,7 +71,7 @@
 	switch(wanted_choice)
 		if("Yes")
 			ADD_TRAIT(H, TRAIT_KNOWNCRIMINAL, TRAIT_GENERIC)
-		if("No") 
+		if("No")
 			to_chat(H, span_warning("I am still relatively new to the gang. My crimes have gone unnoticed so far, but I lack experience."))
 			return null
 	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of Rotwood", "The Grenzelhoftian Holy See")
@@ -115,21 +115,21 @@
 				H.change_stat(STATKEY_SPD, 1)
 	to_chat(H, span_danger("You are playing an Antagonist role. By choosing to spawn as a Bandit, you are expected to actively create conflict with other players regardless of bounty status. Failing to play this role with the appropriate gravitas may result in punishment for Low Roleplay standards."))
 
-/proc/update_bandit_slots()
-	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
-	if(!bandit_job)
-		return
-
-	var/player_count = length(GLOB.joined_player_list)
-	var/slots = 5
-
+// /proc/update_bandit_slots()
+//	var/datum/job/bandit_job = SSjob.GetJob("Bandit")
+//	if(!bandit_job)
+//		return
+//
+//	var/player_count = length(GLOB.joined_player_list)
+//	var/slots = 5
+//
 	//Add 1 slot for every 12 players over 30.
-	if(player_count > 42)
-		var/extra = floor((player_count - 42) / 12)
-		slots += extra
-
+//	if(player_count > 42)
+//		var/extra = floor((player_count - 42) / 12)
+//		slots += extra
+//
 	//5 slots minimum, 7 maximum.
-	slots = min(slots, 9)
-
-	bandit_job.total_positions = slots
-	bandit_job.spawn_positions = slots
+//	slots = min(slots, 9)
+//
+//	bandit_job.total_positions = slots
+//	bandit_job.spawn_positions = slots

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -4,8 +4,8 @@
 	flag = WRETCH
 	department_flag = WANDERERS
 	faction = "Station"
-	total_positions = 5
-	spawn_positions = 5
+	total_positions = 0
+	spawn_positions = 0
 	allowed_races = RACES_ALL_KINDS
 	tutorial = "Somewhere in your lyfe, you fell to the wrong side of civilization. Hounded by the consequences of your actions, you spend your daes prowling the roads for easy marks and loose purses, scraping to get by."
 	outfit = null
@@ -98,21 +98,21 @@
 	to_chat(H, span_danger("You are playing an Antagonist role. By choosing to spawn as a Wretch, you are expected to actively create conflict with other players. Failing to play this role with the appropriate gravitas may result in punishment for Low Roleplay standards."))
 	H.playsound_local(get_turf(H), 'sound/music/traitor.ogg', 60, FALSE, pressure_affected = FALSE)
 
-/proc/update_wretch_slots()
-	var/datum/job/wretch_job = SSjob.GetJob("Wretch")
-	if(!wretch_job)
-		return
-
-	var/player_count = length(GLOB.joined_player_list)
-	var/slots = 5
-
+// /proc/update_wretch_slots()
+//	var/datum/job/wretch_job = SSjob.GetJob("Wretch")
+//	if(!wretch_job)
+//		return
+//
+//	var/player_count = length(GLOB.joined_player_list)
+//	var/slots = 5
+//
 	//Add 1 slot for every 10 players over 30. Less than 40 players, 5 slots. 40 or more players, 6 slots. 50 or more players, 7 slots - etc.
-	if(player_count > 40)
-		var/extra = floor((player_count - 40) / 10)
-		slots += extra
-
-	//5 slots minimum, 10 maximum.
-	slots = min(slots, 10)
-
-	wretch_job.total_positions = slots
-	wretch_job.spawn_positions = slots
+//	if(player_count > 40)
+//		var/extra = floor((player_count - 40) / 10)
+//		slots += extra
+//
+//	//5 slots minimum, 10 maximum.
+//	slots = min(slots, 10)
+//
+//	wretch_job.total_positions = slots
+//	wretch_job.spawn_positions = slots

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			if(ready != tready)
 				ready = tready
 		//if it's post initialisation and they're trying to observe we do the needful
-		
+
 		if(!SSticker.current_state < GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
 			ready = tready
 			make_me_an_observer()
@@ -577,8 +577,8 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 			give_madness(humanc, GLOB.curse_of_madness_triggered)
 */
 	GLOB.joined_player_list += character.ckey
-	update_wretch_slots()
-	update_bandit_slots()
+	//update_wretch_slots()
+	//update_bandit_slots()
 /*
 	if(CONFIG_GET(flag/allow_latejoin_antagonists) && humanc)	//Borgs aren't allowed to be antags. Will need to be tweaked if we get true latejoin ais.
 		if(SSshuttle.emergency)


### PR DESCRIPTION
## About The Pull Request
Disables Wretch and Bandit by commenting out their slot scaling feature and reducing the starting number of slots to 0.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It works. Screenshots later.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Read #last-round-talk. People clearly don't enjoy dedicated external antags anymore.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: 0 slots for Wretches and Bandits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
