### PR TITLE
skeleton scroll change

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -243,7 +243,7 @@
 	icon_state ="scrollpurple"
 	remarks = list("Pallium nihilum..", "Occultare veritatem..", "Veritatem removan menor..")
 
-/obj/item/book/granter/spell/blackstone/skeleton
+/obj/item/book/granter/spell/blackstone/skeleton//BEWARE this is the super powerful LICH player skeleton spawner
 	name = "Scroll of Raise Skeleton"
 	spell = /obj/effect/proc_holder/spell/invoked/raise_undead
 	spellname = "Raise Skeleton"
@@ -408,3 +408,10 @@
 /obj/item/book/granter/spell_points/voiddragon
 	name = "Arcyne Void Insight"
 	spellpoints = 6
+
+/obj/item/book/granter/spell/blackstone/skeleton/lesser
+	name = "Scroll of Lesser Raise Skeletons"
+	spell = /obj/effect/proc_holder/spell/invoked/raise_undead_formation
+	spellname = "Raise Lesser Skeletons"
+	icon_state ="scrolldarkred"
+	remarks = list("Redi damnatos..", "Exitio ad Necram scriptor exolvuntur..", "Ossa in propinquus..")

--- a/code/game/objects/structures/roguetown/deadbodies.dm
+++ b/code/game/objects/structures/roguetown/deadbodies.dm
@@ -240,7 +240,7 @@
 		"necromancer_old", "necro10", "necro20", "necro30", "necro40",
 	)
 	loot_table = list(
-		/obj/item/book/granter/spell/blackstone/skeleton                  = 15,
+		/obj/item/book/granter/spell/blackstone/skeleton/lesser           = 15,
 		/obj/item/book/granter/spell/blackstone/sicknessray               = 12,
 		/obj/item/book/granter/spell/blackstone/bonechill                 = 10,
 		/obj/item/book/granter/spell/blackstone/fetch                     = 8,
@@ -251,12 +251,12 @@
 		/obj/item/reagent_containers/glass/bottle/rogue/healthpot         = 10,
 	)
 	loot_table_lucky = list(
-		/obj/item/book/granter/spell/blackstone/skeleton                  = 20,
+		/obj/item/book/granter/spell/blackstone/skeleton/lesser           = 15,
+		/obj/item/book/granter/spell/blackstone/skeleton                  = 10,
 		/obj/item/book/granter/spell/blackstone/sicknessray               = 15,
 		/obj/item/book/granter/spell/blackstone/invisibility              = 15,
 		/obj/item/book/granter/spell/blackstone/bonechill                 = 10,
 		/obj/item/book/granter/spell/blackstone/familiar                  = 8,
-		/obj/item/skull                                                   = 20,
 		/obj/item/storage/belt/rogue/pouch/coins/rich                     = 15,
 	)
 

--- a/code/game/objects/structures/roguetown/loot.dm
+++ b/code/game/objects/structures/roguetown/loot.dm
@@ -45,7 +45,8 @@
 		/obj/item/book/granter/spell/blackstone/fireball = 5,
 		/obj/item/book/granter/spell/blackstone/sicknessray = 5,
 		/obj/item/book/granter/spell/blackstone/bonechill = 3,
-		/obj/item/book/granter/spell/blackstone/skeleton = 3,
+		/obj/item/book/granter/spell/blackstone/skeleton/lesser = 3,
+		/obj/item/book/granter/spell/blackstone/skeleton = 1,
 		/obj/item/book/granter/spell/blackstone/invisibility = 3,
 		/obj/item/book/granter/spell/blackstone/greaterfireball = 2)))
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Adds a scroll of 'raise lesser skeletons' to mostly-replace the scrolls of 'raise (armored, infinite lich-style skeletons)'. 

Unforunately, without gravemark, they immediately try to kill the caster.

Such is the fate of one who reads aloud forbidden passages from a dusty scroll found on a necromancer's corpse.

a somewhat funner take on https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1732

## Testing Evidence
<img width="346" height="408" alt="image" src="https://github.com/user-attachments/assets/a806542a-cead-4eda-be64-04a7f2b0e938" />
<img width="743" height="360" alt="image" src="https://github.com/user-attachments/assets/4a4664e3-d5cd-4a08-9bff-bf9963e329aa" />

## Why It's Good For The Game

It's funny and we had a bit of a sorta-lich overload.

Leaving in a lucky-lich as a remote possibility, but not nearly as common.

## Changelog

:cl:
balance: scrolls of lich-style raise skeletons mostly replaced in loot pools with scrolls of lesser raise skeletons
/:cl: