### PR TITLE
Necromancer 'Buff' & More! A PR you got but never asked for!

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -60,7 +60,7 @@
 #define TRAIT_MONOTHEIST "Monotheist"
 #define TRAIT_GUARDSMAN "Vigilant Guardsman"
 #define TRAIT_TAVERN_FIGHTER "Tavern Fighter"
-#define TRAIT_NECROBGONE "Necro Be Gone!"
+#define TRAIT_NECROBGONE "Necromancers Fear"
 #define TRAIT_FROZEN_STAMINA "Frozen Stamina"
 #define TRAIT_WOODSMAN "Talented Woodsman"
 #define TRAIT_LAMIAN_TAIL "Lamian Tail"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -60,6 +60,7 @@
 #define TRAIT_MONOTHEIST "Monotheist"
 #define TRAIT_GUARDSMAN "Vigilant Guardsman"
 #define TRAIT_TAVERN_FIGHTER "Tavern Fighter"
+#define TRAIT_NECROBGONE "Necro Be Gone!"
 #define TRAIT_FROZEN_STAMINA "Frozen Stamina"
 #define TRAIT_WOODSMAN "Talented Woodsman"
 #define TRAIT_LAMIAN_TAIL "Lamian Tail"
@@ -315,6 +316,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_LEPROSY = span_necrosis("I'm a disgusting leper..."),
 	TRAIT_VOTARY = span_info("I'm of the Holy See's own. I feel most comfortable on hallowed ground."),
 	TRAIT_TAVERN_FIGHTER = span_info("I am vigilant in my duties. The Tavern is my home, none shall dare oppose me or skip out on payment."),
+	TRAIT_NECROBGONE = Span_info("I'm a dreadful Necromancer, I should avoid setting up home in some locations...")
 	TRAIT_GUARDSMAN = span_info("I am vigilant in my duties. In the town I am sworn to protect, my abilities are sharper due to my routine and familiarity."),
 	TRAIT_WOODSMAN = span_info("I am vigilant in my duties. In the outdoor wilderness I am sworn to protect, my abilities are sharper due to my routine and familiarity."),
 	TRAIT_DEATHBARGAIN = span_info("A horrible deal has been prepared in your name. May you never see it fulfilled..."),

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -22,6 +22,18 @@
 	duration = 100
 	needs_processing = FALSE
 
+/datum/status_effect/debuff/necrodebuff
+	id = "necrodebuff"
+	alert_type = /datum/status_effect/debuff/necrodebuff
+	effectedstats = list(STATKEY_CON = -3,STATKEY_WIL = -3, STATKEY_SPD = -5, STATKEY_PER = -2, STATKEY_INT = -5) // good luck quick casting
+
+/datum/status_effect/debuff/necrodebuff/process()
+	.=..()
+	owner.energy_add(-3)	// we wanna make this tedious and miserable
+	var/area/rogue/our_area = get_area(owner)
+	if(isnull(our_area) || !(our_area.necrobgone_area))
+		owner.remove_status_effect(src)
+
 /atom/movable/screen/alert/status_effect/debuff/hungryt2
 	name = "Hungry"
 	desc = "This living body suffers heavily from hunger."

--- a/code/game/area/mountdecap.dm
+++ b/code/game/area/mountdecap.dm
@@ -110,6 +110,7 @@
 	deathsight_message = "a twisted tangle of soaring peaks"
 	threat_region = THREAT_REGION_MOUNT_DECAP
 	detail_text = DETAIL_TEXT_DECAP_GOBLIN_FORTRESS
+	necrobgone_area = TRUE
 
 /area/rogue/under/cave/scarymaze
 	name = "Necran Labyrinth"

--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	var/keep_area = FALSE
 	var/tavern_area = FALSE
 	var/warden_area = FALSE
+	var/necrobgone_area = FALSE
 	var/holy_area = FALSE
 	var/cell_area = FALSE
 	var/viewing_area = FALSE
@@ -32,6 +33,8 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 		return
 	if((src.town_area == TRUE) && HAS_TRAIT(guy, TRAIT_GUARDSMAN) && !guy.has_status_effect(/datum/status_effect/buff/guardbuffone)) //man at arms
 		guy.apply_status_effect(/datum/status_effect/buff/guardbuffone)
+	if((src.necrobgone_area == TRUE) && HAS_TRAIT(guy, TRAIT_NECROBGONE) && !guy.has_status_effect(/datum/status_effect/debuff/necrodebuff)) // debuffs necros from farming goblin lux lol
+		guy.apply_status_effect(/datum/status_effect/debuff/necrodebuff)
 	if((src.tavern_area == TRUE) && HAS_TRAIT(guy, TRAIT_TAVERN_FIGHTER) && !guy.has_status_effect(/datum/status_effect/buff/barkeepbuff)) // THE FIGHTER
 		guy.apply_status_effect(/datum/status_effect/buff/barkeepbuff)
 	if((src.warden_area == TRUE) && HAS_TRAIT(guy, TRAIT_WOODSMAN) && !guy.has_status_effect(/datum/status_effect/buff/wardenbuff)) // Warden

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -7,14 +7,15 @@
 	cmode_music = 'sound/music/combat_heretic.ogg'
 	class_select_category = CLASS_CAT_MAGE
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_MAGEARMOR, TRAIT_GRAVEROBBER, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT,TRAIT_RITUALIST,TRAIT_OUTLANDER,)
-	maximum_possible_slots = 2 // Going from 1 to 2, because skeleton that are summoned count AGAINST antagonist cap and they don't always shows up
+	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_MAGEARMOR, TRAIT_GRAVEROBBER, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT,TRAIT_RITUALIST,TRAIT_OUTLANDER, TRAIT_WOODWALKER) // free woodwalker, no more triggering ambushes! Set up a base.
+	maximum_possible_slots = 1 // Mini lych. Treat accordingly.
 	subclass_stats = list(
-		STATKEY_INT = 4,
-		STATKEY_PER = 2,
-		STATKEY_WIL = 1,
-		STATKEY_SPD = 1
-	)
+		STATKEY_INT = 5, // you get max cast speed
+		STATKEY_PER = 3,
+		STATKEY_WIL = 3,
+		STATKEY_CON = 2, // you are effectively a mini boss here
+		STATKEY_SPD = -2 // you have a skeleton horde, position yourself or die
+	)	
 	subclass_spellpoints = 16
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -7,7 +7,7 @@
 	cmode_music = 'sound/music/combat_heretic.ogg'
 	class_select_category = CLASS_CAT_MAGE
 	category_tags = list(CTAG_WRETCH)
-	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_MAGEARMOR, TRAIT_GRAVEROBBER, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT,TRAIT_RITUALIST,TRAIT_OUTLANDER, TRAIT_WOODWALKER) // free woodwalker, no more triggering ambushes! Set up a base.
+	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_MAGEARMOR, TRAIT_GRAVEROBBER, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT,TRAIT_RITUALIST,TRAIT_OUTLANDER, TRAIT_WOODWALKER, TRAIT_NECROBGONE) // free woodwalker, no more triggering ambushes! Set up a base.
 	maximum_possible_slots = 1 // Mini lych. Treat accordingly.
 	subclass_stats = list(
 		STATKEY_INT = 5, // you get max cast speed


### PR DESCRIPTION
## About The Pull Request

The following PR shifts necromancer BACK to ONE SLOT and instead grants the necromancer a small number of buffs to stats only. The PR also granted them Woodwalker, allowing them to pick up herbs while also being unable to proc ambushes themselves so they can not AFK Farm Goblins and raid town at 1:30, Also known as the "Hour of Ravox" if one wants to call it that.

This also gives Necromancers a trait I'll rename sometime soon (maybe tomorrow) that debuffs them for going into a certain dungeon that people are using to mass farm lux for skeletons that ultimately get feinted (idiot). 

## Testing Evidence

not yet

## Why It's Good For The Game

Should stop the miserable hyper wars going on, or not solve anything idfk call me a stupid chud antag main I guess.

## Changelog

:cl:
add: "Necromancer be gone" trait to Necromancer
add: Windwalker to necromancer
add: Some buffs (and -2 spd) to Necro
tweak: Where Necromancers can enter without a debuff.
/:cl: