### PR TITLE
Gives Goblins a Physical Descriptor

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/goblin/goblinp.dm
@@ -80,9 +80,10 @@
 	stress_examine = TRUE
 	stress_desc = span_red("Horrid little goblin...")
 	descriptor_choices = list(
+		/datum/descriptor_choice/trait,
+		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/height,
 		/datum/descriptor_choice/body,
-		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/face,
 		/datum/descriptor_choice/face_exp,
 		/datum/descriptor_choice/skin_all,


### PR DESCRIPTION
## About The Pull Request
Adds a physical descriptor option to goblins, so they have an adjective to go with the noun describing them when their face is hidden.

## Testing Evidence
What it now looks currently
<img width="429" height="121" alt="image" src="https://github.com/user-attachments/assets/5c8a5b16-6898-4ffc-80f1-7b56660293ce" />

What it looks like with my change
<img width="334" height="162" alt="image" src="https://github.com/user-attachments/assets/62aa661f-316f-423e-89cf-d164a903f15e" />

And in-game
<img width="183" height="114" alt="image" src="https://github.com/user-attachments/assets/0ab11efa-09cc-4bd8-9f7d-3e5669fd93cc" />


## Why It's Good For The Game

It's a bit jarring to see a hooded figure that is just **Man**. An adjective to your character is fun to have, and goblins deserve it too.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: gives goblins a physical descriptor, just like most everyone else
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
