### PR TITLE
Move sleep per-tick effects into handle_sleep

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -107,37 +107,6 @@
 	human_owner = null
 	return ..()
 
-/datum/status_effect/incapacitating/sleeping/tick()
-	if(owner.maxHealth)
-		var/health_ratio = owner.health / owner.maxHealth
-		var/healing = -0.2
-		if((locate(/obj/structure/bed) in owner.loc))
-			healing -= 0.3
-		else if((locate(/obj/structure/table) in owner.loc))
-			healing -= 0.1
-		for(var/obj/item/bedsheet/bedsheet in range(owner.loc,0))
-			if(bedsheet.loc != owner.loc) //bedsheets in my backpack/neck don't give you comfort
-				continue
-			healing -= 0.1
-			break //Only count the first bedsheet
-		if(health_ratio > 0.8)
-			owner.adjustToxLoss(healing * 0.5, FALSE, TRUE)
-		owner.adjustStaminaLoss(healing)
-	if(human_owner && human_owner.drunkenness)
-		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
-	if(prob(20))
-		if(carbon_owner)
-			carbon_owner.handle_dreams()
-			if(prob(10) && owner.health > owner.crit_threshold)
-				owner.emote("snore")
-	if(isharpy(owner))
-		var/obj/item/clothing/suit/roguetown/armor/skin_armor/harpy_skin = human_owner.skin_armor
-		if(harpy_skin.obj_integrity < harpy_skin.max_integrity)
-			harpy_skin.obj_integrity += 10
-			to_chat(human_owner, "I can feel the skin on my feet mend...")
-		else if((harpy_skin.obj_integrity >= harpy_skin.max_integrity) && harpy_skin.obj_broken)
-			harpy_skin.obj_broken = FALSE
-
 /atom/movable/screen/alert/status_effect/asleep
 	name = "Asleep"
 	desc = ""

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -584,6 +584,8 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 						sleepy_mod = 1.6 // little worse than a bedroll
 		if(sleepy_mod >= 2 && bodytemperature < BODYTEMP_NORMAL_MIN) // if we're sleeping on a bedroll or better
 			adjust_bodytemperature(0.5) // not exactly the best way to regain heat but it'll keep you from freezing to death, won't protect you from a snowstorm though
+		if(drunkenness)
+			drunkenness *= 0.94 //reduce drunkenness by 6% per 2 seconds
 		if(nutrition > 0 || doesnt_hunger)
 			energy_add(sleepy_mod * 15)
 		if(hydration > 0 || doesnt_hunger)
@@ -609,6 +611,20 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 			if(eyesclosed && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 				teleport_to_dream(src, 10000, 2)
 				Sleeping(300)
+		// i would love it if handle_sleep actually handled just sleep instead of also falling asleep
+		// that way i could put this in an override on /mob/living/carbon/human
+		if(ishuman(src))
+			var/mob/living/carbon/human/human_src = src
+			var/obj/item/clothing/suit/roguetown/armor/skin_armor/harpy_skin/skin = human_src.skin_armor
+			if(istype(skin)) // this checks if it's harpy skin specifically
+				if(skin.obj_integrity < skin.max_integrity)
+					skin.obj_integrity = skin.max_integrity
+					to_chat(src, "I can feel the skin on my feet mend...")
+				else if((skin.obj_integrity >= skin.max_integrity) && skin.obj_broken)
+					skin.obj_broken = FALSE
+		// handle_dreams() // this has no functionality currently
+		if(prob(10) && health > crit_threshold)
+			emote("snore")
 	else if(!IsSleeping() && !HAS_TRAIT(src, TRAIT_NOSLEEP))
 		// Resting on a bed or something
 		var/sleepy_mod = 0


### PR DESCRIPTION
`/datum/status_effect/incapacitating/sleeping/tick()` runs 5 times per second while asleep.
`handle_sleep()` runs once every 2 seconds.
Half of what the sleeping effect did every tick was redundant or nonfunctional, e.g. healing TG stam damage or adding a tiny amount of redundant toxins healing. The other half just got moved, e.g. snoring, drunkenness reduction, harpy feet healing, etc.
This means we aren't going to be doing a ton of checks 5 times a second for every sleeping mob. Those include `locate()`/`range(src.loc, 0)` checks too, which are redundant in light of them being done in `handle_sleep()` and REALLY EXPENSIVE in light of them being done 5 times a second instead of once every 2.