### PR TITLE
fix vanguard spawns

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -202,6 +202,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 /obj/effect/landmark/start/bogguardsman
 	name = "Bog Guard"
 	icon_state = "arrow"
+	jobspawn_override = list("Bog Guard", "Vanguard")
 
 /obj/effect/landmark/start/warden
 	name = "Warden"


### PR DESCRIPTION
## About The Pull Request

I previously changed vanguard/warden to not late-spawn in their fort (which muddies things a lot if there's actually fighting happening there) though that caused vanguard to spawn in the vampire lord manor. This ought to fix it

## Testing Evidence

Trrrrrust me...

## Why It's Good For The Game

Fix

## Changelog

:cl:
fix: vanguard spawns
/:cl:
