### PR TITLE
Add pacifism check for twist and choke intent

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -283,6 +283,9 @@
 						else
 							to_chat(user, span_warning("[H]'s neck is covered!"))
 		if(/datum/intent/grab/twist)
+			if(HAS_TRAIT(user, TRAIT_PACIFISM))
+				to_chat(user, span_warning("I don't want to harm [src]!"))
+				return FALSE
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -205,6 +205,9 @@
 			if(M.grippedby(user))			//Aggro grip
 				bleed_suppressing = 0.5		//Better bleed suppression
 		if(/datum/intent/grab/choke)
+			if(HAS_TRAIT(user, TRAIT_PACIFISM))
+				to_chat(user, span_warning("I don't want to harm [src]!"))
+				return FALSE
 			if(user.buckled)
 				to_chat(user, span_warning("I can't do this while buckled!"))
 				return FALSE


### PR DESCRIPTION
## About The Pull Request
as above

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Neck snapping people while you're supposed to be a pacifist is not a very nice thing to do, and solves a lot of problems in regards to forcefully-pacified players. Not all the problems, but this is a good start.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Adds a pacifism check to twisting limbs and choking.
/:cl: