### PR TITLE
Large Gnoll Buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -113,6 +113,7 @@
 		var/obj/item/organ/testicles/testicles = getorganslot(ORGAN_SLOT_TESTICLES)
 		if(!testicles)
 			testicles = new()
+			testicles.ball_size = MAX_TESTICLES_SIZE
 			testicles.Insert(src, TRUE, FALSE)
 	else if(penis)
 		penis.Remove(src)


### PR DESCRIPTION
## About The Pull Request
Gives gnolls large balls (if they chose to have a penis)

## Testing Evidence

<img width="439" height="83" alt="image" src="https://github.com/user-attachments/assets/b8bceb4d-d61c-43fe-b088-97afa9585c13" />

## Why It's Good For The Game
Gnolls should have the proper equipment to fulfill their role as monsters that kidnap people.

## Changelog

:cl:
balance: gives gnolls large balls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
