### PR TITLE
Less skellyclutter

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -102,8 +102,9 @@
 			/obj/item/natural/bone,
 			/obj/item/natural/bone,
 			/obj/item/skull,
-			/obj/item/ammo_casing/caseless/rogue/arrow/iron,
-			/obj/item/ammo_casing/caseless/rogue/arrow/iron,
+			/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+			/obj/item/ammo_casing/caseless/rogue/arrow/stone,
+			/obj/item/ammo_casing/caseless/rogue/arrow/stone,
 			)
 	ai_controller = /datum/ai_controller/skeleton_ranged
 

--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -57,7 +57,7 @@
 	icon_state = "skeleton_axe"
 	icon_living = "skeleton_axe"
 	icon_dead = ""
-	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone,	/obj/item/rogueweapon/stoneaxe/woodcut, /obj/item/skull)
+	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone, /obj/item/skull)
 
 /mob/living/simple_animal/hostile/rogue/skeleton/spear
 	name = "Skeleton"
@@ -68,7 +68,7 @@
 	icon_living = "skeleton_spear"
 	icon_dead = ""
 	attack_sound = 'sound/foley/pierce.ogg'
-	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone,	/obj/item/rogueweapon/spear, /obj/item/skull)
+	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone, /obj/item/skull)
 	ai_controller = /datum/ai_controller/skeleton_spear
 
 /mob/living/simple_animal/hostile/rogue/skeleton/guard
@@ -79,7 +79,7 @@
 	icon_state = "skeleton_guard"
 	icon_living = "skeleton_guard"
 	icon_dead = ""
-	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone,	/obj/item/rogueweapon/sword/iron, /obj/item/skull)
+	loot = list(/obj/item/natural/bone,	/obj/item/natural/bone, /obj/item/natural/bone, /obj/item/skull)
 	maxHealth = 200
 	health = 200
 
@@ -102,8 +102,6 @@
 			/obj/item/natural/bone,
 			/obj/item/natural/bone,
 			/obj/item/skull,
-			/obj/item/gun/ballistic/revolver/grenadelauncher/bow,
-			/obj/item/ammo_casing/caseless/rogue/arrow/iron,
 			/obj/item/ammo_casing/caseless/rogue/arrow/iron,
 			/obj/item/ammo_casing/caseless/rogue/arrow/iron,
 			)


### PR DESCRIPTION
## About The Pull Request

Lesser summoned skeletons don't drop weapons anymore. The archer drops stone arrows, similar to the ones they shoot.

## Testing Evidence

Trrrrrrust me...

## Why It's Good For The Game

Skeletons make so much -clutter-. This cuts down on it somewhat - three weapons per cast and a lot of casts, you wind up with swords everywhere. Can't fit them in sacks so its a nightmare to clean up.

This also makes owning a weapon a little more valuable as there aren't spares just randomly strewn everywhere.

## Changelog

:cl:
balance: lesser skeletons (the simplemob variant spawned in threes by necromancers) no longer drop weapons)
/:cl: