### PR TITLE
R☮TS every last Cursed Collar lock mechanism there is. | Kills fetish content | Enforces Respect of Consent

### DIFF
--- a/modular/code/modules/slave_collar/cursed_collar.dm
+++ b/modular/code/modules/slave_collar/cursed_collar.dm
@@ -98,7 +98,6 @@
 			return
 
 		SEND_SIGNAL(C, COMSIG_CARBON_COLLAR_BOUND, collar_master, src)
-		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		log_combat(user, C, "tried to collar", addition="with [src]")
 	applying = FALSE
 
@@ -169,7 +168,6 @@
 		return
 
 	SEND_SIGNAL(user, COMSIG_CARBON_COLLAR_BOUND, collar_master, src)
-	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 
 	user.visible_message(span_warning("Cursed collar around [user]'s neck clicks shut!"), \
 							span_userdanger("Cursed collar around your neck clicks shut!"))
@@ -192,8 +190,6 @@
 		if(CM && (user in CM.my_pets))
 			CM.remove_pet(user)
 
-	REMOVE_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
-
 /obj/item/clothing/neck/roguetown/cursed_collar/canStrip(mob/living/carbon/human/stripper, mob/living/carbon/human/owner)
 	// Some strip call sites may not pass owner; infer from loc when possible.
 	if(!owner && ishuman(loc))
@@ -209,7 +205,6 @@
 		owner = loc
 
 	if(stripper?.mind == collar_master)
-		REMOVE_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 		if(owner)
 			SEND_SIGNAL(owner, COMSIG_CARBON_LOSE_COLLAR)
 		return owner ? owner.dropItemToGround(src, force = TRUE) : FALSE


### PR DESCRIPTION
## About The Pull Request

Makes the Cursed Collar removable freely and entirely, anyone at any time can remove it by hand. 

I considered making it an Eoran Ritual but I figured it's too much work for gooner material.

Chastity content can be removed with the use of settings, so I didn't change anything regarding that.

## Testing Evidence

I removed three lines. It works I swear.

## Why It's Good For The Game

You should be able to withdraw your consent at any time, for any reason. 

The logic here is simple:
-You CC'd someone:

-> That someone (OOCly) WANTS to be kept CC'd -> They will keep the Collar ON.

-> That someone (OOCly)  DOESN'T want to be CC'd anymore. -> They will take the Collar OFF.

"But what if someone ELSE removes the Cursed Collar?"
-> They did it purely for the love of the game, and had otherwise no valid reason to do it.
- That is a rulebreak. Act accordingly.

-> They did it, while having an actual reason.
- That is not a rulebreak. Act accordingly. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cursed Collar is now removable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
