### PR TITLE
Adds Abyssal to selectable languages under character customization

### DIFF
--- a/code/modules/client/vices_menu.dm
+++ b/code/modules/client/vices_menu.dm
@@ -1793,7 +1793,8 @@ GLOBAL_LIST_EMPTY(cached_loadout_icons)
 				/datum/language/otavan,
 				/datum/language/aavnic,
 				/datum/language/merar,
-				/datum/language/thievescant/signlanguage
+				/datum/language/thievescant/signlanguage,
+				/datum/language/abyssal,
 			)
 			var/list/choices = list("None")
 			for(var/language in selectable_languages)
@@ -1842,7 +1843,8 @@ GLOBAL_LIST_EMPTY(cached_loadout_icons)
 					/datum/language/otavan,
 					/datum/language/aavnic,
 					/datum/language/merar,
-					/datum/language/thievescant/signlanguage
+					/datum/language/thievescant/signlanguage,
+					/datum/language/abyssal,
 				)
 				
 				var/list/choices = list("None")


### PR DESCRIPTION
## About The Pull Request

The only racial language that *isn't* selectable, the racial language of Axians and Lamias, is now selectable as a bonus language like every other racial/cultural language.

## Testing Evidence

<img width="304" height="264" alt="dreamseeker_ZQd5BwWSud" src="https://github.com/user-attachments/assets/a74ae1c8-da04-4d9e-b494-03ef03b24d62" />
<img width="358" height="109" alt="lXOVI9pAa3" src="https://github.com/user-attachments/assets/c396790b-f40c-4c6b-8040-536e5668e9a3" />
<img width="329" height="98" alt="dreamseeker_ALXsU7aZGx" src="https://github.com/user-attachments/assets/18f68946-dc61-4552-a613-7ed189d842a4" />

## Why It's Good For The Game

Probably just due to the rarity of people who play it and know it exists, or care to take it, but felt right to at least do so for consistency's sake, Abyssal is now selectable as a bonus language, should you desire it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Abyssal language as a bonus language under character customization
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
