### PR TITLE
Ungrands your duke (easy version)

### DIFF
--- a/_maps/map_files/dun_world/map_adjustment_dunworld.dm
+++ b/_maps/map_files/dun_world/map_adjustment_dunworld.dm
@@ -36,7 +36,7 @@
 		/datum/job/roguetown/warden = 6,
 	)
 	title_adjust = list(
-		/datum/job/roguetown/lord = list(display_title = "Duke", f_title = "Nightmistress"),
+		/datum/job/roguetown/lord = list(display_title = "Duke", f_title = "Duchess"),
 	)
 	tutorial_adjust = list(
 		/datum/job/roguetown/rookie = "Odd-jobs, running messages, fixing dents and talking to locals; the Men at Arms can always use a spare pair of hands, eyes and ears. Assist your fellow guards in dealing with threats - both within and without. \

--- a/_maps/map_files/dun_world/map_adjustment_dunworld.dm
+++ b/_maps/map_files/dun_world/map_adjustment_dunworld.dm
@@ -36,6 +36,7 @@
 		/datum/job/roguetown/warden = 6,
 	)
 	title_adjust = list(
+		/datum/job/roguetown/lord = list(display_title = "Duke", f_title = "Nightmistress"),
 	)
 	tutorial_adjust = list(
 		/datum/job/roguetown/rookie = "Odd-jobs, running messages, fixing dents and talking to locals; the Men at Arms can always use a spare pair of hands, eyes and ears. Assist your fellow guards in dealing with threats - both within and without. \

--- a/_maps/map_files/rockhill/map_adjustment_rockhill.dm
+++ b/_maps/map_files/rockhill/map_adjustment_rockhill.dm
@@ -34,6 +34,7 @@
 		/datum/job/roguetown/warden = 4,//split with vanguard
 	)
 	title_adjust = list(
+		/datum/job/roguetown/lord = list(display_title = "Duke", f_title = "Nightmistress"),
 		/datum/job/roguetown/physician = list(display_title = "Court Physician"),
 		/datum/job/roguetown/niteman = list(display_title = "Nightmaster", f_title = "Nightmistress"),
 		/datum/job/roguetown/nightmaiden = list(display_title = "Nightswain", f_title = "Nightmaiden"),

--- a/_maps/map_files/rockhill/map_adjustment_rockhill.dm
+++ b/_maps/map_files/rockhill/map_adjustment_rockhill.dm
@@ -34,7 +34,7 @@
 		/datum/job/roguetown/warden = 4,//split with vanguard
 	)
 	title_adjust = list(
-		/datum/job/roguetown/lord = list(display_title = "Duke", f_title = "Nightmistress"),
+		/datum/job/roguetown/lord = list(display_title = "Duke", f_title = "Duchess"),
 		/datum/job/roguetown/physician = list(display_title = "Court Physician"),
 		/datum/job/roguetown/niteman = list(display_title = "Nightmaster", f_title = "Nightmistress"),
 		/datum/job/roguetown/nightmaiden = list(display_title = "Nightswain", f_title = "Nightmaiden"),


### PR DESCRIPTION
## About The Pull Request

Renames Grand Duke to just Duke
Uses the 'title_adjust' function in map_adjustments for dunworld and rockhill

## Testing Evidence

<img width="276" height="239" alt="image" src="https://github.com/user-attachments/assets/cde96e9e-f828-478e-8ea4-4c82cdb3afda" />

## Why It's Good For The Game

Lore person asked me

## Changelog

:cl:
Renames 'Grand Duke' to 'Duke'
/:cl: