### PR TITLE
adjusts some spawning items

### DIFF
--- a/code/game/objects/effects/spawners/equipment_spawners.dm
+++ b/code/game/objects/effects/spawners/equipment_spawners.dm
@@ -411,7 +411,8 @@
 		/obj/item/book/granter/spell/blackstone/fetch = 10,
 		/obj/item/reagent_containers/glass/bottle/alchemical/spdpot = 10,
 		/obj/item/book/granter/spell/blackstone/bonechill = 10,
-		/obj/item/book/granter/spell/blackstone/skeleton = 10,
+		/obj/item/book/granter/spell/blackstone/skeleton = 5,
+		/obj/item/book/granter/spell/blackstone/skeleton/lesser = 15,
 		/obj/item/book/granter/spell/blackstone/sicknessray = 15,
 		/obj/item/reagent_containers/glass/bottle/rogue/emberwine = 10,
 		/obj/item/reagent_containers/glass/bottle/alchemical/spidervenom_paralytic = 5,
@@ -440,7 +441,8 @@
 		/obj/effect/spawner/lootdrop/potion_poisons = 10,
 		/obj/item/reagent_containers/glass/bottle/alchemical/intpot = 5,
 		/obj/item/book/granter/spell/blackstone/bonechill = 10,
-		/obj/item/book/granter/spell/blackstone/skeleton = 10,
+		/obj/item/book/granter/spell/blackstone/skeleton = 5,
+		/obj/item/book/granter/spell/blackstone/skeleton/lesser = 15,
 		/obj/item/book/granter/spell/blackstone/sicknessray = 15,
 	)
 /obj/effect/spawner/lootdrop/graggar


### PR DESCRIPTION
## About The Pull Request

Lowers chance of scrolls of summon lich-skeleton, raises chance of scrolls of summon lesser skeletons.

## Testing Evidence

Trrrrrust me...

## Why It's Good For The Game

Lich skeletons shouldn't be quite so common (they're rare, but with a lot of spawners in the vault the chances wind up semi-high)

## Changelog
:cl:
map: church/inquisition vaults less likely to carry scrolls of summon-lich-skeleton, more likely to carry scrolls of summon-lesser-skeletons
/:cl:
