### PR TITLE
dreaded lightning bolt nerf

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -23,7 +23,7 @@
 	spell_tier = 2
 	invocations = list("Fulmen!")
 	invocation_type = "shout"
-	cost = 6
+	cost = 3
 	xp_gain = TRUE
 
 /obj/projectile/magic/lightning
@@ -56,7 +56,7 @@
 		if(isliving(target))
 			var/mob/living/L = target
 			L.Immobilize(0.5 SECONDS)
-			L.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
+			L.apply_status_effect(/datum/status_effect/debuff/clickcd, 2 SECONDS)
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-			L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
+			L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 3 SECONDS)
 	qdel(src)

--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -23,7 +23,7 @@
 	spell_tier = 2
 	invocations = list("Fulmen!")
 	invocation_type = "shout"
-	cost = 3
+	cost = 6
 	xp_gain = TRUE
 
 /obj/projectile/magic/lightning

--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -94,7 +94,7 @@
 	. = ..()
 	var/mob/living/target = owner
 	target.update_vision_cone()
-	target.add_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, update=TRUE, priority=100, multiplicative_slowdown=4, movetypes=GROUND)
+	target.add_movespeed_modifier(MOVESPEED_ID_LIGHTNINGSTRUCK, update=TRUE, priority=100, multiplicative_slowdown=2, movetypes=GROUND)
 
 /datum/status_effect/buff/lightningstruck/on_remove()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

nerfs bolt of lightning by ~~doubling its cost from three to six, the same as fireball~~ drastically reducing its slowdown and applied forced clickdelay

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

~~one line change webedit~~ three line change webedit

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

okay so this should need no introduction, anyone who's ever been hit by lightning bolt knows this shit is diabolical
I have have problems with *how* diabolical it is, ~~but rather than reduce its strength I think it's fairer to make it cost the same as fireball~~ so I'm nerfing the most frustrating part of it rather than making it more costly, as lightning bolt is arguably stronger than fireball in its utility for *half the cost* of fireball

lightning bolt does these things on top of being hitscan keep in mind these timers are inflated drastically by time dilation as well and thus feel much worse in game

- `forty` damage
- `half a second` of hard immobilization
- `six seconds` of clickdelay, that means no fighting back, picking up items, climbing, etc
- `six seconds` of four multiplicative slowdown and minus two speed

fireball does a flat sixty damage and some burnstacks and is a dodgeable projectile
~~if we wanna dispute balance I can argue in the comments for days but I think it should be pretty agreeable that making this monster of a spell into something you have to actually consider taking rather than mindlessly throwing it into your spellpoint bloated loadout in addition to all the other utility and escape you could possibly yearn for is a positive change towards not making every single mage take bolt of lightning always irrefutably without argument nor exception~~

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: lightning bolt forced click delay reduced from six seconds to two
balance: lightning bolt slowdown reduced from six seconds to three
balance: lightning bolt multiplicative slowdown reduced from four to two
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
