### PR TITLE
Removes STR Affecting Emote Voice Pitch

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -152,19 +152,8 @@
 /mob/living/proc/get_emote_pitch()
 	return clamp(voice_pitch, 0.5, 2)
 
-/mob/living/carbon/human/get_emote_pitch()
-	var/final_pitch = ..()
-	var/pitch_modifier = 0
-	if(STASTR > 10)
-		pitch_modifier -= (STASTR - 10) * 0.03
-	else if(STASTR < 10)
-		pitch_modifier += (10 - STASTR) * 0.03
-	return clamp(final_pitch + pitch_modifier, 0.5, 2)
 /datum/emote/proc/get_env(mob/living/user)
 	return
-
-
-
 
 /datum/emote/living/get_env(mob/living/user)
 	if(ishuman(user))


### PR DESCRIPTION
## About The Pull Request
Originally part of the Eora PR: https://github.com/Rotwood-Vale/Ratwood-2.0/pull/1737
Now, it is separated since that is the way Xander wanted it.

Basically, when you lose your STR stat you sound like someone's grabbing your balls. It happens around the Eora tree a lot. Some people like myself find it annoying and others are saying this is SOVL removal. It sorta is, I suppose.

Now, do you guys actually WANT this feature? You gotta let me know. I'm just putting this up cause some people were happy it was getting removed and others hated it. Just a simple up or down vote to let me know and maybe tell your friends. 

## Testing Evidence
Simple block removal. It was tested in the Eora PR, and I doubled checked here too. It builds. Proof:
<img width="461" height="202" alt="voicepitchbuildtest" src="https://github.com/user-attachments/assets/11d78889-8a3f-47cf-8ea7-25faa0e9cad8" />

## Why It's Good For The Game
STR affecting your character's voice pitch shouldn't be a thing. It is rather silly, albeit comical. But it sorta annoys me, especially during ERP around the eora tree that I have to listen to high pitched masculine or female voices due to the loss of the stat. I think that situation is pretty much the most noticeable difference for this sort of thing too since it is a big stat loss aura. For things that are reducing a character's STR by like -1 for example, you aren't really going to notice that as much.

Keep in mind you can already set your character voice pitch in the settings regardless of STR level!

## Changelog
:cl:
del: Removes STR affecting character voice pitch for emotes. This means you no longer sound like someone is squeezing you down there in a vice grip while you're low on STR or near an eoran's tree.
/:cl: