### PR TITLE
Building QoLs, Mining QoLs & Pick Bumping + Auto Woodcutting

### DIFF
--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -477,12 +477,12 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	if(istype(W, /obj/item/rogueweapon/pick))
 		if(!isliving(user))
 			return ..()
-		var/mob/living/LivingUser = user
-		if(!LivingUser.client || !LivingUser.client.prefs?.autopicking)
+		var/mob/living/living_user = user
+		if(!living_user.client || !living_user.client.prefs?.autopicking)
 			return ..()
 		user.doing = FALSE
 		while(!QDELETED(src) && user.Adjacent(src))
-			if((LivingUser.energy <= 0))
+			if((living_user.energy <= 0))
 				break
 			if(!do_after(user, CLICK_CD_MELEE, TRUE, src))
 				break

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -477,14 +477,14 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 	if(istype(W, /obj/item/rogueweapon/pick))
 		if(!isliving(user))
 			return ..()
-		var/mob/living/L = user
-		if(!L.client || !L.client.prefs?.autopicking)
+		var/mob/living/LivingUser = user
+		if(!LivingUser.client || !LivingUser.client.prefs?.autopicking)
 			return ..()
 		user.doing = FALSE
 		while(!QDELETED(src) && user.Adjacent(src))
-			if((L.energy <= 0)
+			if((LivingUser.energy <= 0))
 				break
-			if(!do_after(user, CLICK_CD_MELEE, TRUE, src)
+			if(!do_after(user, CLICK_CD_MELEE, TRUE, src))
 				break
 			..()
 		return

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -296,6 +296,33 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			S.set_up(1, 1, front)
 			S.start()
 	if( user.used_intent.type == /datum/intent/chisel )
+		if(istype(W, /obj/item/rogueweapon/chisel/assembly))
+			var/obj/item/rogueweapon/chisel/assembly/chisel_set = W
+			if(chisel_set.wielded)
+				var/turf/work_turf = get_turf(src)
+				var/obj/item/natural/stone/current_stone = src
+				while(current_stone)
+					playsound(current_stone.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
+					user.visible_message("<span class='info'>[user] chisels the stone into a block.</span>")
+					if(!do_after(user, work_time, target = current_stone))
+						return
+					new /obj/item/natural/stoneblock(get_turf(current_stone.loc))
+					if(HAS_TRAIT(user, TRAIT_MASTER_MASON)) //double the amount for any in a stone worker role
+						new /obj/item/natural/stoneblock(get_turf(current_stone.loc))
+					new /obj/effect/decal/cleanable/debris/stony(get_turf(current_stone))
+					playsound(current_stone.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
+					qdel(current_stone)
+					user.mind.add_sleep_experience(/datum/skill/craft/masonry, (user.STAINT*0.2))
+					if(QDELETED(chisel_set) || !chisel_set.wielded)
+						return
+					var/obj/item/natural/stone/next_stone = null
+					for(var/obj/item/natural/stone/S in work_turf)
+						next_stone = S
+						break
+					if(!next_stone)
+						return
+					current_stone = next_stone
+				return
 		playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
 		user.visible_message("<span class='info'>[user] chisels the stone into a block.</span>")
 		if(do_after(user, work_time))

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -479,8 +479,7 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			return ..()
 		var/mob/living/L = user
 		if(!L.client || !L.client.prefs?.autopicking)
-			..()
-			return
+			return ..()
 		user.doing = FALSE
 		while(!QDELETED(src) && user.Adjacent(src))
 			if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -474,6 +474,23 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			S.set_up(1, 1, front)
 			S.start()
 		return
+	if(istype(W, /obj/item/rogueweapon/pick))
+		if(!isliving(user))
+			..()
+			return
+		var/mob/living/L = user
+		if(!L.client || !L.client.prefs?.autopicking)
+			..()
+			return
+		user.doing = FALSE
+		while(!QDELETED(src) && user.Adjacent(src))
+			if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))
+				..()
+				if(QDELETED(src))
+					break
+			else
+				break
+		return
 	if( user.used_intent.type == /datum/intent/chisel )
 		playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)
 		user.visible_message("<span class='info'>[user] chisels the boulder into blocks.</span>")

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -482,12 +482,11 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 			return ..()
 		user.doing = FALSE
 		while(!QDELETED(src) && user.Adjacent(src))
-			if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))
-				..()
-				if(QDELETED(src))
-					break
-			else
+			if((L.energy <= 0)
 				break
+			if(!do_after(user, CLICK_CD_MELEE, TRUE, src)
+				break
+			..()
 		return
 	if( user.used_intent.type == /datum/intent/chisel )
 		playsound(src.loc, pick('sound/combat/hits/onrock/onrock (1).ogg', 'sound/combat/hits/onrock/onrock (2).ogg', 'sound/combat/hits/onrock/onrock (3).ogg', 'sound/combat/hits/onrock/onrock (4).ogg'), 100)

--- a/code/game/objects/items/rogueitems/natural/stones.dm
+++ b/code/game/objects/items/rogueitems/natural/stones.dm
@@ -476,8 +476,7 @@ GLOBAL_LIST_INIT(stone_personality_descs, list(
 		return
 	if(istype(W, /obj/item/rogueweapon/pick))
 		if(!isliving(user))
-			..()
-			return
+			return ..()
 		var/mob/living/L = user
 		if(!L.client || !L.client.prefs?.autopicking)
 			..()

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -111,14 +111,14 @@
 /obj/structure/flora/newtree/attackby(obj/item/I, mob/living/user, params)
 	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
 		return ..()
-	var/mob/living/LivingUser = user
-	if(LivingUser.client && !LivingUser.client.prefs?.autowoodcut)
+	var/mob/living/living_user = user
+	if(living_user.client && !living_user.client.prefs?.autowoodcut)
 		return ..()
 	if(user.doing)
 		return ..()
 	user.doing = FALSE
 	while(!QDELETED(src) && user.Adjacent(src))
-		if((LivingUser.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))
+		if((living_user.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))
 			if(QDELETED(src))
 				break
 			..()

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -108,6 +108,20 @@
 			if(L.mind) // idk just following whats going on above
 				L.mind.add_sleep_experience(/datum/skill/misc/climbing, exp_to_gain, FALSE)
 
+/obj/structure/flora/newtree/attackby(obj/item/I, mob/living/user, params)
+	. = ..()
+	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
+		return
+	var/mob/living/L = user
+	user.doing = FALSE
+	while(!QDELETED(src) && user.Adjacent(src))
+		if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))
+			if(QDELETED(src))
+				break
+			..()
+		else
+			break
+
 /obj/structure/flora/newtree/attacked_by(obj/item/I, mob/living/user)
 	var/was_destroyed = obj_destroyed
 	. = ..()

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -109,14 +109,13 @@
 				L.mind.add_sleep_experience(/datum/skill/misc/climbing, exp_to_gain, FALSE)
 
 /obj/structure/flora/newtree/attackby(obj/item/I, mob/living/user, params)
-	. = ..()
 	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
-		return
+		return ..()
 	var/mob/living/L = user
 	if(L.client && !L.client.prefs?.autowoodcut)
-		return
+		return ..()
 	if(user.doing)
-		return
+		return ..()
 	user.doing = FALSE
 	while(!QDELETED(src) && user.Adjacent(src))
 		if((L.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -113,9 +113,13 @@
 	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
 		return
 	var/mob/living/L = user
+	if(L.client && !L.client.prefs?.autowoodcut)
+		return
+	if(user.doing)
+		return
 	user.doing = FALSE
 	while(!QDELETED(src) && user.Adjacent(src))
-		if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))
+		if((L.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))
 			if(QDELETED(src))
 				break
 			..()

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -111,14 +111,14 @@
 /obj/structure/flora/newtree/attackby(obj/item/I, mob/living/user, params)
 	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
 		return ..()
-	var/mob/living/L = user
-	if(L.client && !L.client.prefs?.autowoodcut)
+	var/mob/living/LivingUser = user
+	if(LivingUser.client && !LivingUser.client.prefs?.autowoodcut)
 		return ..()
 	if(user.doing)
 		return ..()
 	user.doing = FALSE
 	while(!QDELETED(src) && user.Adjacent(src))
-		if((L.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))
+		if((LivingUser.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))
 			if(QDELETED(src))
 				break
 			..()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -29,9 +29,13 @@
 	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
 		return
 	var/mob/living/L = user
+	if(L.client && !L.client.prefs?.autowoodcut)
+		return
+	if(user.doing)
+		return
 	user.doing = FALSE
 	while(!QDELETED(src) && user.Adjacent(src))
-		if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))
+		if((L.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))
 			if(QDELETED(src))
 				break
 			..()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -24,6 +24,20 @@
 /obj/structure/flora/roguetree/attack_right(mob/user)
 	handle_special_items_retrieval(user, src)
 
+/obj/structure/flora/roguetree/attackby(obj/item/I, mob/living/user, params)
+	. = ..()
+	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
+		return
+	var/mob/living/L = user
+	user.doing = FALSE
+	while(!QDELETED(src) && user.Adjacent(src))
+		if((L.energy > 0) && do_after(user, CLICK_CD_MELEE, TRUE, src))
+			if(QDELETED(src))
+				break
+			..()
+		else
+			break
+
 /obj/structure/flora/roguetree/attacked_by(obj/item/I, mob/living/user)
 	var/was_destroyed = obj_destroyed
 	. = ..()

--- a/code/game/objects/structures/roguetown/rogueflora.dm
+++ b/code/game/objects/structures/roguetown/rogueflora.dm
@@ -25,14 +25,13 @@
 	handle_special_items_retrieval(user, src)
 
 /obj/structure/flora/roguetree/attackby(obj/item/I, mob/living/user, params)
-	. = ..()
 	if(!isliving(user) || user.used_intent.blade_class != BCLASS_CHOP)
-		return
+		return ..()
 	var/mob/living/L = user
 	if(L.client && !L.client.prefs?.autowoodcut)
-		return
+		return ..()
 	if(user.doing)
-		return
+		return ..()
 	user.doing = FALSE
 	while(!QDELETED(src) && user.Adjacent(src))
 		if((L.energy > 0) && do_after(user, 1.5 SECONDS, TRUE, src))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -48,9 +48,9 @@
 	if (mineralType && mineralAmt && spread && spreadChance)
 		for(var/dir in GLOB.cardinals)
 			if(prob(spreadChance))
-				var/turf/T = get_step(src, dir)
-				if(istype(T, /turf/closed/mineral/random))
-					Spread(T)
+				var/turf/StepTurf = get_step(src, dir)
+				if(istype(StepTurf, /turf/closed/mineral/random))
+					Spread(StepTurf)
 	var/turf/open/transparent/openspace/target = get_step_multiz(src, UP)
 	if(istype(target))
 		target.ChangeTurf(/turf/open/floor/rogue/naturalstone)
@@ -66,44 +66,46 @@
 // My wrists hurt. Let us have this. okay?
 /turf/closed/mineral/Bumped(atom/movable/AM)
 	. = ..()
-	if(ishuman(AM))
-		var/mob/living/carbon/human/user = AM
-		var/obj/item = user.get_active_held_item()
-		if(istype(user.used_intent, /datum/intent/pick) && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
-			if(user.client && !user.client.prefs?.autopicking)
-				return
-			if(do_after(user, 1 SECONDS, TRUE, src, TRUE, null, TRUE))
-				if(!ismineralturf(src))
-					return
-				src.attackby(item, user, multiplier = 2)
-				user.stamina_add(25)
+	if(!ishuman(AM))
+		return
+	var/mob/living/carbon/human/user = AM
+	if(!istype(user.used_intent, /datum/intent/pick) || user.get_skill_level(/datum/skill/labor/mining) < SKILL_LEVEL_APPRENTICE)
+		return
+	if(user.client && !user.client.prefs?.autopicking)
+		return
+	var/obj/item/held_item = user.get_active_held_item()
+	if(do_after(user, 1 SECONDS, TRUE, src, TRUE, null, TRUE))
+		if(!ismineralturf(src))
+			return
+		attackby(held_item, user, multiplier = 2)
+		user.stamina_add(25)
 
-/turf/closed/mineral/attackby(obj/item/I, mob/user, params, multiplier)
+/turf/closed/mineral/attackby(obj/item/item, mob/user, params, multiplier)
 	if (!user.IsAdvancedToolUser())
 		to_chat(usr, span_warning("I don't have the dexterity to do this!"))
 		return
 	lastminer = user
 	..()
-	if(istype(I, /obj/item/rogueweapon/pick))
+	if(istype(item, /obj/item/rogueweapon/pick))
 		if(!isliving(user))
 			return
 
-		var/mob/living/L = user
-		if(L.client && !L.client.prefs?.autopicking)
+		var/mob/living/LivingUser = user
+		if(LivingUser.client && !LivingUser.client.prefs?.autopicking)
 			return
 		user.doing = FALSE
 		// Makes more sense for the check since they always
 		// become an open tile afterwards
 		while(density && user.Adjacent(src))
-			if((L.energy > 0) && (do_after(user, CLICK_CD_MELEE, TRUE, src)))
+			if((LivingUser.energy > 0) && (do_after(user, CLICK_CD_MELEE, TRUE, src)))
 				..()
 				var/olddam = turf_integrity
 				if(turf_integrity && turf_integrity > 10)
 					if(turf_integrity < olddam)
 						if(prob(50))
 							if(user.Adjacent(src))
-								var/obj/item/natural/stone/S = new(src)
-								S.forceMove(get_turf(user))
+								var/obj/item/natural/stone/DroppedStone = new(src)
+								DroppedStone.forceMove(get_turf(user))
 					if(!density)
 						break
 			else
@@ -115,7 +117,7 @@
 		if(do_after(user, 2 SECONDS, TRUE, src))
 			if(!ismineralturf(src))
 				return
-			src.attackby(item, user, multiplier = 4)
+			attackby(item, user, multiplier = 4)
 			user.stamina_add(25)
 	..()
 
@@ -124,9 +126,9 @@
 		return
 	if(damage_flag == "stab" || damage_flag == "blunt")
 		if(istype(src, /turf/closed/mineral/rogue) || istype(src, /turf/closed/mineral/random/rogue)) // if a natural stone wall was destroyed, spawn a trigger trap for mine shaft collapsing
-			var/turf/T = get_turf(src)
-			if(!isnull(T) && !locate(/obj/structure/mine_collapse) in T) // there isn't a trap here, add to turf
-				var/obj/structure/mine_collapse/new_trap = new /obj/structure/mine_collapse(T)
+			var/turf/TargetedTurf = get_turf(src)
+			if(!isnull(TargetedTurf) && !locate(/obj/structure/mine_collapse) in TargetedTurf) // there isn't a trap here, add to turf
+				var/obj/structure/mine_collapse/new_trap = new /obj/structure/mine_collapse(TargetedTurf)
 				if(new_trap) // to any future coders - do not randomize this type, it'll break the salt mines prison camp and let them mine iron, which'll let them break out too easily
 					new_trap.respawn_rock = src.type
 	if(damage_flag == "blunt")
@@ -205,8 +207,8 @@
 			gets_drilled(null, triggered_by_explosion = TRUE)
 	return
 
-/turf/closed/mineral/Spread(turf/T)
-	T.ChangeTurf(type)
+/turf/closed/mineral/Spread(turf/SpreadTurf)
+	SpreadTurf.ChangeTurf(type)
 
 /turf/closed/mineral/random
 	///if this isn't empty, swaps to one of them via pickweight
@@ -224,16 +226,16 @@
 	. = ..()
 	if (prob(mineralChance))
 		var/path = pickweight(mineralSpawnChanceList)
-		var/turf/T = ChangeTurf(path,null,CHANGETURF_IGNORE_AIR)
+		var/turf/NewTurf = ChangeTurf(path,null,CHANGETURF_IGNORE_AIR)
 
-		if(T && ismineralturf(T))
-			var/turf/closed/mineral/M = T
-			M.mineralAmt = rand(1, 5)
-			M.environment_type = src.environment_type
-			M.turf_type = src.turf_type
-			M.baseturfs = src.baseturfs
-			src = M
-			M.levelupdate()
+		if(NewTurf && ismineralturf(NewTurf))
+			var/turf/closed/mineral/MineralTurf = NewTurf
+			MineralTurf.mineralAmt = rand(1, 5)
+			MineralTurf.environment_type = src.environment_type
+			MineralTurf.turf_type = src.turf_type
+			MineralTurf.baseturfs = src.baseturfs
+			src = MineralTurf
+			MineralTurf.levelupdate()
 
 /turf/closed/mineral/random/rogue
 //	layer = ABOVE_MOB_LAYER

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -62,6 +62,20 @@
 		return TRUE
 	return ..()
 
+// This is snowflaked bump code for mineral walls. Bumping into walls allows you to mine them, if you have apprentice+ skill.
+// My wrists hurt. Let us have this. okay?
+/turf/closed/mineral/Bumped(atom/movable/AM)
+	. = ..()
+	if(ishuman(AM))
+		var/mob/living/carbon/human/user = AM
+		var/obj/item = user.get_active_held_item()
+		if(user.used_intent.type == /datum/intent/pick && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
+			if(do_after(user, 1 SECONDS, TRUE, src, TRUE, null, TRUE))
+				if(!ismineralturf(src))
+					return
+				src.attackby(item, user, multiplier = 2)
+				user.stamina_add(25)
+
 /turf/closed/mineral/attackby(obj/item/I, mob/user, params, multiplier)
 	if (!user.IsAdvancedToolUser())
 		to_chat(usr, span_warning("I don't have the dexterity to do this!"))
@@ -93,8 +107,8 @@
 
 /turf/closed/mineral/attack_right(mob/user)
 	var/obj/item = user.get_active_held_item()
-	if(user.used_intent.type == /datum/intent/pick && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_JOURNEYMAN))
-		if(do_after(user, 4 SECONDS, TRUE, src))
+	if(user.used_intent.type == /datum/intent/pick && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
+		if(do_after(user, 2 SECONDS, TRUE, src))
 			if(!ismineralturf(src))
 				return
 			src.attackby(item, user, multiplier = 4)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -74,6 +74,8 @@
 	if(user.client && !user.client.prefs?.autopicking)
 		return
 	var/obj/item/held_item = user.get_active_held_item()
+	if(user.doing)
+		return
 	if(do_after(user, 1 SECONDS, TRUE, src, TRUE, null, TRUE))
 		if(!ismineralturf(src))
 			return
@@ -92,7 +94,8 @@
 		var/mob/living/living_user = user
 		if(living_user.client && !living_user.client.prefs?.autopicking)
 			return
-		user.doing = FALSE
+		if(user.doing)
+			return
 		// Makes more sense for the check since they always
 		// become an open tile afterwards
 		while(density && user.Adjacent(src))

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -78,7 +78,6 @@
 		if(!ismineralturf(src))
 			return
 		attackby(held_item, user, multiplier = 2)
-		user.stamina_add(25)
 
 /turf/closed/mineral/attackby(obj/item/item, mob/user, params, multiplier)
 	if (!user.IsAdvancedToolUser())
@@ -118,7 +117,6 @@
 			if(!ismineralturf(src))
 				return
 			attackby(item, user, multiplier = 4)
-			user.stamina_add(25)
 	..()
 
 /turf/closed/mineral/turf_destruction(damage_flag)

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -69,7 +69,9 @@
 	if(ishuman(AM))
 		var/mob/living/carbon/human/user = AM
 		var/obj/item = user.get_active_held_item()
-		if(user.used_intent.type == /datum/intent/pick && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
+		if(istype(user.used_intent, /datum/intent/pick) && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
+			if(user.client && !user.client.prefs?.autopicking)
+				return
 			if(do_after(user, 1 SECONDS, TRUE, src, TRUE, null, TRUE))
 				if(!ismineralturf(src))
 					return
@@ -87,6 +89,8 @@
 			return
 
 		var/mob/living/L = user
+		if(L.client && !L.client.prefs?.autopicking)
+			return
 		user.doing = FALSE
 		// Makes more sense for the check since they always
 		// become an open tile afterwards
@@ -107,7 +111,7 @@
 
 /turf/closed/mineral/attack_right(mob/user)
 	var/obj/item = user.get_active_held_item()
-	if(user.used_intent.type == /datum/intent/pick && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
+	if(istype(user.used_intent, /datum/intent/pick) && (user.get_skill_level(/datum/skill/labor/mining) >= SKILL_LEVEL_APPRENTICE))
 		if(do_after(user, 2 SECONDS, TRUE, src))
 			if(!ismineralturf(src))
 				return

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -48,9 +48,9 @@
 	if (mineralType && mineralAmt && spread && spreadChance)
 		for(var/dir in GLOB.cardinals)
 			if(prob(spreadChance))
-				var/turf/StepTurf = get_step(src, dir)
-				if(istype(StepTurf, /turf/closed/mineral/random))
-					Spread(StepTurf)
+				var/turf/step_turf = get_step(src, dir)
+				if(istype(step_turf, /turf/closed/mineral/random))
+					Spread(step_turf)
 	var/turf/open/transparent/openspace/target = get_step_multiz(src, UP)
 	if(istype(target))
 		target.ChangeTurf(/turf/open/floor/rogue/naturalstone)
@@ -90,22 +90,22 @@
 		if(!isliving(user))
 			return
 
-		var/mob/living/LivingUser = user
-		if(LivingUser.client && !LivingUser.client.prefs?.autopicking)
+		var/mob/living/living_user = user
+		if(living_user.client && !living_user.client.prefs?.autopicking)
 			return
 		user.doing = FALSE
 		// Makes more sense for the check since they always
 		// become an open tile afterwards
 		while(density && user.Adjacent(src))
-			if((LivingUser.energy > 0) && (do_after(user, CLICK_CD_MELEE, TRUE, src)))
+			if((living_user.energy > 0) && (do_after(user, CLICK_CD_MELEE, TRUE, src)))
 				..()
 				var/olddam = turf_integrity
 				if(turf_integrity && turf_integrity > 10)
 					if(turf_integrity < olddam)
 						if(prob(50))
 							if(user.Adjacent(src))
-								var/obj/item/natural/stone/DroppedStone = new(src)
-								DroppedStone.forceMove(get_turf(user))
+								var/obj/item/natural/stone/dropped_stone = new(src)
+								dropped_stone.forceMove(get_turf(user))
 					if(!density)
 						break
 			else
@@ -126,9 +126,9 @@
 		return
 	if(damage_flag == "stab" || damage_flag == "blunt")
 		if(istype(src, /turf/closed/mineral/rogue) || istype(src, /turf/closed/mineral/random/rogue)) // if a natural stone wall was destroyed, spawn a trigger trap for mine shaft collapsing
-			var/turf/TargetedTurf = get_turf(src)
-			if(!isnull(TargetedTurf) && !locate(/obj/structure/mine_collapse) in TargetedTurf) // there isn't a trap here, add to turf
-				var/obj/structure/mine_collapse/new_trap = new /obj/structure/mine_collapse(TargetedTurf)
+			var/turf/targeted_turf = get_turf(src)
+			if(!isnull(targeted_turf) && !locate(/obj/structure/mine_collapse) in targeted_turf) // there isn't a trap here, add to turf
+				var/obj/structure/mine_collapse/new_trap = new /obj/structure/mine_collapse(targeted_turf)
 				if(new_trap) // to any future coders - do not randomize this type, it'll break the salt mines prison camp and let them mine iron, which'll let them break out too easily
 					new_trap.respawn_rock = src.type
 	if(damage_flag == "blunt")
@@ -207,8 +207,8 @@
 			gets_drilled(null, triggered_by_explosion = TRUE)
 	return
 
-/turf/closed/mineral/Spread(turf/SpreadTurf)
-	SpreadTurf.ChangeTurf(type)
+/turf/closed/mineral/Spread(turf/spread_turf)
+	spread_turf.ChangeTurf(type)
 
 /turf/closed/mineral/random
 	///if this isn't empty, swaps to one of them via pickweight
@@ -226,16 +226,16 @@
 	. = ..()
 	if (prob(mineralChance))
 		var/path = pickweight(mineralSpawnChanceList)
-		var/turf/NewTurf = ChangeTurf(path,null,CHANGETURF_IGNORE_AIR)
+		var/turf/new_turf = ChangeTurf(path,null,CHANGETURF_IGNORE_AIR)
 
-		if(NewTurf && ismineralturf(NewTurf))
-			var/turf/closed/mineral/MineralTurf = NewTurf
-			MineralTurf.mineralAmt = rand(1, 5)
-			MineralTurf.environment_type = src.environment_type
-			MineralTurf.turf_type = src.turf_type
-			MineralTurf.baseturfs = src.baseturfs
-			src = MineralTurf
-			MineralTurf.levelupdate()
+		if(new_turf && ismineralturf(new_turf))
+			var/turf/closed/mineral/mineral_turf = new_turf
+			mineral_turf.mineralAmt = rand(1, 5)
+			mineral_turf.environment_type = src.environment_type
+			mineral_turf.turf_type = src.turf_type
+			mineral_turf.baseturfs = src.baseturfs
+			src = mineral_turf
+			mineral_turf.levelupdate()
 
 /turf/closed/mineral/random/rogue
 //	layer = ABOVE_MOB_LAYER

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -208,6 +208,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/nsfw_examine_always = FALSE
 	var/mute_animal_emotes = FALSE
 	var/autoconsume = FALSE
+	var/autowoodcut = TRUE
+	var/autopicking = TRUE
 	var/runmode = FALSE
 	var/no_examine_blocks = FALSE
 	var/no_autopunctuate = FALSE

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -249,6 +249,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["wildshape_name"]		>> wildshape_name
 	S["mute_animal_emotes"]	>> mute_animal_emotes
 	S["autoconsume"]		>> autoconsume
+	S["autowoodcut"]		>> autowoodcut
+	S["autopicking"]		>> autopicking
 	S["no_examine_blocks"]	>> no_examine_blocks
 	S["no_autopunctuate"]	>> no_autopunctuate
 	S["no_language_fonts"]	>> no_language_fonts
@@ -395,6 +397,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["wildshape_name"], wildshape_name)
 	WRITE_FILE(S["mute_animal_emotes"], mute_animal_emotes)
 	WRITE_FILE(S["autoconsume"], autoconsume)
+	WRITE_FILE(S["autowoodcut"], autowoodcut)
+	WRITE_FILE(S["autopicking"], autopicking)
 	WRITE_FILE(S["no_examine_blocks"], no_examine_blocks)
 	WRITE_FILE(S["no_autopunctuate"], no_autopunctuate)
 	WRITE_FILE(S["no_language_fonts"], no_language_fonts)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -103,6 +103,8 @@
 
 	var/list/gameplay_entries = list(
 		list("id" = "autoconsume", "label" = "AutoConsume", "enabled" = !!owner.prefs.autoconsume, "desc" = "Repeat consume/feed interactions automatically."),
+		list("id" = "autowoodcut", "label" = "AutoWoodcut", "enabled" = !!owner.prefs.autowoodcut, "desc" = "Automatically continue chopping a tree after the first swing."),
+		list("id" = "autopicking", "label" = "AutoPicking", "enabled" = !!owner.prefs.autopicking, "desc" = "Automatically continue mining after clicking or bumping a rock wall with a pickaxe in hand."),
 		list("id" = "show_rolls", "label" = "Show Rolls", "enabled" = !!owner.prefs.showrolls, "desc" = "Show combat and check roll details in chat."),
 		list("id" = "combat_strip", "label" = "Combat Mode Stripping", "enabled" = !!(owner.prefs.toggles & CMODE_STRIPPING), "desc" = "Allow opening strip menu while in combat mode."),
 		list("id" = "hide_unavailable_emotes", "label" = "Hide Unavailable Noises", "enabled" = !!owner.prefs.hide_unavailable_emotes, "desc" = "Hide anatomy-specific noise verbs your current body cannot use."),
@@ -179,6 +181,10 @@
 				owner.toggle_xptext()
 			if("autoconsume")
 				owner.autoconsume()
+			if("autowoodcut")
+				owner.toggle_autowoodcut()
+			if("autopicking")
+				owner.toggle_autopicking()
 			if("show_rolls")
 				owner.show_rolls()
 			if("combat_strip")
@@ -292,6 +298,30 @@
 			to_chat(src, "You will now try to repeatedly consume/feed food/drinks")
 		else
 			to_chat(src, "You will no longer try to repeatedly consume/feed food/drinks")
+
+/client/verb/toggle_autowoodcut()
+	set category = "Options"
+	set name = "Toggle AutoWoodcut"
+	set hidden = 1
+	if(prefs)
+		prefs.autowoodcut = !prefs.autowoodcut
+		prefs.save_preferences()
+		if(prefs.autowoodcut)
+			to_chat(src, "You will now automatically continue chopping trees.")
+		else
+			to_chat(src, "You will no longer automatically continue chopping trees.")
+
+/client/verb/toggle_autopicking()
+	set category = "Options"
+	set name = "Toggle AutoPicking"
+	set hidden = 1
+	if(prefs)
+		prefs.autopicking = !prefs.autopicking
+		prefs.save_preferences()
+		if(prefs.autopicking)
+			to_chat(src, "You will now automatically continue mining rock walls.")
+		else
+			to_chat(src, "You will no longer automatically continue mining rock walls.")
 
 /client/verb/toggle_hide_unavailable_emotes()
 	set category = "Options"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/homesteader.dm
@@ -379,10 +379,9 @@
 			/obj/item/ingot/iron,
 			/obj/item/rogueore/coal
 		),
-		"Carpenter Set" = list(
-			/obj/item/rogueweapon/stoneaxe/woodcut/bronze,
-			/obj/item/rogueweapon/handsaw,
-			/obj/item/rogueweapon/hammer/copper,
+		"Craftsman Set" = list(
+			/obj/item/rogueweapon/stoneaxe/handaxe,
+			/obj/item/rogueweapon/hammer/steel,
 			/obj/item/folding_table_stored
 		),
 		"Hunter Set" = list(
@@ -415,14 +414,6 @@
 			/obj/item/paper,
 			/obj/item/paper/scroll,
 			/obj/item/natural/feather
-		),
-		"Mason Set" = list(
-			/obj/item/rogueweapon/chisel,
-			/obj/item/rogueweapon/hammer/copper,
-			/obj/item/natural/stone,
-			/obj/item/natural/stone,
-			/obj/item/natural/stone,
-			/obj/item/folding_table_stored
 		)
 	)
 
@@ -454,6 +445,9 @@
 						var/unique_key = "[item_name] ([profession_set_name] [counter])"
 						H.mind.special_items[unique_key] = item_path
 					counter++
+				if(profession_set_name == "Craftsman Set")
+					ADD_TRAIT(H, TRAIT_MASTER_CARPENTER, TRAIT_GENERIC)
+					ADD_TRAIT(H, TRAIT_MASTER_MASON, TRAIT_GENERIC)
 				if(profession_set_name in profession_sets)
 					profession_sets -= profession_set_name
 


### PR DESCRIPTION
## About The Pull Request
- Implemented a partial port and expanded a bit upon AP's pick bumping. Basically, you can just walk into a rock wall to initiate auto dig on it. Requires apprentice mining.
- Added in auto woodcutting.
- Added toggles for both these features in the new fancy toggles menu. Pick bumping is bundled in with auto digging.
- Adds auto stone chiseling. It repeats chiseling for each stone on the turf! Chiseling has always been incredibly click intensive.
- Boulders now inherit the same do_after rock walls get when mining them.
- Removed mason set and carpenter set for commoner. Now it the craftsman set. It gives you the traits that let you get the most out of wood and chiseling like builder/architect has. No more handsaw or chisel since you already start out with those. Slightly nicer handaxe and hammer in trade.

## Testing Evidence
<img width="631" height="846" alt="doafterwoodcutandpickbump" src="https://github.com/user-attachments/assets/88dbf5f5-89df-4b04-be9c-6706668be190" />

## Why It's Good For The Game
Clicking over 100 times every round on trees as a builder gets really old. This helps with the fingers, just as autodig did with mining. Pick bumping is just a further QoL expansion to the mining one. Feel free to tell me your gripes about why this is bad, because I really don't see why it is. There's even an option to toggle them both off now if you want 'immersion' or if you enjoy your finger hurting and mouse getting destroyed after hundreds of hours clicking trees.

Also there was some bloat in the commoner class sets and I figured it would be better to just combine carpentry and masonry into one set since most players are going to be doing both anyway if they're building and it makes this set more appealing than the other two which didn't add much. You already get a handsaw and chisel in your starting gear so these two sets were not really useful unless you wanted spares. Now you have an actually handy one that establishes your intent to be building oriented.

## Changelog
:cl:
qol: Implemented a partial port and expanded a bit upon AP's pick bumping. Basically, you can just walk into a rock wall to initiate auto dig on it. Requires apprentice mining.
qol: Added in auto woodcutting.
add: Added toggles for both these features in the new fancy toggles menu. Pick bumping is bundled in with auto digging.
qol: Chiseling stones will now repeat for each stone on the turf.
qol: Boulders now inherit the same do_after rock walls get when mining them.
add: Removed mason set and carpenter set for commoner. Now it the craftsman set. It gives you the traits that let you get the most out of wood and chiseling and a slightly nicer axe + hammer.
/:cl: