### PR TITLE
Master Warden Changes (and two bugfixes)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -111,7 +111,7 @@
 			"None"
 		)
 		var/hoodchoice = input(H, "Choose your Shroud.", "HOOD SELECTION") as anything in hoods
-		if(helmchoice != "None")
+		if(hoodchoice != "None")
 			mask = hoods[hoodchoice]
 
 /datum/advclass/warden/forester

--- a/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
@@ -34,21 +34,17 @@
 
 //All skills/traits are on the loadouts. All are identical. Welcome to the stupid way we have to make sub-classes...
 /datum/outfit/job/roguetown/wardenmaster
-	head = /obj/item/clothing/head/roguetown/helmet/bascinet/antler
 	neck = /obj/item/clothing/neck/roguetown/bevor
-	cloak = /obj/item/clothing/cloak/darkcloak/bear/wardenmaster
+	cloak = /obj/item/clothing/cloak/wardencloak
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/upgraded
-	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	belt = /obj/item/storage/belt/rogue/leather
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
 	backr = /obj/item/storage/backpack/rogue/satchel
-	beltl = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
 	id = /obj/item/scomstone/garrison
 
-//Rare-ish anti-armor two hander sword. Kinda alternative of a bastard sword type. Could be cool.
 /datum/advclass/wardenmaster/wardenmaster
 	name = "Master Warden"
 	tutorial = "You are a not just anybody but the Master Warden of the lowtown fortress. While you may have started as some peasant or mercenary, you have advanced through the ranks to that of someone who commands respect and wields it. Take up arms, WARDENMASTER!"
@@ -109,32 +105,61 @@
 		)
 	H.adjust_blindness(-3)
 	if(H.mind)
-		var/weapons = list("Greataxe","Javelins & Shield","Blackhorn Longbow","Handgonne")	//competent at both sides of wardenry so it's more a matter of what weapon you start with
+		var/weapons = list("Greataxe (+1 STR)","Javelins & Shield (+1 SPD)","Longsword (+1 WIL)","Blackhorn Longbow (+1 PER)","Handgonne (+1 PER)")	//competent at both sides of wardenry so it's more a matter of what weapon you start with
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		var/armor_options = list("Light Armor", "Medium Armor")
 		var/armor_choice = input(H, "Choose your armor.", "TAKE UP ARMS") as anything in armor_options
+		var/helmets = list(
+			"Antlers of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
+			"Skull of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
+			"Skull of the Ram"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat,
+			"Skull of the Bear"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear,
+			"None"
+		)
+		var/helmchoice = input(H, "Choose your Path.", "HELMET SELECTION") as anything in helmets
+		var/hoods = list(
+			"Common Shroud" 	= /obj/item/clothing/head/roguetown/roguehood/warden,
+			"Antlered Shroud"		= /obj/item/clothing/head/roguetown/roguehood/warden/antler,
+			"None"
+		)
+		var/hoodchoice = input(H, "Choose your Shroud.", "HOOD SELECTION") as anything in hoods
 		H.set_blindness(0)
-		switch(weapon_choice)//feel it'd be nice to have a sword version for a real Jeor Mormont?
-			if("Greataxe")			
+		switch(weapon_choice)
+			if("Greataxe (+1 STR)")			
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				l_hand = /obj/item/rogueweapon/greataxe/steel
-			if("Javelins & Shield")
+				H.change_stat(STATKEY_STR, 1)
+			if("Javelins & Shield (+1 SPD)")
 				beltr = /obj/item/quiver/javelin/steel
 				backl = /obj/item/rogueweapon/shield/tower/
-			if("Blackhorn Longbow")
+				H.change_stat(STATKEY_SPD, 1)
+			if("Longsword (+1 WIL)")//Jeor Mormont.
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
+				backl = /obj/item/rogueweapon/scabbard/sword
+				l_hand = /obj/item/rogueweapon/sword/long
+				H.change_stat(STATKEY_WIL, 1)
+			if("Blackhorn Longbow (+1 PER)")
 				beltr = /obj/item/quiver/arrows
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow/warden
-			if("Handgonne")//okay I can remove this later but I think it would be... just... so based
+				H.change_stat(STATKEY_PER, 1)
+			if("Handgonne (+1 PER)")//okay I can remove this later but I think it would be... just... so based
 				r_hand = /obj/item/gun/ballistic/firearm/handgonne
 				l_hand = /obj/item/powderflask
 				beltr = /obj/item/quiver/bullet/lead
+				H.change_stat(STATKEY_PER, 1)
 		switch(armor_choice)
 			if("Light Armor")
 				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
 				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants
+				beltl = /obj/item/rogueweapon/huntingknife/idagger/warden_machete
 			if("Medium Armor")
-				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 				pants = /obj/item/clothing/under/roguetown/chainlegs
+				beltl = /obj/item/rogueweapon/stoneaxe/woodcut/wardenpick
+		if(helmchoice != "None")
+			head = helmets[helmchoice]
+		if(hoodchoice != "None")
+			mask = hoods[hoodchoice]
 
 /obj/effect/proc_holder/spell/self/convertrole/vanguard
 	name = "Recruit Vanguard"

--- a/code/modules/roguetown/roguemachine/scomm/scomm.dm
+++ b/code/modules/roguetown/roguemachine/scomm/scomm.dm
@@ -176,7 +176,7 @@
 /obj/structure/roguemachine/scomm/MiddleClick(mob/living/carbon/human/user)
 	if(.)
 		return
-	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (user.job == "Watchman") || (user.job == "Warden") || (user.job == "Master Warden") || (user.job == "Councillor") || (user.job == "Squire") || (user.job == "Marshal") || (user.job == "Grand Duke") || (user.job == "Knight Captain") || (user.job == "Grand Duchess") ||(user.job == "Hand") ||(user.job == "Vizier") || (user.job == "Sheikh") || (user.job == "Azeb") || (user.job == "Azebagha")))
+	if((HAS_TRAIT(user, TRAIT_GUARDSMAN) || (user.job == "Watchman") || (user.job = "Vanguard") || (user.job == "Warden") || (user.job == "Master Warden") || (user.job == "Councillor") || (user.job == "Squire") || (user.job == "Marshal") || (user.job == "Grand Duke") || (user.job == "Knight Captain") || (user.job == "Grand Duchess") ||(user.job == "Hand") ||(user.job == "Vizier") || (user.job == "Sheikh") || (user.job == "Azeb") || (user.job == "Azebagha")))
 		if(alert("Would you like to swap lines or connect to a jabberline?",, "swap", "jabberline") != "jabberline")
 			garrisonline = !garrisonline
 			to_chat(user, span_info("I [garrisonline ? "connect to the garrison SCOMline" : "connect to the general SCOMLINE"]"))


### PR DESCRIPTION
## About The Pull Request
Updates the master warden to be more in-line with their underlings, giving them a choice of helmet, hood, tying whether they get a warden axe or warden seax to whether they pick medium or light armor, as well as adding +1 to a stat depending on which weapon they take. All weapon skills remain at journeyman or expert, except sword-fighting, which goes up to expert if the master warden chooses to take a longsword to start with.

The renamed direbear cloak was replaced with just a warden cloak.

Two bugfixes unrelated to master warden were, in the warden file, variable 'hoodchoice' was not actually checked, as whoever copied the if statement left it as 'helmchoice'. This had no actual effect, I think, unless you took a helmet and didn't want a hood.

The second bugfix was that vanguards were not added to the check for SCOMs allowing access to the garrison line. Now they can actually use a SCOM to respond to questions and orders.

## Testing Evidence
Weapon choices with their statbuff
<img width="296" height="253" alt="image" src="https://github.com/user-attachments/assets/a4d5464e-d45e-4f11-b2d3-5df526c36854" />

Default Loadout before any selections
<img width="227" height="402" alt="image" src="https://github.com/user-attachments/assets/f6593bf4-8aaa-4749-bc77-7ef43aab0adf" />

Helmet selection
<img width="295" height="255" alt="image" src="https://github.com/user-attachments/assets/3105fcc4-03bc-47d9-8c98-834f9df73bd9" />

Hood selection
<img width="295" height="258" alt="image" src="https://github.com/user-attachments/assets/67152e44-90aa-47fd-b2bd-1c08e23108db" />

Longsword, medium armor, volf helmet, antler hood selected
<img width="292" height="473" alt="image" src="https://github.com/user-attachments/assets/20cb15d7-e18c-4f7b-8972-df85bbe972f0" />

Stats immediately after spawning roundstart (without woodsman buff)
<img width="300" height="207" alt="image" src="https://github.com/user-attachments/assets/39819376-45eb-4561-a10b-f24e4fb07c89" />

Vanguard using a SCOM
<img width="535" height="135" alt="image" src="https://github.com/user-attachments/assets/3e28bfeb-6a4c-4583-a154-f8ff3b08518f" />


## Why It's Good For The Game
Master Warden feels extremely half-finished to play, especially with the trophy-cloak just being a renamed direbear cloak. I am not a spriter, so I cannot make a unique one for them, but giving them the actually good-looking warden cloak feels like a nice compromise. The stat buffs depending on weapon you pick are to help match your subordinate wardens, especially the +1 PER with the longbow.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: gave master warden +1 stat depending on weapon, and a longsword choice
fix: vanguards can talk in SCOM now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
