### PR TITLE
Rend adjustments - Yes, it's a balancejakk

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -149,7 +149,8 @@
 	blade_class = BCLASS_CHOP
 	reach = 1
 	penfactor = BLUNT_DEFAULT_PENFACTOR
-	damfactor = 2.5
+	swingdelay = 10 // in line with chop intent, of which this attack is blade-class'd as to begin with
+	damfactor = 2.0 // just pointing out that the default wielded force of a greatsword is 35. Originally 2.5x dmfactor: 10 strength at 35 force multiplied by 2.5 = 88 force rounded up. Ergo, two shots the highest con statted characters in the game.
 	clickcd = CLICK_CD_CHARGED
 	no_early_release = TRUE
 	hitsound = list('sound/combat/hits/bladed/genslash (1).ogg', 'sound/combat/hits/bladed/genslash (2).ogg', 'sound/combat/hits/bladed/genslash (3).ogg')


### PR DESCRIPTION
## About The Pull Request

Nerfs the egregious over-tuned rend intent to something less absurd.
The intent is chop-classed. Added what should have been there to begin with. A swingdelay of 10 which is standard.
Reduced damfactor from 2.5 to 2.0, still much higher than any chop intent im aware of. Still extremely high damage in the hands of low strength wielders.

## Why It's Good For The Game

Chop class attacks come with a bonus to delimb chances. So that, on top of all the other incredibly over tuned setup. Adding a swingdelay is just good design practice, given chop is the original intent of 'rend' design wise as a high damage, high crit/delimb chance attack with a delay to land in exchange for being a high power, committed attack.

As noted in comments of the line-changes: 35 force is the default greatsword damage. 35 x 2.5 = 88 rounded up. This 2-3 shots even the highest con characters in the game. Never mind everyone else. 
Overwhelmingly all the other weapon types are made almost obsolete by compare. A minor reduction in damfactor to 2.0 seemed reasonable, coming to 70 damage per swing.

~"it's horrible against armor" 70% modifier against integrity. Even at ten strength, 88 damage reduced to 62 damage per swing merely at the cost of sharpness, nearly doubling damage still, and with no real threat of 'Missing' since there was originally no swingdelay for that to come into place. Don't even bother with this line of argument.~

tl;dr everything about rend as it currently stands is a powergamer's wet dream. All this yap is justification for something that should be clear to anyone who plays the game anyways.

## Changelog

:cl:
balance: Added swingdelay to rend base intent
balance: Reduced damfactor from 2.5 to 2.0
/:cl:
