### PR TITLE
Map-neutral names and descriptions

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -310,7 +310,7 @@
 
 GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_STEELHEARTED = span_info("I have hardened nerves, and do not waiver from the sight of violence in battle."),
-	TRAIT_OUTLANDER = span_info("Those of the vale see me as not of their land."),
+	TRAIT_OUTLANDER = span_info("Those of the realm see me as not of their land."),
 	TRAIT_OUTLAW = span_info("This land's nervelocks and castificos reject my touch."),
 	TRAIT_LEPROSY = span_necrosis("I'm a disgusting leper..."),
 	TRAIT_VOTARY = span_info("I'm of the Holy See's own. I feel most comfortable on hallowed ground."),
@@ -454,7 +454,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_NOHUNGER = span_info("I do not hunger, or thirst."),
 	TRAIT_DARKVISION = span_info("I can see better in the dark."),
 	TRAIT_NOCSHADES = span_info("The lens I look through allows me to see in the dark clear as dae, at the cost of greater vision."),
-	TRAIT_RESIDENT = span_info("I've been granted a Nervelock account, and the ownership of a house in the vale."),
+	TRAIT_RESIDENT = span_info("I've been granted a Nervelock account, and the ownership of a house in the realm."),
 	TRAIT_LIGHT_STEP = span_info("My steps are light and swift. I make less noise while sneaking, and can sneak much quicker."),
 	TRAIT_NOMOOD = span_info("I feel no sorrow, no joy, and no stress."),
 	TRAIT_DETACHED = span_info("Nothing could move me. Any emotion I show is a facade."),
@@ -504,7 +504,7 @@ GLOBAL_LIST_INIT(roguetraits, list(
 	TRAIT_SELF_SUSTENANCE = span_greentext("Yils of experience running from the law and living off the land have made me a jack of all trades. All crafting and labor skills can progress to Journeyman levels."),
 	TRAIT_SILVER_WEAK = span_warning("Silver is the greatest threat to my lyfe. Blows from silver weapons will set me alight, inhibit my ability to regenerate, and - if blessed - can outright destroy my vessel."),
 	TRAIT_DYES = span_notice("I know my way around pigments and shades, and I'm able to create the exact colors I want in a dye station."),
-	TRAIT_RACISMISBAD = span_warning("The Black Oaks can spot ANY Foreigners and Outsiders, no matter how long they've lived in the vale. This is an easy skill to master, as it is simply identifying who isn't an elf."),
+	TRAIT_RACISMISBAD = span_warning("The Black Oaks can spot ANY Foreigners and Outsiders, no matter how long they've lived in the realm. This is an easy skill to master, as it is simply identifying who isn't an elf."),
 	TRAIT_GOODWRITER = span_notice("I'm proficient at writing. Any skillbooks made by me will allow the reader to learn the subject more quickly."),
 	TRAIT_PONYGIRL_RIDEABLE = span_notice("Willing or not, I've been trained to carry other people's burdens."),
 	TRAIT_VENOMOUS = span_necrosis("I am venomous. When chewing someone I've bitten, I will inject venom."),

--- a/code/controllers/subsystem/rogue/gnolls_subsystem.dm
+++ b/code/controllers/subsystem/rogue/gnolls_subsystem.dm
@@ -177,7 +177,7 @@ SUBSYSTEM_DEF(gnoll_scaling)
 	if(new_total > old_total || new_spawn > old_spawn)
 		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 			if(player.client)
-				to_chat(player, span_alert("Graggar demands blood, gnolls flock to the Vale!"))
+				to_chat(player, span_alert("Graggar demands blood, gnolls flock to the realm!"))
 
 	if(recheck_below_players > 0 && players_amt < recheck_below_players)
 		queue_scaling_recheck()

--- a/code/controllers/subsystem/rogue/gnolls_subsystem.dm
+++ b/code/controllers/subsystem/rogue/gnolls_subsystem.dm
@@ -177,7 +177,7 @@ SUBSYSTEM_DEF(gnoll_scaling)
 	if(new_total > old_total || new_spawn > old_spawn)
 		for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
 			if(player.client)
-				to_chat(player, span_alert("Graggar demands blood, gnolls flock to the realm!"))
+				to_chat(player, span_alert("Graggar demands blood, gnolls flock to [SSmapping.map_adjustment.realm_name]!"))
 
 	if(recheck_below_players > 0 && players_amt < recheck_below_players)
 		queue_scaling_recheck()

--- a/code/controllers/subsystem/rogue/treasury.dm
+++ b/code/controllers/subsystem/rogue/treasury.dm
@@ -92,6 +92,7 @@ SUBSYSTEM_DEF(treasury)
 						X.demand -= rand(5,15)
 			var/total_generated_cost = 0
 			var/wasted_time = FALSE
+			var/realmname = SSmapping.map_adjustment.realm_name
 			for(var/datum/roguestock/stockpile/A in stockpile_datums) //Generate some remote resources
 				if(wasted_time && A.passive_generation) //Only the suppliers of the resource you couldn't pay get mad
 					A.passive_generation = 0
@@ -105,7 +106,7 @@ SUBSYSTEM_DEF(treasury)
 			if(wasted_time)
 				log_to_steward("-[total_generated_cost]m spent on Passive Imports, treasury drained, unable to pay remaining suppliers. Imports automatically cancelled, prices raised, do not waste supplier time.")
 				treasury_value -= total_generated_cost
-				scom_announce("Rotwood Vale failed to pay the Import Rate. Resources have not been delivered, rates set to 0.") //the treasury just got drained, shame unto the current steward
+				scom_announce("[realmname] failed to pay the Import Rate. Resources have not been delivered, rates set to 0.") //the treasury just got drained, shame unto the current steward
 			else
 				log_to_steward("-[total_generated_cost]m spent on Passive Imports.")
 				treasury_value -= total_generated_cost
@@ -279,6 +280,7 @@ SUBSYSTEM_DEF(treasury)
 	if((D.held_items[1] < D.importexport_amt))
 		return FALSE
 	var/amt = D.get_export_price()
+	var/realmname = SSmapping.map_adjustment.realm_name
 
 	// You should only export from town stockpiles, not from remote. Remote is meant
 	// To fulfill local economic shortfall and not to make $$ for the steward.
@@ -290,12 +292,13 @@ SUBSYSTEM_DEF(treasury)
 	SStreasury.log_to_steward("+[amt] exported [D.name]")
 	record_round_statistic(STATS_STOCKPILE_EXPORTS_VALUE, amt)
 	if(!silent && amt >= EXPORT_ANNOUNCE_THRESHOLD) //Only announce big spending.
-		scom_announce("Rotwood Vale exports [D.name] for [amt] mammon.")
+		scom_announce("[realmname] exports [D.name] for [amt] mammon.")
 	D.lower_demand()
 	return amt
 
 /datum/controller/subsystem/treasury/proc/auto_export()
 	var/total_value_exported = 0
+	var/realmname = SSmapping.map_adjustment.realm_name
 	for(var/datum/roguestock/D in stockpile_datums)
 		if(!D.importexport_amt)
 			continue
@@ -308,7 +311,7 @@ SUBSYSTEM_DEF(treasury)
 			var/exported = do_export(D, TRUE)
 			total_value_exported += exported
 	if(total_value_exported >= EXPORT_ANNOUNCE_THRESHOLD)
-		scom_announce("Rotwood Vale exports [total_value_exported] mammons of surplus goods.")
+		scom_announce("[realmname] exports [total_value_exported] mammons of surplus goods.")
 
 /datum/controller/subsystem/treasury/proc/remove_person(mob/living/person)
 	noble_incomes -= person

--- a/code/datums/character_flaw/lawless.dm
+++ b/code/datums/character_flaw/lawless.dm
@@ -17,7 +17,7 @@
 		return
 
 	var/face_known = input(H, "Is your face known to the authorities?", "Visbility Status") as anything in list ("They know my face", "They know only my features")
-	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of The Vale", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
+	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of The Realm", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
 	var/bounty_severity = input(H, "How severe are your crimes?", "Bounty Amount") as anything in list("Misdeed", "Harm towards lyfe", "Horrific atrocities")
 	var/race = H.dna.species
 	var/gender = H.gender
@@ -44,7 +44,7 @@
 		ADD_TRAIT(H, TRAIT_DISGRACED_NOBLE, TRAIT_GENERIC)
 		H.is_noble()
 	if (face_known == "They know my face")
-		if(bounty_poster == "The Justiciary of The Vale")
+		if(bounty_poster == "The Justiciary of The Realm")
 			GLOB.outlawed_players += H.real_name
 		else
 			GLOB.excommunicated_players += H.real_name

--- a/code/datums/character_flaw/lawless.dm
+++ b/code/datums/character_flaw/lawless.dm
@@ -17,7 +17,7 @@
 		return
 
 	var/face_known = input(H, "Is your face known to the authorities?", "Visbility Status") as anything in list ("They know my face", "They know only my features")
-	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of The Realm", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
+	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of [SSmapping.map_adjustment.realm_name]", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
 	var/bounty_severity = input(H, "How severe are your crimes?", "Bounty Amount") as anything in list("Misdeed", "Harm towards lyfe", "Horrific atrocities")
 	var/race = H.dna.species
 	var/gender = H.gender
@@ -44,7 +44,7 @@
 		ADD_TRAIT(H, TRAIT_DISGRACED_NOBLE, TRAIT_GENERIC)
 		H.is_noble()
 	if (face_known == "They know my face")
-		if(bounty_poster == "The Justiciary of The Realm")
+		if(bounty_poster == "The Justiciary of [SSmapping.map_adjustment.realm_name]")
 			GLOB.outlawed_players += H.real_name
 		else
 			GLOB.excommunicated_players += H.real_name

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -49,7 +49,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 4,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the vale, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/pilgrim_down_one
 	name = "Pilgrimage"
@@ -58,7 +58,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 3,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the vale, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/pilgrim_down_two
 	name = "Pilgrimage"
@@ -67,7 +67,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 2,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the vale, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/pilgrim_down_three
 	name = "Pilgrimage"
@@ -75,7 +75,7 @@
 	roles = list(
 		/datum/migrant_role/pilgrim = 1,
 	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the vale, looking for refuge and work, finally almost being there, almost..."
+	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/adventurer
 	name = "Adventure Party"
@@ -83,7 +83,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 4,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rotwood Vale, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_one
 	name = "Adventure Party"
@@ -92,7 +92,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 3,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rotwood Vale, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_two
 	name = "Adventure Party"
@@ -101,7 +101,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 2,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rotwood Vale, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/adventurer_down_three
 	name = "Adventure Party"
@@ -109,7 +109,7 @@
 	roles = list(
 		/datum/migrant_role/adventurer = 1,
 	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up in the misty and damp bog underneath Rotwood Vale, perhaps getting ourselves into more than what we bargained for."
+	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/bandit
 	name = "Bandit Raid"

--- a/code/datums/migrants/migrant_waves/czwarteki_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/czwarteki_noble_roles.dm
@@ -67,7 +67,7 @@
 
 /datum/migrant_role/czwarteki/servant
 	name = "Czwarteki Servant"
-	greet_text = "You are Servants of your Lord. Taken along upon the Journey through the Vale with the Retinue. Your only goals are but to ensure your Lord and his Heir's well being upon the trip."
+	greet_text = "You are Servants of your Lord. Taken along upon the Journey through the realm with the Retinue. Your only goals are but to ensure your Lord and his Heir's well being upon the trip."
 	advclass_cat_rolls = list(CTAG_CZWAR_SERVANT = 20)
 	allowed_races = RACES_NO_CONSTRUCT
 	grant_lit_torch = TRUE

--- a/code/datums/migrants/migrant_waves/czwarteki_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/czwarteki_noble_wave.dm
@@ -11,7 +11,7 @@
 		/datum/migrant_role/czwarteki/retainer = 4,
 		/datum/migrant_role/czwarteki/servant = 2,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_one
 	name = "Czwarteki Retinue"
@@ -25,7 +25,7 @@
 		/datum/migrant_role/czwarteki/retainer = 3,
 		/datum/migrant_role/czwarteki/servant = 2,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_two
 	name = "Czwarteki Retinue"
@@ -39,7 +39,7 @@
 		/datum/migrant_role/czwarteki/retainer = 2,
 		/datum/migrant_role/czwarteki/servant = 2,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_three
 	name = "Czwarteki Retinue"
@@ -53,7 +53,7 @@
 		/datum/migrant_role/czwarteki/retainer = 2,
 		/datum/migrant_role/czwarteki/servant = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_four
 	name = "Czwarteki Retinue"
@@ -67,7 +67,7 @@
 		/datum/migrant_role/czwarteki/retainer = 2,
 		/datum/migrant_role/czwarteki/servant = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_five
 	name = "Czwarteki Retinue"
@@ -81,7 +81,7 @@
 		/datum/migrant_role/czwarteki/retainer = 1,
 		/datum/migrant_role/czwarteki/servant = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_six
 	name = "Czwarteki Retinue"
@@ -94,7 +94,7 @@
 		/datum/migrant_role/czwarteki/hussar = 1,
 		/datum/migrant_role/czwarteki/retainer = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_seven
 	name = "Czwarteki Retinue"
@@ -106,7 +106,7 @@
 		/datum/migrant_role/czwarteki/heir = 1,
 		/datum/migrant_role/czwarteki/hussar = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 
 /datum/migrant_wave/czwarteki_noble_down_eight
@@ -118,7 +118,7 @@
 		/datum/migrant_role/czwarteki/lord = 1,
 		/datum/migrant_role/czwarteki/hussar = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
 
 /datum/migrant_wave/czwarteki_noble_down_nine
 	name = "Czwarteki Retinue"
@@ -127,4 +127,4 @@
 	roles = list(
 		/datum/migrant_role/czwarteki/lord = 1,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the Vale to see or assist an old alliance."
+	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."

--- a/code/datums/migrants/migrant_waves/fablefield roles.dm
+++ b/code/datums/migrants/migrant_waves/fablefield roles.dm
@@ -1,6 +1,6 @@
 /datum/migrant_role/fablefield/goliard
 	name = "Fablefield Goliard"
-	greet_text = "For years you've travelled to Fablefield, honing your craft at the annual grand festival of tales. You are a respected weaver of glorious and valorous stories, with a tongue and wit as sharp as your blade. Of late, you've been obsessed with the Vale... What fantastical adventures could you embark on here, with your proteges?"
+	greet_text = "For years you've travelled to Fablefield, honing your craft at the annual grand festival of tales. You are a respected weaver of glorious and valorous stories, with a tongue and wit as sharp as your blade. Of late, you've been obsessed with these lands in particular... What fantastical adventures could you embark on here, with your proteges?"
 	outfit = /datum/outfit/job/roguetown/fablefield/goliard
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
@@ -48,7 +48,7 @@
 
 /datum/migrant_role/fablefield/troubadour
 	name = "Fablefield Troubadour"
-	greet_text = "At the last grand festival of tales in Fablefield, you were inspired by a figure who sung of dragons, faeries, gods and heroes. This year, you plan to be the hero of your own story. A talented bard, and good with a blade, you follow your muse with nothing but the highest hopes, although so far the Vale isn't quite what you expected..."
+	greet_text = "At the last grand festival of tales in Fablefield, you were inspired by a figure who sung of dragons, faeries, gods and heroes. This year, you plan to be the hero of your own story. A talented bard, and good with a blade, you follow your muse with nothing but the highest hopes, although so far these lands aren't quite what you expected..."
 	outfit = /datum/outfit/job/roguetown/fablefield/troubadour
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS

--- a/code/datums/migrants/migrant_waves/fablefield wave.dm
+++ b/code/datums/migrants/migrant_waves/fablefield wave.dm
@@ -7,7 +7,7 @@
 		/datum/migrant_role/fablefield/goliard = 1,
 		/datum/migrant_role/fablefield/troubadour = 3,
 	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to the vale seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
+	greet_text = "A troupe of troubadours from fair Fablefield, you travel to these lands seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
 
 /datum/migrant_wave/fablefield_down_one
 	name = "The Fablefield Troupe"
@@ -18,7 +18,7 @@
 		/datum/migrant_role/fablefield/goliard = 1,
 		/datum/migrant_role/fablefield/troubadour = 2,
 	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to the vale seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
+	greet_text = "A troupe of troubadours from fair Fablefield, you travel to these lands seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
 
 /datum/migrant_wave/fablefield_down_two
 	name = "The Fablefield Troupe"
@@ -29,7 +29,7 @@
 		/datum/migrant_role/fablefield/goliard = 1,
 		/datum/migrant_role/fablefield/troubadour = 1,
 	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to the vale seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
+	greet_text = "A troupe of troubadours from fair Fablefield, you travel to these lands seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
 
 /datum/migrant_wave/fablefield_down_three
 	name = "The Fablefield Goliard"
@@ -38,4 +38,4 @@
 	roles = list(
 		/datum/migrant_role/fablefield/goliard = 1
 	)
-	greet_text = "Your friends have abandoned you - lost to the whims of lyfe as Xylix taught you. Yet you march on into the Vale. The people here look like they could do with a good show, give them one they'll remember - for your comrades!"
+	greet_text = "Your friends have abandoned you - lost to the whims of lyfe as Xylix taught you. Yet you march on into these lands. The people here look like they could do with a good show, give them one they'll remember - for your comrades!"

--- a/code/datums/migrants/migrant_waves/gnolls.dm
+++ b/code/datums/migrants/migrant_waves/gnolls.dm
@@ -23,4 +23,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the Vale!"))
+			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the realm!"))

--- a/code/datums/migrants/migrant_waves/gnolls.dm
+++ b/code/datums/migrants/migrant_waves/gnolls.dm
@@ -23,4 +23,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the realm!"))
+			to_chat(player, span_danger("Graggar demands blood, gnolls flock to [SSmapping.map_adjustment.realm_name]!"))

--- a/code/datums/migrants/migrant_waves/knightly_journey_roles.dm
+++ b/code/datums/migrants/migrant_waves/knightly_journey_roles.dm
@@ -27,7 +27,7 @@
 
 /datum/advclass/kj_knight
 	name = "Knight"
-	tutorial = "You are a knight from a distant land, a scion of a noble house visiting Rockwood Vale for one reason or another."
+	tutorial = "You are a knight from a distant land, a scion of a noble house visiting these lands for one reason or another."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/adventurer/knighte_expert

--- a/code/datums/migrants/migrant_waves/otavan_noble_roles.dm
+++ b/code/datums/migrants/migrant_waves/otavan_noble_roles.dm
@@ -85,7 +85,7 @@
 
 /datum/advclass/otavan_knight
 	name = "Gendarme"
-	tutorial = "Whether through merit, blood or renown, you became a knight in service of the Otavan court. Now, tasked with escorting the Émissaire and protecting them at all cost, you ride into the Vale."
+	tutorial = "Whether through merit, blood or renown, you became a knight in service of the Otavan court. Now, tasked with escorting the Émissaire and protecting them at all cost, you ride into these lands."
 	outfit = /datum/outfit/job/roguetown/otavan/knight
 	traits_applied = list(TRAIT_HEAVYARMOR, TRAIT_STEELHEARTED, TRAIT_NOBLE, TRAIT_OUTLANDER)
 	category_tags = list(CTAG_OTAVAN_KNIGHT)

--- a/code/datums/migrants/migrant_waves/runaway_prisoners.dm
+++ b/code/datums/migrants/migrant_waves/runaway_prisoners.dm
@@ -154,9 +154,10 @@
 	var/descriptor_body = build_coalesce_description_nofluff(d_list, H, list(MOB_DESCRIPTOR_SLOT_BODY), "%DESC1%")
 	var/descriptor_voice = build_coalesce_description_nofluff(d_list, H, list(MOB_DESCRIPTOR_SLOT_VOICE), "%DESC1%")
 	var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+	var/realmname = SSmapping.map_adjustment.realm_name
 	if (!my_crime)
 		my_crime = "crimes against the Crown"
-	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, rand(100, 200), FALSE, my_crime, "The Justiciary of Rotwood Vale")
+	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, rand(100, 200), FALSE, my_crime, "The Justiciary of [realmname]")
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 	else if(should_wear_masc_clothes(H))
@@ -175,9 +176,10 @@
 	var/descriptor_body = build_coalesce_description_nofluff(d_list, H, list(MOB_DESCRIPTOR_SLOT_BODY), "%DESC1%")
 	var/descriptor_voice = build_coalesce_description_nofluff(d_list, H, list(MOB_DESCRIPTOR_SLOT_VOICE), "%DESC1%")
 	var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+	var/realmname = SSmapping.map_adjustment.realm_name
 	if (!my_crime)
 		my_crime = "crimes against the Crown"
-	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, rand(100, 200), FALSE, my_crime, "The Justiciary of Rotwood Vale")
+	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, rand(100, 200), FALSE, my_crime, "The Justiciary of [realmname]")
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 	else if(should_wear_masc_clothes(H))
@@ -196,9 +198,10 @@
 	var/descriptor_body = build_coalesce_description_nofluff(d_list, H, list(MOB_DESCRIPTOR_SLOT_BODY), "%DESC1%")
 	var/descriptor_voice = build_coalesce_description_nofluff(d_list, H, list(MOB_DESCRIPTOR_SLOT_VOICE), "%DESC1%")
 	var/my_crime = input(H, "What is your crime?", "Crime") as text|null
+	var/realmname = SSmapping.map_adjustment.realm_name
 	if (!my_crime)
 		my_crime = "crimes against the Crown"
-	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, rand(100, 200), FALSE, my_crime, "The Justiciary of Rotwood Vale")
+	add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, rand(100, 200), FALSE, my_crime, "The Justiciary of [realmname]")
 	if(should_wear_femme_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 	else if(should_wear_masc_clothes(H))

--- a/code/game/gamemodes/objectives_rogue.dm
+++ b/code/game/gamemodes/objectives_rogue.dm
@@ -35,8 +35,8 @@
 
 /datum/objective/vampire
 	name = "conquer"
-	explanation_text = "Put an end to the werewolf menace in Rotwood Vale, or unite with them against the forces of the Nine."
-	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of Rotwood Vale together?"
+	explanation_text = "Put an end to the werewolf menace, or unite with them against the forces of the Nine."
+	team_explanation_text = "The feud between werewolves and vampires reaches back to the dawn of time. Will the two factions destroy each other, or find a way to coexist and face the mortals of this land together?"
 	triumph_count = 5
 
 /datum/objective/vampire/check_completion()

--- a/code/game/objects/items/rogueitems/keys.dm
+++ b/code/game/objects/items/rogueitems/keys.dm
@@ -115,7 +115,7 @@
 		SSroguemachine.key = src
 
 /obj/item/roguekey/lord/proc/anti_stall()
-	src.visible_message(span_warning("The Key of the vale crumbles to dust, the ashes spiriting away in the direction of the Keep."))
+	src.visible_message(span_warning("The Key of the realm crumbles to dust, the ashes spiriting away in the direction of the Keep."))
 	SSroguemachine.key = null //Do not harddel.
 	qdel(src) //Anti-stall
 

--- a/code/game/objects/items/rogueweapons/ranged/bows.dm
+++ b/code/game/objects/items/rogueweapons/ranged/bows.dm
@@ -442,7 +442,7 @@
 	name = "blackhorn bow"
 	desc = "When a northern black-horned saiga is old enough, it will shed its two-metre long antlers. As time passes, they harden progressively more but keep a degree of flexibility that can outdo even yew.\
 		Wardens often collect such antlers in the rare occasion they are found and send them to be filed, strung and treated by a master bowyer. Such tradition carries merit even todae, \
-		and thus one can see the vale's wardens carrying their endemic blackhorn bows with pride."
+		and thus one can see the realm's wardens carrying their endemic blackhorn bows with pride."
 	icon_state = "recurve_warden"
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow/warden

--- a/code/game/objects/items/rogueweapons/shields.dm
+++ b/code/game/objects/items/rogueweapons/shields.dm
@@ -455,7 +455,7 @@
 
 /obj/item/rogueweapon/shield/capbuckler // unique, better buckler for knight captain
 	name = "'Order'"
-	desc = "A special buckler shield made out of blacksteel for the captain of the guard, adorned with the vale's crest."
+	desc = "A special buckler shield made out of blacksteel for the captain of the guard, adorned with the realm's crest."
 	icon_state = "capbuckler"
 	icon = 'icons/roguetown/weapons/special/captain.dmi'
 	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -777,10 +777,11 @@
 
 /obj/structure/fluff/signage/examine(mob/user)
 	. = ..()
+	var/realmname = SSmapping.map_adjustment.realm_name
 	if(!user.is_literate())
 		. += "I have no idea what it says."
 	else
-		. += "It says \"ROTWOOD VALE\""
+		. += "It says \"[realmname]\""
 
 /obj/structure/fluff/buysign
 	icon_state = "signwrote"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -874,7 +874,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			humie.add_stress(/datum/stressevent/maniac_woke_up)
 			to_chat(humie, span_deadsay("<span class='reallybig'>... WHERE AM I? ...</span>"))
 			var/static/list/slop_lore = list(
-				span_deadsay("... Rotwood Vale? No ... It doesn't exist ..."),
+				span_deadsay("... Rockhill? No ... It doesn't exist ..."),
 				span_deadsay("... My name is Trey. Trey Liam, Liamtific Troverseer ..."),
 				span_deadsay("... I'm on NT Liam, a self Treystaining ship, used to Treyserve what Liamains of roguemanity ..."),
 				span_deadsay("... Launched into the Grim Darkness, War and Grim Darkness preserves their grimness ... Their edge ..."),

--- a/code/modules/antagonists/roguetown/roleobjs/suitor.dm
+++ b/code/modules/antagonists/roguetown/roleobjs/suitor.dm
@@ -22,7 +22,7 @@
 	return ..()
 
 /datum/antagonist/suitor/greet()
-	to_chat(owner.current, span_userdanger("I've been sent here with a purpose. I must secure a marriage with the local duke in order to bolster my house's relations with the vale, by any means necessary."))
+	to_chat(owner.current, span_userdanger("I've been sent here with a purpose. I must secure a marriage with the local duke in order to bolster my house's relations with the realm, by any means necessary."))
 	owner.announce_objectives()
 	..()
 
@@ -45,11 +45,11 @@
 	if(traitorwin)
 		owner.adjust_triumphs(3)
 		to_chat(owner.current, span_greentext("I've successfully married into the throne and secured an alliance for my house!"))
-		to_chat(world, span_greentext("[owner.current.real_name] successfully married [marriagepartner] and secured an alliance with the vale for their house!"))
+		to_chat(world, span_greentext("[owner.current.real_name] successfully married [marriagepartner] and secured an alliance with the realm for their house!"))
 		if(owner?.current)
 			owner.current.playsound_local(get_turf(owner.current), 'sound/misc/triumph.ogg', 100, FALSE, pressure_affected = FALSE)
 	else
-		to_chat(owner.current, span_redtext("I've failed to secure a marriage into the throne of the vale! My house will be disappointed!"))
+		to_chat(owner.current, span_redtext("I've failed to secure a marriage into the throne of the realm! My house will be disappointed!"))
 		to_chat(world, span_redtext("[owner.current.real_name] failed to secure a marriage with the throne!"))
 		if(owner?.current)
 			owner.current.playsound_local(get_turf(owner.current), 'sound/misc/fail.ogg', 100, FALSE, pressure_affected = FALSE)

--- a/code/modules/antagonists/roguetown/villain/maniac/maniac.dm
+++ b/code/modules/antagonists/roguetown/villain/maniac/maniac.dm
@@ -193,7 +193,7 @@
 		to_chat(trey_liam, span_deadsay("<span class='reallybig'>... WHERE AM I? ...</span>"))
 		sleep(1.5 SECONDS)
 		var/static/list/slop_lore = list(
-			span_deadsay("... Rotwood Vale? No ... It doesn't exist ..."),
+			span_deadsay("... [SSmapping.map_adjustment.realm_name]? No ... It doesn't exist ..."),
 			span_deadsay("... My name is Trey. Trey Liam, Liamtific Troverseer ..."),
 			span_deadsay("... I'm on NT Liam, a self Treystaining ship, used to Treyserve what Liamains of roguemanity ..."),
 			span_deadsay("... Launched into the Grim Darkness, Fart Grimness preserves their grimness ... Their edge ..."),

--- a/code/modules/cargo/packsrogue/bandit/classes/Mage.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Mage.dm
@@ -183,7 +183,7 @@
 	contains = list(/obj/item/clothing/neck/roguetown/talkstone)
 
 /datum/supply_pack/rogue/Mage/serfstone
-	name = "Vale serfstone"
+	name = "Realm-aligned serfstone"
 	cost = 80
 	contains = list(/obj/item/scomstone/bad)
 

--- a/code/modules/client/roundendmanifest.dm
+++ b/code/modules/client/roundendmanifest.dm
@@ -4,7 +4,7 @@
 	for(var/X in GLOB.character_list)
 		dat += "[GLOB.character_list[X]]"
 
-	var/datum/browser/popup = new(src, "actors", "<center>Inhabitants of Rotwood Vale</center>", 387, 420)
+	var/datum/browser/popup = new(src, "actors", "<center>Inhabitants of the Realm</center>", 387, 420)
 	popup.set_content(dat)
 	popup.open(FALSE)
 

--- a/code/modules/clothing/rogueclothes/armor/brigandine.dm
+++ b/code/modules/clothing/rogueclothes/armor/brigandine.dm
@@ -208,7 +208,7 @@
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/captain
 	name = "captain's brigandine"
-	desc = "A coat with plates specifically tailored and forged for the captain of the vale."
+	desc = "A coat with plates specifically tailored and forged for the captain of the realm."
 	icon_state = "capplate"
 	icon = 'icons/roguetown/clothing/special/captain.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/captain.dmi'

--- a/code/modules/clothing/rogueclothes/cloaks.dm
+++ b/code/modules/clothing/rogueclothes/cloaks.dm
@@ -1703,7 +1703,7 @@
 
 /obj/item/clothing/cloak/wardencloak
 	name = "warden cloak"
-	desc = "A cloak worn by the Wardens of the vale's Forests"
+	desc = "A cloak worn by the Wardens of the realm's Forests"
 	icon_state = "wardencloak"
 	alternate_worn_layer = CLOAK_BEHIND_LAYER
 	slot_flags = ITEM_SLOT_BACK_R|ITEM_SLOT_CLOAK
@@ -1901,7 +1901,7 @@
 
 /obj/item/clothing/cloak/captain
 	name = "captain's cape"
-	desc = "A cape with a gold embroided heraldry of the vale."
+	desc = "A cape with a gold embroided heraldry of the realm."
 	icon = 'icons/roguetown/clothing/special/captain.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/captain.dmi'
 	sleeved = 'icons/roguetown/clothing/special/onmob/captain.dmi'
@@ -1934,7 +1934,7 @@
 
 /obj/item/clothing/cloak/kazengun
 	name = "jinbaori"
-	desc = "A simple kind of Kazengunite surcoat, worn here in the distant battlefields of Rotwood Vale to differentiate friend from foe."
+	desc = "A simple kind of Kazengunite surcoat, worn here in these distant battlefields, so far from its homelands, to differentiate friend from foe."
 	icon_state = "kazenguncoat"
 	item_state = "kazenguncoat"
 	detail_tag = "_detail"

--- a/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/heavy_helmet.dm
@@ -577,7 +577,7 @@
 
 /obj/item/clothing/head/roguetown/helmet/heavy/ravox_visor
 	name = "plumed ravox helmet"
-	desc = "A helmet with a great, red plume. They will know, in time, that you are the true justiciar of the Vale."
+	desc = "A helmet with a great, red plume. They will know, in time, that you are the true justiciar of the realm."
 	icon_state = "ravoxhelm"
 	item_state = "ravoxhelm"
 	emote_environment = 3
@@ -677,7 +677,7 @@
 
 /obj/item/clothing/head/roguetown/helmet/heavy/frogmouth
 	name = "froggemund helmet"
-	desc = "A tall and imposing frogmouth-style helm popular in the highest plateaus of the vale. It covers not only the entire head and face, but the neck as well. Add a cloth to show the colors of your family or allegiance."
+	desc = "A tall and imposing frogmouth-style helm popular in the highest plateaus of the realm. It covers not only the entire head and face, but the neck as well. Add a cloth to show the colors of your family or allegiance."
 	icon_state = "frogmouth"
 	item_state = "frogmouth"
 	emote_environment = 3

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -537,7 +537,7 @@
 // Warden Helmets
 /obj/item/clothing/head/roguetown/helmet/bascinet/antler
 	name = "wardens's helmet"
-	desc = "A beastly snouted armet with the large horns of an elder saiga protruding from it. Residents of the vale know not to fear such a sight in the wilds, for they are exclusively associated with the Rotwood wardens."
+	desc = "A beastly snouted armet with the large horns of an elder saiga protruding from it. Residents of the realm know not to fear such a sight in the wilds, for they are exclusively associated with the Wardens."
 	icon = 'icons/roguetown/clothing/special/warden.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/warden64.dmi'
 	bloody_icon = 'icons/effects/blood64.dmi'

--- a/code/modules/events/antagonist/migrant_waves/assassins.dm
+++ b/code/modules/events/antagonist/migrant_waves/assassins.dm
@@ -23,4 +23,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, assassins flock to The Vale. An assassin slot has been opened."))
+			to_chat(player, span_danger("Graggar demands blood, assassins flock to the realm. An assassin slot has been opened."))

--- a/code/modules/events/antagonist/migrant_waves/assassins.dm
+++ b/code/modules/events/antagonist/migrant_waves/assassins.dm
@@ -23,4 +23,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, assassins flock to the realm. An assassin slot has been opened."))
+			to_chat(player, span_danger("Graggar demands blood, assassins flock to [SSmapping.map_adjustment.realm_name]. An assassin slot has been opened."))

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -24,4 +24,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Matthios, is this true? Bandits flock to the vale. Three bandit slots have been opened."))
+			to_chat(player, span_danger("Matthios, is this true? Bandits flock to the realm. Three bandit slots have been opened."))

--- a/code/modules/events/antagonist/migrant_waves/bandits.dm
+++ b/code/modules/events/antagonist/migrant_waves/bandits.dm
@@ -24,4 +24,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Matthios, is this true? Bandits flock to the realm. Three bandit slots have been opened."))
+			to_chat(player, span_danger("Matthios, is this true? Bandits flock to [SSmapping.map_adjustment.realm_name]. Three bandit slots have been opened."))

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -22,4 +22,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the vale."))
+			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the realm."))

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -22,4 +22,4 @@
 			if(!player.client)
 				continue
 
-			to_chat(player, span_danger("Graggar demands blood, gnolls flock to the realm."))
+			to_chat(player, span_danger("Graggar demands blood, gnolls flock to [SSmapping.map_adjustment.realm_name]."))

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritan.dm
@@ -8,7 +8,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT		//Would you trust a machine to handle a role that requires non-logical intuition and commanding? Maybe. Could undo this if the community likes it. Purpose-built supermachines sound cool, too.
 	allowed_patrons = list(/datum/patron/old_god) //Requires your character's patron to be Psydon. This role is explicitly designed to be played by Psydonites, only, and almost everything they have - down to the equipment and statblock - is rooted in Psydonism. Do NOT make this accessable to other faiths, unless you go through the efforts of redesigning it from the ground up.
-	tutorial = "You are a puritan of unmatched aptitude, adherent to the Psydonic doctrine and entrusted with the authority to lead a local sect. Otava - the largest Psydonic kingdom left on this world - has seen it fit to treat you like a silver-tipped olive branch, gifted to The Vale to ward off the encroaching darkness. Tread carefully when pursuing your missives, lest the faithless strap you to the pyre as well."
+	tutorial = "You are a puritan of unmatched aptitude, adherent to the Psydonic doctrine and entrusted with the authority to lead a local sect. Otava - the largest Psydonic kingdom left on this world - has seen it fit to treat you like a silver-tipped olive branch, gifted to the realm to ward off the encroaching darkness. Tread carefully when pursuing your missives, lest the faithless strap you to the pyre as well."
 	whitelist_req = TRUE
 	cmode_music = 'sound/music/inquisitorcombat.ogg'
 	selection_color = JCOLOR_INQUISITION

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -74,8 +74,8 @@
 		if("No") 
 			to_chat(H, span_warning("I am still relatively new to the gang. My crimes have gone unnoticed so far, but I lack experience."))
 			return null
-	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of Rotwood", "The Grenzelhoftian Holy See")
-	var/bounty_severity = input(H, "How notorious are you?", "Bounty Amount") as anything in list("Small Game", "Highwayman", "Vale Boogeyman")
+	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of the Realm", "The Grenzelhoftian Holy See")
+	var/bounty_severity = input(H, "How notorious are you?", "Bounty Amount") as anything in list("Small Game", "Highwayman", "Realm Boogeyman")
 	var/race = H.dna.species
 	var/gender = H.gender
 	var/list/d_list = H.get_mob_descriptors()

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -74,7 +74,7 @@
 		if("No") 
 			to_chat(H, span_warning("I am still relatively new to the gang. My crimes have gone unnoticed so far, but I lack experience."))
 			return null
-	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of the Realm", "The Grenzelhoftian Holy See")
+	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of [SSmapping.map_adjustment.realm_name]", "The Grenzelhoftian Holy See")
 	var/bounty_severity = input(H, "How notorious are you?", "Bounty Amount") as anything in list("Small Game", "Highwayman", "Realm Boogeyman")
 	var/race = H.dna.species
 	var/gender = H.gender

--- a/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/pilgrim.dm
@@ -6,7 +6,7 @@
 	total_positions = 40
 	spawn_positions = 40 //brings back round-start spawn of pilgrims!!!
 	allowed_races = RACES_ALL_KINDS
-	tutorial = "Fleeing misfortune you head your way towards Rotwood Vale, you're not a soldier or an explorer, but a humble migrant trying to look for a better life, if you get to survive the trip that is."
+	tutorial = "Fleeing misfortune you head your way towards the Duchy. You are not a soldier or an explorer, but a humble migrant trying to look for a better life, if you get to survive the trip that is."
 
 	outfit = null
 	outfit_female = null

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -58,7 +58,7 @@
 
 /datum/advclass/noble/knighte
 	name = "Knight Errant"
-	tutorial = "You are a knight from a distant land, a scion of a noble house visiting The Vale for one reason or another."
+	tutorial = "You are a knight from a distant land, a scion of a noble house visiting these lands for one reason or another."
 	outfit = /datum/outfit/job/roguetown/adventurer/knighte
 	subclass_social_rank = SOCIAL_RANK_MINOR_NOBLE
 	traits_applied = list(TRAIT_NOBLE, TRAIT_HEAVYARMOR)
@@ -91,7 +91,7 @@
 /datum/outfit/job/roguetown/adventurer/knighte/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
-		to_chat(H, span_warning("You are a knight from a distant land, a scion of a noble house visiting The Vale for one reason or another."))
+		to_chat(H, span_warning("You are a knight from a distant land, a scion of a noble house visiting these lands for one reason or another."))
 		var/helmets = list(
 			"Pigface Bascinet" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/pigface,
 			"Guard Helmet"		= /obj/item/clothing/head/roguetown/helmet/heavy/guard,

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/ranger.dm
@@ -67,7 +67,7 @@
 
 /datum/advclass/ranger/wayfarer
 	name = "Wayfarer"
-	tutorial = "You've spent countless years homing many trades; man-hunting, picking locks, breaking into places you had no right being.. but you are no mere thief. You are trained to track men and recover stolen goods. And The Vale is a prime paycheck.."
+	tutorial = "You've spent countless years homing many trades; man-hunting, picking locks, breaking into places you had no right being.. but you are no mere thief. You are trained to track men and recover stolen goods. And these lands are a prime paycheck.."
 	outfit = /datum/outfit/job/roguetown/adventurer/assassin
 	cmode_music = 'sound/music/cmode/adventurer/combat_outlander.ogg'
 	subclass_languages = list(/datum/language/thievescant)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/czwarteki/czwartekiservant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/czwarteki/czwartekiservant.dm
@@ -1,6 +1,6 @@
 /datum/advclass/czwarteki/servant
 	name = "Czwarteki Servant"
-	tutorial = "You are Servants of your Lord. Taken along upon the Journey through the Vale with the Retinue. Your only goals are but to ensure your Lord and his Heir's well being upon the trip."
+	tutorial = "You are Servants of your Lord. Taken along upon the Journey through these lands with the Retinue. Your only goals are but to ensure your Lord and his Heir's well being upon the trip."
 	outfit = /datum/outfit/job/roguetown/czwarteki/servant
 	traits_applied = list(TRAIT_SLEUTH, TRAIT_KEENEARS, TRAIT_CICERONE, TRAIT_HOMESTEAD_EXPERT)
 	category_tags = list(CTAG_CZWAR_SERVANT)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfelthand.dm
@@ -1,7 +1,7 @@
 /datum/job/roguetown/heartfelt/hand
 	title = "Hand of Heartfelt"
 	tutorial = "You are the Hand of Heartfelt, burdened by the perception of failure in protecting your Lord's domain. \
-	Despite doubts from others, your loyalty remains steadfast as you journey to the Vale, determined to fulfill your duties."
+	Despite doubts from others, your loyalty remains steadfast as you journey to these lands, determined to fulfill your duties."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	outfit = /datum/outfit/job/roguetown/heartfelt/hand
@@ -36,7 +36,7 @@
 /datum/advclass/heartfelt/hand/marshal
 	name = "Marshal of Heartfelt"
 	tutorial = "Renowned for your command of war, you laid down your blade in peaceful years, but peace died with Heartfelt. \
-	Pressed once more into service by tragedy, you climb towards the Vale."
+	Pressed once more into service by tragedy, you climb towards these lands."
 	outfit = /datum/outfit/job/roguetown/heartfelt/hand/marshal
 	category_tags = list(CTAG_HFT_HAND)
 	subclass_social_rank = SOCIAL_RANK_NOBLE
@@ -117,7 +117,7 @@
 	name = "Steward of Heartfelt"
 	tutorial = "You are the Steward of Heartfelt, once the quiet architect behind the barony's \
 	order—keeper of ledgers, harvests, and the lifeblood that sustained your people. \
-	Pressed once more into service by tragedy, you climb towards the Vale."
+	Pressed once more into service by tragedy, you climb towards these lands."
 	outfit = /datum/outfit/job/roguetown/heartfelt/hand/steward
 	category_tags = list(CTAG_HFT_HAND)
 	subclass_social_rank = SOCIAL_RANK_NOBLE
@@ -180,7 +180,7 @@
 /datum/advclass/heartfelt/hand/advisor
 	name = "Advisor of Heartfelt"
 	tutorial = "You are the Advisor of Heartfelt, trusted for your measured counsel and keen insight into matters of state. \
-	Bound once more to serve in the wake of ruin, you climb towards the Vale."
+	Bound once more to serve in the wake of ruin, you climb towards these lands."
 	outfit = /datum/outfit/job/roguetown/heartfelt/hand/advisor
 	category_tags = list(CTAG_HFT_HAND)
 	subclass_social_rank = SOCIAL_RANK_NOBLE

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltknight.dm
@@ -45,7 +45,7 @@
 /datum/advclass/heartfelt/knight
 	name = "Knight of Heartfelt"
 	tutorial = "You are a Knight of Heartfelt, once part of a brotherhood in service to your Lord. \
-	Now, alone and committed to safeguarding what remains of your court, you ride to the Vale, resolved to ensure their safe arrival."
+	Now, alone and committed to safeguarding what remains of your court, you ride to these lands, resolved to ensure their safe arrival."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/heartfelt/knight

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/heartfeltlord.dm
@@ -23,7 +23,7 @@
 /datum/advclass/heartfelt/lord/lord
 	name = "Lord of Heartfelt"
 	tutorial = "You are the Lord of Heartfelt, ruler of a once-prosperous barony now in ruin. \
-	Guided by your Magos, you journey to the Vale, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
+	Guided by your Magos, you journey to these lands, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	category_tags = list(CTAG_HFT_LORD)
 	maximum_possible_slots = 1
 	outfit = /datum/outfit/job/heartfelt/lord/lord
@@ -250,7 +250,7 @@
 /datum/advclass/heartfelt/lord/chief
 	name = "Chief of Heartfelt"
 	tutorial = "You are the Chieftain of Heartfelt, ruler of a once-prosperous barony now in ruin. \
-	Guided by your Magos, you journey to the Vale, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
+	Guided by your Magos, you journey to these lands, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	category_tags = list(CTAG_HFT_LORD)
 	maximum_possible_slots = 1
 	outfit = /datum/outfit/job/heartfelt/lord/chief
@@ -360,7 +360,7 @@
 		to_chat(recruiter, span_warning("They're already part of our cause!"))
 		return FALSE
 	if(HAS_TRAIT(recruit, TRAIT_GUARDSMAN))
-		to_chat(recruiter, span_warning("They're already part of the Vale's guard! They can't join our cause!"))
+		to_chat(recruiter, span_warning("They're already part of these lands's guard! They can't join our cause!"))
 		return FALSE
 	if(HAS_TRAIT(recruit, TRAIT_INQUISITION))
 		to_chat(recruiter, span_warning("Their loyalty is to Psydon alone! They can't join our cause!"))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltarmorer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltarmorer.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/armorer
 	name = "Heartfeltian Armorer"
 	tutorial = "You are the Heartfeltian's Armorer destined for greatness, but fate intervened with the barony's downfall,\
-	With your home in ruins, you look to the Vale, hoping to find new purpose or refuge amidst the chaos."
+	With your home in ruins, you look to these lands, hoping to find new purpose or refuge amidst the chaos."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/armorer
 	maximum_possible_slots = 1

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltcourtier.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltcourtier.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/courtier
 	name = "Heartfeltian Courtier"
 	tutorial = "You are a Courtier of Heartfelt, once a respected noblewoman now struggling to survive in a desolate landscape. \
-	With your home in ruins, you look to the Vale, hoping to find new purpose or refuge amidst the chaos."
+	With your home in ruins, you look to these lands, hoping to find new purpose or refuge amidst the chaos."
 	allowed_sexes = list(FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/courtier

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltjester.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltjester.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/jester
 	name = "Heartfeltian Jester"
 	tutorial = "You are the Jester of Heartfelt, a bringer of laughter in brighter days, now left to wander through the ashes of a fallen home. \
-	Though grief weighs heavy beneath your painted smile, you turn your steps toward the Vale—hoping your wit, charm, and cunning may yet carve out a place for joy amidst the ruin."
+	Though grief weighs heavy beneath your painted smile, you turn your steps toward these lands—hoping your wit, charm, and cunning may yet carve out a place for joy amidst the ruin."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/jester

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltmagos.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltmagos.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/magos
 	name = "Heartfeltian Magos"
 	tutorial = "You are the Magos of Heartfelt, renowned for your arcane knowledge yet unable to foresee the tragedy that befell your home. \
-	Drawn by a guiding star to the Vale, you seek answers and perhaps a new purpose in the wake of destruction."
+	Drawn by a guiding star to these lands, you seek answers and perhaps a new purpose in the wake of destruction."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/magos

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltphyscian.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltphyscian.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/physician
 	name = "Heartfeltian Physician"
 	tutorial = "You are the Physician of Heartfelt, once celebrated for your steady hands and healing wisdom, yet powerless to save your barony from its grim fate. \
-	Haunted by those you could not protect, you ascend toward the Vale-seeking redemption, renewed purpose, and perhaps a cure for the wounds the world has inflicted."
+	Haunted by those you could not protect, you ascend toward these lands, seeking redemption, renewed purpose, and perhaps a cure for the wounds the world has inflicted."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/physician

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltprior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltprior.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/prior
 	name = "Heartfeltian Prior"
 	tutorial = "The Prior of Heartfelt, you were destined for ascension within the Church, but fate intervened with the barony's downfall, \
-	delaying it indefinitely. Still guided by the blessings of Astrata, you journey to the Vale, determined to offer what aid and solace you can."
+	delaying it indefinitely. Still guided by the blessings of Astrata, you journey to these lands, determined to offer what aid and solace you can."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/prior

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltwarriors.dm
@@ -2,7 +2,7 @@
 /datum/advclass/heartfelt/retinue/houseguard
 	name = "Heartfeltian House Guard"
 	tutorial = "You are a House Guard for the Lord of Heartfelt, a valiant defender of the once-prosperous barony now in ruin. \
-	Guided by the Magos, you journey to the Vale, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
+	Guided by the Magos, you journey to these lands, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/houseguard
@@ -111,7 +111,7 @@
 /datum/advclass/heartfelt/retinue/housearb
 	name = "Heartfeltian Missilite"
 	tutorial = "You are a Missilite for the Lord of Heartfelt, a ranged combatant of the once-prosperous barony now in ruin. \
-	Guided by the Magos, you journey to the Vale, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
+	Guided by the Magos, you journey to these lands, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/housearb
 	category_tags = list(CTAG_HFT_RETINUE)
@@ -219,7 +219,7 @@
 /datum/advclass/heartfelt/retinue/squire
 	name = "Heartfeltian Squire"
 	tutorial = "You are a Squire for the Knights of Heartfelt, a trainee of the valiant defenders of the once-prosperous barony now in ruin. \
-	Guided by the Magos, you journey to the Vale, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
+	Guided by the Magos, you journey to these lands, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/squire

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltworkers.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/migrant/heartfelt/retinue/heartfeltworkers.dm
@@ -1,7 +1,7 @@
 /datum/advclass/heartfelt/retinue/servant
 	name = "Heartfeltian Servant"		
 	tutorial = "You are Servant of Heartfelt, Serant of a once-prosperous barony now in ruin. \
-	Guided by the Magos, you journey to the Vale, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
+	Guided by the Magos, you journey to these lands, seeking aid to restore your domain to its former glory, or perhaps claim a new throne."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
 	outfit = /datum/outfit/job/roguetown/heartfelt/retinue/servant

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/pyromaniac.dm
@@ -1,6 +1,6 @@
 /datum/advclass/wretch/pyromaniac
 	name = "Pyromaniac"
-	tutorial = "A notorious arsonist with a penchant for fire, you wield your own personal vendetta against the chaotic forces within the vale. Bring mayhem and destruction with flame and misfortune! Just... try not to hit yourself with your explosives - you aren't fireproof, after all."
+	tutorial = "A notorious arsonist with a penchant for fire, you wield your own personal vendetta against the chaotic forces within the realm. Bring mayhem and destruction with flame and misfortune! Just... try not to hit yourself with your explosives - you aren't fireproof, after all."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/wretch/pyromaniac

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -63,7 +63,7 @@
 
 // Proc for wretch to select a bounty
 /proc/wretch_select_bounty(mob/living/carbon/human/H)
-	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of The Vale", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
+	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of The Realm", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
 	// Felinid said we should gate it at 100 or so on at the lowest, so that wretch cannot ezmode it.
 	var/bounty_severity = input(H, "How severe are your crimes?", "Bounty Amount") as anything in list("Misdeed", "Harm towards lyfe (+1 FOR)", "Horrific atrocities (+1 ALL STATS)")
 	var/race = H.dna.species
@@ -88,7 +88,7 @@
 			H.change_stat("willpower", 1)
 			H.change_stat("speed", 1)
 			H.change_stat("fortune", 1)
-			if(bounty_poster == "The Justiciary of The Vale")
+			if(bounty_poster == "The Justiciary of The Realm")
 				GLOB.outlawed_players += H.real_name
 			else
 				GLOB.excommunicated_players += H.real_name

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -63,7 +63,7 @@
 
 // Proc for wretch to select a bounty
 /proc/wretch_select_bounty(mob/living/carbon/human/H)
-	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of The Realm", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
+	var/bounty_poster = input(H, "Who placed a bounty on you?", "Bounty Poster") as anything in list("The Justiciary of [SSmapping.map_adjustment.realm_name]", "The Grenzelhoftian Holy See", "The Otavan Orthodoxy")
 	// Felinid said we should gate it at 100 or so on at the lowest, so that wretch cannot ezmode it.
 	var/bounty_severity = input(H, "How severe are your crimes?", "Bounty Amount") as anything in list("Misdeed", "Harm towards lyfe (+1 FOR)", "Horrific atrocities (+1 ALL STATS)")
 	var/race = H.dna.species

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -230,7 +230,7 @@ GLOBAL_LIST_EMPTY(priest_swap_timers)
 /mob/living/carbon/human/proc/coronate_lord()
 	set name = "Coronate"
 	set category = "Priest"
-	to_chat (src, span_warning("The process of crowning a new ruler, and binding his soul to the Throne of the Vale takes a most heavy toil. Any newly coronated Noble Liege will not be able to be revived. You should probably mention this."))
+	to_chat (src, span_warning("The process of crowning a new ruler, and binding his soul to the Throne of the Realm takes a most heavy toil. Any newly coronated Noble Liege will not be able to be revived. You should probably mention this."))
 	if(!mind)
 		return
 	if(world.time < 30 MINUTES)
@@ -266,8 +266,8 @@ GLOBAL_LIST_EMPTY(priest_swap_timers)
 		SSticker.regentmob = null
 		var/dispjob = mind.assigned_role
 		removeomen(OMEN_NOLORD)
-		say("By the authority of the gods, I pronounce you Ruler of all the vale!")
-		priority_announce("[real_name] the [dispjob] has named [HU.real_name] the inheritor of ROTWOOD VALE!", title = "Long Live [HU.real_name]!", sound = 'sound/misc/bell.ogg')
+		say("By the authority of the gods, I pronounce you Ruler of all the realm!")
+		priority_announce("[real_name] the [dispjob] has named [HU.real_name] the inheritor of [SSmapping.map_adjustment.realm_name]!", title = "Long Live [HU.real_name]!", sound = 'sound/misc/bell.ogg')
 		var/datum/job/roguetown/nomoredukes = SSjob.GetJob("Grand Duke")
 		if(nomoredukes)
 			nomoredukes.total_positions = -1000 //We got what we got now.
@@ -283,7 +283,7 @@ GLOBAL_LIST_EMPTY(priest_swap_timers)
 		to_chat(src, span_warning("I need to do this in the chapel."))
 		return FALSE
 
-	var/announcementinput = input("Bellow to the vale", "Make an Announcement") as text|null
+	var/announcementinput = input("Bellow to the realm", "Make an Announcement") as text|null
 	if(announcementinput)
 		if(!src.can_speak_vocal())
 			to_chat(src,span_warning("I can't speak!"))

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/ferentia.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/ferentia.dm
@@ -1,10 +1,10 @@
 /proc/ferentia_locality(mob/living/carbon/human/H)
-	var/is_local = input(H, "Are you a local?", "Ferentia Kingdom") as anything in list("I am from the Vale", "I am a foreigner")
+	var/is_local = input(H, "Are you a local?", "Ferentia Kingdom") as anything in list("I am from these lands", "I am a foreigner")
 	switch(is_local)
-		if("I am from the Vale")
+		if("I am from these lands")
 			REMOVE_TRAIT(H, TRAIT_OUTLANDER, JOB_TRAIT)
 		else
-			to_chat(H, span_notice("I have arrived at the Vale's mercenary guild after travelling from a different county within the Ferentian kingdom."))
+			to_chat(H, span_notice("I have arrived at this duchy's mercenary guild after travelling from a different county within the Ferentian kingdom."))
 
 
 /datum/advclass/mercenary/ferentia

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -50,6 +50,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 /datum/job/roguetown/lord/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(L)
+		var/realmname = SSmapping.map_adjustment.realm_name
 		var/list/chopped_name = splittext(L.real_name, " ")
 		if(length(chopped_name) > 1)
 			chopped_name -= chopped_name[1]
@@ -57,7 +58,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 		else
 			GLOB.lordsurname = "of [L.real_name]"
 		SSticker.set_ruler_mob(L)
-		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is [SSticker.rulertype] of Rotwood Vale.</span></span></b>")
+		to_chat(world, "<b><span class='notice'><span class='big'>[L.real_name] is [SSticker.rulertype] of [realmname].</span></span></b>")
 		if(istype(SSticker.regentmob, /mob/living/carbon/human))
 			var/mob/living/carbon/human/regentbuddy = SSticker.regentmob
 			to_chat(L, span_notice("Word reached me on the approach that [regentbuddy.real_name], the [regentbuddy.job], served as regent in my absence."))
@@ -178,7 +179,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 */
 /datum/advclass/lord/merchant
 	name = "Merchant Lord"
-	tutorial = "You were always talented with coins and trade. And your talents have brought you to the position of the Lord of Rotwood Vale. You could be a merchant who bought his way into nobility and power, or an exceptionally talented noble who were inclined to be good with coins. Fighting directly is not your forte\
+	tutorial = "You were always talented with coins and trade. And your talents have brought you to the position of the Lord of the Realm. You could be a merchant who bought his way into nobility and power, or an exceptionally talented noble who were inclined to be good with coins. Fighting directly is not your forte\
 	But you have plenty of wealth, keen ears, and know a good deal from a bad one."
 	outfit = /datum/outfit/job/roguetown/lord/merchant
 	category_tags = list(CTAG_LORD)
@@ -263,7 +264,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 */
 /datum/advclass/lord/inbred
 	name = "Inbred Lord"
-	tutorial = "Psydon and Astrata smiles upon you. For despite your inbred and weak body, and your family's conspiracies to remove you from succession, you have somehow become the Lord of Rotwood Vale. May your reign lasts a hundred years."
+	tutorial = "Psydon and Astrata smiles upon you. For despite your inbred and weak body, and your family's conspiracies to remove you from succession, you have somehow become the Lord of the Realm. May your reign lasts a hundred years."
 	outfit = /datum/outfit/job/roguetown/lord/inbred
 	category_tags = list(CTAG_LORD)
 	traits_applied = list(TRAIT_NOBLE, TRAIT_CRITICAL_WEAKNESS, TRAIT_DNR, TRAIT_NORUN, TRAIT_HEAVYARMOR, TRAIT_GOODLOVER)

--- a/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
@@ -9,7 +9,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
 	advclass_cat_rolls = list(CTAG_CONSORT = 20)
-	tutorial = "You are a noble from a foreign court who has travelled to Rotwood Vale in order to win the hand of the Vale's most eligible bachelor and secure a political ally for your house. Competition is fierce, and it seems you're not the only one vying for the duke's favor..."
+	tutorial = "You are a noble from a foreign court who has travelled to the realm in order to win the hand of the realm's most eligible bachelor and secure a political ally for your house. Competition is fierce, and it seems you're not the only one vying for the duke's favor..."
 
 	outfit = /datum/outfit/job/roguetown/suitor
 

--- a/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 4
 
 	allowed_races = RACES_ALL_KINDS
-	tutorial = "You have a simple role at the Vale's Pint; please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."
+	tutorial = "You have a simple role at the city tavern; please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."
 
 	outfit = /datum/outfit/job/roguetown/knavewench
 	display_order = JDO_KNAVEWENCH
@@ -28,7 +28,7 @@
 
 /datum/advclass/tapster
 	name = "Tapster"
-	tutorial = "You have a simple role at the Vales Pint; please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."
+	tutorial = "You have a simple role at the city tavern; please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."
 	outfit = /datum/outfit/job/roguetown/knavewench/basic
 	category_tags = list(CTAG_TAPSTER)
 	// 5 points weighted

--- a/code/modules/jobs/job_types/roguetown/peasants/lunatic.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/lunatic.dm
@@ -16,7 +16,7 @@
 	bypass_jobban = FALSE
 	min_pq = 100 //the magic of an allowlist server.
 	max_pq = null
-	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that the vale drives those most familiar with it, the most insane."
+	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that these lands drive those most familiar with it, the most insane."
 	display_order = JDO_LUNATIC
 	social_rank = SOCIAL_RANK_PEASANT
 	cmode_music = 'sound/music/combat_bum.ogg'
@@ -30,7 +30,7 @@
 
 /datum/advclass/lunatic
 	name = "Lunatic"
-	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that The Vale drives those most familiar with it, the most insane."
+	tutorial = "The Lunatic, shunned by society and a magnet for misfortune. Your task is simple yet perilous: survive by any means, though your very existence invites danger from every corner. It is said that these lands drive those most familiar with it, the most insane."
 	outfit = /datum/outfit/job/roguetown/lunatic/basic
 	category_tags = list(CTAG_LUNATIC)
 	subclass_stats = list(

--- a/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/barkeep.dm
@@ -8,7 +8,7 @@
 
 	allowed_races = ACCEPTED_RACES
 
-	tutorial = "Adventurers and warriors alike have two exit plans; the early grave or even earlier retirement. As the proud owner of this fine establishment, you took the latter: The Vale's Pint, tavern, inn, and bathhouse! You even have an assortment of staff to help you, and plenty of business from the famished townsfolk looking to eat, weary travelers looking to rest, and characters of dubious repute seeking their own sort of success. Your bladework has gotten a little rusty, and the church across the street gives you the odd evil eye for the extra 'delights' of the bathhouse--but, well...you can't win 'em all!"
+	tutorial = "Adventurers and warriors alike have two exit plans; the early grave or even earlier retirement. As the proud owner of this fine establishment, you took the latter: The local tavern, inn, and bathhouse! You even have an assortment of staff to help you, and plenty of business from the famished townsfolk looking to eat, weary travelers looking to rest, and characters of dubious repute seeking their own sort of success. Your bladework has gotten a little rusty, and the church across the street gives you the odd evil eye for the extra 'delights' of the bathhouse--but, well...you can't win 'em all!"
 	social_rank = SOCIAL_RANK_YEOMAN
 	outfit = /datum/outfit/job/roguetown/barkeep
 	display_order = JDO_BARKEEP
@@ -28,7 +28,7 @@
 
 /datum/advclass/barkeep
 	name = "Innkeeper"
-	tutorial = "Adventurers and warriors alike have two exit plans; the early grave or even earlier retirement. As the proud owner of this fine establishment, you took the latter: The Vale's Pint, tavern, inn, and bathhouse! You even have an assortment of staff to help you, and plenty of business from the famished townsfolk looking to eat, weary travelers looking to rest, and characters of dubious repute seeking their own sort of success. Your bladework has gotten a little rusty, and the church across the street gives you the odd evil eye for the extra 'delights' of the bathhouse--but, well...you can't win 'em all!"
+	tutorial = "Adventurers and warriors alike have two exit plans; the early grave or even earlier retirement. As the proud owner of this fine establishment, you took the latter: The local tavern, inn, and bathhouse! You even have an assortment of staff to help you, and plenty of business from the famished townsfolk looking to eat, weary travelers looking to rest, and characters of dubious repute seeking their own sort of success. Your bladework has gotten a little rusty, and the church across the street gives you the odd evil eye for the extra 'delights' of the bathhouse--but, well...you can't win 'em all!"
 	outfit = /datum/outfit/job/roguetown/barkeep/basic
 	category_tags = list(CTAG_INNKEEPER)
 	subclass_stats = list(

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildmaster.dm
@@ -12,7 +12,7 @@
 	social_rank = SOCIAL_RANK_YEOMAN
 	allowed_races = ACCEPTED_RACES
 
-	tutorial = "You are the leader of the Rotwood Vale Guild of Crafts. You represents the interests of all of the craftsmen underneath you - including the Tailor\
+	tutorial = "You are the leader of the Duchy's Guild of Crafts. You represents the interests of all of the craftsmen underneath you - including the Tailor\
 	the Blacksmiths, the Artificers and the Architects. Other townspeople may look to you for guidance, but they are not under your control. You are an experienced smith and artificer, and can do their work easily. Protect the craftsmen's interests."
 
 	outfit = /datum/outfit/job/roguetown/guildmaster
@@ -35,7 +35,7 @@
 
 /datum/advclass/guildmaster
 	name = "Guildmaster"
-	tutorial = "You are the leader of the Vale Guild of Crafts. You represents the interests of all of the craftsmen underneath you - including the Tailor\
+	tutorial = "You are the leader of the Duchy's Guild of Crafts. You represents the interests of all of the craftsmen underneath you - including the Tailor\
 	the Blacksmiths, the Artificers and the Architects. Other townspeople may look to you for guidance, but they are not under your control. You are an experienced smith and artificer, and can do their work easily. Protect the craftsmen's interests."
 	outfit = /datum/outfit/job/roguetown/guildmaster/basic
 	category_tags = list(CTAG_GUILDSMASTER)
@@ -113,7 +113,7 @@
 	set category = "GUILDMASTER"
 	if(stat)
 		return
-	var/announcementinput = input("Bellow to the vale", "Make an Announcement") as text|null
+	var/announcementinput = input("Bellow to the realm", "Make an Announcement") as text|null
 	if(announcementinput)
 		if(!src.can_speak_vocal())
 			to_chat(src,span_warning("I can't speak!"))

--- a/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/guildsman.dm
@@ -11,7 +11,7 @@
 	social_rank = SOCIAL_RANK_YEOMAN
 	allowed_races = ACCEPTED_RACES
 
-	tutorial = "You are a member of the Rotwood Vale Guild of Crafts, a massive guild formed to represent the interests of all craftsmen in the township of Rotwood Vale.\
+	tutorial = "You are a member of the Duchy's Guild of Crafts, a massive guild formed to represent the interests of all craftsmen in the township.\
 	As a Guildsman, you hail from the three most important constituent guilds: The Smith's Guild, the Artificer's Guild, and the Architect's Guild. The Guildsmaster has sway over you, but it is not absolute."
 	job_traits = list(TRAIT_TRAINED_SMITH, TRAIT_SMITHING_EXPERT)
 

--- a/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/shophand.dm
@@ -10,7 +10,7 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_ages = list(AGE_ADULT)
 
-	tutorial = "You work the largest store in the vale by grace of the Merchant who has shackled you to this drudgery. The work of stocking shelves and taking inventory for your employer is mind-numbing and repetitive--but at least you have a roof over your head and comfortable surroundings. With time, perhaps you will one day be more than a glorified servant."
+	tutorial = "You work the largest store in the city by grace of the Merchant who has shackled you to this drudgery. The work of stocking shelves and taking inventory for your employer is mind-numbing and repetitive--but at least you have a roof over your head and comfortable surroundings. With time, perhaps you will one day be more than a glorified servant."
 
 	outfit = /datum/outfit/job/roguetown/shophand
 	display_order = JDO_SHOPHAND

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/excommunicado.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/excommunicado.dm
@@ -1,6 +1,6 @@
 /datum/advclass/vagabond_excommunicated
 	name = "Excommunicated"
-	tutorial = "The Church has found you bereft of mercy, and you walk the lands of the vale with nothing but the tattered shreds of the faith you cling to."
+	tutorial = "The Church has found you bereft of mercy, and you walk these lands with nothing but the tattered shreds of your faith."
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/vagabond/excommunicated

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/wanted.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/wanted.dm
@@ -56,5 +56,5 @@
 			if ("Massive")
 				bounty_total = rand(150, 200)
 	
-		add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, bounty_total, FALSE, my_crime, "The Justiciary of Rotwood")
+		add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, bounty_total, FALSE, my_crime, "The Justiciary of the Realm")
 		to_chat(H, span_notice("I'm on the run from the law, and there's a [LOWER_TEXT(bounty_amount)] sum of mammons out on my head... better lay low."))

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/wanted.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/wanted.dm
@@ -56,5 +56,5 @@
 			if ("Massive")
 				bounty_total = rand(150, 200)
 	
-		add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, bounty_total, FALSE, my_crime, "The Justiciary of the Realm")
+		add_bounty(H.real_name, race, gender, descriptor_height, descriptor_body, descriptor_voice, bounty_total, FALSE, my_crime, "The Justiciary of [SSmapping.map_adjustment.realm_name]")
 		to_chat(H, span_notice("I'm on the run from the law, and there's a [LOWER_TEXT(bounty_amount)] sum of mammons out on my head... better lay low."))

--- a/code/modules/language/roguetown/regional/kazengunese.dm
+++ b/code/modules/language/roguetown/regional/kazengunese.dm
@@ -1,6 +1,6 @@
 /datum/language/kazengunese
 	name = "Kazengunese"
-	desc = "The language of the islands of Kazengun. With intricate honorifics and complex grammar. The version spoken commonly in the vale is a result of centuries of cultural contact between the Kazengunese and Zhongese, and is a trade language combining Zhongese & Kazengunese vocabulary"
+	desc = "The language of the islands of Kazengun. With intricate honorifics and complex grammar. The version spoken commonly in Ferentia is a result of centuries of cultural contact between the Kazengunese and Zhongese, and is a trade language combining Zhongese & Kazengunese vocabulary"
 	speech_verb = "says"
 	whisper_verb = "whispers"
 	exclaim_verb = "yells"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -799,7 +799,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return
 	var/bt = world.time
 	SEND_SOUND(src, sound('sound/misc/notice (2).ogg'))
-	if(alert(src, "You have been summoned you to destroy the vale!", "Join the Horde", "Yes", "No") == "Yes")
+	if(alert(src, "You have been summoned you to destroy!", "Join the Horde", "Yes", "No") == "Yes")
 		if(world.time > bt + 5 MINUTES)
 			to_chat(src, span_warning("Too late."))
 			return FALSE

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/gnome.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/gnome.dm
@@ -7,7 +7,7 @@
 	desc = "<b>Gnome</b><br>\
 	Gnomes are short delicate creatures known for their quick thinking and wit.<br>\
 The naturally inquisitive mind of a Gnome inclines them towards arcane pursuits, artificing and teaching others.\
-Gnomish folk have an earned reputation for being brilliant tradespeople and crafters, although their rapid thoughts often lead to them seeming scatterbrained to the other beings of The Vale.<br>\
+Gnomish folk have an earned reputation for being brilliant tradespeople and crafters, although their rapid thoughts often lead to them seeming scatterbrained to the other beings of the realm.<br>\
 Gnomes are typically a mixed race of Dwarves and a magical race, typically Elves when the two aren't arguing, but some are born with fae blood as well. <br>\
 Even though they are of mixed blood and smaller than typical dwarves, most gnomes and dwarves still regard each other as kin.<br>\
 	(+1 Intelligence, +1 Perception)"

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/aasimar.dm
@@ -11,7 +11,7 @@
 	Most commonly, Aasimar are similar to Humens, albeit taller, and commonly possess an uncanny beauty. \
 	When compared to the average Humen, they have strangely colored skin and are more physically frail. \
 	Because of their upbringing, they make for natural conduits for godly powers. \
-	The vale's populace holds them with a mixture of uneasy mixture of fear and respect. \
+	The realm's populace holds them with a mixture of uneasy mixture of fear and respect. \
 	Due to their celestial nature, it is widely believed that an Aasimar's death is a bad omen...<br>\
 	(+1 Stat of their choice, Lack of Hunger & Thirst)"
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/halforc.dm
@@ -12,7 +12,7 @@
 	being born in these rough places otherwise devoid of a fairer sex. Your mother-clan is in thrall \
 	to the Ironmask. True orcs would kill you on sight, seeing you as a mongrel dog, and non-orcish \
 	people cannot decide between regarding you with either mere distrust or outright disgust. Yet \
-	somehow your wandering feet came to the vale, where half-orcs ply muscle and their hardiness \
+	somehow your wandering feet came to these lands, where half-orcs ply muscle and their hardiness \
 	in the rough underbelly or outer reaches of society.<br>\
 	(+1 Strength, Big Guy Trait, Bed Breaker Trait)"
 

--- a/code/modules/mob/living/simple_animal/rogue/creacher/raccoon.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/raccoon.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/hostile/retaliate/rogue/wolf/raccoon
 	icon = 'icons/roguetown/mob/monster/raccoon.dmi'
 	name = "rakun"
-	desc = "An adorable albeit dangerous creacher of The Vale's northern coast, known to steal food from bins or eat small game."
+	desc = "An adorable albeit dangerous creacher, known to steal food from bins or eat small game."
 	icon_state = "raccoon"
 	icon_living = "raccoon"
 	icon_dead = "raccoon_dead"

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -96,7 +96,7 @@
 //Fake reskin of a scroll for the dwarf mercs -- just a fluffy toy
 /obj/item/paper/scroll/grudge
 	name = "Book of Grudges"
-	desc = "A copy you've taken with you. Unfortunately the dampness of the vale made it unreadable. You can still add new entries, however. It looks bulky enough to act as a mild blunt weapon."
+	desc = "A copy you've taken with you. Unfortunately the dampness of your travels made it unreadable. You can still add new entries, however. It looks bulky enough to act as a mild blunt weapon."
 	icon_state ="grudge_closed"
 	drop_sound = 'sound/foley/dropsound/book_drop.ogg'
 	grid_width = 32
@@ -256,6 +256,7 @@
 	info = null
 	info += "<h2>Shipping Order</h2>"
 	info += "<hr/>"
+	var/realmname = SSmapping.map_adjustment.realm_name
 
 	if(orders.len)
 		info += "Orders: <br/>"
@@ -268,7 +269,7 @@
 
 	if(signedname)
 		info += "SIGNED,<br/>"
-		info += "<font face=\"[FOUNTAIN_PEN_FONT]\" color=#27293f>[signedname] the [signedjob] of Rotwood Vale</font>"
+		info += "<font face=\"[FOUNTAIN_PEN_FONT]\" color=#27293f>[signedname] the [signedjob] of [realmname]</font>"
 
 /obj/item/paper/inqslip
 	name = "inquisition slip"

--- a/code/modules/reagents/chemistry/reagents/rt_alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/rt_alcohol_reagents.dm
@@ -568,7 +568,7 @@
 
 /datum/reagent/consumable/ethanol/whipwine // dont ask
 	name = "Magickal Whip Wine"
-	description = "A recipe recently floated into the vale. Magickal Whip Wine is said to increase one's potence and stamina sevenfold."
+	description = "A recipe recently floated into these lands. Magickal Whip Wine is said to increase one's potence and stamina sevenfold."
 	boozepwr = 10 // it's a whip. it's an actual whip.
 	taste_description = "leather, bitter herbs, and regret" // what did you expect
 	color = "#3a1d18"

--- a/code/modules/roguetown/roguemachine/ATM.dm
+++ b/code/modules/roguetown/roguemachine/ATM.dm
@@ -1,6 +1,6 @@
 /obj/structure/roguemachine/atm
 	name = "nervelock"
-	desc = "Stores and withdraws currency for accounts managed by the Grand Duchy of the vale."
+	desc = "Stores and withdraws currency for accounts managed by the Grand Duchy of the realm."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "atm"
 	density = FALSE

--- a/code/modules/roguetown/roguemachine/noticeboard/noticeboard.dm
+++ b/code/modules/roguetown/roguemachine/noticeboard/noticeboard.dm
@@ -122,7 +122,7 @@
 		contents += "Scouts rate how dangerous a region is from Safe -> Low -> Moderate -> Dangerous -> Bleak <br>"
 		contents += "A safe region is safe and travelers are unlikely to be ambushed by common creechurs and brigands <br>"
 		contents += "A low threat region is unlikely to manifest any great threat and brigands and creechurs are often found alone.<br>"
-		contents += "Only Vale Basin, Vale Grove and the Terrorbog can be rendered safe entirely. <br>"
+		contents += "Only certain locations can be rendered safe entirely. <br>"
 		contents += "Regions not listed are beyond the charge of the wardens. Danger will be constant in these regions.<br>"
 		contents += "Danger is reduced by luring villains and creechurs and killing them when they ambush you. The signal horns wardens have been issued can help with this. Take care with using it."
 	var/datum/browser/popup = new(user, "NOTICEBOARD", "", 800, 650)

--- a/code/modules/roguetown/roguemachine/steward/steward.dm
+++ b/code/modules/roguetown/roguemachine/steward/steward.dm
@@ -118,6 +118,7 @@
 
 /obj/structure/roguemachine/steward/Topic(href, href_list)
 	. = ..()
+	var/realmname = SSmapping.map_adjustment.realm_name
 	if(!usr.canUseTopic(src, BE_CLOSE) || locked)
 		return
 	if(href_list["switchtab"])
@@ -135,7 +136,7 @@
 		SStreasury.log_to_steward("-[amt] imported [D.name]")
 		record_round_statistic(STATS_STOCKPILE_IMPORTS_VALUE, amt)
 		if(amt >= 100) //Only announce big spending.
-			scom_announce("Rotwood Vale imports [D.name] for [amt] mammon.", )
+			scom_announce("[realmname] imports [D.name] for [amt] mammon.", )
 		D.raise_demand()
 		addtimer(CALLBACK(src, PROC_REF(do_import), D.type), 10 SECONDS)
 	if(href_list["export"])
@@ -205,7 +206,7 @@
 			if(findtext(num2text(newrate), "."))
 				return
 			newrate = CLAMP(newrate, 0, D.generation_max)
-			scom_announce("Rotwood Vale will [newrate ? "now import [newrate] [D.name] every 5 hours." : "no longer import [D.name] periodically"]")
+			scom_announce("[realmname] will [newrate ? "now import [newrate] [D.name] every 5 hours." : "no longer import [D.name] periodically"]")
 			D.passive_generation = newrate
 	if(href_list["setlimit"])
 		var/datum/roguestock/D = locate(href_list["setlimit"]) in SStreasury.stockpile_datums

--- a/code/modules/roguetown/roguemachine/throne.dm
+++ b/code/modules/roguetown/roguemachine/throne.dm
@@ -1,7 +1,7 @@
 GLOBAL_VAR(king_throne)
 
 /obj/structure/roguethrone
-	name = "throne of Rotwood Vale"
+	name = "throne of The Realm"
 	desc = "A big throne, to hold the Lord's giant personality. Say 'secrets of the throat' with the crown on your head if you are confused."
 	icon = 'icons/roguetown/misc/96x96.dmi'
 	icon_state = "throne"

--- a/code/modules/roguetown/roguemachine/titan.dm
+++ b/code/modules/roguetown/roguemachine/titan.dm
@@ -362,7 +362,7 @@ GLOBAL_VAR_INIT(last_crown_announcement_time, -1000)
 /proc/make_outlaw(raw_message)
 	if(raw_message in GLOB.outlawed_players)
 		GLOB.outlawed_players -= raw_message
-		priority_announce("[raw_message] is no longer an outlaw in the vale.", "The [SSticker.rulertype] Decrees", 'sound/misc/royal_decree.ogg', "Captain")
+		priority_announce("[raw_message] is no longer an outlaw in the realm.", "The [SSticker.rulertype] Decrees", 'sound/misc/royal_decree.ogg', "Captain")
 		return FALSE
 	var/found = FALSE
 	for(var/mob/living/carbon/human/H in GLOB.player_list)

--- a/code/modules/roguetown/roguemachine/vaultbank.dm
+++ b/code/modules/roguetown/roguemachine/vaultbank.dm
@@ -1,6 +1,6 @@
 /obj/structure/roguemachine/vaultbank
 	name = "\improper JAWBANK"
-	desc = "Collects and secures the treasury of the Grand Duchy of the vale."
+	desc = "Collects and secures the treasury of the Grand Duchy of the realm."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "jawbank"
 	density = TRUE

--- a/code/modules/roguetown/roguestock/import.dm
+++ b/code/modules/roguetown/roguestock/import.dm
@@ -163,7 +163,7 @@
 
 /datum/roguestock/import/horsecrate
 	name = "Horse Crate"
-	desc = "A strange and unfamiliar mount in the vale. Horses, unlike saigas, have uniquely uncloven, single-toed hooves."
+	desc = "A strange and unfamiliar mount in Ferentia. Horses, unlike saigas, have uniquely uncloven, single-toed hooves."
 	item_type = /obj/structure/closet/crate/chest/steward/horsecrate
 	export_price = 500
 	importexport_amt = 1

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -59,7 +59,7 @@
 /obj/item/bodypart/head/examine()
 	. = ..()
 	if(sellprice)
-		. += span_notice("This head seems to be wanted by the Judiciary of The Vale. It can be sold at the merchant or a HEADEATER.")
+		. += span_notice("This head seems to be wanted by the Judiciary of The Realm. It can be sold at the merchant or a HEADEATER.")
 
 /obj/item/bodypart/head/grabbedintents(mob/living/user, precise)
 	var/used_limb = precise

--- a/modular/Neu_Food/code/drinks/tea_coffee_drinks.dm
+++ b/modular/Neu_Food/code/drinks/tea_coffee_drinks.dm
@@ -36,7 +36,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/coffeebeansroasted
 	name = "roasted coffee beans"
-	desc = "Roasted coffee beans, with a much deeper flavor. Can be used to brew coffee. The variant grown in the vale can be brewed without being ground."
+	desc = "Roasted coffee beans, with a much deeper flavor. Can be used to brew coffee. The variant grown in these lands can be brewed without being ground."
 	icon = 'modular/Neu_Food/icons/drinks.dmi'
 	icon_state = "coffeebeans_roasted"
 	tastes = list("rich caramel smoothness" = 1)

--- a/modular/Neu_Food/code/raw/raw_fish.dm
+++ b/modular/Neu_Food/code/raw/raw_fish.dm
@@ -143,7 +143,7 @@
 
 /obj/item/reagent_containers/food/snacks/fish/clownfish
 	name = "clownfish"
-	desc = "This fish brings vibrant hues to the dark world of the vale."
+	desc = "This fish brings vibrant hues to this dark world."
 	icon_state = "clownfish"
 	faretype = FARE_NEUTRAL
 	sellprice = 40

--- a/modular_azurepeak/code/game/objects/items/mercmedals.dm
+++ b/modular_azurepeak/code/game/objects/items/mercmedals.dm
@@ -1,6 +1,6 @@
 /obj/item/merctoken
 	name = "writ of commendation"
-	desc = "A small, palm-fitting bound scroll - a writ of commendation for a mercenary in the Duchy of Rotwood Vale."
+	desc = "A small, palm-fitting bound scroll - a writ of commendation for a mercenary of the Realm."
 	icon_state = "merctoken"
 	icon = 'modular_azurepeak/icons/clothing/mercmedals.dmi'
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
@@ -32,7 +32,7 @@
 				signeejob = user.mind.assigned_role
 				visible_message("<span class='warning'>[user] writes their name down on the token.</span>")
 				playsound(src, 'sound/items/write.ogg', 100, FALSE)
-				desc = "A small, palm-fitting bound scroll that can be sent by mail to the Guild. Most of the fine print is unintelligible, save for one bold SIGNEE: [signee], [signeejob] of Rotwood Vale."
+				desc = "A small, palm-fitting bound scroll that can be sent by mail to the Guild. Most of the fine print is unintelligible, save for one bold SIGNEE: [signee], [signeejob] of The Realm."
 				signed = 1
 				return
 		else
@@ -58,7 +58,7 @@
 
 /obj/item/clothing/neck/roguetown/luckcharm/mercmedal/blackoak
 	name = "guardian's seedpouch"
-	desc = "A pouch, sealed tight, bearing the acorn of an oak native to the vale. May your end be a new beginning for Rotwood Vale."
+	desc = "A pouch, sealed tight, bearing the acorn of an oak native to the vale. May your end be a new beginning for the Realm."
 	icon_state = "blackoak_pouch"
 
 /obj/item/clothing/neck/roguetown/luckcharm/mercmedal/condottiero
@@ -87,7 +87,7 @@
 
 /obj/item/clothing/neck/roguetown/luckcharm/mercmedal/atgervi
 	name = "northmanne's idol"
-	desc = "A humble token of tightly-wound canvas, fur, and wood. A piece of home, clutched tight against the chest. Feel its heart beat in tyme with your own. Even here, in the distant vale, \
+	desc = "A humble token of tightly-wound canvas, fur, and wood. A piece of home, clutched tight against the chest. Feel its heart beat in tyme with your own. Even here, in this distant realm, \
 	the gods walk, and they walk with you."
 	icon_state = "atgervi_idol"
 

--- a/modular_azurepeak/code/game/objects/items/quicksilver.dm
+++ b/modular_azurepeak/code/game/objects/items/quicksilver.dm
@@ -163,7 +163,7 @@
 	name = "Inquisitorial Missive"
 	desc = "A letter from the Grand Cathedral in Otava. It reeks of zig smoke."
 	info = {"
-		<font face=\"Segoe Script\" color=#00000>Greetings to ye, distant missionaries in The Vale<br><br>This missive serves to inform of a breakthrough of alchemy.
+		<font face=\"Segoe Script\" color=#00000>Greetings to ye, distant missionaries in these lands<br><br>This missive serves to inform of a breakthrough of alchemy.
 		Enclosed is a substance, <b>Quicksilver</b>, that may be of keen use in the preservation of lyfe against those unholy creechers that are repelled by divine silver.
 		We speak of the werevolf and the vampyre. Herein lies the method.<br><br>Gather an ore of silver, a vessel of blessed water- a bottle's worth shall suffice, and a
 		simple strip of cloth to add structure to the poultice. Take the warm bud of a fyritius flower, and immerse it in the bleeding wound of an unholy creecher. The warmth

--- a/modular_azurepeak/code/game/objects/structures/fartravel.dm
+++ b/modular_azurepeak/code/game/objects/structures/fartravel.dm
@@ -73,7 +73,7 @@
 	if(departing_mob.stat == DEAD)
 		departing_mob.visible_message("<span class='notice'>[user] sends the body of [departing_mob] away. They're someone else's problem now.</span>")
 	else
-		departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] leaves the vale.</span>")
+		departing_mob.visible_message("<span class='notice'>[departing_mob == user ? "Out of their own volition, " : "Ushered by [user], "][departing_mob] leaves [SSmapping.map_adjustment.realm_name].</span>")
 		// If departure is a lord, remove them from found_lords to prevent false omen triggers
 	if(departing_mob.mind && departing_mob.ckey)
 		if(departing_mob.mind.assigned_role == "Grand Duke" || departing_mob.mind.assigned_role == "Grand Duchess")

--- a/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
+++ b/modular_azurepeak/code/modules/clothing/rogueclothes/crown.dm
@@ -30,7 +30,7 @@
 	become_hearing_sensitive()
 
 /obj/item/clothing/head/roguetown/crown/serpcrown/proc/anti_stall()
-	src.visible_message(span_warning("The Crown of the Vale crumbles to dust, the ashes spiriting away in the direction of the Keep."))
+	src.visible_message(span_warning("The Crown of [SSmapping.map_adjustment.realm_name] crumbles to dust, the ashes spiriting away in the direction of the Keep."))
 	SSroguemachine.scomm_machines -= src
 	SSroguemachine.crown = null //Do not harddel.
 	qdel(src) //Anti-stall
@@ -59,7 +59,7 @@
 
 			GLOB.broadcast_list += list(list(
 			"message"   = input_text,
-			"tag"		= "The Crown of the Vale",
+			"tag"		= "The Crown of [SSmapping.map_adjustment.realm_name]",
 			"timestamp" = station_time_timestamp("hh:mm:ss")
 			))
 

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -41,7 +41,7 @@
 
 /datum/virtue/utility/resident
 	name = "Resident"
-	desc = "I'm a resident of the vale. I have an account in the city's treasury and a home in the city."
+	desc = "I'm a resident of these lands. I have an account in the city's treasury and a home in the city."
 	added_traits = list(TRAIT_RESIDENT)
 
 /datum/virtue/utility/resident/apply_to_human(mob/living/carbon/human/recipient)

--- a/modular_deserttown/desertstuff.dm
+++ b/modular_deserttown/desertstuff.dm
@@ -435,7 +435,7 @@
 
 /obj/structure/fluff/walldeco/customflag/deserttown
 	name = "Al-Ashur flag"
-
+	desc = "A banner flutters in the breeze in the proud heraldic colors of the Sultanate."
 
 /obj/item/rogueweapon/shield/iron/zybantine
 	name = "brass shield"


### PR DESCRIPTION
## About The Pull Request

The game is chock-full of references to Azure Peak that were machine-replaced to Rotwood Vale or The Vale
The game is only sometimes (lately only rarely) actually *set* in Rotwood Vale, since we have Rockhill (which has gotten more popular) and Al-Ashur.

I went and changed a lot of descriptions to, instead of referring to the Vale, refer to 'The Realm', 'These Lands', or [realm_name], which prints the name of the realm of whatever map is currently being played. 
This applies to a lot of things; most of them are job or object descriptions, and a few important ones are the message that prints when the duke is crowned (so instead of 'x is now Duke of Rotwood Vale' it says 'x is now y of z' (so Duke of Rockhill or Sultan of Al-Ashur, depending)

When picking your bounty instead of the Justiciary of Rotwood Vale it is the Justiciary of [realm name]

## Testing Evidence

<img width="647" height="328" alt="image" src="https://github.com/user-attachments/assets/1877086c-9c7d-4be4-874a-9f624ffb852f" />
<img width="371" height="64" alt="image" src="https://github.com/user-attachments/assets/c1e63d02-953b-4f00-98e8-d22ce897a18f" />
<img width="364" height="132" alt="image" src="https://github.com/user-attachments/assets/ee488744-2002-4a6e-8c57-c088c68577f8" />

<img width="436" height="360" alt="image" src="https://github.com/user-attachments/assets/1d5fc778-3401-4345-aa34-7c1ea455567e" />
<img width="655" height="471" alt="image" src="https://github.com/user-attachments/assets/dae51e2a-e8bb-4c91-8300-dcaa6d734712" />
<img width="365" height="290" alt="image" src="https://github.com/user-attachments/assets/254820f2-1d4c-49de-9495-705f119cc6d0" />

<img width="382" height="115" alt="image" src="https://github.com/user-attachments/assets/c3c7a0e7-7695-44c7-a223-8f46fe5d198c" />


## Why It's Good For The Game

Less confusing, more fitting

## Changelog

:cl:
spellcheck: a lot of references to 'Rotwood Vale' or 'The Vale' are changed with references that are either vague (such as 'the realm' or 'these lands') or refer to the exact realm name depending on the map (so Rockhill when the map is Rockhill, Al-Ashur when the map is Al-Ashur)
/:cl:
