### PR TITLE
Give Lamia a Descriptor

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/lamia.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/lamia.dm
@@ -142,9 +142,10 @@
 		/datum/body_marking/stripes,
 	)
 	descriptor_choices = list(
+		/datum/descriptor_choice/trait,
+		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/height,
 		/datum/descriptor_choice/body,
-		/datum/descriptor_choice/stature,
 		/datum/descriptor_choice/face,
 		/datum/descriptor_choice/face_exp,
 		/datum/descriptor_choice/skin_lamia,


### PR DESCRIPTION
## About The Pull Request

Same as for goblins, adds the descriptor variable so they don't show up as just 'Man'.

## Testing Evidence

Two line code change, refer to [my previous PR](https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1802) for test screenshots when I did it with goblins.

## Why It's Good For The Game

More variation for characters.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: gives lamia a physical descriptor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
