### PR TITLE
Cleaning up some areatypes

### DIFF
--- a/_maps/map_files/deserttown/deserttown.dmm
+++ b/_maps/map_files/deserttown/deserttown.dmm
@@ -20,7 +20,7 @@
 "aaN" = (
 /obj/structure/fluff/statue/gargoyle,
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aaR" = (
 /turf/open/floor/rogue/darkpath,
 /area/rogue/under/town/basement/desert/keep)
@@ -99,7 +99,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "acS" = (
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/under/cave)
@@ -335,7 +335,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ahC" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -714,7 +714,7 @@
 "apk" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "apu" = (
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/desert)
@@ -830,7 +830,7 @@
 "arV" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "arW" = (
 /obj/effect/decal/carpet/kover_black{
 	pixel_y = 7
@@ -1207,7 +1207,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/rogue/pie/cooked/apple,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aAr" = (
 /obj/structure/fluff/walldeco/painting{
 	pixel_x = 32
@@ -1360,7 +1360,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aCq" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -1393,7 +1393,7 @@
 "aDn" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aDp" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/tavern/desert)
@@ -1410,7 +1410,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aDG" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/suit/roguetown/armor/plate/half,
@@ -1613,7 +1613,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aHi" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/item/reagent_containers/glass/cup/golden{
@@ -1683,7 +1683,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aIw" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -1797,7 +1797,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aLL" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/medical,
@@ -1977,7 +1977,7 @@
 "aQd" = (
 /obj/item/roguecoin/copper/pile,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aQi" = (
 /obj/machinery/light/rogue/smelter/great,
 /turf/open/floor/rogue/concrete,
@@ -1996,7 +1996,7 @@
 "aQU" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aRc" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -2264,7 +2264,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "aUd" = (
 /obj/structure/well,
 /obj/item/reagent_containers/glass/bucket{
@@ -2811,9 +2811,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "bgx" = (
 /obj/item/book/rogue/law,
 /obj/structure/table/wood{
@@ -3486,7 +3484,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry/baked,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "bsu" = (
 /obj/machinery/light/rogue/cauldron,
 /turf/open/floor/rogue/concrete,
@@ -3785,7 +3783,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "byB" = (
 /obj/item/rope,
 /mob/living/carbon/human/species/skeleton/npc/miner,
@@ -4169,7 +4167,7 @@
 /area/rogue/indoors/town/desert/warden)
 "bFM" = (
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "bFY" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/water/sewer,
@@ -4280,7 +4278,7 @@
 "bHD" = (
 /obj/structure/bearpelt,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "bHK" = (
 /obj/item/cushion/desert1,
 /turf/open/floor/carpet/red,
@@ -4740,7 +4738,7 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/wood/window,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "bQQ" = (
 /turf/open/floor/rogue/deserttile{
 	icon_state = "tilegreyblu"
@@ -4985,7 +4983,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "bUJ" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -5113,7 +5111,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "bXq" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -5362,7 +5360,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ccC" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/sandbrick,
@@ -5670,7 +5668,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cjO" = (
 /turf/open/floor/rogue/tile/masonic,
 /area/rogue/indoors/town/manor/desert)
@@ -5825,7 +5823,7 @@
 "cnf" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cnk" = (
 /obj/item/cushion/desert1,
 /turf/open/floor/rogue/lightpath,
@@ -5936,7 +5934,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "coX" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/concrete{
@@ -6583,7 +6581,7 @@
 "cBz" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cBE" = (
 /turf/closed/wall/mineral/rogue/sandstone{
 	max_integrity = 9999;
@@ -6683,9 +6681,7 @@
 "cDv" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "cDB" = (
 /obj/item/chair/rogue/crafted,
 /turf/open/floor/rogue/sandbrick,
@@ -6782,7 +6778,7 @@
 /obj/item/clothing/suit/roguetown/armor/leather/hide/goblin,
 /obj/item/rogueweapon/stoneaxe,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cFi" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -7032,7 +7028,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cLA" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/long{
 	dir = 1
@@ -7065,9 +7061,7 @@
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerb,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "cMj" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/sandbrick,
@@ -7660,13 +7654,13 @@
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cWS" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/wood/window,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "cWV" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -8220,9 +8214,7 @@
 /area/rogue/indoors/town/desert/arenaview)
 "din" = (
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "diq" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/random,
@@ -8368,7 +8360,7 @@
 "dkU" = (
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dlm" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -8378,9 +8370,7 @@
 "dlx" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "dlA" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border{
@@ -8399,10 +8389,10 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dlQ" = (
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dlS" = (
 /obj/structure/table/wood/large_table/south_east,
 /obj/item/cooking/platter/copper,
@@ -8444,7 +8434,7 @@
 "dmA" = (
 /obj/structure/toilet,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dmE" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/ruinedwood{
@@ -8877,7 +8867,7 @@
 	},
 /obj/item/trash/candle,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "duV" = (
 /turf/open/floor/carpet/red,
 /area/rogue/outdoors/town/roofs/desert)
@@ -9029,7 +9019,7 @@
 /obj/item/rogueweapon/shield/wood,
 /obj/item/rogueweapon/shield/wood,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dyy" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles{
 	pixel_y = -10
@@ -9152,7 +9142,7 @@
 /obj/item/clothing/suit/roguetown/armor/leather/goblin,
 /obj/item/clothing/suit/roguetown/armor/leather/goblin,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dAG" = (
 /obj/structure/closet/crate/chest/gold,
 /obj/machinery/light/rogue/candle/green/l,
@@ -9176,7 +9166,7 @@
 	dir = 1
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dAX" = (
 /turf/closed/wall/mineral/rogue/decostone/long{
 	dir = 1
@@ -9353,7 +9343,7 @@
 /obj/item/reagent_containers/powder/flour,
 /obj/item/reagent_containers/food/snacks/rogue/meat/bacon,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dEp" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/flint,
@@ -9379,9 +9369,7 @@
 "dEG" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "dEK" = (
 /obj/structure/flora/roguetree/palm,
 /turf/open/floor/rogue/desert_grass,
@@ -9559,7 +9547,7 @@
 	dir = 6
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dHC" = (
 /obj/structure/fluff/wallclock,
 /obj/effect/wisp/prestidigitation{
@@ -9733,7 +9721,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dKQ" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -9774,7 +9762,7 @@
 /turf/open/floor/rogue/cobblerock{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dKY" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/blocks/stonered,
@@ -10049,7 +10037,7 @@
 	lockid = "gobbo"
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dQA" = (
 /turf/open/floor/rogue/desert_grass,
 /area/rogue/outdoors/desert)
@@ -10121,7 +10109,7 @@
 	redstone_id = "goblingate"
 	},
 /turf/open/floor/rogue/naturalstone/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dSh" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -10146,7 +10134,7 @@
 	},
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "dSs" = (
 /obj/machinery/light/rogue/candle,
 /obj/effect/decal/cobbleedge{
@@ -10606,7 +10594,7 @@
 	dir = 5
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ebe" = (
 /turf/open/floor/rogue/cobblerock{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
@@ -10669,7 +10657,7 @@
 /obj/item/rope/chain,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ecO" = (
 /obj/structure/rack/rogue,
 /obj/item/ammo_casing/caseless/rogue/javelin/aalloy,
@@ -10763,7 +10751,7 @@
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/clothing,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eeO" = (
 /obj/machinery/light/rogue/firebowl/church,
 /turf/open/floor/rogue/citybrick/citybrick6,
@@ -10891,7 +10879,7 @@
 	name = "fancy goblin key"
 	},
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ehd" = (
 /turf/open/floor/rogue/sandbrick{
 	color = "#78acff"
@@ -11082,7 +11070,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ekT" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -11098,7 +11086,7 @@
 /obj/machinery/light/rogue/candle/l,
 /obj/item/trash/applecore,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "els" = (
 /turf/open/floor/rogue/sandbrick,
 /area/rogue/indoors/town/desert/warden)
@@ -11326,7 +11314,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eqx" = (
 /obj/item/roguestatue/silver,
 /obj/machinery/light/rogue/candle/blue/r,
@@ -11428,7 +11416,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "esK" = (
 /obj/structure/mannequin/male,
 /turf/open/floor/rogue/darkpath,
@@ -11499,7 +11487,7 @@
 /obj/structure/fluff/nest,
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eut" = (
 /obj/effect/landmark/mapGenerator/rogue/desert,
 /turf/closed/mineral/rogue/sandstone,
@@ -12183,9 +12171,7 @@
 	},
 /obj/item/reagent_containers/food/snacks/rogue/crackerscooked,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "eHH" = (
 /obj/structure/fermentation_keg/sandpot/water,
 /turf/open/floor/rogue/tile/brownbrick{
@@ -12276,7 +12262,7 @@
 	icon_state = "paving";
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eJF" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/dress/gen/random,
@@ -12332,7 +12318,7 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /obj/item/clothing/cloak/lordcloak,
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eKx" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -12860,7 +12846,7 @@
 /obj/structure/fluff/nest,
 /mob/living/simple_animal/hostile/retaliate/rogue/troll/bog,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eWB" = (
 /obj/structure/fluff/statue/knight{
 	icon = 'modular_deserttown/icons/alt/tallstructure.dmi'
@@ -12910,7 +12896,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eYt" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/sandbrick,
@@ -12948,7 +12934,7 @@
 	name = "goblin key"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eZb" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/roguegrass,
@@ -12978,7 +12964,7 @@
 /obj/effect/decal/cleanable/food/egg_smudge,
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "eZI" = (
 /obj/structure/stairs{
 	dir = 1;
@@ -13149,7 +13135,7 @@
 "fcL" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "fcT" = (
 /obj/structure/table/wood,
 /obj/structure/bars{
@@ -13342,7 +13328,7 @@
 	pixel_y = 14
 	},
 /turf/open/floor/carpet/royalblack,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "fhk" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/decal/duneedge,
@@ -13732,9 +13718,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "fqk" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/water/bath,
@@ -14794,7 +14778,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "fLH" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -15239,7 +15223,7 @@
 	dir = 5
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "fVX" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/chapel)
@@ -15382,7 +15366,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gbr" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/wool,
@@ -15471,7 +15455,7 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/mace/goden,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gdv" = (
 /turf/open/floor/rogue/sandbrick,
 /area/rogue/indoors/inq/basement)
@@ -16073,7 +16057,7 @@
 /area/rogue/indoors/town/desert)
 "goO" = (
 /turf/open/floor/carpet/red,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "goT" = (
 /obj/item/roguebin/water/gross,
 /turf/open/floor/rogue/tile{
@@ -16107,7 +16091,7 @@
 /obj/structure/fluff/nest,
 /obj/item/trash/applecore,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gpO" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -16409,7 +16393,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gys" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/darkpath,
@@ -16562,7 +16546,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gBk" = (
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/bath/desert)
@@ -16672,7 +16656,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gCG" = (
 /obj/structure/flora/roguegrass/bush/desert,
 /turf/open/floor/rogue/desert_grass,
@@ -16943,7 +16927,7 @@
 "gID" = (
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/naturalstone/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "gIL" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -16999,9 +16983,7 @@
 	name = "Cell Door"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "gJN" = (
 /mob/living/carbon/human/species/orc/npc/marauder,
 /turf/open/floor/rogue/twig,
@@ -17847,7 +17829,7 @@
 	name = "Storage"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "haT" = (
 /obj/machinery/light/roguestreet/orange/walllamp,
 /turf/closed/wall/mineral/rogue/wooddark/window,
@@ -18275,7 +18257,7 @@
 	dir = 5
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hiD" = (
 /obj/structure/lever{
 	redstone_id = "dungeonanimal2"
@@ -18451,9 +18433,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "hmy" = (
 /obj/structure/stairs/desert,
 /turf/open/floor/rogue/darkpath,
@@ -18557,7 +18537,7 @@
 "hox" = (
 /obj/item/natural/poo/horse,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hoz" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/rogue/darkpath,
@@ -18697,7 +18677,7 @@
 	icon_state = "paving";
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hrX" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -18805,7 +18785,7 @@
 	},
 /obj/item/rogueweapon/tongs,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hvn" = (
 /obj/structure/bed/rogue/shit,
 /turf/open/floor/rogue/cobble,
@@ -19019,7 +18999,7 @@
 /turf/open/floor/rogue/cobblerock{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hBD" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -19131,7 +19111,7 @@
 	lockid = "gobbo_chief"
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hEd" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/wool,
@@ -19595,7 +19575,7 @@
 /obj/structure/rack/rogue,
 /obj/item/reagent_containers/food/snacks/rogue/bread,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hNB" = (
 /obj/structure/mineral_door/wood/donjon{
 	dir = 4;
@@ -19604,7 +19584,7 @@
 	name = "Smithery"
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hNM" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8
@@ -19860,7 +19840,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hTe" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/structure/pillory/reinforced{
@@ -19910,7 +19890,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hVh" = (
 /obj/structure/fluff/walldeco/mageguild{
 	pixel_y = 32
@@ -19931,7 +19911,7 @@
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hVu" = (
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/carpet/royalblack,
@@ -20092,7 +20072,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "hYM" = (
 /obj/item/natural/poo/horse,
 /turf/open/floor/rogue/dirt/desert,
@@ -20101,9 +20081,7 @@
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerb,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "hZj" = (
 /obj/item/cushion/desert1,
 /turf/open/floor/carpet/red,
@@ -20452,7 +20430,7 @@
 /area/rogue/outdoors/desertdeep)
 "igO" = (
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "igP" = (
 /obj/machinery/light/rogue/campfire/fireplace/desert{
 	pixel_x = -32
@@ -20646,7 +20624,7 @@
 /obj/item/ingot/iron,
 /obj/item/ingot/iron,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ikX" = (
 /obj/structure/fluff/railing/border,
 /turf/open/transparent/openspace,
@@ -20837,7 +20815,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "iox" = (
 /obj/structure/closet/crate/drawer{
 	keylock = 1;
@@ -20911,7 +20889,7 @@
 "ipv" = (
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp/deep,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ipD" = (
 /obj/structure/rack/rogue/shelf,
 /obj/structure/fluff/railing/border{
@@ -21019,7 +20997,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ish" = (
 /obj/structure/bed/rogue/inn/wool{
 	dir = 1
@@ -21126,7 +21104,7 @@
 	},
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "iup" = (
 /obj/structure/shisha/hookah,
 /turf/open/floor/carpet/royalblack,
@@ -21408,7 +21386,7 @@
 	faction = list("neutral")
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "iBc" = (
 /obj/structure/closet/crate/roguecloset/dark{
 	keylock = 1;
@@ -21653,7 +21631,7 @@
 	icon_state = "tablewood1"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "iHi" = (
 /obj/structure/closet/crate/roguecloset{
 	keylock = 1;
@@ -22349,7 +22327,7 @@
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jaj" = (
 /obj/structure/table/wood,
 /obj/structure/fluff/walldeco/mageguild{
@@ -22372,7 +22350,7 @@
 /obj/item/rogueweapon/mace/woodclub,
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jaO" = (
 /obj/structure/fluff/walldeco/bigpainting,
 /obj/structure/chair/zybantine_sofa/left,
@@ -22987,9 +22965,7 @@
 	pixel_y = -15
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "jmP" = (
 /obj/structure/fluff/clock{
 	pixel_y = 2
@@ -23104,7 +23080,7 @@
 	},
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "joq" = (
 /obj/item/cushion/zybantine,
 /turf/open/floor/rogue/blocks/stonered,
@@ -23495,7 +23471,7 @@
 	name = "Shaman's Room"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jvU" = (
 /obj/structure/fluff/walldeco/rpainting{
 	pixel_y = 32
@@ -23565,7 +23541,7 @@
 /area/rogue/under/town/basement/desert)
 "jxl" = (
 /turf/closed/mineral/rogue/bedrock,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jxo" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -23664,7 +23640,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jzz" = (
 /obj/item/reagent_containers/powder/ozium,
 /obj/item/reagent_containers/powder/ozium,
@@ -23759,7 +23735,7 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jAJ" = (
 /obj/structure/roguewindow/harem3,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -24169,7 +24145,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /obj/item/clothing/head/roguetown/helmet/heavy/bucket/iron,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jHk" = (
 /obj/machinery/light/rogue/torchholder/l,
 /obj/structure/rack/rogue,
@@ -24378,7 +24354,7 @@
 	name = "Outside"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jMj" = (
 /obj/machinery/light/rogue/candle/green,
 /turf/open/floor/rogue/cobble/mossy{
@@ -24388,9 +24364,7 @@
 "jMC" = (
 /obj/structure/well,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "jMD" = (
 /obj/machinery/light/rogue/candle/green/l,
 /turf/open/floor/rogue/cobble/mossy{
@@ -24511,7 +24485,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jPa" = (
 /obj/machinery/light/rogue/campfire/fireplace/desert{
 	pixel_x = -32
@@ -24709,7 +24683,7 @@
 	},
 /obj/item/rogueweapon/surgery/saw/improv,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jSu" = (
 /obj/structure/fluff/railing/fence{
 	dir = 4
@@ -24784,7 +24758,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jTP" = (
 /turf/open/floor/rogue/naturalstone/sandstone,
 /area/rogue/outdoors/desert)
@@ -24809,7 +24783,7 @@
 /area/rogue/outdoors/town/desert)
 "jUs" = (
 /turf/closed/mineral/random/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jUB" = (
 /obj/machinery/light/rogue/hearth{
 	pixel_y = 10
@@ -24891,7 +24865,7 @@
 "jVX" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jWf" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -24942,7 +24916,7 @@
 /obj/structure/fluff/nest,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "jWP" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/twig,
@@ -25896,7 +25870,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "krn" = (
 /obj/machinery/light/rogue/candle/r,
 /obj/item/bedsheet/rogue/cloth,
@@ -26499,7 +26473,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/rogue/metal,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kFB" = (
 /obj/machinery/light/rogue/candle/red,
 /obj/structure/fluff/walldeco/chains{
@@ -26580,7 +26554,7 @@
 /obj/item/clothing/head/roguetown/helmet/leather/goblin,
 /obj/item/clothing/head/roguetown/helmet/leather/goblin,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kGK" = (
 /obj/machinery/light/rogue/firebowl,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -26627,7 +26601,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kHE" = (
 /turf/closed/wall/mineral/rogue/sandbrick,
 /area/rogue/indoors/inq/office)
@@ -26735,7 +26709,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kKW" = (
 /obj/effect/wisp/prestidigitation,
 /turf/open/floor/rogue/darkpath,
@@ -27013,7 +26987,7 @@
 "kQQ" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kQR" = (
 /obj/structure/fermentation_keg/sandpot/beer,
 /turf/open/floor/rogue/sandbrick,
@@ -27065,7 +27039,7 @@
 	},
 /obj/item/rogueweapon/surgery/retractor/improv,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kRS" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -27177,9 +27151,7 @@
 "kUm" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "kUq" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -27304,7 +27276,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "kWM" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -27689,7 +27661,7 @@
 /area/rogue/indoors/town/magician/desert)
 "lfn" = (
 /turf/open/floor/rogue/metal,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lfr" = (
 /obj/item/restraints/legcuffs/beartrap/armed/camouflage,
 /turf/open/floor/rogue/citybrick,
@@ -27793,7 +27765,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lit" = (
 /turf/open/floor/rogue/dirt/road/desert,
 /area/rogue/outdoors/mountains)
@@ -27852,9 +27824,7 @@
 "ljb" = (
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "ljc" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	lockid = "church";
@@ -28031,7 +28001,7 @@
 	name = "goblin key"
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lng" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -28255,7 +28225,7 @@
 /obj/item/clothing/neck/roguetown/collar/catbell,
 /obj/item/clothing/neck/roguetown/collar/catbell,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lsD" = (
 /obj/structure/roguewindow/harem1,
 /turf/closed/wall/mineral/rogue/sandbrick,
@@ -28291,7 +28261,7 @@
 "ltt" = (
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ltx" = (
 /obj/machinery/light/roguestreet/walllamp{
 	dir = 4;
@@ -28347,7 +28317,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "luT" = (
 /obj/structure/closet/crate/chest{
 	locked = 1;
@@ -28881,11 +28851,11 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/spear,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lFw" = (
 /obj/structure/table/wood,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lFA" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/desert/above)
@@ -29037,7 +29007,7 @@
 /obj/structure/closet/crate/chest,
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "lIT" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -30003,7 +29973,7 @@
 	dir = 9
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mcy" = (
 /obj/structure/fluff/railing/border{
 	dir = 9
@@ -30098,7 +30068,7 @@
 "mer" = (
 /obj/structure/mineral_door/wood/deadbolt,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "met" = (
 /obj/structure/fluff/littlebanners/bluewhite{
 	color = "#b5b0aa";
@@ -30161,14 +30131,14 @@
 "mfA" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mfD" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
 	},
 /obj/item/rogueweapon/hammer/iron,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mgh" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/food,
@@ -30398,7 +30368,7 @@
 /turf/closed/wall/mineral/rogue/stone/window/moss{
 	icon_state = "stonewindow"
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mko" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -30900,7 +30870,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "muq" = (
 /turf/open/floor/rogue/sandbrick,
 /area/rogue/under/town/basement/desert/town)
@@ -31371,7 +31341,7 @@
 /area/rogue/indoors/shelter/desertdeep)
 "mFj" = (
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mFz" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall";
@@ -31465,7 +31435,7 @@
 "mHn" = (
 /obj/structure/mineral_door/wood/fancywood,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mHq" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -31716,7 +31686,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mOk" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone,
@@ -32044,7 +32014,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mVk" = (
 /obj/structure/mineral_door/wood{
 	chat_color_name = "room";
@@ -32202,7 +32172,7 @@
 "mYC" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mYI" = (
 /obj/structure/chair/zybantine_sofa/left,
 /obj/effect/decal/cobbleedge{
@@ -32220,7 +32190,7 @@
 /obj/item/roguecoin/copper,
 /obj/item/roguecoin/gold,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "mZz" = (
 /obj/structure/sandrock/sandrock3,
 /turf/open/floor/rogue/dunes,
@@ -32413,7 +32383,7 @@
 "ncs" = (
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ncu" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -32619,7 +32589,7 @@
 "ngn" = (
 /obj/structure/flora/roguegrass/reedbush,
 /turf/open/water/swamp/deep,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ngx" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -32728,7 +32698,7 @@
 /obj/machinery/light/rogue/hearth,
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nih" = (
 /obj/item/cushion/desert1,
 /turf/open/floor/rogue/wood,
@@ -32748,9 +32718,7 @@
 "niw" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "niy" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -32946,7 +32914,7 @@
 "nmr" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nmF" = (
 /obj/structure/chair/zybantine_sofa/left,
 /obj/effect/decal/cobbleedge{
@@ -33129,7 +33097,7 @@
 /area/rogue/under/underdarker)
 "nqS" = (
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nqT" = (
 /obj/structure/roguewindow/harem3,
 /turf/open/floor/rogue/tile/harem1,
@@ -33216,7 +33184,7 @@
 /area/rogue/indoors/town/shop/desert)
 "nsz" = (
 /turf/closed/mineral/random/rogue/sandstone/high,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nsB" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/hoe,
@@ -33284,7 +33252,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ntB" = (
 /obj/structure/closet/crate/chest/inqcrate{
 	lockid = "inquisition"
@@ -33407,7 +33375,7 @@
 /area/rogue/indoors/town/desert)
 "nwc" = (
 /turf/open/floor/carpet/royalblack,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nwd" = (
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = 9;
@@ -33559,7 +33527,7 @@
 /obj/structure/closet/crate/roguecloset/inn/south,
 /obj/item/natural/cloth,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nyk" = (
 /obj/structure/roguewindow/harem3,
 /obj/structure/curtain/directional/orange{
@@ -33624,13 +33592,11 @@
 	},
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nzK" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "nzT" = (
 /obj/structure/stairs{
 	dir = 8;
@@ -33886,7 +33852,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nFh" = (
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
 /turf/open/floor/carpet/royalblack,
@@ -33934,9 +33900,7 @@
 "nGc" = (
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "nGq" = (
 /obj/machinery/light/rogue/forge{
 	status = 1
@@ -33950,7 +33914,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /obj/item/rogueweapon/sword/stone,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nGY" = (
 /obj/item/natural/rock/desert,
 /turf/open/floor/rogue/dunes,
@@ -33980,9 +33944,7 @@
 /area/rogue/indoors/town/bath/desert)
 "nHF" = (
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "nHP" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -34013,7 +33975,7 @@
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nID" = (
 /obj/structure/bookcase/random,
 /obj/item/book/rogue/festus,
@@ -34095,7 +34057,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nLr" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/indoors/town/magician/desert)
@@ -34315,7 +34277,7 @@
 /obj/effect/decal/cleanable/blood,
 /mob/living/carbon/human/species/goblin/npc/moon,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nQe" = (
 /obj/structure/fermentation_keg/sandpot/water,
 /turf/open/floor/rogue/darkpath,
@@ -34440,7 +34402,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nSi" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -34460,11 +34422,11 @@
 	name = "Riches"
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nSn" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nSE" = (
 /obj/structure/fluff/psycross/copper,
 /obj/machinery/light/rogue/torchholder/r,
@@ -34587,7 +34549,7 @@
 "nUQ" = (
 /obj/item/clothing/head/roguetown/helmet/leather/goblin,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nVd" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -34729,7 +34691,7 @@
 "nXm" = (
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "nXr" = (
 /obj/machinery/light/rogue/candle/l,
 /obj/structure/rack/rogue,
@@ -34938,7 +34900,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "obK" = (
 /obj/structure/bed/rogue/shit,
 /obj/effect/landmark/start/prisonerr,
@@ -35282,7 +35244,7 @@
 "ojk" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ojl" = (
 /obj/machinery/light/rogue/candle/green,
 /obj/structure/globe{
@@ -35409,7 +35371,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "olE" = (
 /obj/structure/mineral_door/wood{
 	lockid = "manor";
@@ -35543,7 +35505,7 @@
 "onA" = (
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "onQ" = (
 /obj/effect/decal/carpet/square{
 	pixel_y = 15;
@@ -35640,7 +35602,7 @@
 "ops" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "opt" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/tile/harem1,
@@ -36113,9 +36075,7 @@
 	pixel_x = 15
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "oxu" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -36170,7 +36130,7 @@
 "oxT" = (
 /obj/structure/stairs/desert,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "oxU" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -36253,7 +36213,7 @@
 "ozG" = (
 /obj/item/natural/rock,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ozV" = (
 /obj/structure/table/wood{
 	dir = 9;
@@ -36364,7 +36324,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "oDl" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -36390,7 +36350,7 @@
 	},
 /obj/item/restraints/legcuffs/beartrap/armed,
 /turf/open/floor/rogue/naturalstone/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "oDO" = (
 /turf/closed/mineral/rogue/bedrock/sandstone,
 /area/rogue/outdoors/desert)
@@ -36493,7 +36453,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "oGF" = (
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pick,
@@ -36755,7 +36715,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "oKP" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall";
@@ -37413,9 +37373,7 @@
 	lockid = "warden"
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "oWo" = (
 /turf/open/floor/rogue/hexstone,
 /area/rogue/outdoors/mountains)
@@ -37843,7 +37801,7 @@
 	dir = 6
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "phN" = (
 /obj/machinery/light/rogue/candle/floorcandle{
 	pixel_x = -4;
@@ -37999,7 +37957,7 @@
 "pkh" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pkr" = (
 /obj/item/cushion/zybantine,
 /obj/effect/decal/cobbleedge{
@@ -38097,14 +38055,14 @@
 /obj/item/paper,
 /obj/item/paper/scroll,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pms" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pmv" = (
 /obj/item/cushion/desert2,
 /obj/effect/decal/carpet{
@@ -38202,7 +38160,7 @@
 /obj/machinery/light/rogue/candle/blue,
 /obj/item/roguestatue/iron,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "por" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -38469,7 +38427,7 @@
 "pta" = (
 /obj/structure/chair/wood/rogue/throne,
 /turf/open/floor/carpet/royalblack,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ptj" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/suit/roguetown/shirt/robe/necra,
@@ -38905,7 +38863,7 @@
 	dir = 9
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pCB" = (
 /obj/structure/roguetent,
 /turf/open/floor/rogue/sandbrick,
@@ -38934,7 +38892,7 @@
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron/goblin,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron/goblin,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pDC" = (
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/carpet/royalblack,
@@ -39325,7 +39283,7 @@
 /obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
 /obj/item/reagent_containers/food/snacks/rogue/dough,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pLh" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/bigrat,
 /turf/open/floor/rogue/ruinedwood,
@@ -39628,7 +39586,7 @@
 "pRB" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pRG" = (
 /obj/item/cushion/zybantine,
 /turf/open/floor/rogue/citybrick/citybrick1,
@@ -40000,7 +39958,7 @@
 "pYT" = (
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "pYU" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -40219,7 +40177,7 @@
 "qdu" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qdC" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -40325,7 +40283,7 @@
 	lockid = "gobbo"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qfU" = (
 /obj/structure/fluff/walldeco/fakewall{
 	icon = 'icons/turf/Rougewall_mossy.dmi';
@@ -40373,7 +40331,7 @@
 /area/rogue/indoors/town/manor/desert)
 "qgY" = (
 /turf/closed/mineral/random/rogue/sandstone/med,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qhg" = (
 /obj/structure/chair/bench{
 	dir = 8
@@ -40487,7 +40445,7 @@
 "qjq" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qjD" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -40778,7 +40736,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qpr" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/naturalstone/sandstone,
@@ -41064,7 +41022,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qwO" = (
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/manor/desert)
@@ -41146,7 +41104,7 @@
 "qyK" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qyL" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/tavern/desert)
@@ -41478,7 +41436,7 @@
 	dir = 4
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qEq" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
 	dir = 4
@@ -41823,7 +41781,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qME" = (
 /obj/structure/flora/roguegrass/bush/wall/tall/desert,
 /turf/open/floor/rogue/dirt/road/desert,
@@ -41875,7 +41833,7 @@
 	},
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qNV" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -42063,7 +42021,7 @@
 /area/rogue/outdoors/desertdeep/above)
 "qRU" = (
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qSi" = (
 /obj/machinery/light/rogue/firebowl/standing,
 /turf/open/floor/rogue/darkpath,
@@ -42156,7 +42114,7 @@
 "qUg" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qUl" = (
 /obj/structure/flora/roguegrass/bush/jungle,
 /obj/structure/fluff/railing/border{
@@ -42363,7 +42321,7 @@
 	name = "mean goblin key"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qXQ" = (
 /obj/structure/closet/crate/roguecloset,
 /turf/open/floor/carpet/royalblack,
@@ -42423,7 +42381,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "qZt" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1"
@@ -42676,7 +42634,7 @@
 	dir = 8
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rfN" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -42782,7 +42740,7 @@
 "rgX" = (
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rhi" = (
 /obj/structure/winch{
 	redstone_id = "dungeon";
@@ -42793,7 +42751,7 @@
 "rhG" = (
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rhN" = (
 /obj/machinery/light/rogue/torchholder/r,
 /turf/open/floor/rogue/wood,
@@ -42865,7 +42823,7 @@
 	pixel_x = 10
 	},
 /turf/open/floor/carpet/red,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rjG" = (
 /obj/structure/fluff/railing/border,
 /obj/item/cushion/desert1,
@@ -42874,7 +42832,7 @@
 "rjK" = (
 /obj/structure/pillory/double,
 /turf/open/floor/rogue/metal,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rjW" = (
 /obj/structure/table/vtable,
 /obj/item/paper,
@@ -42918,7 +42876,7 @@
 "rly" = (
 /obj/item/rogue/instrument/drum,
 /turf/open/floor/carpet/red,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rlA" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "keeper2"
@@ -43123,7 +43081,7 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/materials,
 /obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rqp" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood1";
@@ -43534,7 +43492,7 @@
 "rxX" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ryB" = (
 /obj/structure/drape/zybantine,
 /turf/closed/wall/mineral/rogue/sandbrick,
@@ -43844,7 +43802,7 @@
 "rEl" = (
 /obj/structure/fluff/grindwheel,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rEr" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -43852,7 +43810,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rEz" = (
 /turf/open/water/swamp,
 /area/rogue/outdoors/desertdeep)
@@ -43984,9 +43942,7 @@
 	lockid = "warden"
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "rJh" = (
 /obj/structure/chair/arrestchair,
 /turf/open/floor/rogue/wood,
@@ -44333,7 +44289,7 @@
 /area/rogue/outdoors/desertdeep)
 "rPU" = (
 /turf/closed/wall/mineral/rogue/wood/window,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rQa" = (
 /obj/structure/fluff/railing/border{
 	dir = 4;
@@ -44383,7 +44339,7 @@
 "rQR" = (
 /obj/item/roguebin/water,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rQW" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -44462,7 +44418,7 @@
 "rSr" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "rSs" = (
 /obj/structure/rack/rogue,
 /obj/item/kitchen/fork,
@@ -45135,7 +45091,7 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/rogue/wood/window,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "sgy" = (
 /turf/open/floor/rogue/cobblerock{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
@@ -45758,7 +45714,7 @@
 	dir = 10
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ssM" = (
 /obj/structure/flora/roguegrass/herb/random,
 /turf/open/floor/rogue/dirt/desert,
@@ -46204,9 +46160,7 @@
 "sCr" = (
 /obj/machinery/light/rogue/candle/l,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "sCt" = (
 /obj/structure/fluff/railing/corner,
 /obj/structure/flora/roguetree/palm,
@@ -46243,7 +46197,7 @@
 "sCU" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "sCV" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -46634,7 +46588,7 @@
 	name = "Holding Cell"
 	},
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "sMe" = (
 /obj/structure/closet/crate/chest/wicker,
 /turf/open/floor/rogue/citybrick/citybrick1,
@@ -46723,7 +46677,7 @@
 	name = "Barracks"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "sOm" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/desert/warden)
@@ -47426,7 +47380,7 @@
 "taA" = (
 /obj/item/trash/candle,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "taG" = (
 /obj/machinery/light/rogue/candle/blue,
 /turf/open/floor/rogue/metal/barograte{
@@ -47658,7 +47612,7 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "teg" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -47879,9 +47833,7 @@
 "tjz" = (
 /obj/effect/decal/cleanable/dirt/cobweb,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "tjM" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/citybrick/citybrick1,
@@ -48168,7 +48120,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "toX" = (
 /obj/structure/roguewindow/harem3,
 /turf/open/floor/rogue/herringbone,
@@ -48321,7 +48273,7 @@
 "tqT" = (
 /obj/item/roguecoin/copper/pile,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "trh" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/rogue/sandbrick,
@@ -48554,7 +48506,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/rogueweapon/shovel/small,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "twg" = (
 /obj/item/legwears/silk/black,
 /obj/structure/closet/crate/roguecloset,
@@ -48757,7 +48709,7 @@
 "tBu" = (
 /obj/structure/fluff/nest,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tBQ" = (
 /obj/structure/bars/pipe{
 	dir = 1;
@@ -48983,9 +48935,7 @@
 /area/rogue/indoors/town/warehouse)
 "tHk" = (
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "tHm" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -49059,7 +49009,7 @@
 "tII" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tIJ" = (
 /obj/structure/fluff/walldeco/church/line,
 /obj/structure/fluff/walldeco/church/line{
@@ -49101,7 +49051,7 @@
 /obj/item/rogueweapon/stoneaxe,
 /obj/item/rogueweapon/stoneaxe,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tJD" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall";
@@ -49401,7 +49351,7 @@
 	dir = 10
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tNV" = (
 /obj/structure/bed/rogue/inn,
 /obj/item/bedsheet/rogue/fabric,
@@ -49410,7 +49360,7 @@
 "tNZ" = (
 /obj/item/roguecoin/copper,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tOi" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall";
@@ -49831,7 +49781,7 @@
 "tWh" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tWi" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -49866,7 +49816,7 @@
 	pixel_x = 8
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tWV" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -49917,7 +49867,7 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "tXZ" = (
 /obj/structure/stairs/desert,
 /turf/open/floor/rogue/darkpath,
@@ -50109,7 +50059,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ubj" = (
 /obj/item/cushion/desert2,
 /mob/living/simple_animal/hostile/retaliate/rogue/lamia,
@@ -50704,7 +50654,7 @@
 /area/rogue/under/town/basement/desert)
 "unL" = (
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "unU" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Sheikh Office"
@@ -50735,7 +50685,7 @@
 "uot" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uow" = (
 /obj/machinery/light/rogue/candle,
 /mob/living/simple_animal/hostile/rogue/skeleton/bow,
@@ -50762,7 +50712,7 @@
 /turf/open/floor/rogue/blocks/green{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "upb" = (
 /turf/open/floor/rogue/darkpath,
 /area/rogue/outdoors/desert/above)
@@ -50848,9 +50798,7 @@
 "uqW" = (
 /obj/structure/fluff/walldeco/chains,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "uqX" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/bottle/rogue/manapot,
@@ -51269,7 +51217,7 @@
 "uyH" = (
 /mob/living/carbon/human/species/goblin/npc/cave,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uyO" = (
 /turf/open/floor/rogue/wood/nosmooth,
 /area/rogue/outdoors/desert)
@@ -51409,7 +51357,7 @@
 "uBF" = (
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uBY" = (
 /obj/structure/stairs/desert{
 	dir = 1
@@ -51429,7 +51377,7 @@
 	},
 /obj/item/dice,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uCF" = (
 /obj/structure/fermentation_keg/sandpot/beer,
 /turf/open/floor/rogue/tile/brownbrick{
@@ -52344,7 +52292,7 @@
 /obj/structure/rack/rogue,
 /obj/item/rogueweapon/pick,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uSF" = (
 /obj/effect/landmark/events/haunts,
 /turf/open/floor/rogue/dunes,
@@ -52402,7 +52350,7 @@
 /obj/item/reagent_containers/food/snacks/smallrat,
 /mob/living/carbon/human/species/goblin/npc/moon,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uTm" = (
 /obj/structure/bookcase/random/archive,
 /obj/item/book/rogue/bibble,
@@ -52589,7 +52537,7 @@
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "uWO" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq/office)
@@ -53355,7 +53303,7 @@
 "vnm" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vnI" = (
 /obj/item/cushion/desert1,
 /turf/open/floor/carpet/royalblack,
@@ -53475,9 +53423,7 @@
 "vqC" = (
 /obj/effect/decal/cleanable/debris,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "vqJ" = (
 /turf/open/floor/rogue/dirt/road/desert,
 /area/rogue/outdoors/town/manor/desert)
@@ -53599,7 +53545,7 @@
 /turf/open/floor/rogue/metal{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vtr" = (
 /obj/structure/curtain/magenta{
 	color = "#a1254a";
@@ -53741,7 +53687,7 @@
 	},
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vwy" = (
 /obj/effect/decal/cobbleedge{
 	dir = 8;
@@ -53766,7 +53712,7 @@
 	name = "fancy goblin key"
 	},
 /turf/open/floor/rogue/blocks/stonered,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vwF" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/desert_grass,
@@ -54057,7 +54003,7 @@
 /turf/open/floor/rogue/greenstone{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vDo" = (
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/grove)
@@ -54158,7 +54104,7 @@
 	dir = 4
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vEx" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -54370,7 +54316,7 @@
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vIW" = (
 /turf/open/floor/rogue/underworld/space/quiet,
 /area/rogue/indoors/town/church/basement)
@@ -54513,7 +54459,7 @@
 	name = "fancy goblin key"
 	},
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vMn" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/deserttile,
@@ -54720,7 +54666,7 @@
 	icon_state = "paving";
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vPX" = (
 /obj/structure/table/wood{
 	dir = 8;
@@ -55015,7 +54961,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vWA" = (
 /obj/structure/roguemachine/vendor{
 	keycontrol = "archive"
@@ -55105,7 +55051,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "vYx" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -55581,7 +55527,7 @@
 	},
 /obj/item/reagent_containers/glass/bowl,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "whd" = (
 /obj/machinery/light/roguestreet/orange/midlamp{
 	density = 0;
@@ -55848,7 +55794,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wlj" = (
 /obj/structure/flora/roguegrass,
 /obj/structure/flora/roguetree/jungle,
@@ -56249,7 +56195,7 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wuy" = (
 /obj/structure/fermentation_keg/sandpot/water,
 /turf/open/floor/rogue/cobble,
@@ -56424,7 +56370,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wxV" = (
 /obj/structure/stairs{
 	dir = 4
@@ -56545,7 +56491,7 @@
 	name = "Bad Room"
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wBS" = (
 /obj/structure/rack/rogue/shelf/biggest,
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
@@ -56755,7 +56701,7 @@
 	dir = 1
 	},
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wHm" = (
 /obj/structure/mineral_door/wood/donjon/stone{
 	locked = 1;
@@ -57134,9 +57080,7 @@
 /area/rogue/indoors/town/tavern/desert)
 "wNI" = (
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "wNL" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/orc/ranged,
 /turf/open/floor/rogue/wood/nosmooth,
@@ -57235,7 +57179,7 @@
 	},
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wPC" = (
 /obj/structure/fermentation_keg/sandpot,
 /turf/open/floor/rogue/wood,
@@ -57415,7 +57359,7 @@
 	name = "Barracks"
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "wTJ" = (
 /obj/structure/handcart,
 /turf/open/floor/rogue/wood,
@@ -57733,7 +57677,7 @@
 /obj/item/rope/chain,
 /obj/item/rope/chain,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xaA" = (
 /turf/closed/wall/mineral/rogue/wooddark,
 /area/rogue/under/cave)
@@ -57759,7 +57703,7 @@
 "xaU" = (
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xaZ" = (
 /obj/structure/stairs/stone{
 	dir = 1;
@@ -57768,7 +57712,7 @@
 /turf/open/floor/rogue/cobblerock{
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xbd" = (
 /obj/machinery/tanningrack,
 /turf/open/floor/rogue/wood,
@@ -57883,11 +57827,11 @@
 /obj/item/clothing/head/roguetown/helmet/goblin,
 /obj/item/clothing/head/roguetown/helmet/goblin,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xdc" = (
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xdn" = (
 /obj/structure/roguemachine/scomm/r,
 /turf/open/floor/carpet/stellar,
@@ -58115,7 +58059,7 @@
 "xfT" = (
 /obj/structure/bed/rogue/inn/hay,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xgb" = (
 /obj/structure/mineral_door/wood/donjon{
 	locked = 1;
@@ -58129,7 +58073,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xgz" = (
 /obj/structure/fluff/clock,
 /turf/open/floor/carpet/royalblack,
@@ -58859,9 +58803,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/rogue/darkpath,
-/area/rogue/indoors/town/cell{
-	warden_area = 1
-	})
+/area/rogue/indoors/town/cell/warden)
 "xvT" = (
 /obj/item/rope,
 /obj/item/rope/chain,
@@ -59320,7 +59262,7 @@
 	dir = 5
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xHj" = (
 /obj/structure/fluff/railing/border{
 	dir = 5
@@ -59358,7 +59300,7 @@
 	},
 /obj/item/rogueweapon/huntingknife/cleaver,
 /turf/open/floor/rogue/darkpath,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xHX" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border,
@@ -59789,7 +59731,7 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xPK" = (
 /turf/closed/wall/mineral/rogue/decostone,
 /area/rogue/indoors/town/church)
@@ -59886,7 +59828,7 @@
 	dir = 8
 	},
 /turf/closed/wall/mineral/rogue/sandstone,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xRI" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -60058,7 +60000,7 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/citybrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xTN" = (
 /obj/structure/bed/rogue/shit,
 /mob/living/carbon/human/species/human/northern/highwayman/ambush,
@@ -60149,7 +60091,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xWE" = (
 /turf/open/floor/rogue/citybrick/citybrick6,
 /area/rogue/indoors/inq/basement)
@@ -60180,7 +60122,7 @@
 	pixel_y = -8
 	},
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xWX" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -60326,7 +60268,7 @@
 "xZG" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/dirt/road/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xZL" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/twig,
@@ -60336,7 +60278,7 @@
 	icon_state = "largetable"
 	},
 /turf/open/floor/rogue/dirt/desert,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "xZV" = (
 /obj/item/reagent_containers/glass/bucket{
 	anchored = 1
@@ -60590,7 +60532,7 @@
 	pixel_x = -5
 	},
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "yfl" = (
 /obj/structure/flora/roguegrass/bush/jungle/large,
 /turf/open/floor/rogue/dirt/road/desert,
@@ -60713,7 +60655,7 @@
 	},
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/swamp/deep,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ygS" = (
 /obj/structure/ritualcircle/zizo,
 /turf/open/floor/rogue/churchrough{
@@ -60909,7 +60851,7 @@
 "ykE" = (
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/rogue/sandbrick,
-/area/rogue/under/cave/rhgoblinencampment)
+/area/rogue/under/dungeon/oldgoblincamp)
 "ykI" = (
 /obj/structure/table/church/m/alt,
 /obj/item/necra_censer,

--- a/code/game/area/actualcoast.dm
+++ b/code/game/area/actualcoast.dm
@@ -14,12 +14,7 @@
 /area/rogue/outdoors/beach/harbor
 	name = "harbor"
 	icon_state = "harbor"
-	ambientsounds = AMB_BEACH
-	ambientnight = AMB_BEACH
-	ambush_times = null
-	ambush_mobs = null
 	droning_sound = 'sound/music/area/harbor.ogg'
-	converted_type = /area/rogue/under/lake
 	first_time_text = "Rockhill Harbor"
 	deathsight_message = "a bustling, windswept harbor"
 	town_area = TRUE

--- a/code/game/area/actualcoast.dm
+++ b/code/game/area/actualcoast.dm
@@ -2,7 +2,6 @@
 /area/rogue/outdoors/beach
 	name = "Central Coast"
 	icon_state = "beach"
-	warden_area = TRUE
 	ambientsounds = AMB_BEACH
 	ambientnight = AMB_BEACH
 	droning_sound = 'sound/music/area/harbor.ogg'

--- a/code/game/area/basingrove.dm
+++ b/code/game/area/basingrove.dm
@@ -16,7 +16,6 @@
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/rtfield
 	deathsight_message = "somewhere in the wilds, next to towering walls"
-	warden_area = TRUE
 	threat_region = THREAT_REGION_AZURE_BASIN
 	// detail_text = DETAIL_TEXT_AZURE_BASIN
 

--- a/code/game/area/bogrockhill.dm
+++ b/code/game/area/bogrockhill.dm
@@ -3,7 +3,6 @@
 /area/rogue/outdoors/bograt
 	name = "Rockhill Bog"
 	icon_state = "bog"
-	warden_area = TRUE
 	ambientsounds = AMB_BOGDAY
 	ambientnight = AMB_BOGNIGHT
 	spookysounds = SPOOKY_FROG
@@ -132,7 +131,6 @@
 	ambush_mobs = null
 	deathsight_message = "a foreign, distant pass, leading to the fetid bog"
 	icon_state = "bog"
-	warden_area = TRUE
 	ambientsounds = AMB_BOGDAY
 	ambientnight = AMB_BOGNIGHT
 	spookysounds = SPOOKY_FROG

--- a/code/game/area/byos.dm
+++ b/code/game/area/byos.dm
@@ -1,7 +1,6 @@
 /area/rogue/outdoors/jungle
 	name = "The Jungle of Dread"
 	icon_state = "bog"
-	warden_area = TRUE
 	ambientsounds = AMB_BOGDAY
 	ambientnight = AMB_BOGNIGHT
 	spookysounds = SPOOKY_FROG
@@ -57,7 +56,6 @@
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
 	converted_type = /area/rogue/indoors/shelter/rtfield
 	deathsight_message = "the outskirts of the colony of New Kingsfield and all its bustling souls"
-	warden_area = TRUE
 	threat_region = THREAT_REGION_ISLAND
 	detail_text = THREAT_REGION_ISLAND
 
@@ -100,15 +98,7 @@
 /area/rogue/under/cavewet/byos
 	name = "The Undergrove"
 	icon_state = "cavewet"
-	warden_area = TRUE
 	// first_time_text = "The Undergrove"
-	ambientsounds = AMB_CAVEWATER
-	ambientnight = AMB_CAVEWATER
-	spookysounds = SPOOKY_CAVE
-	spookynight = SPOOKY_CAVE
-	droning_sound = 'sound/music/area/caves.ogg'
-	droning_sound_dusk = null
-	droning_sound_night = null
 	ambush_times = list("night","dawn","dusk","day")
 	ambush_mobs = list(
 				/mob/living/carbon/human/species/skeleton/npc/easy = 10,
@@ -156,11 +146,6 @@
 /area/rogue/outdoors/beach/byos
 	name = "Island Coast"
 	icon_state = "beach"
-	warden_area = TRUE
-	ambientsounds = AMB_BEACH
-	ambientnight = AMB_BEACH
-	droning_sound = 'sound/music/area/harbor.ogg'
-	converted_type = /area/rogue/under/lake
 	first_time_text = null
 	deathsight_message = "a brackish shore"
 	detail_text = null

--- a/code/game/area/random_dungeons/dungeons.dm
+++ b/code/game/area/random_dungeons/dungeons.dm
@@ -20,6 +20,7 @@
 	// 			/mob/living/simple_animal/hostile/retaliate/rogue/minotaur = 5)
 	converted_type = /area/rogue/outdoors/caves
 	deathsight_message = "A dwelling deep below, a dark recess beyond and beneath."
+	ceiling_protected = TRUE
 
 /area/rogue/under/dungeon/sunkenchurch
 	name = "Sunken Church"
@@ -46,3 +47,18 @@
 	name = "Drow Outpost"
 	droning_sound = 'sound/music/area/underdark.ogg'
 	deathsight_message = "A deep, dark house of pain and dominance."
+
+/area/rogue/under/dungeon/oldgoblincamp
+	name = "goblin encampment"
+	first_time_text = "Lost Encampment"
+	droning_sound = 'sound/music/area/gobcamp.ogg'
+	deathsight_message = "A hidden goblin-stained fortress"
+
+/area/rogue/under/dungeon/inferno
+	name = "inferno"
+	icon_state = "fire_chamber"
+	first_time_text = "Another Place"
+	ambientsounds = AMB_CAVELAVA
+	ambientnight = AMB_CAVELAVA
+	droning_sound = 'sound/music/area/inferno.ogg'
+	deathsight_message = "A blistering realm beyond this mortal sphere"

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -93,7 +93,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	deathsight_message = "an ancient dread-manor, home of a great and terrible evil. Red eyes look back at you, warning you not to pry further."
 
 /area/rogue/outdoors/woods/vampire_lair
-	warden_area = FALSE
 	ambush_times = null
 	ambush_mobs = null
 	threat_region = ""
@@ -146,6 +145,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	converted_type = /area/rogue/indoors/shelter
 	soundenv = 16
 	deathsight_message = "somewhere in the wilds"
+	warden_area = TRUE
 
 /area/rogue/outdoors/banditcamp
 	name = "Bandit Camp"
@@ -173,7 +173,6 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	ambientnight = AMB_MOUNTAIN
 	spookysounds = SPOOKY_GEN
 	spookynight = SPOOKY_GEN
-	warden_area = TRUE
 	soundenv = 17
 	converted_type = /area/rogue/indoors/shelter/mountains
 	deathsight_message = "a twisted tangle of soaring peaks"

--- a/code/game/area/terrorbog.dm
+++ b/code/game/area/terrorbog.dm
@@ -1,7 +1,6 @@
 /area/rogue/outdoors/bog
 	name = "The Terrorbog"
 	icon_state = "bog"
-	warden_area = TRUE
 	ambientsounds = AMB_BOGDAY
 	ambientnight = AMB_BOGNIGHT
 	spookysounds = SPOOKY_FROG

--- a/code/game/area/town/town.dm
+++ b/code/game/area/town/town.dm
@@ -16,6 +16,7 @@
 	converted_type = /area/rogue/indoors/shelter/town
 	first_time_text = "THE CITY OF ROTWOOD VALE"
 	town_area = TRUE
+	warden_area = FALSE
 	deathsight_message = "the city of Rotwood Vale and all its bustling souls"
 
 /area/rogue/outdoors/town/graveyard

--- a/code/game/area/town/town.dm
+++ b/code/game/area/town/town.dm
@@ -60,6 +60,7 @@
 	droning_sound = 'sound/music/area/towngen.ogg'
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
 	droning_sound_night = 'sound/music/area/sleeping.ogg'
+	town_area = TRUE
 
 /area/rogue/outdoors/exposed/town/keep
 	name = "Keep"

--- a/code/game/area/undergrove.dm
+++ b/code/game/area/undergrove.dm
@@ -62,31 +62,6 @@
 	deathsight_message = "root-bound caverns"
 	detail_text = DETAIL_TEXT_GOBLIN_CAMP
 
-
-/area/rogue/under/cave/rhgoblinencampment
-	name = "goblin encampment"
-	icon_state = "under"
-	first_time_text = "Lost Encampment"
-	ambientsounds = AMB_BASEMENT
-	ambientnight = AMB_BASEMENT
-	droning_sound = 'sound/music/area/gobcamp.ogg'
-	droning_sound_dusk = null
-	droning_sound_night = null
-	ceiling_protected = TRUE
-	deathsight_message = "A hidden goblin-stained fortress"
-	
-/area/rogue/under/cave/inferno
-	name = "inferno"
-	icon_state = "fire_chamber"
-	first_time_text = "Another Place"
-	ambientsounds = AMB_CAVELAVA
-	ambientnight = AMB_CAVELAVA
-	droning_sound = 'sound/music/area/inferno.ogg'
-	droning_sound_dusk = null
-	droning_sound_night = null
-	ceiling_protected = TRUE
-	deathsight_message = "A blistering realm beyond this mortal sphere"
-
 /area/rogue/under/cave/skeletoncrypt
 	name = "Skeleton Crypt"
 	icon_state = "under"

--- a/modular_deserttown/desertareas.dm
+++ b/modular_deserttown/desertareas.dm
@@ -22,7 +22,6 @@
 	droning_sound_dusk = 'sound/music/area/desert/NightPrayer.ogg'
 	droning_sound_night = 'sound/music/area/desert/Moonrise.ogg'
 	deathsight_message = "somewhere in the dunes, next to towering walls"
-	warden_area = TRUE
 	threat_region = THREAT_REGION_DESERT_NEAR
 	
 /area/rogue/outdoors/desert/river
@@ -36,7 +35,6 @@
 /area/rogue/outdoors/desertdeep
 	name = "Deep Dunes"
 	icon_state = "desertdeep"
-	warden_area = TRUE
 	ambientsounds = AMB_TOWNDAY
 	ambientnight = AMB_TOWNNIGHT
 	spookysounds = SPOOKY_GEN


### PR DESCRIPTION
## About The Pull Request

Makes Outdoors a Warden_Area by default instead of going to every different type of outdoor area and assigning each of them as warden_areas. Also repaths some old janky area types I used for some old dungeons. Shouldn't effect much in-game

## Testing Evidence

Trrrrrust me...

## Why It's Good For The Game

Just a bit cleaner

## Changelog

:cl:
refactor: cleaned up some area-code for some dungeons
/:cl:
