### PR TITLE
small Hand drip-check and minor spymaster rebalancing

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -86,10 +86,6 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_f
 	else if(should_wear_masc_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_m
-	if(SSmapping.config.map_name == "Rockhill")
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/newkeep/hand
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/formal
-		head = null
 	if(SSmapping.config.map_name == "Desert Town")
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		r_hand = /obj/item/rogueweapon/sword/sabre/dec
@@ -119,7 +115,7 @@
 		STATKEY_SPD = 3,
 		STATKEY_PER = 2,
 		STATKEY_INT = 2,
-		STATKEY_STR = -1,
+		STATKEY_LCK = 1,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/crossbows = SKILL_LEVEL_EXPERT,
@@ -163,10 +159,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/stealing, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, 6, TRUE)
-	if(SSmapping.config.map_name == "Rockhill")
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/newkeep/hand
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/formal
-		cloak = null
 	if(SSmapping.config.map_name == "Desert Town")
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		head = /obj/item/clothing/head/roguetown/turban/fancypurple
@@ -216,10 +208,6 @@
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_f
 	else if(should_wear_masc_clothes(H))
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/hand_m
-	if(SSmapping.config.map_name == "Rockhill")
-		armor = /obj/item/clothing/suit/roguetown/armor/leather/newkeep/hand
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/formal
-		cloak = null
 	if(SSmapping.config.map_name == "Desert Town")
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		head = /obj/item/clothing/head/roguetown/turban/fancypurple

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -110,7 +110,7 @@
 
 	category_tags = list(CTAG_HAND)
 	subclass_languages = list(/datum/language/thievescant)
-	traits_applied = list(TRAIT_KEENEARS, TRAIT_DODGEEXPERT, TRAIT_PERFECT_TRACKER, TRAIT_SLEUTH)//Spy not a royal champion
+	traits_applied = list(TRAIT_KEENEARS, TRAIT_DODGEEXPERT, TRAIT_PERFECT_TRACKER)//Spy not a royal champion
 	subclass_stats = list(
 		STATKEY_SPD = 3,
 		STATKEY_PER = 2,

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -110,7 +110,7 @@
 
 	category_tags = list(CTAG_HAND)
 	subclass_languages = list(/datum/language/thievescant)
-	traits_applied = list(TRAIT_KEENEARS, TRAIT_DODGEEXPERT, TRAIT_PERFECT_TRACKER)//Spy not a royal champion
+	traits_applied = list(TRAIT_KEENEARS, TRAIT_DODGEEXPERT, TRAIT_PERFECT_TRACKER, TRAIT_SLEUTH)//Spy not a royal champion
 	subclass_stats = list(
 		STATKEY_SPD = 3,
 		STATKEY_PER = 2,


### PR DESCRIPTION

## About The Pull Request

removes the lines of code that changed the hand's clothes on the rockhill map, given that the newkeep/hand vest already spawns in the hand's closet at round start. (at least, from what I can see on strongdmm.) ((This change is made because people, including myself, complained about it.))
removes the -1 strength from spymaster, gives it +1 luck instead. Hand, in general, feels pretty neglected, and Spymaster is neglected most out of all three subclasses. This small step towards un-fucking this class's stats should hold us over until I/someone figure(s) out a more concrete solution.
Gives spymaster the Sleuth trait, as per request.

## Testing Evidence

it's only a few line changes, it compiles.

## Why It's Good For The Game

The spymaster fit was immaculate, and the rockhill jacket was taking it away from us. Plus the jacket spawns in the closet anyways.
More variety when it comes to spymaster's playstyle now that the statset isn't AS gimped as it used to be.

## Changelog

:cl:

del: The Hand's fit changing on the rockhill map
balance: Spymaster's stats
add: Sleuth to Spymaster

/:cl: