### PR TITLE
Change lightning bolt hitscan spell debuffs from 6 to 2 seconds because I died to it. 

### DIFF
--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -56,7 +56,7 @@
 		if(isliving(target))
 			var/mob/living/L = target
 			L.Immobilize(0.5 SECONDS)
-			L.apply_status_effect(/datum/status_effect/debuff/clickcd, 6 SECONDS)
+			L.apply_status_effect(/datum/status_effect/debuff/clickcd, 2 SECONDS)
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
-			L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 6 SECONDS)
+			L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 2 SECONDS)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
2 character number change. I love balancejakking...
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Parity with the feint changes. If feints and exposed status are now just a single free hit, our other disabling combat abilities should follow suit. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Lightning Bolt CD and Lightning Struck effects reduced from 6 seconds to 2 seconds on hit. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
