### PR TITLE
graggar net slop

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -177,7 +177,7 @@
 	id = "net"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/netted
 	effectedstats = list(STATKEY_SPD = -5, STATKEY_WIL = -2)
-	duration = 3 MINUTES
+	duration = 30 SECONDS
 
 /datum/status_effect/debuff/netted/on_apply()
 		. = ..()

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -1,5 +1,5 @@
 #ifndef TESTING
-//    #define FASTLOAD
+    #define FASTLOAD
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif

--- a/code/rt.dm
+++ b/code/rt.dm
@@ -1,5 +1,5 @@
 #ifndef TESTING
-    #define FASTLOAD
+//    #define FASTLOAD
 //    #define DEPLOY_TEST
 //    #define ROGUEWORLD
 #endif

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -27,7 +27,6 @@
 	return TRUE
 
 //Unholy Grasp - Throws disappearing net made of viscera at enemy. Creates blood on impact.
-//Unholy Grasp - Throws disappearing net made of viscera at enemy. Creates blood on impact.
 /obj/effect/proc_holder/spell/invoked/projectile/blood_net
 	name = "Unholy Grasp"
 	desc = "Toss forth an unholy snare of blood and guts a short distance, summoned from your leftover trophies sacrificed to Graggar. Like a net, may it snare your target!"

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -57,16 +57,14 @@
 /obj/projectile/magic/unholy_grasp/proc/ensnare(mob/living/carbon/carbon)
 	if(carbon.legcuffed || carbon.get_num_legs(FALSE) < 2)
 		return
-	var/obj/item/net/unholy_grasp/net = new(get_turf(carbon))
+	var/obj/item/net/net = new(carbon)
 	visible_message(span_danger("\The [src] ensnares [carbon] in vicera!"))
 	to_chat(carbon, span_danger("\The [src] ensnares you!"))
 	carbon.legcuffed = net
-	net.forceMove(carbon)
 	carbon.update_inv_legcuffed()
 	carbon.Knockdown(knockdown)
-	carbon.apply_status_effect(/datum/status_effect/debuff/netted)
+	carbon.apply_status_effect(/datum/status_effect/debuff/netted, 30 SECONDS)
 	playsound(src, 'sound/combat/caught.ogg', 50, TRUE)
-	addtimer(CALLBACK(net, PROC_REF(remove_effect)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
 /obj/item/net/unholy_grasp
 	name = "visceral net"

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -27,6 +27,7 @@
 	return TRUE
 
 //Unholy Grasp - Throws disappearing net made of viscera at enemy. Creates blood on impact.
+//Unholy Grasp - Throws disappearing net made of viscera at enemy. Creates blood on impact.
 /obj/effect/proc_holder/spell/invoked/projectile/blood_net
 	name = "Unholy Grasp"
 	desc = "Toss forth an unholy snare of blood and guts a short distance, summoned from your leftover trophies sacrificed to Graggar. Like a net, may it snare your target!"
@@ -42,37 +43,41 @@
 	chargetime = 15
 	recharge_time = 10 SECONDS
 
+/obj/effect/proc_holder/spell/invoked/projectile/blood_net/cast(list/targets, mob/user = usr)
+	var/obj/item/I = user.get_active_held_item()
+	if(!istype(I, req_inhand))
+		to_chat(user, span_warning("I'm missing viscera in my hand to cast this."))
+		return FALSE
+	. = ..()
+	if(. && I)
+		qdel(I)
+
 /obj/projectile/magic/unholy_grasp
 	name = "viceral organ net"
 	icon_state = "tentacle_end"
 	nodamage = TRUE
 	knockdown = 3 SECONDS
 
-/obj/effect/proc_holder/spell/invoked/projectile/blood_net/cast(list/targets, mob/user = usr)
-	var/obj/item/I = user.get_active_held_item()
-	if(!istype(I, req_inhand))
-		to_chat(user, span_warning("I'm missing viscera in my hand to cast this."))
-		return FALSE
-	qdel(I)
-	return ..()
-
 /obj/projectile/magic/unholy_grasp/on_hit(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(. == BULLET_ACT_MISS || . == BULLET_ACT_BLOCK || !iscarbon(hit_atom))
 		return
+
 	ensnare(hit_atom)
 
 /obj/projectile/magic/unholy_grasp/proc/ensnare(mob/living/carbon/carbon)
 	if(carbon.legcuffed || carbon.get_num_legs(FALSE) < 2)
 		return
-	var/obj/item/net/unholy_grasp/net = new(carbon)
+
+	var/obj/item/net/unholy_grasp/net = new(get_turf(carbon))
 	net.slipouttime = max(2 SECONDS, 10 SECONDS - max(0, carbon.STASTR - 10) * 0.5 SECONDS)
 	visible_message(span_danger("\The [src] ensnares [carbon] in vicera!"))
 	to_chat(carbon, span_danger("\The [src] ensnares you!"))
 	carbon.legcuffed = net
+	net.forceMove(carbon)
 	carbon.update_inv_legcuffed()
 	carbon.Knockdown(knockdown)
-	carbon.apply_status_effect(/datum/status_effect/debuff/netted, 30 SECONDS)
+	carbon.apply_status_effect(/datum/status_effect/debuff/netted)
 	playsound(src, 'sound/combat/caught.ogg', 50, TRUE)
 
 /obj/item/net/unholy_grasp
@@ -90,7 +95,6 @@
 			if(M.has_status_effect(/datum/status_effect/debuff/netted))
 				M.remove_status_effect(/datum/status_effect/debuff/netted)
 		forceMove(M.loc)
-	qdel(src)
 
 /obj/item/net/unholy_grasp/Destroy()
 	remove_effect()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -48,6 +48,14 @@
 	nodamage = TRUE
 	knockdown = 3 SECONDS
 
+/obj/effect/proc_holder/spell/invoked/projectile/blood_net/cast(list/targets, mob/user = usr)
+	var/obj/item/I = user.get_active_held_item()
+	if(!istype(I, req_inhand))
+		to_chat(user, span_warning("I'm missing viscera in my hand to cast this."))
+		return FALSE
+	qdel(I)
+	return ..()
+
 /obj/projectile/magic/unholy_grasp/on_hit(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(. == BULLET_ACT_MISS || . == BULLET_ACT_BLOCK || !iscarbon(hit_atom))
@@ -57,7 +65,8 @@
 /obj/projectile/magic/unholy_grasp/proc/ensnare(mob/living/carbon/carbon)
 	if(carbon.legcuffed || carbon.get_num_legs(FALSE) < 2)
 		return
-	var/obj/item/net/net = new(carbon)
+	var/obj/item/net/unholy_grasp/net = new(carbon)
+	net.slipouttime = max(2 SECONDS, 10 SECONDS - max(0, carbon.STASTR - 10) * 0.5 SECONDS)
 	visible_message(span_danger("\The [src] ensnares [carbon] in vicera!"))
 	to_chat(carbon, span_danger("\The [src] ensnares you!"))
 	carbon.legcuffed = net

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -55,11 +55,39 @@
 	ensnare(hit_atom)
 
 /obj/projectile/magic/unholy_grasp/proc/ensnare(mob/living/carbon/carbon)
+	if(carbon.legcuffed || carbon.get_num_legs(FALSE) < 2)
+		return
+	var/obj/item/net/unholy_grasp/net = new(get_turf(carbon))
 	visible_message(span_danger("\The [src] ensnares [carbon] in vicera!"))
 	to_chat(carbon, span_danger("\The [src] ensnares you!"))
+	carbon.legcuffed = net
+	net.forceMove(carbon)
+	carbon.update_inv_legcuffed()
 	carbon.Knockdown(knockdown)
-	carbon.apply_status_effect(/datum/status_effect/debuff/netted, 30 SECONDS)
+	carbon.apply_status_effect(/datum/status_effect/debuff/netted)
 	playsound(src, 'sound/combat/caught.ogg', 50, TRUE)
+	addtimer(CALLBACK(net, PROC_REF(remove_effect)), 30 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
+
+/obj/item/net/unholy_grasp
+	name = "visceral net"
+	desc = "A disgusting mass of viscera binding the victim's legs."
+	color = "#80182e"
+
+/obj/item/net/unholy_grasp/remove_effect()
+	if(iscarbon(loc))
+		var/mob/living/carbon/M = loc
+		if(M.legcuffed == src)
+			M.legcuffed = null
+			M.remove_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN, TRUE)
+			M.update_inv_legcuffed()
+			if(M.has_status_effect(/datum/status_effect/debuff/netted))
+				M.remove_status_effect(/datum/status_effect/debuff/netted)
+		forceMove(M.loc)
+	qdel(src)
+
+/obj/item/net/unholy_grasp/Destroy()
+	remove_effect()
+	return ..()
 
 /obj/effect/proc_holder/spell/invoked/revel_in_slaughter
 	name = "Revel in Slaughter"

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -70,7 +70,7 @@
 		return
 
 	var/obj/item/net/unholy_grasp/net = new(get_turf(carbon))
-	net.slipouttime = max(2 SECONDS, 10 SECONDS - max(0, carbon.STASTR - 10) * 0.5 SECONDS)
+	net.slipouttime = max(2 SECONDS, 13 SECONDS - max(0, carbon.STASTR - 10) * 0.5 SECONDS)
 	visible_message(span_danger("\The [src] ensnares [carbon] in vicera!"))
 	to_chat(carbon, span_danger("\The [src] ensnares you!"))
 	carbon.legcuffed = net
@@ -94,10 +94,19 @@
 			M.update_inv_legcuffed()
 			if(M.has_status_effect(/datum/status_effect/debuff/netted))
 				M.remove_status_effect(/datum/status_effect/debuff/netted)
-		forceMove(M.loc)
+		var/turf/T = get_turf(M)
+		if(T)
+			forceMove(T)
 
-/obj/item/net/unholy_grasp/Destroy()
-	remove_effect()
+/obj/item/net/unholy_grasp/Destroy() //we avoud forceMove() my manna caused by destroy as its not good to put it together
+	if(iscarbon(loc))
+		var/mob/living/carbon/M = loc
+		if(M.legcuffed == src)
+			M.legcuffed = null
+			M.remove_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN, TRUE)
+			M.update_inv_legcuffed()
+		if(M.has_status_effect(/datum/status_effect/debuff/netted))
+			M.remove_status_effect(/datum/status_effect/debuff/netted)
 	return ..()
 
 /obj/effect/proc_holder/spell/invoked/revel_in_slaughter


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

fix

## Testing Evidence

<img width="1784" height="985" alt="image" src="https://github.com/user-attachments/assets/b7b5b786-bf5a-4a92-a530-99be438969e4" />

https://github.com/user-attachments/assets/8fc85321-9f95-4715-81ac-1c108d182112

https://github.com/user-attachments/assets/3ca5744f-054b-4c9b-8e11-20713bfb7036

<img width="1844" height="992" alt="image" src="https://github.com/user-attachments/assets/b345b9ba-326b-4dbd-b59c-fc53e5d23bdb" />


## Why It's Good For The Game
now consumes viscera after use.
the netted debuff now itself falls off after 30 seconds if you do nuffin (was 3 mins)
You can manually remove the debuff by clicking the net icon. The stronger you are, the faster you break free:
13 seconds base removal time, reduced by 0.5 seconds for each str point above 10 you have. STR 15+ beasts can ignore it and insta break
One legged characters cannot get hit by thus shit i dunno man try finding a worthy opponent not some cripple 
It doesnt spawn leg_cuff around your leg as sometimes there nasty bug that prevents you from checking your health sooooooooo get the icon clicking this always works 
if people already under this shitte it will do nuffin to them (will not increase debuff's time)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: graggar's net fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
