### PR TITLE
Magejack

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_aoe/repulse.dm
@@ -6,7 +6,7 @@
 	releasedrain = 50
 	chargedrain = 1
 	chargetime = 5
-	recharge_time = 25 SECONDS
+	recharge_time = 30 SECONDS
 	human_req = TRUE
 	ignore_los = TRUE
 	warnie = "spellwarning"

--- a/code/modules/spells/spell_types/wizard/misc/blink.dm
+++ b/code/modules/spells/spell_types/wizard/misc/blink.dm
@@ -6,7 +6,7 @@
 	releasedrain = 30
 	chargedrain = 1
 	chargetime = 3
-	recharge_time = 10 SECONDS
+	recharge_time = 13 SECONDS
 	human_req = TRUE
 	warnie = "spellwarning"
 	no_early_release = TRUE

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball.dm
@@ -30,7 +30,7 @@
 	exp_light = 0
 	exp_flash = 0
 	exp_fire = 1
-	damage = 60
+	damage = 50
 	damage_type = BURN
 	npc_simple_damage_mult = 2 // HAHAHA
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor

--- a/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball_artillery.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_aoe/fireball_artillery.dm
@@ -41,7 +41,7 @@
 	exp_light = 0
 	exp_flash = 0
 	exp_fire = 1
-	damage = 50 // 10 less damage than actual fireball on direct fire
+	damage = 40 // 10 less damage than actual fireball on direct fire
 	damage_type = BURN
 	npc_simple_damage_mult = 2 // HAHAHA
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
@@ -52,7 +52,7 @@
 
 /obj/projectile/magic/aoe/fireball/rogue/artillery/arc
 	name = "Arced Artillery Fireball"
-	damage = 65 // 5 damage more than actual fireball on arc'd fire hit
+	damage = 55 // 5 damage more than actual fireball on arc'd fire hit
 	arcshot = TRUE
 
 /obj/projectile/magic/aoe/fireball/rogue/artillery/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/projectiles_single/acid_splash.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/acid_splash.dm
@@ -38,7 +38,7 @@
 /obj/projectile/magic/acidsplash //port. todo: the sounds these came with aren't good and drink_blood sounds like ur slurpin pintle
 	name = "acid bubble"
 	icon_state = "green_laser"
-	damage = 10
+	damage = 15
 	damage_type = BURN
 	flag = "magic"
 	range = 15

--- a/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/arcyne_bolt.dm
@@ -12,7 +12,7 @@
 	releasedrain = 20
 	chargedrain = 1
 	chargetime = 0
-	recharge_time = 4 SECONDS
+	recharge_time = 3 SECONDS
 	human_req = TRUE
 	warnie = "spellwarning"
 	no_early_release = TRUE

--- a/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/lightning_bolt.dm
@@ -56,7 +56,7 @@
 		if(isliving(target))
 			var/mob/living/L = target
 			L.Immobilize(0.5 SECONDS)
-			L.apply_status_effect(/datum/status_effect/debuff/clickcd, 2 SECONDS)
+			L.apply_status_effect(/datum/status_effect/debuff/clickcd, 3 SECONDS)
 			L.electrocute_act(1, src, 1, SHOCK_NOSTUN)
 			L.apply_status_effect(/datum/status_effect/buff/lightningstruck, 3 SECONDS)
 	qdel(src)

--- a/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
+++ b/code/modules/spells/spell_types/wizard/projectiles_single/spitfire.dm
@@ -43,7 +43,7 @@
 	exp_light = 0
 	exp_flash = 0
 	exp_fire = 0
-	damage = 20
+	damage = 15
 	npc_simple_damage_mult = 2 // Makes it more effective against NPCs.
 	accuracy = 40 // Base accuracy is lower for burn projectiles because they bypass armor
 	damage_type = BURN
@@ -54,7 +54,7 @@
 
 /obj/projectile/magic/aoe/fireball/spitfire/arc
 	name = "Arced Spitfire"
-	damage = 15 // 25% damage penalty
+	damage = 12 // 25% damage penalty
 	arcshot = TRUE
 
 /obj/projectile/magic/aoe/fireball/spitfire/on_hit(target)

--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -55,7 +55,7 @@
 /datum/status_effect/buff/witherd
 	id = "withered"
 	alert_type = /atom/movable/screen/alert/status_effect/buff/witherd
-	duration = 30 SECONDS
+	duration = 90 SECONDS
 	effectedstats = list(STATKEY_SPD = -2,STATKEY_STR = -2,STATKEY_CON= -2,STATKEY_WIL = -2)
 
 /atom/movable/screen/alert/status_effect/buff/witherd


### PR DESCRIPTION
## About The Pull Request

Hello mage main here, As it turns out I've come to realize that escapes and true damage is really strong! I've come to nerf a few of the "Meta" Spells and buff some of the lesser used ones. 

## Testing Evidence
It's a few line changes let it ride


## Why It's Good For The Game

So this is part of an ongoing thing I'm going to be doing with mages to make them more interesting overall, Fixing a few of their much lesser used spells while reducing the effectiveness of their most popular picks. Before some of you ask "Why is this not nerfed more?" Or "Why is this spell still dogshit?" I am a fan of small balancing changes over time instead of gutting a spell outright (See Lbolt nerfs). I will continue to make changes if required as i feel like I'm well suited to talk about mage balance at this point.

## Changelog

Jacks mage spells with no mercy

:cl:
balance: Spitfire 20 > 15 damage
balance: Arced spitfire 15 > 12 damage
balance: Fireball 60 > 50 damage
balance: Artillery fireball 50 > 40
balance: Arced Artillery fireball 65 > 55
balance: Blink 10 > 13 CD
balance: Repulse 25 > 30 CD
balance: Wither debuff 30 > 90 seconds debuff
balance: Arcane bolt 4 > 3 Recharge
balance: Acid splash 10 > 15 direct damage
balance: Lbolt 2 > 3 Click CD (Unnerf's it a tiny bit as a treat, If you don't count the recent nerf it would be 6 > 3 click cd)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
