### PR TITLE
fixes missed staves datums

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -712,7 +712,7 @@
 				H.adjust_skillrank_up_to(/datum/skill/craft/sewing, 3, TRUE)
 			if("Path of the Shepard")//The "combat" variant. The core stat spread should keep this class from ever overshadowing the others, but it's worth keeping an eye out anyway.
 				r_hand = /obj/item/rogueweapon/woodstaff/quarterstaff/iron
-				H.adjust_skillrank_up_to(/datum/skill/combat/staves, 4, TRUE)//Staves are pretty mediocre. Mostly just makes it really hard to get past their wielded parry.
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)//Good luck fighting like a monk without monk stats or Dodge Expert.
 

--- a/code/modules/jobs/job_types/roguetown/courtier/chaplain.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/chaplain.dm
@@ -45,7 +45,6 @@
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_NOVICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,
@@ -191,7 +190,7 @@
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_GRAVEROBBER, TRAIT_GENERIC)
-		H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE)//For the stave. Beat back the dead. +1 from base, like Ravox.
+		H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)//For the stave. Beat back the dead. +1 from base, like Ravox.
 		H.adjust_skillrank_up_to(/datum/skill/combat/maces, 2, TRUE)//Or the shovel, I guess... loser...
 		H.cmode_music = 'sound/music/cmode/church/combat_necra.ogg'
 	// if(H.patron?.type == /datum/patron/divine/pestra) //that's what the court physician is for!
@@ -212,7 +211,7 @@
 		H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE) //Who even plays Ravoxian acolyte? Whatever, this isn't a huge buff.
 		H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE) //Who even plays Ravoxian acolyte? Whatever, this isn't a huge buff.
 		H.adjust_skillrank_up_to(/datum/skill/misc/athletics, 3, TRUE) //Who even plays Ravoxian acolyte? Whatever, this isn't a huge buff.
-		H.adjust_skillrank_up_to(/datum/skill/combat/staves, 3, TRUE) //On par with an Adventuring Monk. Seems quite fitting.
+		H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE) //On par with an Adventuring Monk. Seems quite fitting.
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	// if(H.patron?.type == /datum/patron/divine/xylix)  // Maybe that's what the Jester is for!
 	// 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)

--- a/modular_deserttown/jobs/dtchaplain.dm
+++ b/modular_deserttown/jobs/dtchaplain.dm
@@ -39,7 +39,6 @@
 	)
 	subclass_skills = list(
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/combat/staves = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT,


### PR DESCRIPTION
## About The Pull Request

oops

court chaplain got merged before staves removal did and some datums got missed from their job

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="473" height="76" alt="image" src="https://github.com/user-attachments/assets/5c45fd84-0b11-4269-b881-e78cd07edd9e" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

errors go away

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
