### PR TITLE
Less Statpack Minmaxxing

### DIFF
--- a/modular_azurepeak/statpacks/agile.dm
+++ b/modular_azurepeak/statpacks/agile.dm
@@ -8,4 +8,4 @@
 /datum/statpack/agile/wary
 	name = "Wary"
 	desc = "Some call it fear, others call it cowardice. You, however, call it caution and prudence."
-	stat_array = list(STAT_PERCEPTION = 1)
+	stat_array = list(STAT_PERCEPTION = 2)

--- a/modular_azurepeak/statpacks/agile.dm
+++ b/modular_azurepeak/statpacks/agile.dm
@@ -1,35 +1,11 @@
 // Ranger/rogue archetypes
-/datum/statpack/agile/swift
-	name = "Swift"
-	desc = "With the wind in your hair and trouble at your back, your speed has oft been your salvation."
-	stat_array = list(STAT_SPEED = 2, STAT_WILLPOWER = 1, STAT_STRENGTH = -1, STAT_CONSTITUTION = -1)
 
-/datum/statpack/agile/hardy
-	name = "Hardy"
-	desc = "Uniquely Pestran fortitude affords you the means to shrug off illnesses and poisons that others might not."
-	stat_array = list(STAT_CONSTITUTION = 3, STAT_WILLPOWER = 3, STAT_STRENGTH = -2, STAT_SPEED = -2)
-
-/datum/statpack/agile/tricky
-	name = "Tricky"
-	desc = "Swift feet with a mind to match and a tiny sliver of the Ten's own luck."
-	stat_array = list(STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_SPEED = 1, STAT_FORTUNE = 1, STAT_WILLPOWER = -1, STAT_STRENGTH = -1)
-
-/datum/statpack/agile/thug
-	name = "Thuggish"
-	desc = "Your robust physique and keen eyes oft been your most valuable friends in such trying times."
-	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = 1, STAT_FORTUNE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1, STAT_SPEED = -1)
+/datum/statpack/agile/nimble
+	name = "Nimble"
+	desc = "Your motor skills are nothing short of excellent and you regularly impress your peers with displays of legerdemain."
+	stat_array = list(STAT_SPEED = 1)
 
 /datum/statpack/agile/wary
 	name = "Wary"
-	desc = "Eyes forward, ever and always. A careful course has always seen you through... so far."
-	stat_array = list(STAT_PERCEPTION = 3, STAT_INTELLIGENCE = 3, STAT_STRENGTH = -2, STAT_CONSTITUTION = -2)
-
-/datum/statpack/agile/dextrous
-	name = "Dextrous"
-	desc = "You see. You dash. You spring. You dodge. Can you keep it up?"
-	stat_array = list(STAT_SPEED = 2, STAT_PERCEPTION = 1, STAT_CONSTITUTION = -2, STAT_INTELLIGENCE = -1)
-
-/datum/statpack/agile/deft
-	name = "Deft"
-	desc = "Being quick on the draw has left you weaker when they live past your first strike."
-	stat_array = list(STAT_PERCEPTION = 1, STAT_SPEED = 1, STAT_WILLPOWER = 1, STAT_STRENGTH = -1)
+	desc = "Some call it fear, others call it cowardice. You, however, call it caution and prudence."
+	stat_array = list(STAT_PERCEPTION = 1)

--- a/modular_azurepeak/statpacks/mental.dm
+++ b/modular_azurepeak/statpacks/mental.dm
@@ -1,45 +1,6 @@
 // Mental-based archetypes
-/datum/statpack/mental/scholarly
-	name = "Studious"
-	desc = "Your understanding of the world avails you, more often than not."
-	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_PERCEPTION = 1, STAT_STRENGTH = -1, STAT_WILLPOWER = -1)
 
-/datum/statpack/mental/faithdriven
-	name = "Resolute"
-	desc = "Look ever to the Gods for guidance in these trying times - and so you have, to the exclusion of the world around you."
-	stat_array = list(STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_FORTUNE = -1)
-
-/datum/statpack/mental/zealous
-	name = "Zealous"
-	desc = "Faith in something drives your body and mind to match what neither can see."
-	stat_array = list(STAT_STRENGTH = 1, STAT_INTELLIGENCE = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_SPEED = -1)
-
-/datum/statpack/mental/augury
-	name = "Foresighted"
-	desc = "You see what is and what will sometimes be."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_INTELLIGENCE = 1, STAT_STRENGTH = -1, STAT_WILLPOWER = -1)
-
-/datum/statpack/mental/adept
-	name = "Adept"
-	desc = "Your will leads the way."
-	stat_array = list(STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_SPEED = 1, STAT_STRENGTH = -1, STAT_CONSTITUTION = -1)
-
-/datum/statpack/mental/aware
-	name = "Aware"
-	desc = "Your keen senses have not led you astray."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_SPEED = 1, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -1)
-
-/datum/statpack/mental/precise
-	name = "Precise"
-	desc = "You've seen it all. You've heard it all. An eye to the horizon, and an ear to the ground, and the right place to strike."
-	stat_array = list(STAT_PERCEPTION = 2, STAT_STRENGTH = 1, STAT_WILLPOWER = -1, STAT_CONSTITUTION = -1)
-
-/datum/statpack/mental/diligent
-	name = "Diligent"
-	desc = "You take your time, but you have a lot of it to spare."
-	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_WILLPOWER = 1, STAT_SPEED = -1)
-
-/datum/statpack/mental/industrious
-	name = "Industrious"
-	desc = "You waste no time. You know enough to get by, and strive towards it."
-	stat_array =  list(STAT_INTELLIGENCE = 2, STAT_SPEED = 1, STAT_CONSTITUTION = -1, STAT_PERCEPTION = -1)
+/datum/statpack/mental/shrewd
+	name = "Shrewd"
+	desc = "A keen mind is a weapon on its own, and you've been sharpening it since your youth."
+	stat_array =  list(STAT_INTELLIGENCE = 1)

--- a/modular_azurepeak/statpacks/mental.dm
+++ b/modular_azurepeak/statpacks/mental.dm
@@ -3,4 +3,4 @@
 /datum/statpack/mental/shrewd
 	name = "Shrewd"
 	desc = "A keen mind is a weapon on its own, and you've been sharpening it since your youth."
-	stat_array =  list(STAT_INTELLIGENCE = 1)
+	stat_array =  list(STAT_INTELLIGENCE = 2)

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -8,9 +8,9 @@
 /datum/statpack/physical/tough
 	name = "Tough"
 	desc = "Maybe it took you too long to learn how to give a beating, but you know how to take a beating better than most."
-	stat_array = list(STAT_CONSTITUTION = 1)
+	stat_array = list(STAT_CONSTITUTION = 2)
 
 /datum/statpack/physical/determined
 	name = "Determined"
 	desc = "Where your peers prevailed thanks to their craftiness or talents, you relied on your diligence alone to make it through."
-	stat_array = list(STAT_WILLPOWER = 1)
+	stat_array = list(STAT_WILLPOWER = 2)

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -1,36 +1,16 @@
 // Martial/warrior archetypes
 
-/datum/statpack/physical/trained
-	name = "Trained"
-	desc = "Years honing your physique has left you with a physical edge, but your faculties have been somewhat neglected."
-	stat_array = list(STAT_STRENGTH = 1, STAT_CONSTITUTION = 1, STAT_WILLPOWER = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
+/datum/statpack/physical/brawny
+	name = "Brawny"
+	desc = "You've always been stronger and taller than your peers."
+	stat_array = list(STAT_STRENGTH = 1)
 
-/datum/statpack/physical/muscular
-	name = "Muscular"
-	desc = "Hard labor has honed you into a mass of sinew - a valuable trait in a world where might makes right."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1, STAT_SPEED = -2)
+/datum/statpack/physical/tough
+	name = "Tough"
+	desc = "Maybe it took you too long to learn how to give a beating, but you know how to take a beating better than most."
+	stat_array = list(STAT_CONSTITUTION = 1)
 
-/datum/statpack/physical/tactician
-	name = "Alert"
-	desc = "You sharpened both your body and your mind as best you were able, and vigilance has been your reward."
-	stat_array = list(STAT_STRENGTH = 1, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_CONSTITUTION = -1, STAT_WILLPOWER = -1)
-
-/datum/statpack/physical/taut
-	name = "Taut"
-	desc = "Wound tight like the limbs of a time-teller, your physicality is poised to strike - or flee - at a moment's notice."
-	stat_array = list(STAT_STRENGTH = 1, STAT_WILLPOWER = 1, STAT_SPEED = 1, STAT_PERCEPTION = -2, STAT_CONSTITUTION = -1)
-
-/datum/statpack/physical/toil
-	name = "Toil-hardened"
-	desc = "Your lyfe, hard-lyved, has imparted one solitary adage: carry on above all else. And so you endure."
-	stat_array = list(STAT_WILLPOWER = 2, STAT_CONSTITUTION = 1, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1)
-
-/datum/statpack/physical/struggler
-	name = "Struggler"
-	desc = "Lyfe's dealt you a poor hand, so you've opted to simply flip the table instead."
-	stat_array = list(STAT_STRENGTH = 2, STAT_CONSTITUTION = 2, STAT_WILLPOWER = 2, STAT_INTELLIGENCE = -3, STAT_PERCEPTION = -3, STAT_FORTUNE = -2)
-
-/datum/statpack/physical/enduring
-	name = "Enduring"
-	desc = "You've spent yils willingly submitting your body through a most perilous journey. Stalwart in your faith, you've sworn to never flee again."
-	stat_array = list(STAT_CONSTITUTION = 3, STAT_WILLPOWER = 3, STAT_SPEED = -4)
+/datum/statpack/physical/determined
+	name = "Determined"
+	desc = "Where your peers prevailed thanks to their craftiness or talents, you relied on your diligence alone to make it through."
+	stat_array = list(STAT_WILLPOWER = 1)

--- a/modular_azurepeak/statpacks/wildcard.dm
+++ b/modular_azurepeak/statpacks/wildcard.dm
@@ -1,25 +1,29 @@
 // Miscellaneous/novelty statpacks
 
-/datum/statpack/wildcard/wretched
-	name = "Wretched"
-	desc = "The cruelty of Enigma leaves many in its wake - you among them. But with her terrible eye turned elsewhere, perhaps it is time for your fortune to be made..."
-	stat_array = list(STAT_STRENGTH = -2, STAT_PERCEPTION = -2, STAT_INTELLIGENCE = -2, STAT_CONSTITUTION = -2, STAT_WILLPOWER = -2, STAT_SPEED = -2, STAT_FORTUNE = 3)
+/datum/statpack/wildcard/lucky
+	name = "Lucky"
+	desc = "You were born on a sunny day under double rainbow when the stars were in alignment. A more believable explanation for your luckiness is hard to find."
+	stat_array = list(STAT_FORTUNE = 2)
 
 /datum/statpack/wildcard/fated
 	name = "Fated"
-	desc = "The first or the last - let destiny's fickle loom decree what your fate shall be."
-	stat_array = list(STAT_STRENGTH = list(-2, 2), STAT_PERCEPTION = list(-2, 2), STAT_INTELLIGENCE = list(-2, 2), STAT_CONSTITUTION = list(-2, 2), STAT_WILLPOWER = list(-2, 2), STAT_SPEED = list(-2, 2), STAT_FORTUNE = list(-2, 2))
+	desc = "You are but a victim of a Xylix's joke. Let his whims decree what your fate shall be."
+	stat_array = list(STAT_STRENGTH = list(-1, 1), STAT_PERCEPTION = list(-1, 1), STAT_INTELLIGENCE = list(-1, 1), STAT_CONSTITUTION = list(-1, 1), STAT_WILLPOWER = list(-1, 1), STAT_SPEED = list(-1, 1), STAT_FORTUNE = list(-1, 1))
+
+/datum/statpack/wildcard/wretched
+	name = "Wretched"
+	desc = "The cruelty of fate leaves many in its wake - you among them. But with its terrible eye turned elsewhere, perhaps it is time for your fortune to be made..."
+	stat_array = list(STAT_STRENGTH = -2, STAT_PERCEPTION = -2, STAT_INTELLIGENCE = -2, STAT_CONSTITUTION = -2, STAT_WILLPOWER = -2, STAT_SPEED = -2, STAT_FORTUNE = 3)
 
 /datum/statpack/wildcard/frail
 	name = "Frail"
 	desc = "The growing dark lines your vision more with every passing day: your flesh and mind are failing you, and destiny has turned her gaze from you. How will your tale endure such hardship?"
 	stat_array = list(STAT_STRENGTH = -4, STAT_PERCEPTION = -4, STAT_INTELLIGENCE = -4, STAT_CONSTITUTION = -4, STAT_WILLPOWER = -4, STAT_SPEED = -4, STAT_FORTUNE = -4)
 
-/datum/statpack/wildcard/austere
-	name = "Austere"
-	desc = "You've kept your humors balanced, your body honed and mind sharp enough. Fate has left you mostly unchanged, in every way."
+/datum/statpack/wildcard/boring
+	name = "Boring"
+	desc = "You are as normal and boring as it can get. You will live a middle life and be buried in a middle grave."
 
 /datum/statpack/wildcard/virtuous
 	name = "Virtuous"
-	desc = "The breadth of my being is one of many, distinguished talents. \n (Allows access to 'virtues', special traits/quirks that replace the bonus normally given by a statpack.)"
-
+	desc = "The breadth of your being is one of many, distinguished talents. \n (Lets you pick a second 'virtue', special traits/quirks that replace the bonus normally given by a statpack.)"


### PR DESCRIPTION
## About The Pull Request
This completely rebalances statpacks. Now they give only flat, no-strings-attached +2 to a stat of your choice, except for Brawny and Nimble, which give you +1 to STR and +1 to SPD respectively. Wildcard statpacks are preserved, except for Fated, which ranges between -1 and +1 for each stat now instead of -2 and +2

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
THE SECOND AND THE THIRD SCREENSHOTS ARE OUTDATED!!!
<img width="758" height="529" alt="image" src="https://github.com/user-attachments/assets/dd416c9b-dba5-4b0d-a4d1-1626b77a2a29" />
<img width="723" height="318" alt="image" src="https://github.com/user-attachments/assets/e38b7cd3-f18e-435c-a35f-62bb22279d42" />
<img width="482" height="389" alt="image" src="https://github.com/user-attachments/assets/82bd2d95-11f9-4f0e-a835-1bdab4d7cc05" />
THE SECOND AND THE THIRD SCREENSHOTS ARE OUTDATED!!!

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Let's have this very difficult but necessary talk.

Azure Peak is a primarily-PvE codebase with much stricter moderation and generally less violent players than Ratwood. When they added statpacks, they did with full trust in their playerbase. They hoped that players wouldn't abuse statpacks and minmax to then play cancer builds and annihilate other players, and even if they did, moderators would quickly ban fragbots, shitters and people who played in bad faith.

Can we trust Ratwood players and moderation the same way?... A rhetoric question.

A flat +2 to any stat is a far lesser advantage than nuking stats you don't need that much for what is basically a perfect stat array for your class.

If you pick statpacks for roleplay, they are still there. You can still play an acolyte who's a bit stronger than their peers, or a barbarian who's as stupid as grass rather than as rocks. If one really needs extreme stat changes for roleplay, on a codebase where stats barely influence anything non-combat-related, then maybe something is wrong with them.

As a side note, Iconoclasts, Berserkers and Lunacy Embracers will be less oppressive, since Struggler isn't a thing anymore.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Statpacks give flat +2 to a stat of your choice (except for STR and SPD).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
