### PR TITLE
Southwest Rockhill District Changes

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -2314,6 +2314,9 @@
 /area/rogue/indoors/town/garrison)
 "aAP" = (
 /obj/structure/stairs,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
 /turf/open/floor/rogue/ruinedwood{
 	dir = 1;
 	icon_state = "vertw"
@@ -4060,9 +4063,7 @@
 	},
 /area/rogue/indoors)
 "aUW" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
-	},
+/obj/effect/decal/carpet,
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "aUY" = (
@@ -6516,10 +6517,16 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "bzN" = (
+/obj/structure/table/wood/poor{
+	pixel_x = -1
+	},
 /obj/structure/closet/crate/chest{
 	locked = 1;
 	lockid = "street_smithshop01"
 	},
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "bzP" = (
@@ -7549,14 +7556,10 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "bLf" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -8
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "bLn" = (
 /turf/open/floor/rogue/cobble/mossy,
@@ -7598,6 +7601,10 @@
 "bLV" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/grove)
+"bLZ" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "bMb" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -9967,16 +9974,11 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "cmu" = (
-/obj/structure/bed/rogue/inn/wool{
-	dir = 1
-	},
-/obj/item/bedsheet/rogue/wool{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood{
+/obj/structure/fluff/pillow/red{
 	dir = 1;
-	icon_state = "vertw"
+	pixel_y = -3
 	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "cmw" = (
 /turf/closed/wall/mineral/rogue/decostone/mossy/blue/end{
@@ -13979,7 +13981,14 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "deD" = (
-/obj/machinery/light/rogue/torchholder/c,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32;
+	pixel_x = 0
+	},
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = -1;
+	pixel_y = -2
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "deO" = (
@@ -14685,6 +14694,10 @@
 "dlR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
+"dlT" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/checkeralt,
+/area/rogue/indoors/town)
 "dma" = (
 /turf/open/lava,
 /area/rogue/under/cave)
@@ -15151,13 +15164,10 @@
 	},
 /area/rogue/indoors/town/cell)
 "drT" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "drY" = (
 /obj/item/bedsheet/rogue/wool{
@@ -15660,12 +15670,9 @@
 /turf/open/floor/carpet/red,
 /area/rogue/indoors/town/manor/rockhill)
 "dyb" = (
-/obj/structure/fluff/railing/wood,
 /obj/structure/closet/crate/roguecloset/inn/south,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "dye" = (
 /obj/structure/table/wood{
@@ -18039,6 +18046,13 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
+"dZc" = (
+/obj/machinery/light/rogue/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "dZf" = (
 /obj/effect/wisp{
 	pixel_x = 17;
@@ -18432,6 +18446,12 @@
 /obj/item/reagent_containers/glass/bowl/gold,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
+"ecJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "ecL" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
@@ -26329,10 +26349,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 5
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "fSx" = (
 /turf/closed/wall/mineral/rogue/wooddark/end,
@@ -26803,6 +26820,13 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
+"fXs" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "fXu" = (
 /obj/structure/roguewindow/stained/silver,
 /obj/structure/vine,
@@ -31890,11 +31914,11 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
+/obj/structure/fluff/clock{
+	pixel_x = -3;
+	pixel_y = 3
 	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "hin" = (
 /obj/effect/decal/cleanable/dirt/cobweb{
@@ -32437,6 +32461,12 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
+"hoc" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "hoj" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/twig,
@@ -33053,6 +33083,9 @@
 /area/rogue/under/dungeon/wizarddungeon)
 "hvs" = (
 /obj/machinery/light/rogue/candle,
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "hvz" = (
@@ -35415,10 +35448,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "hXT" = (
 /obj/structure/bars,
@@ -39772,13 +39802,10 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/inq/basement)
 "jbc" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/wool,
 /obj/machinery/light/rogue/candle/r,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/obj/structure/bed/rogue/inn/wooldouble,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "jbf" = (
 /obj/structure/fluff/walldeco/med6{
@@ -42646,14 +42673,14 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church/chapel)
 "jHF" = (
-/obj/structure/chair/wood/rogue{
+/obj/structure/rack/rogue/shelf,
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "jHI" = (
 /obj/machinery/light/rogue/campfire/fireplace{
@@ -43708,10 +43735,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 9
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "jUk" = (
 /obj/structure/flora/roguegrass,
@@ -46891,10 +46915,7 @@
 	pixel_x = -9;
 	pixel_y = -17
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "kGu" = (
 /obj/structure/rack/rogue/shelf,
@@ -49748,10 +49769,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "lpa" = (
 /obj/structure/fluff/railing/wood,
@@ -49930,6 +49948,10 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/roofs)
+"lra" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "lrb" = (
 /obj/effect/decal/cleanable/roguerune/arcyne/summoning/mid,
 /turf/open/floor/rogue/concrete,
@@ -55293,10 +55315,7 @@
 /obj/structure/fluff/railing/border{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "mBx" = (
 /obj/structure/fluff/railing/border{
@@ -55711,10 +55730,13 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church)
 "mGd" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_x = 2;
+	pixel_y = 4
 	},
-/turf/open/floor/rogue/wood,
+/obj/machinery/light/rogue/oven/west,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "mGg" = (
 /obj/structure/bed/rogue/inn/double,
@@ -60493,7 +60515,7 @@
 /obj/structure/chair/wood/rogue{
 	dir = 4
 	},
-/turf/open/floor/rogue/woodturned,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "nNZ" = (
 /obj/structure/closet/crate/chest,
@@ -61175,6 +61197,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light/rogue/oven/west,
+/obj/structure/rack/rogue/shelf,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "nVH" = (
@@ -61645,13 +61668,11 @@
 	},
 /area/rogue/indoors/town)
 "oba" = (
-/obj/structure/closet/crate/chest,
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
+/obj/structure/table/wood{
+	icon_state = "tablewood3"
 	},
+/obj/structure/roguemachine/musicbox,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "obb" = (
 /obj/structure/fluff/railing/wood{
@@ -61690,6 +61711,12 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin/rockhill)
+"obr" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "obs" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -63749,6 +63776,13 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield/rockhill/above)
+"ozw" = (
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "ozB" = (
 /obj/structure/curtain/brown{
 	icon_state = "curtain-closed";
@@ -63946,13 +63980,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
 "oCI" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/chair/bench/couch/r{
+	pixel_y = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
 "oCO" = (
 /turf/open/floor/rogue/twig,
@@ -66641,6 +66672,15 @@
 /obj/item/clothing/neck/roguetown/psicross/noc,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
+"pja" = (
+/obj/structure/chair/bench/couch{
+	pixel_y = 8
+	},
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "pjf" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/dirt,
@@ -67373,6 +67413,10 @@
 	dir = 4;
 	pixel_x = 2
 	},
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = -1;
+	pixel_y = -2
+	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "prP" = (
@@ -67579,10 +67623,7 @@
 /area/rogue/outdoors/mountains/decap/rockhill)
 "puo" = (
 /obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "pus" = (
 /turf/open/water/river{
@@ -69682,15 +69723,10 @@
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/beach/harbor)
 "pTp" = (
-/obj/structure/closet/crate/roguecloset{
-	keylock = 1
+/obj/structure/fluff/pillow/red{
+	pixel_x = -2
 	},
-/obj/item/clothing/suit/roguetown/shirt/shortshirt,
-/obj/item/clothing/under/roguetown/trou,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "pTq" = (
 /obj/structure/table/wood{
@@ -70267,8 +70303,12 @@
 /turf/open/water/cleanshallow,
 /area/rogue/outdoors/beach/harbor)
 "qaS" = (
-/obj/structure/closet/crate/roguecloset,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/machinery/light/rogue/campfire/fireplace{
+	pixel_y = 32
+	},
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "qaT" = (
 /obj/structure/closet/crate/roguecloset/lord{
@@ -70814,10 +70854,7 @@
 /area/rogue/under/cavewet)
 "qhX" = (
 /obj/effect/decal/carpet/kover_black,
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "qia" = (
 /obj/structure/table/wood,
@@ -77483,6 +77520,10 @@
 /obj/item/grown/log/tree/small,
 /obj/item/natural/bundle/stick,
 /obj/structure/closet/crate/roguecloset/inn/chest,
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	pixel_x = 2
+	},
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town)
 "rNI" = (
@@ -79017,10 +79058,7 @@
 /obj/structure/roguewindow/openclose{
 	dir = 4
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "shb" = (
 /obj/structure/fluff/statue/small{
@@ -81420,11 +81458,12 @@
 /turf/open/floor/rogue/carpet/lord/center,
 /area/rogue/indoors/town/manor/rockhill)
 "sKT" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood3"
+/obj/machinery/light/rogue/oven/west{
+	pixel_x = -32
 	},
-/obj/structure/roguemachine/musicbox,
-/turf/open/floor/rogue/tile,
+/obj/machinery/light/rogue/hearth,
+/obj/item/reagent_containers/glass/bucket/pot,
+/turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town)
 "sKX" = (
 /turf/open/floor/rogue/twig,
@@ -82885,9 +82924,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
 "tdk" = (
-/obj/structure/bed/rogue/inn/wool,
-/obj/item/bedsheet/rogue/cloth,
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "tds" = (
 /obj/machinery/light/rogue/torchholder{
@@ -98042,10 +98082,12 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/warden)
 "wEi" = (
-/obj/machinery/light/rogue/campfire/fireplace{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 4;
+	pixel_x = 2
 	},
-/turf/open/floor/rogue/ruinedwood/spiral,
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "wEk" = (
 /obj/structure/fluff/railing/border{
@@ -98915,6 +98957,10 @@
 /obj/structure/stairs{
 	dir = 4
 	},
+/obj/structure/fluff/railing/border{
+	dir = 6;
+	pixel_x = 2
+	},
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town)
 "wNf" = (
@@ -99272,8 +99318,9 @@
 	},
 /area/rogue/indoors/town/church)
 "wQN" = (
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/wood,
+/obj/structure/bed/rogue/inn/wooldouble,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "wQS" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
@@ -99581,14 +99628,11 @@
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town/grove)
 "wUU" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8;
-	pixel_x = -2
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "wUV" = (
 /obj/structure/fluff/railing/border{
@@ -102379,7 +102423,7 @@
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "xDt" = (
 /obj/structure/fermentation_keg/water,
@@ -103901,10 +103945,7 @@
 	pixel_y = 32;
 	pixel_x = 0
 	},
-/turf/open/floor/rogue/ruinedwood{
-	dir = 1;
-	icon_state = "vertw"
-	},
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "xVY" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
@@ -384398,8 +384439,8 @@ fnA
 pZg
 pZg
 hXU
-ngc
-ngc
+tdk
+tdk
 qzU
 awP
 atP
@@ -384820,7 +384861,7 @@ wNn
 fnA
 aOv
 xdj
-kfk
+obr
 jlu
 xre
 xdj
@@ -385253,8 +385294,8 @@ aOv
 fnA
 xdj
 hvs
-kfk
-kfk
+hoc
+ecJ
 hsC
 wbg
 fnA
@@ -385684,11 +385725,11 @@ eSt
 pGJ
 fnA
 xdj
-kfk
+pja
 aUW
-wQN
+kfk
 xdj
-wVI
+ouA
 fnA
 vdN
 wbg
@@ -386115,10 +386156,10 @@ xPD
 orb
 fnA
 vdN
-bQs
-jGG
-iDu
-iDu
+xdj
+oCI
+kfk
+lra
 xre
 xcx
 wbg
@@ -386547,10 +386588,10 @@ jPq
 wNn
 fCu
 vdN
-mPW
+evo
 wEi
-eBW
-eBW
+mGd
+bKn
 xdj
 wVI
 fUg
@@ -386979,10 +387020,10 @@ kVc
 wNn
 wVI
 vdN
-bQs
+mPW
 qaS
-xRx
-tdk
+evo
+bzN
 xdj
 wVI
 fUg
@@ -386990,7 +387031,7 @@ cxv
 xFN
 xPN
 rYy
-rYy
+dlT
 cPR
 xFN
 xAt
@@ -387411,10 +387452,10 @@ ksz
 lyG
 oAn
 fnA
-xre
-iDu
-iDu
-iDu
+vbM
+evo
+evo
+evo
 xre
 wVI
 fCu
@@ -390004,10 +390045,10 @@ slE
 lyG
 vJr
 bQs
-vfP
+fXs
 czF
 xfc
-bKn
+bLZ
 sKT
 evo
 wVI
@@ -390439,7 +390480,7 @@ mPW
 uFM
 bKn
 bKn
-bKn
+vfP
 bzN
 xFN
 wVI
@@ -409911,9 +409952,9 @@ fnA
 fnA
 hsC
 bKn
-bKn
+ozw
 kfk
-mGd
+nNN
 pPG
 xlA
 xlA
@@ -410777,7 +410818,7 @@ evo
 atb
 prO
 kvv
-aUW
+tdk
 pPG
 xlA
 xlA
@@ -494984,8 +495025,8 @@ xdj
 dyb
 oTD
 aAP
-nNJ
-xdj
+hwk
+hXS
 fZJ
 fZJ
 fZJ
@@ -495416,8 +495457,8 @@ xdj
 jHF
 bLf
 bLf
-qnM
-xdj
+dZc
+hXS
 fZJ
 fZJ
 fZJ
@@ -495847,7 +495888,7 @@ fZJ
 mPW
 xVM
 qhX
-xrP
+vra
 xre
 xre
 fZJ
@@ -496278,8 +496319,8 @@ xvv
 fZJ
 xdj
 wUU
-xrP
-ixw
+vra
+wQN
 xdj
 fZJ
 fZJ
@@ -496710,7 +496751,7 @@ fHB
 fZJ
 xre
 iDu
-hWg
+drT
 iDu
 xre
 fZJ
@@ -499304,7 +499345,7 @@ pZg
 fhy
 tRs
 loY
-xrP
+puo
 pZg
 jqs
 fZJ
@@ -499733,10 +499774,10 @@ auG
 wNn
 fZJ
 pZg
-drT
-oCI
+jNb
+bLf
 jUj
-xrP
+nNJ
 hXS
 jqs
 fZJ
@@ -500166,8 +500207,8 @@ xvv
 fZJ
 mPW
 kGq
-xrP
-puo
+vra
+vra
 jbc
 pZg
 jqs

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1038,9 +1038,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/dungeon/sunkenchurch)
 "alB" = (
-/obj/structure/curtain/black,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "alD" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/indoors/town/magician/rockhill)
@@ -1899,12 +1902,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
-"awf" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "awj" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
@@ -3242,6 +3239,14 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/grove)
+"aLF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "aLJ" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -6039,15 +6044,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave)
-"bug" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "buj" = (
 /obj/structure/mineral_door/bars/tough{
 	lockid = "inquisition";
@@ -6524,10 +6520,16 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "bzN" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = -1;
-	pixel_y = -2
+/obj/structure/table/wood/poor{
+	pixel_x = -1
 	},
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "street_smithshop01"
+	},
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "bzP" = (
@@ -7557,15 +7559,11 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "bLf" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/chair/wood/rogue{
+	dir = 8
 	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 5
-	},
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "bLn" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/oldgoblincamp)
@@ -7711,6 +7709,10 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
+"bMU" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/checkeralt,
+/area/rogue/indoors/town)
 "bMV" = (
 /turf/open/floor/rogue/church{
 	color = "#d4ffcf"
@@ -11029,6 +11031,17 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"czI" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "czK" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -12094,6 +12107,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor/rockhill)
+"cJX" = (
+/obj/structure/chair/bench/couch{
+	pixel_y = 8
+	},
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "cJY" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -12328,9 +12350,7 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 9
-	},
+/turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "cMD" = (
 /obj/machinery/artificer_table,
@@ -12744,12 +12764,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "cQz" = (
-/obj/effect/landmark/start/villager,
-/obj/structure/chair/bench{
-	pixel_y = 5
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "cQB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -13347,16 +13366,6 @@
 /obj/effect/decal/carpet,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
-"cXD" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "cXJ" = (
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/herringbone,
@@ -13476,9 +13485,12 @@
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "cZw" = (
-/obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town/rockhill)
+/obj/machinery/light/rogue/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "cZx" = (
 /obj/effect/landmark/quest_spawner/easy,
 /turf/open/floor/rogue/cobblerock,
@@ -13963,15 +13975,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
-"deu" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "dew" = (
 /obj/item/natural/wood/plank,
 /obj/item/natural/wood/plank{
@@ -15176,9 +15179,8 @@
 	},
 /area/rogue/indoors/town/cell)
 "drT" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "drY" = (
 /obj/item/bedsheet/rogue/wool{
 	dir = 1
@@ -15459,13 +15461,6 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
-"duV" = (
-/obj/machinery/light/rogue/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
 "dvh" = (
 /obj/structure/mineral_door/wood{
 	lockid = "foodshoproom1";
@@ -16266,6 +16261,17 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town/rockhill)
+"dEE" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "dEG" = (
 /obj/structure/hotspring/border/six,
 /turf/open/floor/rogue/grass,
@@ -16538,6 +16544,10 @@
 "dHE" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/church/basement)
+"dHF" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "dHH" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -16606,12 +16616,6 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
-"dIt" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "dIw" = (
 /obj/structure/table/wood,
 /obj/item/candle/skull/lit,
@@ -19787,16 +19791,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/grove)
-"eub" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "eud" = (
 /obj/structure/table/wood,
 /obj/item/roguestatue/glass,
@@ -21156,6 +21150,12 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
+"eIC" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "eID" = (
 /obj/structure/table/wood/poor,
 /obj/machinery/light/rogue/candle/l,
@@ -22982,6 +22982,17 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
+"feq" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/closet/crate/chest/wicker{
+	pixel_x = -5
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "feu" = (
 /obj/structure/bondage/torture_table/lever,
 /turf/open/floor/rogue/cobble,
@@ -23838,10 +23849,6 @@
 "foA" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church)
-"foD" = (
-/obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
 "foE" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -26278,6 +26285,10 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor/rockhill)
+"fRl" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town/rockhill)
 "fRm" = (
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = 32
@@ -27478,6 +27489,13 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church)
+"ggn" = (
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "ggu" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -28678,7 +28696,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/harbor)
 "gvg" = (
-/turf/open/floor/rogue/ruinedwood/platform,
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/town/roofs)
 "gvs" = (
 /obj/structure/flora/roguegrass/bush/jungle/large{
@@ -29861,6 +29884,17 @@
 /obj/item/needle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
+"gJx" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/roguebin/water/gross{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "gJF" = (
 /obj/structure/chair/stool/rogue,
 /obj/item/clothing/cloak/abyssortabard,
@@ -32137,6 +32171,13 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/mountains/decap/rockhill)
+"hkq" = (
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "hkv" = (
 /obj/machinery/light/roguestreet/orange{
 	pixel_x = 40;
@@ -35393,6 +35434,19 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
+"hWK" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "hWT" = (
 /obj/structure/bed/rogue/shit,
 /obj/machinery/light/rogue/candle/blue,
@@ -38523,6 +38577,12 @@
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /turf/open/floor/rogue/grass/nospawn,
 /area/rogue/outdoors/woodsrat/safe)
+"iLD" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "iLJ" = (
 /obj/structure/fluff/walldeco/church/line{
 	layer = 2.2
@@ -38819,14 +38879,6 @@
 	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
-"iOU" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 2
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/rockhill)
 "iOX" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/rogueore/coal,
@@ -38976,13 +39028,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "iRA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "iRH" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -40262,12 +40312,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
-"jeK" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "jeP" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -40629,9 +40673,12 @@
 	},
 /area/rogue/under/dungeon/tricksntraps)
 "jkg" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "jkh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -40844,6 +40891,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
+"jmq" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/poor,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "jmu" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
@@ -41978,14 +42035,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/beach/harbor)
-"jAQ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
 "jAV" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -43466,16 +43515,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
-"jQI" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/table/wood/poor,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "jQP" = (
 /obj/structure/table/wood,
 /obj/item/millstone,
@@ -45496,12 +45535,6 @@
 /mob/living/simple_animal/chicken,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
-"knX" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "knY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -46576,20 +46609,6 @@
 /obj/machinery/anvil,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
-"kAX" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "kBe" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8;
@@ -47762,6 +47781,12 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/tavern)
+"kPq" = (
+/obj/structure/chair/bench/couch/r{
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "kPs" = (
 /obj/structure/curtain/magenta,
 /obj/structure/roguewindow/harem3,
@@ -48144,6 +48169,19 @@
 "kTg" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/cell/warden)
+"kTi" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "kTj" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/rogue/meat_rotten,
@@ -48989,15 +49027,6 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
-"leC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "leF" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -49104,11 +49133,8 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet)
 "lgg" = (
-/obj/structure/chair/bench/couch{
-	pixel_y = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
+/obj/structure/fluff/railing/border{
+	dir = 9
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town)
@@ -49653,6 +49679,10 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
+"lmr" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "lmw" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -49826,17 +49856,6 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
-"loX" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "loY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -51445,18 +51464,20 @@
 /area/rogue/indoors/town/manor/rockhill)
 "lKh" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 2
 	},
-/turf/open/floor/rogue/rooftop/green{
-	dir = 8
-	},
-/area/rogue/outdoors/town/roofs)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/rockhill)
 "lKj" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/sewer)
+"lKl" = (
+/obj/structure/curtain/black,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "lKt" = (
 /obj/machinery/light/rogue/candle/green/r,
 /obj/item/dummy/treasure{
@@ -51528,6 +51549,12 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
+"lKS" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "lKT" = (
 /obj/structure/handcart{
 	dir = 4
@@ -52090,16 +52117,6 @@
 /obj/structure/manaflower,
 /turf/open/floor/rogue/grassgrey,
 /area/rogue/outdoors/bograt/sunken)
-"lRO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 10
-	},
-/area/rogue/outdoors/town/roofs)
 "lRR" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -55927,6 +55944,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/water/swamp,
 /area/rogue/under/dungeon/sunkenchurch)
+"mHQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "mHU" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -56162,12 +56185,6 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
-"mKo" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "mKs" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -58046,6 +58063,12 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
+"nhF" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "nhG" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
@@ -58268,17 +58291,6 @@
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church)
-"nkl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/closet/crate/chest/wicker{
-	pixel_x = -5
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "nkr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -58441,6 +58453,16 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
+"nmP" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 10
+	},
+/area/rogue/outdoors/town/roofs)
 "nmU" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -58714,6 +58736,10 @@
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/volcanic,
 /area/rogue/indoors/town/magician/rockhill)
+"npt" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "npK" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -60601,11 +60627,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
 "nNN" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/fluff/railing/border{
+	dir = 5
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "nNZ" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/concrete,
@@ -60660,12 +60686,6 @@
 /obj/structure/bed/rogue/inn/wool,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet)
-"nOU" = (
-/obj/structure/chair/bench/couch/r{
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "nOY" = (
 /obj/machinery/light/rogue/lanternpost,
 /obj/structure/fluff/railing/wood{
@@ -63531,6 +63551,11 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/harbor)
+"ovi" = (
+/obj/structure/bed/rogue/inn/wooldouble,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "ovk" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless{
@@ -63972,6 +63997,16 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/church)
+"oAJ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "oAO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt/road,
@@ -65124,13 +65159,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "oPQ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "oPR" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grassyel,
@@ -65239,6 +65270,12 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor/rockhill)
+"oRc" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "oRe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -66325,6 +66362,16 @@
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield/rockhill)
+"pds" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "pdz" = (
 /obj/structure/closet/crate/drawer/inn{
 	pixel_x = 4;
@@ -67695,11 +67742,11 @@
 /area/rogue/outdoors/mountains/decap/rockhill)
 "puo" = (
 /obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/turf/open/floor/rogue/ruinedwood/platform,
+/turf/open/transparent/openspace,
 /area/rogue/outdoors/town/roofs)
 "pus" = (
 /turf/open/water/river{
@@ -69456,6 +69503,12 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor/rockhill)
+"pOO" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "pOR" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32;
@@ -69992,6 +70045,12 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town/grove)
+"pVK" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "pVP" = (
 /obj/machinery/light/rogue/candle/floorcandle{
 	pixel_x = -4;
@@ -70328,12 +70387,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
-"qaj" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "qal" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
@@ -70603,19 +70656,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
-"qdl" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/obj/item/roguebin/trash{
-	pixel_y = 10;
-	pixel_x = -9
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "qdm" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -72584,6 +72624,15 @@
 "qBf" = (
 /turf/closed/mineral/random/rogue/boglava/high,
 /area/rogue/under/cave)
+"qBg" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/machinery/light/rogue/oven/west,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "qBi" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32;
@@ -73686,10 +73735,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/sunkenchurch)
-"qPr" = (
-/obj/structure/well,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/rockhill)
 "qPs" = (
 /obj/machinery/light/rogue/firebowl/standing/red,
 /turf/open/floor/rogue/naturalstone,
@@ -75358,10 +75403,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/grove)
-"rmn" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "rmt" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -75778,13 +75819,6 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/ocean,
 /area/rogue/outdoors/beach/harbor)
-"rrc" = (
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/rockhill)
 "rri" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -76629,6 +76663,14 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/bath)
+"rBp" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "rBC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -78019,12 +78061,10 @@
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
 "rSD" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/transparent/openspace,
+/turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "rSJ" = (
 /obj/item/clothing/cloak/stabard/guardhood,
@@ -78395,6 +78435,15 @@
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/oldgoblincamp)
+"rXD" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "rXQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -78405,6 +78454,14 @@
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
+"rXY" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "rXZ" = (
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
@@ -79017,6 +79074,10 @@
 /obj/item/natural/poo,
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/rtfield/rockhill/above)
+"sfC" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "sfH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -80080,10 +80141,6 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor/rockhill)
-"stN" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "stS" = (
 /obj/structure/fluff/railing/wood/east{
 	pixel_x = 9
@@ -80667,11 +80724,13 @@
 /area/rogue/indoors/town/cell)
 "sBp" = (
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/ruinedwood/platform,
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 9
+	},
 /area/rogue/outdoors/town/roofs)
 "sBs" = (
 /obj/machinery/light/rogue/candle/blue/l,
@@ -82094,8 +82153,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/dungeon/oldgoblincamp)
 "sSO" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "sSP" = (
 /obj/effect/decal/cobbleedge{
@@ -83035,17 +83094,10 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
 "tdk" = (
-/obj/structure/table/wood/poor{
-	pixel_x = -1
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "street_smithshop01"
-	},
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/natural/bundle/stick,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "tds" = (
 /obj/machinery/light/rogue/torchholder{
@@ -83154,10 +83206,10 @@
 /area/rogue/indoors/town/dwarfin/rockhill)
 "teF" = (
 /obj/structure/fluff/railing/border{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town/rockhill)
 "teN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/rogue/candle/red/r,
@@ -84136,6 +84188,15 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
+"tqw" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "tqA" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/dirt/road,
@@ -84413,17 +84474,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
-"ttU" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "ttV" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
 	dir = 4
@@ -84727,6 +84777,16 @@
 "txa" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement)
+"txd" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 5
+	},
+/area/rogue/outdoors/town/roofs)
 "txm" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile/bath{
@@ -84861,6 +84921,12 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"tyQ" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "tyW" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -85292,6 +85358,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bograt/above)
+"tEP" = (
+/obj/structure/well,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "tER" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -86894,12 +86964,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor/rockhill)
-"tXy" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "tXC" = (
 /obj/structure/fluff/clock{
 	pixel_y = 2
@@ -87601,12 +87665,6 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/beach/harbor)
-"ugz" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
 "ugC" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
@@ -87656,6 +87714,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
+"uhi" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "uhk" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/head/roguetown/cookhat,
@@ -88821,6 +88883,14 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsrat/safe)
+"uuw" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "uuB" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border/east,
@@ -90086,12 +90156,6 @@
 /obj/machinery/light/rogue/candle/off,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/sewer)
-"uKa" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "uKc" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -90965,19 +91029,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/inq)
-"uUF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "uUJ" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -91663,10 +91714,6 @@
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
-"vcR" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town)
 "vcW" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -92710,12 +92757,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/town/sewer)
-"vqo" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "vqq" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/fermentation_keg/water,
@@ -93447,11 +93488,6 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
-"vxN" = (
-/obj/structure/bed/rogue/inn/wooldouble,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "vxQ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobble,
@@ -94235,12 +94271,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors)
-"vHM" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "vHN" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -94508,7 +94538,12 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/transparent/openspace,
+/obj/machinery/light/rogue/torchholder/c,
+/obj/item/roguebin/trash{
+	pixel_y = 10;
+	pixel_x = -9
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "vKN" = (
 /obj/effect/decal/cobbleedge{
@@ -95399,6 +95434,13 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town)
+"vVJ" = (
+/obj/effect/landmark/start/villager,
+/obj/structure/chair/bench{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/rockhill)
 "vVM" = (
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -95965,6 +96007,13 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/church)
+"wdm" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "wdq" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -96685,10 +96734,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor/rockhill)
-"wmg" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "wmo" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -99491,9 +99536,17 @@
 	},
 /area/rogue/indoors/town/church)
 "wQN" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/poor,
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "wQS" = (
@@ -99814,13 +99867,6 @@
 	pixel_x = 4
 	},
 /turf/open/floor/rogue/wood/nosmooth,
-/area/rogue/indoors/town)
-"wVa" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "wVc" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -102319,12 +102365,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town/rockhill)
-"xAk" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town/rockhill)
 "xAq" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/metal,
@@ -102494,13 +102534,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/church)
-"xBJ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "xBK" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -103425,19 +103458,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/town/rockhill)
-"xML" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "xMY" = (
 /obj/effect/wisp,
 /turf/open/floor/rogue/cobble,
@@ -103519,17 +103539,6 @@
 /obj/effect/decal/remains/saiga,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
-"xNZ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/roguebin/water/gross{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "xOa" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -104048,12 +104057,6 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/dungeon/oldgoblincamp)
-"xUk" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "xUl" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -105334,6 +105337,16 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/shop)
+"yjL" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "yjM" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -383360,7 +383373,7 @@ pdi
 pdi
 pdi
 pdi
-foD
+sSO
 wbg
 wbg
 fUg
@@ -383792,7 +383805,7 @@ fnA
 fnA
 vJr
 vJr
-cZw
+fRl
 fUg
 fUg
 fCu
@@ -384663,8 +384676,8 @@ fnA
 pZg
 pZg
 hXU
-nNN
-nNN
+bLf
+bLf
 qzU
 awP
 atP
@@ -385085,7 +385098,7 @@ wNn
 fnA
 aOv
 xdj
-ugz
+tdk
 jlu
 xre
 xdj
@@ -385518,8 +385531,8 @@ aOv
 fnA
 xdj
 hvs
-mKo
-tXy
+pVK
+lgg
 hsC
 wbg
 fnA
@@ -385949,7 +385962,7 @@ eSt
 pGJ
 fnA
 xdj
-lgg
+cJX
 aUW
 kfk
 xdj
@@ -386381,9 +386394,9 @@ orb
 fnA
 vdN
 xdj
-nOU
+kPq
 kfk
-wmg
+sfC
 xre
 xcx
 wbg
@@ -386814,7 +386827,7 @@ fCu
 vdN
 evo
 wEi
-bug
+qBg
 bKn
 xdj
 wVI
@@ -387247,7 +387260,7 @@ vdN
 mPW
 qaS
 evo
-tdk
+bzN
 xdj
 wVI
 fUg
@@ -387255,16 +387268,16 @@ cxv
 xFN
 xPN
 rYy
-vcR
+bMU
 cPR
 xFN
 xAt
 xAt
 vBZ
-xML
-qaj
+hWK
+nNN
 wbg
-qPr
+tEP
 fnA
 wbg
 uEF
@@ -387693,10 +387706,10 @@ vbM
 xAt
 xAt
 oAn
-jeK
+lKS
 wbg
 fUg
-rrc
+ggn
 fnA
 aOv
 neV
@@ -388109,7 +388122,7 @@ wNn
 rUO
 fnA
 fnA
-stN
+npt
 vJr
 fnA
 fnA
@@ -388124,9 +388137,9 @@ fCu
 fnA
 hxg
 cvG
-xAk
+teF
 hLP
-uKa
+iRA
 aOv
 fCu
 aOv
@@ -389861,7 +389874,7 @@ fJa
 evo
 xFN
 wbg
-uKa
+iRA
 fnA
 wVI
 wVI
@@ -390269,10 +390282,10 @@ slE
 lyG
 vJr
 bQs
-wVa
+jkg
 czF
 xfc
-drT
+lmr
 sKT
 evo
 wVI
@@ -390292,7 +390305,7 @@ aLZ
 pZg
 xre
 xFN
-iOU
+lKh
 oeR
 wVI
 wVI
@@ -390705,7 +390718,7 @@ uFM
 bKn
 bKn
 vfP
-tdk
+bzN
 xFN
 wVI
 xre
@@ -392012,9 +392025,9 @@ pZg
 kJF
 xre
 wbg
-fnA
-aOv
-fCu
+cnH
+nhF
+alB
 aOv
 aOv
 wbg
@@ -392442,7 +392455,7 @@ bAk
 xre
 fnA
 fCu
-sSO
+uhi
 fnA
 aZE
 wiA
@@ -394612,8 +394625,8 @@ esR
 xGW
 xGW
 xGW
-foD
-foD
+sSO
+sSO
 tDA
 yht
 gAR
@@ -395041,7 +395054,7 @@ xFN
 xFN
 evo
 lDc
-cQz
+vVJ
 wVI
 wbg
 fnA
@@ -410176,7 +410189,7 @@ fnA
 fnA
 hsC
 bKn
-bzN
+hkq
 kfk
 mGd
 pPG
@@ -411042,7 +411055,7 @@ evo
 atb
 prO
 kvv
-nNN
+bLf
 pPG
 xlA
 xlA
@@ -494397,9 +494410,9 @@ pZg
 xre
 fZJ
 fZJ
-kAX
-leC
-bLf
+wQN
+tqw
+txd
 xaT
 xaT
 xaT
@@ -494829,9 +494842,9 @@ swX
 xdj
 fZJ
 fZJ
-cXD
-gvg
-lKh
+yjL
+drT
+oAJ
 gxc
 gft
 krf
@@ -495261,9 +495274,9 @@ mAN
 pZg
 fZJ
 fZJ
-puo
-gvg
-lKh
+cMC
+drT
+oAJ
 col
 eNY
 lHE
@@ -495681,7 +495694,7 @@ xdj
 jHF
 oCI
 oCI
-duV
+cZw
 hXS
 fZJ
 fZJ
@@ -495693,9 +495706,9 @@ tAE
 pZg
 fZJ
 fZJ
-puo
-gvg
-lKh
+cMC
+drT
+oAJ
 col
 eNY
 lHE
@@ -496125,9 +496138,9 @@ pZg
 xre
 fZJ
 fZJ
-puo
-gvg
-lKh
+cMC
+drT
+oAJ
 vjf
 lwY
 orm
@@ -496544,7 +496557,7 @@ fZJ
 xdj
 wUU
 vra
-vxN
+ovi
 xdj
 fZJ
 fZJ
@@ -496557,9 +496570,9 @@ mGB
 pZg
 fZJ
 fZJ
-puo
-gvg
 cMC
+drT
+sBp
 vdf
 vdf
 vdf
@@ -496975,7 +496988,7 @@ fHB
 fZJ
 xre
 iDu
-awf
+pOO
 iDu
 xre
 fZJ
@@ -496989,9 +497002,9 @@ iiT
 pZg
 fZJ
 fZJ
-puo
-gvg
-rSD
+cMC
+drT
+aLF
 fZJ
 fZJ
 fZJ
@@ -497419,17 +497432,17 @@ vra
 vra
 mrB
 pZg
-qdl
-ttU
-teF
-teF
-loX
-sBp
-sBp
-sBp
-sBp
-sBp
-lKh
+vKJ
+czI
+rSD
+rSD
+dEE
+rXY
+rXY
+rXY
+rXY
+rXY
+oAJ
 pNY
 tvA
 hyc
@@ -497851,17 +497864,17 @@ pZg
 hWg
 xdj
 xre
-gvg
-deu
-vHM
+drT
+rXD
+oRc
 fZJ
-xUk
-gvg
-uUF
-vKJ
+mHQ
+drT
+kTi
 puo
-gvg
 cMC
+drT
+sBp
 vdf
 vdf
 vdf
@@ -498283,19 +498296,19 @@ fZJ
 fZJ
 fZJ
 fZJ
-xBJ
-vqo
-wQN
-wQN
-knX
-gvg
-oPQ
+wdm
+eIC
+tyQ
+tyQ
+cQz
+drT
+uuw
 fZJ
-puo
-gvg
-eub
-jQI
-rSD
+cMC
+drT
+pds
+jmq
+aLF
 fZJ
 fZJ
 fZJ
@@ -498715,19 +498728,19 @@ pZg
 xre
 pZg
 pZg
-jAQ
-vKJ
-vKJ
-xNZ
-gvg
-gvg
-sBp
-sBp
-gvg
-jkg
-gvg
-gvg
-rSD
+rBp
+puo
+puo
+gJx
+drT
+drT
+rXY
+rXY
+drT
+dHF
+drT
+drT
+aLF
 fZJ
 fZJ
 fZJ
@@ -499150,16 +499163,16 @@ xqX
 kIY
 fZJ
 hox
-iRA
-iRA
-iRA
-iRA
-iRA
-lRO
+gvg
+gvg
+gvg
+gvg
+gvg
+nmP
 jBi
-dIt
-nkl
-rSD
+iLD
+feq
+aLF
 fZJ
 fZJ
 eDa
@@ -499569,7 +499582,7 @@ pZg
 fhy
 tRs
 loY
-rmn
+oPQ
 pZg
 jqs
 fZJ
@@ -499590,7 +499603,7 @@ lDN
 hKm
 lVX
 fZJ
-vKJ
+puo
 fZJ
 fZJ
 fZJ
@@ -503901,7 +503914,7 @@ fZJ
 cbg
 vBU
 wAo
-alB
+lKl
 eBW
 eBW
 gdM
@@ -520766,8 +520779,8 @@ fZJ
 fZJ
 fZJ
 pZg
-eBW
 fVh
+nIH
 nIH
 xre
 pMr

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1037,13 +1037,6 @@
 /obj/item/rogueweapon/thresher/decrepit,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/dungeon/sunkenchurch)
-"alB" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "alD" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/indoors/town/magician/rockhill)
@@ -3446,16 +3439,6 @@
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
-"aNY" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 5
-	},
-/area/rogue/outdoors/town/roofs)
 "aOe" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood,
@@ -7454,15 +7437,11 @@
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/grove)
 "bKj" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/bars/grille{
+	dir = 5
 	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/rockhill)
 "bKn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
@@ -7578,16 +7557,6 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
-"bLf" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 9
-	},
-/area/rogue/outdoors/town/roofs)
 "bLn" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/oldgoblincamp)
@@ -9099,17 +9068,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
-"ccp" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/roguebin/water/gross{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "ccw" = (
 /obj/machinery/light/roguestreet/orange/midlamp{
 	pixel_y = 8
@@ -11234,16 +11192,6 @@
 "cBA" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/inq/basement)
-"cBC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "cBG" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1;
@@ -12786,14 +12734,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
-"cQz" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
 "cQB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -13509,14 +13449,6 @@
 	},
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
-"cZw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "cZx" = (
 /obj/effect/landmark/quest_spawner/easy,
 /turf/open/floor/rogue/cobblerock,
@@ -15207,14 +15139,6 @@
 	icon_state = "bluestone"
 	},
 /area/rogue/indoors/town/cell)
-"drT" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "drY" = (
 /obj/item/bedsheet/rogue/wool{
 	dir = 1
@@ -22777,14 +22701,6 @@
 /obj/structure/bars,
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/cell)
-"fbD" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/metal,
-/area/rogue/outdoors/town/rockhill)
 "fbF" = (
 /obj/structure/bars/pipe{
 	dir = 4;
@@ -26900,19 +26816,6 @@
 /obj/item/natural/rock,
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach/harbor)
-"fYp" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/obj/item/roguebin/trash{
-	pixel_y = 10;
-	pixel_x = -9
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "fYq" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles{
 	pixel_y = -5
@@ -27646,12 +27549,6 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
-"giJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "giK" = (
 /obj/item/storage/roguebag,
 /obj/structure/fluff/railing/border{
@@ -35242,16 +35139,6 @@
 	},
 /turf/open/water/bath/fakepond,
 /area/rogue/indoors/town/bath)
-"hUW" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 10
-	},
-/area/rogue/outdoors/town/roofs)
 "hUX" = (
 /obj/structure/chair/wood,
 /turf/open/floor/rogue/herringbone,
@@ -40673,20 +40560,6 @@
 	dir = 8
 	},
 /area/rogue/under/dungeon/tricksntraps)
-"jkg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "jkh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -45714,12 +45587,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
-"kqz" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "kqB" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -51454,9 +51321,6 @@
 /obj/item/reagent_containers/glass/bottle/rogue/redwine,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor/rockhill)
-"lKh" = (
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "lKj" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/blocks/paving,
@@ -55495,14 +55359,6 @@
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/volcanic,
 /area/rogue/outdoors/bograt/above)
-"mDb" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "mDf" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Artisan Guild";
@@ -55805,17 +55661,6 @@
 	},
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church)
-"mGd" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/closet/crate/chest/wicker{
-	pixel_x = -5
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "mGg" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -56880,9 +56725,6 @@
 /area/rogue/indoors/town/manor/rockhill)
 "mTS" = (
 /obj/structure/fluff/walldeco/wantedposter,
-/obj/structure/stairs{
-	dir = 8
-	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "mTT" = (
@@ -59243,14 +59085,11 @@
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church)
 "nwa" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
+/obj/structure/bars/grille{
+	dir = 8
 	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/rockhill)
 "nwg" = (
 /obj/machinery/light/rogue/hearth{
 	pixel_y = 2
@@ -61329,10 +61168,6 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
-"nVM" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "nVO" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -61606,10 +61441,6 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor/rockhill)
-"nYx" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "nYz" = (
 /obj/structure/fermentation_keg,
 /turf/open/floor/rogue/dirt/road,
@@ -63720,9 +63551,6 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
 /obj/structure/chair/stool/rogue,
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/cobble/mossy,
@@ -65168,14 +64996,6 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
-"oPQ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/town/roofs)
 "oPR" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grassyel,
@@ -65360,13 +65180,6 @@
 /obj/effect/spawner/lootdrop/general_loot_mid,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cavewet)
-"oSA" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 6
-	},
-/turf/open/floor/rogue/concrete,
-/area/rogue/outdoors/town/rockhill)
 "oSF" = (
 /obj/machinery/light/rogue/campfire,
 /turf/open/floor/rogue/dirt/road,
@@ -67738,17 +67551,6 @@
 /obj/effect/spawner/lootdrop/potion_ingredient/herb,
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/rockhill)
-"puo" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "pus" = (
 /turf/open/water/river{
 	dir = 1;
@@ -69223,17 +69025,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/south)
-"pMj" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "pMp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -74446,19 +74237,6 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/magician/rockhill)
-"qYZ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "qZb" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/structure/bars/grille,
@@ -78982,12 +78760,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
-"seO" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "seS" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -80741,14 +80513,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/cell)
-"sBp" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "sBs" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/table/finestone,
@@ -82178,14 +81942,6 @@
 /obj/item/rogueweapon/mace/woodclub,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/dungeon/oldgoblincamp)
-"sSO" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "sSP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -83123,15 +82879,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
-"tdk" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "tds" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -83237,16 +82984,6 @@
 "teE" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/dwarfin/rockhill)
-"teF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/rooftop/green{
-	dir = 8
-	},
-/area/rogue/outdoors/town/roofs)
 "teN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/rogue/candle/red/r,
@@ -83776,12 +83513,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/rockhill)
-"tkK" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "tkM" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/fluff/railing/wood,
@@ -84102,12 +83833,6 @@
 "tox" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bograt/above)
-"toA" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "toG" = (
 /obj/structure/glowshroom{
 	icon_state = "glowshroom3"
@@ -85231,12 +84956,6 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
-"tCG" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "tCI" = (
 /obj/structure/fluff/walldeco/psybanner,
 /obj/structure/fluff/walldeco/church/line{
@@ -86028,12 +85747,6 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach/harbor)
-"tNh" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "tNj" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
@@ -86525,12 +86238,6 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/grove)
-"tSx" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "tSy" = (
 /obj/structure/spider/stickyweb{
 	color = "#d1cdc7"
@@ -92507,16 +92214,6 @@
 /obj/item/rogueweapon/hoe,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
-"vmS" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/table/wood/poor,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "vmU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -95560,12 +95257,6 @@
 /obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/basement)
-"vXx" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "vXz" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/river)
@@ -99579,12 +99270,6 @@
 	dir = 1
 	},
 /area/rogue/indoors/town/church)
-"wQN" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town/rockhill)
 "wQS" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet)
@@ -100670,15 +100355,6 @@
 /obj/effect/spawner/lootdrop/contraband,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/basement/keep)
-"xfk" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "xfn" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/academy)
@@ -102182,12 +101858,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
-"xxx" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "xxz" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/basement)
@@ -387344,9 +387014,9 @@ cPR
 xFN
 xAt
 xAt
-vBZ
+xAt
 owW
-tkK
+fnA
 wbg
 mQk
 fnA
@@ -387776,8 +387446,8 @@ evo
 vbM
 xAt
 xAt
-oAn
-kqz
+xAt
+hXK
 wbg
 fUg
 ooT
@@ -388193,7 +387863,7 @@ wNn
 rUO
 fnA
 fnA
-nYx
+aOv
 vJr
 fnA
 fnA
@@ -388203,14 +387873,14 @@ bcC
 fnA
 wbg
 fUg
-yht
+wbg
 fCu
 fnA
 hxg
 cvG
-wQN
-hLP
-giJ
+cvG
+wbg
+fnA
 aOv
 fCu
 aOv
@@ -388637,9 +388307,9 @@ oUf
 wMg
 wMg
 wMg
-oSA
+uQS
 aOv
-yht
+wbg
 fnA
 fnA
 aOv
@@ -389080,8 +388750,8 @@ pZg
 xOa
 xFN
 vbM
-oAn
-bdL
+wbg
+aOv
 wbg
 eqP
 xAt
@@ -389513,7 +389183,7 @@ ryw
 lbg
 evo
 mTS
-kYn
+aOv
 fnA
 cvG
 pWS
@@ -389945,7 +389615,7 @@ fJa
 evo
 xFN
 wbg
-tdk
+cnH
 ktb
 aZT
 rtB
@@ -392104,7 +391774,7 @@ aOv
 wbg
 fnA
 uTY
-fbD
+uTY
 wbg
 uMk
 hpj
@@ -395954,7 +395624,7 @@ cVT
 cVT
 wVI
 gTw
-wbg
+bKj
 aOv
 aOv
 wbg
@@ -395983,9 +395653,9 @@ wbg
 wbg
 wbg
 wbg
-fnA
 wbg
 wbg
+bKj
 wbg
 wbg
 fCu
@@ -403313,7 +402983,7 @@ fnA
 wbg
 oAn
 hAv
-fnA
+wbg
 wVI
 evo
 gSu
@@ -404189,7 +403859,7 @@ dYj
 gAw
 rLD
 wbg
-wbg
+nwa
 wbg
 meI
 msH
@@ -405473,7 +405143,7 @@ umg
 wbg
 oAn
 hAv
-fnA
+wbg
 oTg
 evo
 evo
@@ -494481,9 +494151,9 @@ pZg
 xre
 fZJ
 fZJ
-jkg
-xfk
-aNY
+fZJ
+fZJ
+hox
 xaT
 xaT
 xaT
@@ -494913,9 +494583,9 @@ swX
 xdj
 fZJ
 fZJ
-bKj
-lKh
-teF
+fZJ
+fZJ
+fjX
 gxc
 gft
 krf
@@ -495345,9 +495015,9 @@ mAN
 pZg
 fZJ
 fZJ
-sBp
-lKh
-teF
+fZJ
+fZJ
+fjX
 col
 eNY
 lHE
@@ -495777,9 +495447,9 @@ tAE
 pZg
 fZJ
 fZJ
-sBp
-lKh
-teF
+fZJ
+fZJ
+fjX
 col
 eNY
 lHE
@@ -496209,9 +495879,9 @@ pZg
 xre
 fZJ
 fZJ
-sBp
-lKh
-teF
+fZJ
+fZJ
+fjX
 vjf
 lwY
 orm
@@ -496641,9 +496311,9 @@ mGB
 pZg
 fZJ
 fZJ
-sBp
-lKh
-bLf
+fZJ
+fZJ
+ptX
 vdf
 vdf
 vdf
@@ -497073,9 +496743,9 @@ iiT
 pZg
 fZJ
 fZJ
-sBp
-lKh
-cZw
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -497503,17 +497173,17 @@ vra
 vra
 mrB
 pZg
-fYp
-puo
-xxx
-xxx
-pMj
-drT
-drT
-drT
-drT
-drT
-teF
+fJM
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fjX
 pNY
 tvA
 hyc
@@ -497935,17 +497605,17 @@ pZg
 hWg
 xdj
 xre
-lKh
-nwa
-vXx
 fZJ
-tNh
-lKh
-qYZ
-sSO
-sBp
-lKh
-bLf
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+ptX
 vdf
 vdf
 vdf
@@ -498367,19 +498037,19 @@ fZJ
 fZJ
 fZJ
 fZJ
-alB
-tSx
-seO
-seO
-toA
-lKh
-mDb
 fZJ
-sBp
-lKh
-cBC
-vmS
-cZw
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -498799,19 +498469,19 @@ pZg
 xre
 pZg
 pZg
-cQz
-sSO
-sSO
-ccp
-lKh
-lKh
-drT
-drT
-lKh
-nVM
-lKh
-lKh
-cZw
+xre
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 fZJ
@@ -499234,16 +498904,16 @@ xqX
 kIY
 fZJ
 hox
-oPQ
-oPQ
-oPQ
-oPQ
-oPQ
-hUW
-jBi
-tCG
-mGd
-cZw
+xaT
+xaT
+xaT
+xaT
+xaT
+lVX
+fZJ
+fZJ
+fZJ
+fZJ
 fZJ
 fZJ
 eDa
@@ -499674,7 +499344,7 @@ lDN
 hKm
 lVX
 fZJ
-sSO
+fZJ
 fZJ
 fZJ
 fZJ

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1038,17 +1038,9 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/dungeon/sunkenchurch)
 "alB" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/flora/roguegrass/reedbush{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/machinery/light/roguestreet/orange,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town/rockhill)
+/obj/structure/curtain/black,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "alD" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/indoors/town/magician/rockhill)
@@ -1907,6 +1899,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
+"awf" = (
+/obj/structure/roguewindow/openclose{
+	dir = 8
+	},
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "awj" = (
 /obj/item/reagent_containers/food/snacks/crow{
 	dir = 1
@@ -6041,6 +6039,15 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cave)
+"bug" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/machinery/light/rogue/oven/west,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "buj" = (
 /obj/structure/mineral_door/bars/tough{
 	lockid = "inquisition";
@@ -6517,16 +6524,10 @@
 	},
 /area/rogue/indoors/town/manor/rockhill)
 "bzN" = (
-/obj/structure/table/wood/poor{
-	pixel_x = -1
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = -1;
+	pixel_y = -2
 	},
-/obj/structure/closet/crate/chest{
-	locked = 1;
-	lockid = "street_smithshop01"
-	},
-/obj/item/grown/log/tree/small,
-/obj/item/grown/log/tree/small,
-/obj/item/natural/bundle/stick,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "bzP" = (
@@ -7283,7 +7284,7 @@
 /area/rogue/indoors/town/bath)
 "bIk" = (
 /obj/structure/chair/bench{
-	pixel_x = -6
+	pixel_y = 5
 	},
 /obj/effect/landmark/start/villager,
 /turf/open/floor/rogue/blocks,
@@ -7556,11 +7557,15 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "bLf" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 5
+	},
+/area/rogue/outdoors/town/roofs)
 "bLn" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/oldgoblincamp)
@@ -7601,10 +7606,6 @@
 "bLV" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/grove)
-"bLZ" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "bMb" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -12323,12 +12324,14 @@
 /area/rogue/under/cavewet)
 "cMC" = (
 /obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = -1
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 9
+	},
+/area/rogue/outdoors/town/roofs)
 "cMD" = (
 /obj/machinery/artificer_table,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12741,8 +12744,11 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "cQz" = (
-/obj/machinery/light/rogue/torchholder/l,
-/turf/open/floor/rogue/cobblerock,
+/obj/effect/landmark/start/villager,
+/obj/structure/chair/bench{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "cQB" = (
 /obj/structure/fluff/railing/wood{
@@ -13341,6 +13347,16 @@
 /obj/effect/decal/carpet,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
+"cXD" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "cXJ" = (
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/herringbone,
@@ -13460,18 +13476,8 @@
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "cZw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/bars/grille,
-/turf/open/transparent/openspace,
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town/rockhill)
 "cZx" = (
 /obj/effect/landmark/quest_spawner/easy,
@@ -13954,8 +13960,18 @@
 	pixel_x = -5;
 	pixel_y = 2
 	},
+/obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
+"deu" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "dew" = (
 /obj/item/natural/wood/plank,
 /obj/item/natural/wood/plank{
@@ -14694,10 +14710,6 @@
 "dlR" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors)
-"dlT" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town)
 "dma" = (
 /turf/open/lava,
 /area/rogue/under/cave)
@@ -15164,10 +15176,8 @@
 	},
 /area/rogue/indoors/town/cell)
 "drT" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "drY" = (
 /obj/item/bedsheet/rogue/wool{
@@ -15449,6 +15459,13 @@
 /obj/item/reagent_containers/glass/cup/wooden,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
+"duV" = (
+/obj/machinery/light/rogue/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "dvh" = (
 /obj/structure/mineral_door/wood{
 	lockid = "foodshoproom1";
@@ -16589,6 +16606,12 @@
 /obj/item/reagent_containers/glass/bucket/pot,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/indoors)
+"dIt" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "dIw" = (
 /obj/structure/table/wood,
 /obj/item/candle/skull/lit,
@@ -18046,13 +18069,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/garrison)
-"dZc" = (
-/obj/machinery/light/rogue/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
 "dZf" = (
 /obj/effect/wisp{
 	pixel_x = 17;
@@ -18446,12 +18462,6 @@
 /obj/item/reagent_containers/glass/bowl/gold,
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/cave/goblinfort)
-"ecJ" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "ecL" = (
 /obj/structure/fluff/railing/fence,
 /turf/open/floor/rogue/dirt/road,
@@ -19777,6 +19787,16 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/cleanshallow,
 /area/rogue/indoors/town/grove)
+"eub" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "eud" = (
 /obj/structure/table/wood,
 /obj/item/roguestatue/glass,
@@ -23818,6 +23838,10 @@
 "foA" = (
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church)
+"foD" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/rockhill)
 "foE" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcv";
@@ -26820,13 +26844,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/bath)
-"fXs" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "fXu" = (
 /obj/structure/roguewindow/stained/silver,
 /obj/structure/vine,
@@ -28661,11 +28678,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/harbor)
 "gvg" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "gvs" = (
 /obj/structure/flora/roguegrass/bush/jungle/large{
 	color = "#9a8acf"
@@ -32461,12 +32475,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/garrison)
-"hoc" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "hoj" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/twig,
@@ -38811,6 +38819,14 @@
 	},
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors/town/bath)
+"iOU" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/rockhill)
 "iOX" = (
 /obj/structure/closet/crate/chest/old_crate,
 /obj/item/rogueore/coal,
@@ -38962,14 +38978,11 @@
 "iRA" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
-	pixel_x = -4
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/structure/chair/bench{
-	pixel_x = 8
-	},
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/town/roofs)
 "iRH" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -40249,6 +40262,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/town/grove)
+"jeK" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "jeP" = (
 /obj/item/reagent_containers/food/snacks/smallrat,
 /turf/open/floor/rogue/cobble,
@@ -40610,12 +40629,9 @@
 	},
 /area/rogue/under/dungeon/tricksntraps)
 "jkg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -4
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "jkh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -41962,6 +41978,14 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/beach/harbor)
+"jAQ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "jAV" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -43442,6 +43466,16 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
+"jQI" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/poor,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "jQP" = (
 /obj/structure/table/wood,
 /obj/item/millstone,
@@ -45462,6 +45496,12 @@
 /mob/living/simple_animal/chicken,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
+"knX" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "knY" = (
 /obj/structure/stairs{
 	dir = 1
@@ -46536,6 +46576,20 @@
 /obj/machinery/anvil,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
+"kAX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "kBe" = (
 /obj/structure/chair/wood/rogue{
 	dir = 8;
@@ -48935,6 +48989,15 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
+"leC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "leF" = (
 /obj/structure/mineral_door/bars{
 	locked = 1;
@@ -49041,16 +49104,14 @@
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet)
 "lgg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -4
+/obj/structure/chair/bench/couch{
+	pixel_y = 8
 	},
-/obj/structure/chair/bench{
-	dir = 4;
-	pixel_x = 5
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "lgi" = (
 /obj/structure/fluff/statue/gargoyle/moss{
 	pixel_x = -4;
@@ -49765,6 +49826,17 @@
 /obj/item/natural/feather,
 /turf/open/floor/rogue/twig,
 /area/rogue/outdoors/town/grove)
+"loX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "loY" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -49948,10 +50020,6 @@
 /obj/structure/fluff/statue/gargoyle,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/roofs)
-"lra" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "lrb" = (
 /obj/effect/decal/cleanable/roguerune/arcyne/summoning/mid,
 /turf/open/floor/rogue/concrete,
@@ -51378,11 +51446,13 @@
 "lKh" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
-	pixel_y = 6
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "lKj" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/blocks/paving,
@@ -52020,6 +52090,16 @@
 /obj/structure/manaflower,
 /turf/open/floor/rogue/grassgrey,
 /area/rogue/outdoors/bograt/sunken)
+"lRO" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 10
+	},
+/area/rogue/outdoors/town/roofs)
 "lRR" = (
 /obj/structure/mineral_door/wood{
 	icon_state = "wcr";
@@ -54968,12 +55048,8 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "mwY" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/transparent/openspace,
+/obj/structure/flora/roguegrass,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town/rockhill)
 "mxb" = (
 /obj/structure/stairs{
@@ -55730,13 +55806,10 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church)
 "mGd" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = 2;
-	pixel_y = 4
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/tile,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "mGg" = (
 /obj/structure/bed/rogue/inn/double,
@@ -56089,6 +56162,12 @@
 /obj/item/rogueweapon/huntingknife/stoneknife,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
+"mKo" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "mKs" = (
 /obj/structure/table/wood{
 	dir = 10;
@@ -56798,6 +56877,9 @@
 /area/rogue/indoors/town/manor/rockhill)
 "mTS" = (
 /obj/structure/fluff/walldeco/wantedposter,
+/obj/structure/stairs{
+	dir = 8
+	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "mTT" = (
@@ -58186,6 +58268,17 @@
 /obj/machinery/light/rogue/candle/floorcandle,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/indoors/town/church)
+"nkl" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/closet/crate/chest/wicker{
+	pixel_x = -5
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "nkr" = (
 /obj/effect/decal/cobbleedge{
 	dir = 10;
@@ -58671,12 +58764,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
 "nqE" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/grass,
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town/rockhill)
 "nqK" = (
 /obj/machinery/light/rogue/torchholder{
@@ -60513,7 +60602,7 @@
 /area/rogue/indoors)
 "nNN" = (
 /obj/structure/chair/wood/rogue{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
@@ -60571,6 +60660,12 @@
 /obj/structure/bed/rogue/inn/wool,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/under/cavewet)
+"nOU" = (
+/obj/structure/chair/bench/couch/r{
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "nOY" = (
 /obj/machinery/light/rogue/lanternpost,
 /obj/structure/fluff/railing/wood{
@@ -61711,12 +61806,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/dwarfin/rockhill)
-"obr" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
 "obs" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -63776,13 +63865,6 @@
 /obj/item/reagent_containers/food/snacks/crow,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/rtfield/rockhill/above)
-"ozw" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "ozB" = (
 /obj/structure/curtain/brown{
 	icon_state = "curtain-closed";
@@ -63980,10 +64062,10 @@
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
 "oCI" = (
-/obj/structure/chair/bench/couch/r{
-	pixel_y = 8
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
-/turf/open/floor/rogue/wood,
+/turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town)
 "oCO" = (
 /turf/open/floor/rogue/twig,
@@ -65042,11 +65124,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "oPQ" = (
-/obj/structure/bars/grille{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = -4
 	},
 /turf/open/transparent/openspace,
-/area/rogue/outdoors/town/rockhill)
+/area/rogue/outdoors/town/roofs)
 "oPR" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grassyel,
@@ -66672,15 +66756,6 @@
 /obj/item/clothing/neck/roguetown/psicross/noc,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/chapel)
-"pja" = (
-/obj/structure/chair/bench/couch{
-	pixel_y = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "pjf" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/rogue/dirt,
@@ -67507,9 +67582,6 @@
 /obj/structure/chair/bench{
 	dir = 4
 	},
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/town/rockhill)
 "ptj" = (
@@ -67622,9 +67694,13 @@
 /turf/open/floor/rogue/tile,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "puo" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "pus" = (
 /turf/open/water/river{
 	dir = 1;
@@ -69785,8 +69861,9 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/obj/structure/bars/grille,
-/turf/open/transparent/openspace,
+/obj/structure/table/wood/poor,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/cobble,
 /area/rogue/outdoors/town/rockhill)
 "pUn" = (
 /obj/structure/table/wood/poor,
@@ -70251,6 +70328,12 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
+"qaj" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "qal" = (
 /obj/machinery/light/rogue/firebowl/standing/blue,
 /turf/open/floor/rogue/grass,
@@ -70520,6 +70603,19 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/cavewet)
+"qdl" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/obj/item/roguebin/trash{
+	pixel_y = 10;
+	pixel_x = -9
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "qdm" = (
 /obj/structure/table/wood{
 	icon_state = "tablewood3"
@@ -73590,6 +73686,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/sunkenchurch)
+"qPr" = (
+/obj/structure/well,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "qPs" = (
 /obj/machinery/light/rogue/firebowl/standing/red,
 /turf/open/floor/rogue/naturalstone,
@@ -75258,6 +75358,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/grove)
+"rmn" = (
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "rmt" = (
 /obj/structure/fluff/walldeco/church/line{
 	dir = 8
@@ -75674,6 +75778,13 @@
 /obj/structure/flora/roguegrass/water,
 /turf/open/water/ocean,
 /area/rogue/outdoors/beach/harbor)
+"rrc" = (
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "rri" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -77908,13 +78019,13 @@
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
 "rSD" = (
-/obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/fluff/railing/wood{
 	dir = 1;
-	pixel_y = 6
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/grass,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "rSJ" = (
 /obj/item/clothing/cloak/stabard/guardhood,
 /obj/item/clothing/cloak/stabard/guardhood,
@@ -79709,7 +79820,7 @@
 /obj/item/bedsheet/rogue/double_pelt{
 	dir = 1
 	},
-/turf/open/floor/rogue/ruinedwood/chevron,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "spV" = (
 /obj/structure/table/wood/poor,
@@ -79969,6 +80080,10 @@
 	},
 /turf/open/floor/rogue/tile/masonic/inverted,
 /area/rogue/indoors/town/manor/rockhill)
+"stN" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "stS" = (
 /obj/structure/fluff/railing/wood/east{
 	pixel_x = 9
@@ -80556,9 +80671,8 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/structure/bars/grille,
-/turf/open/floor/rogue/metal,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "sBs" = (
 /obj/machinery/light/rogue/candle/blue/l,
 /obj/structure/table/finestone,
@@ -81980,11 +82094,8 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/dungeon/oldgoblincamp)
 "sSO" = (
-/obj/structure/chair/bench{
-	dir = 4;
-	pixel_x = -3
-	},
-/turf/open/floor/rogue/blocks,
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "sSP" = (
 /obj/effect/decal/cobbleedge{
@@ -82924,10 +83035,17 @@
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/town/bath)
 "tdk" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/table/wood/poor{
+	pixel_x = -1
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/closet/crate/chest{
+	locked = 1;
+	lockid = "street_smithshop01"
+	},
+/obj/item/grown/log/tree/small,
+/obj/item/grown/log/tree/small,
+/obj/item/natural/bundle/stick,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "tds" = (
 /obj/machinery/light/rogue/torchholder{
@@ -83035,13 +83153,11 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "teF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/fluff/railing/border{
+	dir = 4
 	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "teN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/rogue/candle/red/r,
@@ -83572,12 +83688,8 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "tkK" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = -1
-	},
-/turf/open/floor/rogue/cobble/mossy,
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/naturalstone,
 /area/rogue/outdoors/town/rockhill)
 "tkM" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -84301,6 +84413,17 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/town/basement/keep)
+"ttU" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "ttV" = (
 /obj/machinery/light/roguestreet/orange/walllamp{
 	dir = 4
@@ -85587,7 +85710,7 @@
 /obj/structure/closet/crate/roguecloset/inn/south{
 	pixel_y = 6
 	},
-/turf/open/floor/rogue/ruinedwood/chevron,
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "tKb" = (
 /obj/structure/fluff/railing/wood{
@@ -85768,8 +85891,7 @@
 	dir = 5
 	},
 /obj/structure/fluff/railing/border{
-	dir = 6;
-	pixel_x = 2
+	dir = 6
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
@@ -86772,6 +86894,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood/turned,
 /area/rogue/indoors/town/manor/rockhill)
+"tXy" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "tXC" = (
 /obj/structure/fluff/clock{
 	pixel_y = 2
@@ -87473,6 +87601,12 @@
 /obj/structure/fluff/railing/border,
 /turf/closed/wall/mineral/rogue/stone/moss,
 /area/rogue/outdoors/beach/harbor)
+"ugz" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "ugC" = (
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/mountains)
@@ -89952,6 +90086,12 @@
 /obj/machinery/light/rogue/candle/off,
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/sewer)
+"uKa" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "uKc" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/cobblerock,
@@ -90825,6 +90965,19 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/inq)
+"uUF" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "uUJ" = (
 /obj/structure/fluff/railing/border,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -91510,6 +91663,10 @@
 /obj/machinery/light/rogue/candle,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"vcR" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/checkeralt,
+/area/rogue/indoors/town)
 "vcW" = (
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/cobble,
@@ -92553,6 +92710,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/under/town/sewer)
+"vqo" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "vqq" = (
 /obj/machinery/light/rogue/candle,
 /obj/structure/fermentation_keg/water,
@@ -93284,6 +93447,11 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
+"vxN" = (
+/obj/structure/bed/rogue/inn/wooldouble,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vxQ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobble,
@@ -94067,6 +94235,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors)
+"vHM" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vHN" = (
 /obj/item/grown/log/tree/small,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -94331,16 +94505,11 @@
 "vKJ" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
-	pixel_x = -8;
-	pixel_y = -1
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	layer = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vKN" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall"
@@ -96516,6 +96685,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/manor/rockhill)
+"wmg" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "wmo" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -99318,10 +99491,11 @@
 	},
 /area/rogue/indoors/town/church)
 "wQN" = (
-/obj/structure/bed/rogue/inn/wooldouble,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "wQS" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet)
@@ -99640,6 +99814,13 @@
 	pixel_x = 4
 	},
 /turf/open/floor/rogue/wood/nosmooth,
+/area/rogue/indoors/town)
+"wVa" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "wVc" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles,
@@ -102138,6 +102319,12 @@
 /obj/machinery/gear_painter,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/outdoors/town/rockhill)
+"xAk" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town/rockhill)
 "xAq" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/metal,
@@ -102307,6 +102494,13 @@
 	},
 /turf/open/floor/rogue/ruinedwood/chevron,
 /area/rogue/indoors/town/church)
+"xBJ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "xBK" = (
 /obj/structure/roguewindow/openclose{
 	dir = 1
@@ -103231,6 +103425,19 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/outdoors/town/rockhill)
+"xML" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "xMY" = (
 /obj/effect/wisp,
 /turf/open/floor/rogue/cobble,
@@ -103312,6 +103519,17 @@
 /obj/effect/decal/remains/saiga,
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/cave)
+"xNZ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/roguebin/water/gross{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "xOa" = (
 /obj/structure/roguewindow/openclose{
 	dir = 4
@@ -103830,6 +104048,12 @@
 /obj/structure/chair/wood/rogue/chair3,
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/dungeon/oldgoblincamp)
+"xUk" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "xUl" = (
 /obj/structure/fluff/railing/fence{
 	dir = 1
@@ -276013,8 +276237,8 @@ rSC
 otg
 fIL
 udz
-oGO
-rSC
+mXk
+uEX
 rSC
 rSC
 rSC
@@ -276446,8 +276670,8 @@ uEX
 mXk
 gLf
 gLf
-wuy
-rSC
+fIL
+uEX
 rSC
 rSC
 rSC
@@ -276878,8 +277102,8 @@ rSC
 oGO
 rRb
 gLf
-oGO
-rSC
+mXk
+uEX
 mXk
 uEX
 uEX
@@ -277310,7 +277534,7 @@ rSC
 rSC
 gLf
 gLf
-oGO
+mXk
 uEX
 uEX
 otg
@@ -277741,8 +277965,8 @@ gLf
 gLf
 gLf
 gLf
-rSC
-rSC
+uEX
+uEX
 mXk
 uEX
 hFG
@@ -278173,7 +278397,7 @@ gLf
 lrs
 lrs
 lrs
-rSC
+uEX
 rSC
 rSC
 uEX
@@ -382274,14 +382498,14 @@ xAt
 xAt
 xAt
 xAt
-xAt
-vKJ
-cMC
+tDA
+xGW
+tkK
 tkK
 nqE
-nqE
-nqE
-auT
+tkK
+tkK
+tkK
 vRu
 vRu
 vRu
@@ -382704,10 +382928,10 @@ xAt
 xAt
 xAt
 xAt
-xAt
-vKJ
-pdi
-fUg
+xGW
+xGW
+xGW
+wbg
 fUg
 fCu
 mwE
@@ -383136,8 +383360,8 @@ pdi
 pdi
 pdi
 pdi
-pdi
-fUg
+foD
+wbg
 wbg
 fUg
 vbM
@@ -383568,15 +383792,15 @@ fnA
 fnA
 vJr
 vJr
+cZw
 fUg
 fUg
-wbg
 fCu
 evo
 hPe
 ryw
-nNN
-nNN
+mGd
+mGd
 pZg
 xAt
 xAt
@@ -384000,7 +384224,7 @@ fnA
 mXp
 iJB
 kRg
-wbg
+tDA
 fnA
 wbg
 fUg
@@ -384439,8 +384663,8 @@ fnA
 pZg
 pZg
 hXU
-tdk
-tdk
+nNN
+nNN
 qzU
 awP
 atP
@@ -384861,7 +385085,7 @@ wNn
 fnA
 aOv
 xdj
-obr
+ugz
 jlu
 xre
 xdj
@@ -385294,8 +385518,8 @@ aOv
 fnA
 xdj
 hvs
-hoc
-ecJ
+mKo
+tXy
 hsC
 wbg
 fnA
@@ -385725,7 +385949,7 @@ eSt
 pGJ
 fnA
 xdj
-pja
+lgg
 aUW
 kfk
 xdj
@@ -386157,9 +386381,9 @@ orb
 fnA
 vdN
 xdj
-oCI
+nOU
 kfk
-lra
+wmg
 xre
 xcx
 wbg
@@ -386174,11 +386398,11 @@ xif
 cmZ
 xAt
 det
-cQz
-vdN
-oPQ
-oPQ
-vdN
+wbg
+wbg
+aOv
+wbg
+kim
 fnA
 pZg
 icp
@@ -386590,7 +386814,7 @@ fCu
 vdN
 evo
 wEi
-mGd
+bug
 bKn
 xdj
 wVI
@@ -386607,11 +386831,11 @@ xAt
 xAt
 pUl
 aOv
-neV
+wbg
+srT
+fUg
 mwY
-mwY
-mwY
-dko
+fnA
 pZg
 kDB
 wAo
@@ -387023,7 +387247,7 @@ vdN
 mPW
 qaS
 evo
-bzN
+tdk
 xdj
 wVI
 fUg
@@ -387031,19 +387255,19 @@ cxv
 xFN
 xPN
 rYy
-dlT
+vcR
 cPR
 xFN
 xAt
 xAt
-xAt
-fyD
+vBZ
+xML
+qaj
+wbg
+qPr
 fnA
-eqP
-xAt
-xAt
-xAt
-oeR
+wbg
+uEF
 vbM
 cnp
 bQs
@@ -387468,14 +387692,14 @@ evo
 vbM
 xAt
 xAt
-cZw
+oAn
+jeK
 wbg
+fUg
+rrc
 fnA
-eqP
-xAt
-xAt
-xAt
-mwY
+aOv
+neV
 xAt
 fyD
 vJr
@@ -387885,7 +388109,7 @@ wNn
 rUO
 fnA
 fnA
-aOv
+stN
 vJr
 fnA
 fnA
@@ -387897,17 +388121,17 @@ wbg
 fUg
 yht
 fCu
-tPM
+fnA
 hxg
 cvG
-fUg
-fnA
+xAk
+hLP
+uKa
 aOv
-fbD
-uTY
-sBp
+fCu
+aOv
+wbg
 eqP
-xAt
 xAt
 oeR
 yht
@@ -388334,11 +388558,11 @@ aOv
 yht
 fnA
 fnA
-esR
+aOv
 wbg
 wbg
 wVI
-teF
+wVI
 vTl
 opi
 wbg
@@ -388772,8 +388996,8 @@ pZg
 xOa
 xFN
 vbM
-wVI
-yht
+oAn
+bdL
 wbg
 eqP
 xAt
@@ -389205,7 +389429,7 @@ ryw
 lbg
 evo
 mTS
-aOv
+kYn
 fnA
 cvG
 hxg
@@ -389637,7 +389861,7 @@ fJa
 evo
 xFN
 wbg
-fnA
+uKa
 fnA
 wVI
 wVI
@@ -390045,10 +390269,10 @@ slE
 lyG
 vJr
 bQs
-fXs
+wVa
 czF
 xfc
-bLZ
+drT
 sKT
 evo
 wVI
@@ -390068,7 +390292,7 @@ aLZ
 pZg
 xre
 xFN
-mwY
+iOU
 oeR
 wVI
 wVI
@@ -390481,7 +390705,7 @@ uFM
 bKn
 bKn
 vfP
-bzN
+tdk
 xFN
 wVI
 xre
@@ -391797,7 +392021,7 @@ wbg
 fnA
 uTY
 fbD
-xFd
+wbg
 uMk
 hpj
 gVS
@@ -392208,17 +392432,17 @@ evo
 kAp
 xFN
 qdU
-wVI
-sSO
-wVI
-wbg
+xGW
+xGW
+xGW
+gdv
 hRS
 guN
 bAk
 xre
 fnA
-fnA
 fCu
+sSO
 fnA
 aZE
 wiA
@@ -392661,7 +392885,7 @@ eVZ
 xHm
 wbg
 fnA
-vdN
+xFd
 uMk
 hpj
 gVS
@@ -393092,7 +393316,7 @@ uwa
 mwE
 fwy
 xez
-aOv
+vdN
 vdN
 mWX
 uMk
@@ -393524,9 +393748,9 @@ kDS
 dpZ
 idC
 gFP
-wbg
 yht
-alB
+yht
+tDA
 mWX
 uMk
 hpj
@@ -393958,7 +394182,7 @@ gZW
 gFP
 udS
 bSM
-rSD
+tDA
 ptg
 uMk
 dGp
@@ -394385,13 +394609,13 @@ vYT
 mbc
 evo
 esR
-iRA
-jkg
-lgg
-wVI
-wVI
-lKh
-gFP
+xGW
+xGW
+xGW
+foD
+foD
+tDA
+yht
 gAR
 yht
 kEs
@@ -394817,13 +395041,13 @@ xFN
 xFN
 evo
 lDc
-wVI
+cQz
 wVI
 wbg
 fnA
-vAB
-hLP
-gvg
+wbg
+wbg
+aOv
 bnq
 vcn
 dZU
@@ -409952,9 +410176,9 @@ fnA
 fnA
 hsC
 bKn
-ozw
+bzN
 kfk
-nNN
+mGd
 pPG
 xlA
 xlA
@@ -410818,7 +411042,7 @@ evo
 atb
 prO
 kvv
-tdk
+nNN
 pPG
 xlA
 xlA
@@ -494173,9 +494397,9 @@ pZg
 xre
 fZJ
 fZJ
-fZJ
-fZJ
-hox
+kAX
+leC
+bLf
 xaT
 xaT
 xaT
@@ -494603,11 +494827,11 @@ tJZ
 spU
 swX
 xdj
-uHa
-uHa
-uHa
-uHa
-fjX
+fZJ
+fZJ
+cXD
+gvg
+lKh
 gxc
 gft
 krf
@@ -495037,9 +495261,9 @@ mAN
 pZg
 fZJ
 fZJ
-fZJ
-fZJ
-fjX
+puo
+gvg
+lKh
 col
 eNY
 lHE
@@ -495455,9 +495679,9 @@ xvv
 fZJ
 xdj
 jHF
-bLf
-bLf
-dZc
+oCI
+oCI
+duV
 hXS
 fZJ
 fZJ
@@ -495469,9 +495693,9 @@ tAE
 pZg
 fZJ
 fZJ
-fZJ
-fZJ
-fjX
+puo
+gvg
+lKh
 col
 eNY
 lHE
@@ -495901,9 +496125,9 @@ pZg
 xre
 fZJ
 fZJ
-fZJ
-fZJ
-fjX
+puo
+gvg
+lKh
 vjf
 lwY
 orm
@@ -496320,7 +496544,7 @@ fZJ
 xdj
 wUU
 vra
-wQN
+vxN
 xdj
 fZJ
 fZJ
@@ -496333,9 +496557,9 @@ mGB
 pZg
 fZJ
 fZJ
-fZJ
-fZJ
-ptX
+puo
+gvg
+cMC
 vdf
 vdf
 vdf
@@ -496751,7 +496975,7 @@ fHB
 fZJ
 xre
 iDu
-drT
+awf
 iDu
 xre
 fZJ
@@ -496765,9 +496989,9 @@ iiT
 pZg
 fZJ
 fZJ
-fZJ
-fZJ
-osQ
+puo
+gvg
+rSD
 fZJ
 fZJ
 fZJ
@@ -497195,17 +497419,17 @@ vra
 vra
 mrB
 pZg
-fZJ
-fZJ
-fZJ
-fZJ
-osQ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fjX
+qdl
+ttU
+teF
+teF
+loX
+sBp
+sBp
+sBp
+sBp
+sBp
+lKh
 pNY
 tvA
 hyc
@@ -497627,17 +497851,17 @@ pZg
 hWg
 xdj
 xre
+gvg
+deu
+vHM
 fZJ
-fZJ
-fZJ
-fZJ
-osQ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-ptX
+xUk
+gvg
+uUF
+vKJ
+puo
+gvg
+cMC
 vdf
 vdf
 vdf
@@ -498059,19 +498283,19 @@ fZJ
 fZJ
 fZJ
 fZJ
+xBJ
+vqo
+wQN
+wQN
+knX
+gvg
+oPQ
 fZJ
-fZJ
-fZJ
-fZJ
-osQ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
+puo
+gvg
+eub
+jQI
+rSD
 fZJ
 fZJ
 fZJ
@@ -498491,19 +498715,19 @@ pZg
 xre
 pZg
 pZg
-xre
-fZJ
-fZJ
-fZJ
-osQ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
-fZJ
+jAQ
+vKJ
+vKJ
+xNZ
+gvg
+gvg
+sBp
+sBp
+gvg
+jkg
+gvg
+gvg
+rSD
 fZJ
 fZJ
 fZJ
@@ -498926,16 +499150,16 @@ xqX
 kIY
 fZJ
 hox
-xaT
-xaT
-xaT
-xaT
-xaT
-xaT
-lVX
-fZJ
-fZJ
-fZJ
+iRA
+iRA
+iRA
+iRA
+iRA
+lRO
+jBi
+dIt
+nkl
+rSD
 fZJ
 fZJ
 eDa
@@ -499345,7 +499569,7 @@ pZg
 fhy
 tRs
 loY
-puo
+rmn
 pZg
 jqs
 fZJ
@@ -499363,10 +499587,10 @@ gqM
 gqM
 gqM
 lDN
-rZi
-jqs
+hKm
+lVX
 fZJ
-fZJ
+vKJ
 fZJ
 fZJ
 fZJ
@@ -499775,7 +499999,7 @@ wNn
 fZJ
 pZg
 jNb
-bLf
+oCI
 jUj
 nNJ
 hXS
@@ -503677,7 +503901,7 @@ fZJ
 cbg
 vBU
 wAo
-jmL
+alB
 eBW
 eBW
 gdM

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -1038,12 +1038,12 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/under/dungeon/sunkenchurch)
 "alB" = (
-/obj/structure/flora/roguegrass,
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "alD" = (
 /turf/open/floor/rogue/greenstone,
 /area/rogue/indoors/town/magician/rockhill)
@@ -3239,14 +3239,6 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/grove)
-"aLF" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "aLJ" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -3454,6 +3446,16 @@
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/eora)
+"aNY" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 5
+	},
+/area/rogue/outdoors/town/roofs)
 "aOe" = (
 /obj/item/grown/log/tree/stick,
 /turf/open/floor/rogue/ruinedwood,
@@ -4066,8 +4068,10 @@
 	},
 /area/rogue/indoors)
 "aUW" = (
-/obj/effect/decal/carpet,
-/turf/open/floor/rogue/wood,
+/obj/structure/chair/wood/rogue{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "aUY" = (
 /obj/structure/stairs/stone,
@@ -7236,6 +7240,12 @@
 	},
 /turf/open/floor/rogue/naturalstone,
 /area/rogue/under/dungeon)
+"bHn" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "bHy" = (
 /turf/closed/wall/mineral/rogue/roofwall/outercorner{
 	dir = 8
@@ -7443,6 +7453,16 @@
 /obj/structure/flora/roguegrass/thorn_bush,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/town/grove)
+"bKj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "bKn" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
@@ -7559,11 +7579,15 @@
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
 "bLf" = (
-/obj/structure/chair/wood/rogue{
-	dir = 8
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 9
+	},
+/area/rogue/outdoors/town/roofs)
 "bLn" = (
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/oldgoblincamp)
@@ -7709,10 +7733,6 @@
 	},
 /turf/open/floor/rogue/tile/bath,
 /area/rogue/indoors/town/bath)
-"bMU" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile/checkeralt,
-/area/rogue/indoors/town)
 "bMV" = (
 /turf/open/floor/rogue/church{
 	color = "#d4ffcf"
@@ -8634,6 +8654,12 @@
 "bWx" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bogsafe)
+"bWB" = (
+/obj/structure/chair/bench/couch/r{
+	pixel_y = 8
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "bWE" = (
 /obj/structure/mineral_door/wood/deadbolt{
 	locked = 1
@@ -9073,6 +9099,17 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/manor/rockhill)
+"ccp" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/roguebin/water/gross{
+	pixel_x = -8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "ccw" = (
 /obj/machinery/light/roguestreet/orange/midlamp{
 	pixel_y = 8
@@ -11031,17 +11068,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"czI" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "czK" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -11208,6 +11234,16 @@
 "cBA" = (
 /turf/open/floor/rogue/metal,
 /area/rogue/indoors/inq/basement)
+"cBC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "cBG" = (
 /obj/structure/mineral_door/wood/violet{
 	locked = 1;
@@ -12107,15 +12143,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/manor/rockhill)
-"cJX" = (
-/obj/structure/chair/bench/couch{
-	pixel_y = 8
-	},
-/obj/structure/fluff/walldeco/rpainting/forest{
-	pixel_y = 32
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "cJY" = (
 /obj/machinery/light/rogue/candle{
 	pixel_y = -32
@@ -12345,13 +12372,9 @@
 /turf/open/floor/rogue/hexstone,
 /area/rogue/under/cavewet)
 "cMC" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/bars/cemetery,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town/rockhill)
 "cMD" = (
 /obj/machinery/artificer_table,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -12764,11 +12787,13 @@
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/church/chapel)
 "cQz" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/turf/closed/wall/mineral/rogue/wooddark,
+/area/rogue/indoors/town)
 "cQB" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -13485,12 +13510,13 @@
 /turf/open/water/bath,
 /area/rogue/indoors/town/bath)
 "cZw" = (
-/obj/machinery/light/rogue/candle/r,
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "cZx" = (
 /obj/effect/landmark/quest_spawner/easy,
 /turf/open/floor/rogue/cobblerock,
@@ -14585,6 +14611,9 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "dkq" = (
@@ -15179,6 +15208,11 @@
 	},
 /area/rogue/indoors/town/cell)
 "drT" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "drY" = (
@@ -16261,17 +16295,6 @@
 	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/outdoors/town/rockhill)
-"dEE" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/border{
-	dir = 5
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "dEG" = (
 /obj/structure/hotspring/border/six,
 /turf/open/floor/rogue/grass,
@@ -16544,10 +16567,6 @@
 "dHE" = (
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/church/basement)
-"dHF" = (
-/obj/machinery/light/rogue/torchholder/r,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "dHH" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/river{
@@ -21150,12 +21169,6 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
-"eIC" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "eID" = (
 /obj/structure/table/wood/poor,
 /obj/machinery/light/rogue/candle/l,
@@ -22982,17 +22995,6 @@
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town/tavern)
-"feq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/closet/crate/chest/wicker{
-	pixel_x = -5
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "feu" = (
 /obj/structure/bondage/torture_table/lever,
 /turf/open/floor/rogue/cobble,
@@ -24407,6 +24409,10 @@
 	color = "#ffd9f2"
 	},
 /area/rogue/indoors/town/bath)
+"fvW" = (
+/obj/structure/rack/rogue,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "fwh" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -26285,10 +26291,6 @@
 	},
 /turf/open/floor/rogue/carpet/lord/left,
 /area/rogue/indoors/town/manor/rockhill)
-"fRl" = (
-/obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town/rockhill)
 "fRm" = (
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = 32
@@ -26892,6 +26894,19 @@
 /obj/item/natural/rock,
 /turf/open/water/ocean/deep,
 /area/rogue/outdoors/beach/harbor)
+"fYp" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/light/rogue/torchholder/c,
+/obj/item/roguebin/trash{
+	pixel_y = 10;
+	pixel_x = -9
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "fYq" = (
 /obj/structure/fluff/statue/gargoyle/moss/candles{
 	pixel_y = -5
@@ -27489,13 +27504,6 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church)
-"ggn" = (
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/rockhill)
 "ggu" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -27632,6 +27640,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors)
+"giJ" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "giK" = (
 /obj/item/storage/roguebag,
 /obj/structure/fluff/railing/border{
@@ -28696,13 +28710,11 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/beach/harbor)
 "gvg" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/structure/roguewindow/openclose{
+	dir = 8
 	},
-/turf/open/floor/rogue/rooftop/green,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "gvs" = (
 /obj/structure/flora/roguegrass/bush/jungle/large{
 	color = "#9a8acf"
@@ -29884,17 +29896,6 @@
 /obj/item/needle,
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
-"gJx" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/roguebin/water/gross{
-	pixel_x = -8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "gJF" = (
 /obj/structure/chair/stool/rogue,
 /obj/item/clothing/cloak/abyssortabard,
@@ -32171,13 +32172,6 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/mountains/decap/rockhill)
-"hkq" = (
-/obj/structure/fluff/walldeco/church/line{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "hkv" = (
 /obj/machinery/light/roguestreet/orange{
 	pixel_x = 40;
@@ -35242,6 +35236,16 @@
 	},
 /turf/open/water/bath/fakepond,
 /area/rogue/indoors/town/bath)
+"hUW" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/rooftop/green/corner1{
+	dir = 10
+	},
+/area/rogue/outdoors/town/roofs)
 "hUX" = (
 /obj/structure/chair/wood,
 /turf/open/floor/rogue/herringbone,
@@ -35434,19 +35438,6 @@
 /obj/structure/chair/stool/rogue,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cavewet)
-"hWK" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "hWT" = (
 /obj/structure/bed/rogue/shit,
 /obj/machinery/light/rogue/candle/blue,
@@ -38577,12 +38568,6 @@
 /obj/machinery/light/rogue/torchholder/hotspring/standing,
 /turf/open/floor/rogue/grass/nospawn,
 /area/rogue/outdoors/woodsrat/safe)
-"iLD" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "iLJ" = (
 /obj/structure/fluff/walldeco/church/line{
 	layer = 2.2
@@ -39028,11 +39013,12 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
 "iRA" = (
-/obj/structure/fluff/railing/border{
-	dir = 9
+/obj/structure/fluff/walldeco/church/line{
+	pixel_x = -1;
+	pixel_y = -2
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "iRH" = (
 /obj/structure/stairs/stone{
 	dir = 1
@@ -40394,6 +40380,15 @@
 /obj/item/flashlight/flare/torch/metal,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church)
+"jgj" = (
+/obj/structure/fluff/railing/border{
+	dir = 5;
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/machinery/light/rogue/oven/west,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "jgs" = (
 /obj/machinery/light/rogue/campfire/fireplace{
 	pixel_x = -16;
@@ -40673,12 +40668,19 @@
 	},
 /area/rogue/under/dungeon/tricksntraps)
 "jkg" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/obj/structure/rack/rogue/shelf,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/poor,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "jkh" = (
 /obj/effect/decal/cobbleedge{
 	dir = 1;
@@ -40891,16 +40893,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/garrison)
-"jmq" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/table/wood/poor,
-/obj/item/reagent_containers/glass/cup/wooden,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "jmu" = (
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
@@ -45716,6 +45708,12 @@
 	},
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/north)
+"kqz" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "kqB" = (
 /obj/structure/stairs/stone{
 	dir = 4
@@ -45953,6 +45951,12 @@
 /obj/structure/chair/bench/couchablack/r,
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor/rockhill)
+"ktb" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "ktc" = (
 /obj/structure/table/wood{
 	dir = 6;
@@ -46092,6 +46096,10 @@
 	},
 /turf/open/floor/rogue/twig,
 /area/rogue/indoors/shelter/bog)
+"kuL" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile,
+/area/rogue/indoors/town)
 "kuP" = (
 /obj/structure/curtain/magenta{
 	color = "#a1254a"
@@ -47781,12 +47789,6 @@
 /obj/machinery/light/rogue/candle/r,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/tavern)
-"kPq" = (
-/obj/structure/chair/bench/couch/r{
-	pixel_y = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "kPs" = (
 /obj/structure/curtain/magenta,
 /obj/structure/roguewindow/harem3,
@@ -48169,19 +48171,6 @@
 "kTg" = (
 /turf/closed/mineral/rogue,
 /area/rogue/indoors/town/cell/warden)
-"kTi" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "kTj" = (
 /obj/structure/closet/crate/chest/wicker,
 /obj/item/reagent_containers/food/snacks/rogue/meat_rotten,
@@ -49134,9 +49123,10 @@
 /area/rogue/under/cavewet)
 "lgg" = (
 /obj/structure/fluff/railing/border{
-	dir = 9
+	dir = 10
 	},
-/turf/open/floor/rogue/wood,
+/obj/structure/rack/rogue/shelf,
+/turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "lgi" = (
 /obj/structure/fluff/statue/gargoyle/moss{
@@ -49679,10 +49669,6 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors/town/church)
-"lmr" = (
-/obj/structure/fluff/railing/border,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "lmw" = (
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/dirt/road,
@@ -51463,21 +51449,12 @@
 /turf/open/floor/rogue/carpet,
 /area/rogue/indoors/town/manor/rockhill)
 "lKh" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -10;
-	pixel_y = 2
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "lKj" = (
 /obj/structure/glowshroom,
 /turf/open/floor/rogue/blocks/paving,
 /area/rogue/under/town/sewer)
-"lKl" = (
-/obj/structure/curtain/black,
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
 "lKt" = (
 /obj/machinery/light/rogue/candle/green/r,
 /obj/item/dummy/treasure{
@@ -51549,12 +51526,6 @@
 	},
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors/town)
-"lKS" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "lKT" = (
 /obj/structure/handcart{
 	dir = 4
@@ -55520,6 +55491,14 @@
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/volcanic,
 /area/rogue/outdoors/bograt/above)
+"mDb" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "mDf" = (
 /obj/structure/roguemachine/mail{
 	mailtag = "Artisan Guild";
@@ -55823,11 +55802,16 @@
 /turf/open/floor/rogue/churchbrick,
 /area/rogue/indoors/town/church)
 "mGd" = (
-/obj/structure/chair/wood/rogue{
-	dir = 4
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/obj/structure/closet/crate/chest/wicker{
+	pixel_x = -5
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "mGg" = (
 /obj/structure/bed/rogue/inn/double,
 /obj/item/bedsheet/rogue/fabric_double,
@@ -55944,12 +55928,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/water/swamp,
 /area/rogue/under/dungeon/sunkenchurch)
-"mHQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 1
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "mHU" = (
 /obj/machinery/light/rogue/hearth,
 /obj/item/cooking/pan,
@@ -56650,6 +56628,10 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/under/town/basement)
+"mQk" = (
+/obj/structure/well,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "mQm" = (
 /obj/structure/fluff/railing/border/west{
 	pixel_x = -8
@@ -58063,12 +58045,6 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
-"nhF" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "nhG" = (
 /obj/structure/flora/roguegrass/water/reeds,
 /turf/open/water/swamp/deep,
@@ -58453,16 +58429,6 @@
 	},
 /turf/open/floor/rogue/herringbone,
 /area/rogue/indoors/inq)
-"nmP" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 10
-	},
-/area/rogue/outdoors/town/roofs)
 "nmU" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -58736,10 +58702,6 @@
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/volcanic,
 /area/rogue/indoors/town/magician/rockhill)
-"npt" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/cobblerock,
-/area/rogue/outdoors/town/rockhill)
 "npK" = (
 /obj/structure/table/wood{
 	icon_state = "longtable"
@@ -59270,6 +59232,15 @@
 /obj/structure/rack/rogue/shelf/biggest,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/church)
+"nwa" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "nwg" = (
 /obj/machinery/light/rogue/hearth{
 	pixel_y = 2
@@ -60627,11 +60598,11 @@
 /turf/closed/wall/mineral/rogue/wooddark/window,
 /area/rogue/indoors)
 "nNN" = (
-/obj/structure/fluff/railing/border{
-	dir = 5
+/obj/structure/chair/wood/rogue{
+	dir = 4
 	},
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "nNZ" = (
 /obj/structure/closet/crate/chest,
 /turf/open/floor/rogue/concrete,
@@ -61331,6 +61302,10 @@
 	},
 /turf/open/floor/rogue/church,
 /area/rogue/indoors/town/church)
+"nVM" = (
+/obj/machinery/light/rogue/torchholder/r,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "nVO" = (
 /turf/closed/wall/mineral/rogue/pipe{
 	dir = 1;
@@ -61604,6 +61579,10 @@
 	icon_state = "bfloorz"
 	},
 /area/rogue/indoors/town/manor/rockhill)
+"nYx" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "nYz" = (
 /obj/structure/fermentation_keg,
 /turf/open/floor/rogue/dirt/road,
@@ -62973,6 +62952,13 @@
 /obj/effect/spawner/lootdrop/heresy,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/inq/basement)
+"ooT" = (
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "opi" = (
 /obj/structure/fluff/railing/wood{
 	dir = 8;
@@ -63551,11 +63537,6 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/beach/harbor)
-"ovi" = (
-/obj/structure/bed/rogue/inn/wooldouble,
-/obj/item/bedsheet/rogue/double_pelt,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "ovk" = (
 /obj/structure/flora/newleaf,
 /obj/structure/flora/newbranch/leafless{
@@ -63707,6 +63688,19 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/under/cave)
+"owW" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/obj/structure/chair/stool/rogue,
+/obj/effect/landmark/start/villager,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "oxb" = (
 /obj/machinery/light/rogue/candle/blue/r{
 	pixel_x = 0;
@@ -63997,16 +63991,6 @@
 /obj/structure/table/wood/poor,
 /turf/open/floor/rogue/tile/checkeralt,
 /area/rogue/indoors/town/church)
-"oAJ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/rooftop/green{
-	dir = 8
-	},
-/area/rogue/outdoors/town/roofs)
 "oAO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/rogue/dirt/road,
@@ -65159,9 +65143,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "oPQ" = (
-/obj/structure/closet/crate/drawer,
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/rogue/rooftop/green,
+/area/rogue/outdoors/town/roofs)
 "oPR" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/rogue/grassyel,
@@ -65270,12 +65258,6 @@
 	},
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/town/manor/rockhill)
-"oRc" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "oRe" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1;
@@ -66362,16 +66344,6 @@
 /obj/structure/fluff/statue/knightalt,
 /turf/open/floor/rogue/blocks,
 /area/rogue/outdoors/rtfield/rockhill)
-"pds" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "pdz" = (
 /obj/structure/closet/crate/drawer/inn{
 	pixel_x = 4;
@@ -67746,7 +67718,10 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/transparent/openspace,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "pus" = (
 /turf/open/water/river{
@@ -68332,6 +68307,10 @@
 /obj/item/bedsheet/rogue/pelt,
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors)
+"pBE" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town/rockhill)
 "pBF" = (
 /obj/structure/flora/roguegrass/bush/wall,
 /obj/structure/fluff/railing/wood{
@@ -69218,6 +69197,17 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/woodsrat/south)
+"pMj" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "pMp" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -69503,12 +69493,6 @@
 	},
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/manor/rockhill)
-"pOO" = (
-/obj/structure/roguewindow/openclose{
-	dir = 8
-	},
-/turf/open/floor/rogue/herringbone,
-/area/rogue/indoors/town)
 "pOR" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32;
@@ -70045,12 +70029,6 @@
 	},
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/town/grove)
-"pVK" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "pVP" = (
 /obj/machinery/light/rogue/candle/floorcandle{
 	pixel_x = -4;
@@ -70109,6 +70087,17 @@
 	icon_state = "bathtileratwood"
 	},
 /area/rogue/under/town/basement/keep)
+"pWS" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "pWT" = (
 /obj/item/roguebin/trash{
 	pixel_y = 6
@@ -70633,6 +70622,14 @@
 /obj/structure/bars/shop,
 /turf/open/floor/rogue/cobble,
 /area/rogue/indoors/town/cell)
+"qcX" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -10;
+	pixel_y = 2
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/rockhill)
 "qcZ" = (
 /obj/structure/fluff/walldeco/bigpainting/lake,
 /obj/effect/decal/cobbleedge{
@@ -71190,6 +71187,10 @@
 	icon_state = "rockwd"
 	},
 /area/rogue/outdoors/beach/harbor)
+"qlt" = (
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/tile/checkeralt,
+/area/rogue/indoors/town)
 "qlv" = (
 /obj/structure/fluff/walldeco/wantedposter{
 	pixel_x = 32;
@@ -71252,6 +71253,13 @@
 	},
 /turf/open/floor/rogue/blocks,
 /area/rogue/indoors/town/church/basement)
+"qmk" = (
+/obj/structure/flora/roguegrass,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "qmq" = (
 /turf/closed/wall/mineral/rogue/wood,
 /area/rogue/indoors/town/church)
@@ -72624,15 +72632,6 @@
 "qBf" = (
 /turf/closed/mineral/random/rogue/boglava/high,
 /area/rogue/under/cave)
-"qBg" = (
-/obj/structure/fluff/railing/border{
-	dir = 5;
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/machinery/light/rogue/oven/west,
-/turf/open/floor/rogue/tile,
-/area/rogue/indoors/town)
 "qBi" = (
 /obj/structure/roguemachine/scomm{
 	pixel_y = -32;
@@ -74421,6 +74420,19 @@
 /obj/structure/bars,
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/magician/rockhill)
+"qYZ" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_y = 12;
+	pixel_x = -4
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "qZb" = (
 /obj/structure/fluff/walldeco/chains,
 /obj/structure/bars/grille,
@@ -76663,14 +76675,6 @@
 	dir = 8
 	},
 /area/rogue/indoors/town/bath)
-"rBp" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/closed/wall/mineral/rogue/wooddark,
-/area/rogue/indoors/town)
 "rBC" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -78061,11 +78065,9 @@
 /turf/open/water/sewer,
 /area/rogue/under/town/sewer)
 "rSD" = (
-/obj/structure/fluff/railing/border{
-	dir = 4
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/closet/crate/drawer,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "rSJ" = (
 /obj/item/clothing/cloak/stabard/guardhood,
 /obj/item/clothing/cloak/stabard/guardhood,
@@ -78435,15 +78437,6 @@
 /obj/item/roguegem/green,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/dungeon/oldgoblincamp)
-"rXD" = (
-/obj/structure/fluff/railing/border{
-	dir = 6
-	},
-/obj/structure/fluff/railing/border{
-	dir = 10
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "rXQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 1
@@ -78454,14 +78447,6 @@
 /obj/structure/flora/roguetree/evil,
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cave)
-"rXY" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "rXZ" = (
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
@@ -78971,6 +78956,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/rogue/indoors)
+"seO" = (
+/obj/structure/fluff/railing/border{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "seS" = (
 /obj/structure/fluff/railing/wood{
 	pixel_y = -4
@@ -79074,10 +79065,6 @@
 /obj/item/natural/poo,
 /turf/open/floor/rogue/rooftop/green,
 /area/rogue/outdoors/rtfield/rockhill/above)
-"sfC" = (
-/obj/structure/rack/rogue,
-/turf/open/floor/rogue/wood,
-/area/rogue/indoors/town)
 "sfH" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4;
@@ -79556,6 +79543,12 @@
 	},
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/outdoors/beach/harbor)
+"slN" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/cobblerock,
+/area/rogue/outdoors/town/rockhill)
 "slO" = (
 /obj/structure/table/wood/poor,
 /obj/item/paper{
@@ -80728,9 +80721,7 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 9
-	},
+/turf/open/floor/rogue/ruinedwood/platform,
 /area/rogue/outdoors/town/roofs)
 "sBs" = (
 /obj/machinery/light/rogue/candle/blue/l,
@@ -81697,6 +81688,15 @@
 /obj/effect/decal/cleanable/roguerune/arcyne/summoning/max,
 /turf/open/floor/rogue/church,
 /area/rogue/under/cave/goblinfort)
+"sLz" = (
+/obj/structure/chair/bench/couch{
+	pixel_y = 8
+	},
+/obj/structure/fluff/walldeco/rpainting/forest{
+	pixel_y = 32
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "sLD" = (
 /obj/structure/fluff/statue/gargoyle/candles,
 /turf/open/floor/rogue/concrete,
@@ -82153,9 +82153,13 @@
 /turf/open/floor/rogue/blocks,
 /area/rogue/under/dungeon/oldgoblincamp)
 "sSO" = (
-/obj/structure/mineral_door/bars,
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "sSP" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -83095,10 +83099,13 @@
 /area/rogue/indoors/town/bath)
 "tdk" = (
 /obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/obj/structure/fluff/railing/border{
 	dir = 6
 	},
-/turf/open/floor/carpet/royalblack,
-/area/rogue/indoors/town)
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "tds" = (
 /obj/machinery/light/rogue/torchholder{
 	pixel_y = 26
@@ -83205,11 +83212,15 @@
 /turf/closed/wall/mineral/rogue/decostone/cand,
 /area/rogue/indoors/town/dwarfin/rockhill)
 "teF" = (
-/obj/structure/fluff/railing/border{
-	dir = 10
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
 	},
-/turf/open/floor/rogue/naturalstone,
-/area/rogue/outdoors/town/rockhill)
+/turf/open/floor/rogue/rooftop/green{
+	dir = 8
+	},
+/area/rogue/outdoors/town/roofs)
 "teN" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/rogue/candle/red/r,
@@ -83740,8 +83751,10 @@
 /turf/open/floor/rogue/wood,
 /area/rogue/outdoors/mountains/decap/rockhill)
 "tkK" = (
-/obj/structure/bars/cemetery,
-/turf/open/floor/rogue/naturalstone,
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/cobble/mossy,
 /area/rogue/outdoors/town/rockhill)
 "tkM" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -84063,6 +84076,12 @@
 "tox" = (
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/bograt/above)
+"toA" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "toG" = (
 /obj/structure/glowshroom{
 	icon_state = "glowshroom3"
@@ -84188,15 +84207,6 @@
 	},
 /turf/open/floor/rogue/wood,
 /area/rogue/indoors/town/church/chapel)
-"tqw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/chair/stool/rogue,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "tqA" = (
 /obj/structure/fermentation_keg/random/beer,
 /turf/open/floor/rogue/dirt/road,
@@ -84777,16 +84787,6 @@
 "txa" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/under/town/basement)
-"txd" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/rooftop/green/corner1{
-	dir = 5
-	},
-/area/rogue/outdoors/town/roofs)
 "txm" = (
 /obj/structure/bars,
 /turf/open/floor/rogue/tile/bath{
@@ -84921,12 +84921,6 @@
 /obj/machinery/light/rogue/candle/blue/r,
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
-"tyQ" = (
-/obj/structure/fluff/railing/border{
-	dir = 8
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "tyW" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/cow,
 /turf/open/floor/rogue/ruinedwood/spiral,
@@ -85211,6 +85205,12 @@
 	},
 /turf/open/floor/rogue/tile/harem1,
 /area/rogue/indoors/town/bath)
+"tCG" = (
+/obj/structure/stairs{
+	dir = 8
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "tCI" = (
 /obj/structure/fluff/walldeco/psybanner,
 /obj/structure/fluff/walldeco/church/line{
@@ -85358,10 +85358,6 @@
 	},
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bograt/above)
-"tEP" = (
-/obj/structure/well,
-/turf/open/floor/rogue/cobble,
-/area/rogue/outdoors/town/rockhill)
 "tER" = (
 /obj/structure/rack/rogue,
 /turf/open/floor/rogue/ruinedwood,
@@ -86006,6 +86002,12 @@
 /obj/structure/fluff/railing/border/east,
 /turf/open/transparent/openspace,
 /area/rogue/outdoors/beach/harbor)
+"tNh" = (
+/obj/structure/fluff/railing/border{
+	dir = 1
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "tNj" = (
 /turf/closed/wall/mineral/rogue/craftstone,
 /area/rogue/indoors/town/garrison)
@@ -86497,6 +86499,12 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/town/grove)
+"tSx" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "tSy" = (
 /obj/structure/spider/stickyweb{
 	color = "#d1cdc7"
@@ -87714,10 +87722,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/rogue/indoors)
-"uhi" = (
-/obj/structure/plasticflaps,
-/turf/open/floor/rogue/cobble/mossy,
-/area/rogue/outdoors/town/rockhill)
 "uhk" = (
 /obj/structure/closet/crate/roguecloset,
 /obj/item/clothing/head/roguetown/cookhat,
@@ -87785,10 +87789,23 @@
 /obj/structure/flora/newleaf,
 /turf/open/floor/rogue/grassred,
 /area/rogue/outdoors/town/grove)
+"uih" = (
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "uii" = (
 /obj/structure/bars/cemetery,
 /turf/open/water/bath,
 /area/rogue/indoors/town/church)
+"uij" = (
+/obj/effect/landmark/start/villager,
+/obj/structure/chair/bench{
+	pixel_y = 5
+	},
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/rockhill)
 "uik" = (
 /obj/structure/rack/rogue,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
@@ -88357,6 +88374,10 @@
 	},
 /turf/open/floor/rogue/blocks/stonered/tiny,
 /area/rogue/indoors/town/tavern)
+"uoO" = (
+/obj/structure/plasticflaps,
+/turf/open/floor/rogue/cobble/mossy,
+/area/rogue/outdoors/town/rockhill)
 "uoP" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/rogue/grass/nospawn,
@@ -88883,14 +88904,6 @@
 /obj/structure/flora/roguegrass,
 /turf/open/floor/rogue/grassyel,
 /area/rogue/outdoors/woodsrat/safe)
-"uuw" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12;
-	pixel_x = -4
-	},
-/turf/open/transparent/openspace,
-/area/rogue/outdoors/town/roofs)
 "uuB" = (
 /obj/structure/fluff/railing/border,
 /obj/structure/fluff/railing/border/east,
@@ -92468,6 +92481,16 @@
 /obj/item/rogueweapon/hoe,
 /turf/open/floor/rogue/dirt,
 /area/rogue/outdoors/rtfield/rockhill)
+"vmS" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/table/wood/poor,
+/obj/item/reagent_containers/glass/cup/wooden,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "vmU" = (
 /obj/effect/decal/cobbleedge{
 	dir = 4;
@@ -94533,18 +94556,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/church)
 "vKJ" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/light/rogue/torchholder/c,
-/obj/item/roguebin/trash{
-	pixel_y = 10;
-	pixel_x = -9
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/obj/structure/bed/rogue/inn/wooldouble,
+/obj/item/bedsheet/rogue/double_pelt,
+/turf/open/floor/rogue/herringbone,
+/area/rogue/indoors/town)
 "vKN" = (
 /obj/effect/decal/cobbleedge{
 	icon_state = "borderfall"
@@ -95434,13 +95449,6 @@
 	},
 /turf/open/floor/rogue/metal/barograte,
 /area/rogue/indoors/town)
-"vVJ" = (
-/obj/effect/landmark/start/villager,
-/obj/structure/chair/bench{
-	pixel_y = 5
-	},
-/turf/open/floor/rogue/blocks,
-/area/rogue/outdoors/town/rockhill)
 "vVM" = (
 /obj/effect/decal/cleanable/debris/woody,
 /turf/open/floor/rogue/ruinedwood/herringbone,
@@ -95520,6 +95528,12 @@
 /obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/indoors/town/church/basement)
+"vXx" = (
+/obj/structure/stairs{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/rogue/outdoors/town/roofs)
 "vXz" = (
 /turf/open/water/cleanshallow,
 /area/rogue/under/cavewet/river)
@@ -96007,13 +96021,6 @@
 /obj/machinery/light/rogue/hearth,
 /turf/open/floor/rogue/tile/brick,
 /area/rogue/indoors/town/church)
-"wdm" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_y = 12
-	},
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "wdq" = (
 /obj/structure/bed/rogue/inn/wool,
 /obj/item/bedsheet/rogue/fabric,
@@ -99141,6 +99148,10 @@
 /obj/structure/fluff/railing/wood,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/woodsrat/safe)
+"wMy" = (
+/obj/effect/decal/carpet,
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "wMA" = (
 /obj/structure/stairs/stone,
 /turf/open/floor/rogue/blocks,
@@ -99536,19 +99547,11 @@
 	},
 /area/rogue/indoors/town/church)
 "wQN" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
+/obj/structure/fluff/railing/border{
+	dir = 10
 	},
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/table/wood/poor,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
+/turf/open/floor/rogue/naturalstone,
+/area/rogue/outdoors/town/rockhill)
 "wQS" = (
 /turf/closed/wall/mineral/rogue/stonebrick,
 /area/rogue/under/cavewet)
@@ -100634,6 +100637,15 @@
 /obj/effect/spawner/lootdrop/contraband,
 /turf/open/floor/rogue/churchrough,
 /area/rogue/under/town/basement/keep)
+"xfk" = (
+/obj/structure/fluff/railing/wood{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/structure/chair/stool/rogue,
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "xfn" = (
 /turf/open/floor/carpet/stellar,
 /area/rogue/indoors/town/academy)
@@ -101719,6 +101731,10 @@
 "xsd" = (
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/church)
+"xsp" = (
+/obj/structure/curtain/black,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "xsr" = (
 /obj/structure/well,
 /turf/open/floor/rogue/cobble,
@@ -102133,6 +102149,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/cobblerock,
 /area/rogue/indoors)
+"xxx" = (
+/obj/structure/fluff/railing/border{
+	dir = 4
+	},
+/turf/open/floor/rogue/ruinedwood/platform,
+/area/rogue/outdoors/town/roofs)
 "xxz" = (
 /turf/open/floor/rogue/churchmarble,
 /area/rogue/indoors/town/church/basement)
@@ -103084,6 +103106,10 @@
 "xIh" = (
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town/tavern)
+"xIj" = (
+/obj/structure/mineral_door/bars,
+/turf/open/floor/rogue/blocks,
+/area/rogue/outdoors/town/rockhill)
 "xIl" = (
 /obj/machinery/light/rogue/oven/west,
 /turf/open/floor/rogue/concrete,
@@ -103673,6 +103699,15 @@
 "xPB" = (
 /turf/closed/wall/mineral/rogue/decostone/center,
 /area/rogue/outdoors/rtfield/rockhill)
+"xPC" = (
+/obj/structure/fluff/railing/wood{
+	dir = 1;
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/structure/fluff/railing/border,
+/turf/open/floor/rogue/cobble,
+/area/rogue/outdoors/town/rockhill)
 "xPD" = (
 /obj/structure/table/wood{
 	dir = 1;
@@ -103704,6 +103739,13 @@
 /mob/living/carbon/human/species/npc/deadite,
 /turf/open/floor/rogue/hexstone,
 /area/rogue/indoors/shelter/bog)
+"xPQ" = (
+/obj/machinery/light/rogue/candle/r,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town)
 "xQg" = (
 /obj/structure/closet/crate/drawer,
 /obj/effect/spawner/lootdrop/roguetown/dungeon/armor,
@@ -104595,6 +104637,12 @@
 /obj/effect/spawner/lootdrop/roguetown/dungeon/weapons,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/under/cavewet)
+"ybv" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/wood,
+/area/rogue/indoors/town)
 "ybD" = (
 /obj/structure/rack/rogue,
 /obj/item/clothing/gloves/roguetown/leather,
@@ -105337,16 +105385,6 @@
 	},
 /turf/open/floor/carpet/inn,
 /area/rogue/indoors/town/shop)
-"yjL" = (
-/obj/structure/fluff/railing/wood{
-	dir = 1;
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/structure/chair/stool/rogue,
-/obj/effect/landmark/start/villager,
-/turf/open/floor/rogue/ruinedwood/platform,
-/area/rogue/outdoors/town/roofs)
 "yjM" = (
 /obj/structure/fluff/railing/border{
 	dir = 8
@@ -382513,12 +382551,12 @@ xAt
 xAt
 tDA
 xGW
-tkK
-tkK
+cMC
+cMC
 nqE
-tkK
-tkK
-tkK
+cMC
+cMC
+cMC
 vRu
 vRu
 vRu
@@ -383373,7 +383411,7 @@ pdi
 pdi
 pdi
 pdi
-sSO
+xIj
 wbg
 wbg
 fUg
@@ -383805,15 +383843,15 @@ fnA
 fnA
 vJr
 vJr
-fRl
+pBE
 fUg
 fUg
 fCu
 evo
 hPe
 ryw
-mGd
-mGd
+nNN
+nNN
 pZg
 xAt
 xAt
@@ -384676,8 +384714,8 @@ fnA
 pZg
 pZg
 hXU
-bLf
-bLf
+aUW
+aUW
 qzU
 awP
 atP
@@ -385098,7 +385136,7 @@ wNn
 fnA
 aOv
 xdj
-tdk
+uih
 jlu
 xre
 xdj
@@ -385531,8 +385569,8 @@ aOv
 fnA
 xdj
 hvs
-pVK
-lgg
+bHn
+ybv
 hsC
 wbg
 fnA
@@ -385962,8 +386000,8 @@ eSt
 pGJ
 fnA
 xdj
-cJX
-aUW
+sLz
+wMy
 kfk
 xdj
 ouA
@@ -386394,9 +386432,9 @@ orb
 fnA
 vdN
 xdj
-kPq
+bWB
 kfk
-sfC
+fvW
 xre
 xcx
 wbg
@@ -386827,7 +386865,7 @@ fCu
 vdN
 evo
 wEi
-qBg
+jgj
 bKn
 xdj
 wVI
@@ -387268,16 +387306,16 @@ cxv
 xFN
 xPN
 rYy
-bMU
+qlt
 cPR
 xFN
 xAt
 xAt
 vBZ
-hWK
-nNN
+owW
+tkK
 wbg
-tEP
+mQk
 fnA
 wbg
 uEF
@@ -387706,10 +387744,10 @@ vbM
 xAt
 xAt
 oAn
-lKS
+kqz
 wbg
 fUg
-ggn
+ooT
 fnA
 aOv
 neV
@@ -388122,7 +388160,7 @@ wNn
 rUO
 fnA
 fnA
-npt
+nYx
 vJr
 fnA
 fnA
@@ -388137,9 +388175,9 @@ fCu
 fnA
 hxg
 cvG
-teF
+wQN
 hLP
-iRA
+giJ
 aOv
 fCu
 aOv
@@ -389445,8 +389483,8 @@ mTS
 kYn
 fnA
 cvG
-hxg
-wVI
+pWS
+aZT
 vRu
 vRu
 vRu
@@ -389874,10 +389912,10 @@ fJa
 evo
 xFN
 wbg
-iRA
-fnA
-wVI
-wVI
+tdk
+ktb
+aZT
+rtB
 geg
 bMj
 vRu
@@ -390282,10 +390320,10 @@ slE
 lyG
 vJr
 bQs
-jkg
+lgg
 czF
 xfc
-lmr
+kuL
 sKT
 evo
 wVI
@@ -390305,10 +390343,10 @@ aLZ
 pZg
 xre
 xFN
-lKh
-oeR
-wVI
-wVI
+qcX
+xPC
+osy
+idC
 bMj
 vRu
 vRu
@@ -390738,8 +390776,8 @@ vra
 pZg
 xAt
 xAt
-oeR
-wVI
+xPC
+uwa
 mWX
 uMk
 uMk
@@ -392026,8 +392064,8 @@ kJF
 xre
 wbg
 cnH
-nhF
-alB
+slN
+qmk
 aOv
 aOv
 wbg
@@ -392455,7 +392493,7 @@ bAk
 xre
 fnA
 fCu
-uhi
+uoO
 fnA
 aZE
 wiA
@@ -394625,8 +394663,8 @@ esR
 xGW
 xGW
 xGW
-sSO
-sSO
+xIj
+xIj
 tDA
 yht
 gAR
@@ -395054,7 +395092,7 @@ xFN
 xFN
 evo
 lDc
-vVJ
+uij
 wVI
 wbg
 fnA
@@ -410189,9 +410227,9 @@ fnA
 fnA
 hsC
 bKn
-hkq
+iRA
 kfk
-mGd
+nNN
 pPG
 xlA
 xlA
@@ -411055,7 +411093,7 @@ evo
 atb
 prO
 kvv
-bLf
+aUW
 pPG
 xlA
 xlA
@@ -494410,9 +494448,9 @@ pZg
 xre
 fZJ
 fZJ
-wQN
-tqw
-txd
+jkg
+xfk
+aNY
 xaT
 xaT
 xaT
@@ -494842,9 +494880,9 @@ swX
 xdj
 fZJ
 fZJ
-yjL
-drT
-oAJ
+bKj
+lKh
+teF
 gxc
 gft
 krf
@@ -495274,9 +495312,9 @@ mAN
 pZg
 fZJ
 fZJ
-cMC
-drT
-oAJ
+sBp
+lKh
+teF
 col
 eNY
 lHE
@@ -495694,7 +495732,7 @@ xdj
 jHF
 oCI
 oCI
-cZw
+xPQ
 hXS
 fZJ
 fZJ
@@ -495706,9 +495744,9 @@ tAE
 pZg
 fZJ
 fZJ
-cMC
-drT
-oAJ
+sBp
+lKh
+teF
 col
 eNY
 lHE
@@ -496138,9 +496176,9 @@ pZg
 xre
 fZJ
 fZJ
-cMC
-drT
-oAJ
+sBp
+lKh
+teF
 vjf
 lwY
 orm
@@ -496557,7 +496595,7 @@ fZJ
 xdj
 wUU
 vra
-ovi
+vKJ
 xdj
 fZJ
 fZJ
@@ -496570,9 +496608,9 @@ mGB
 pZg
 fZJ
 fZJ
-cMC
-drT
 sBp
+lKh
+bLf
 vdf
 vdf
 vdf
@@ -496988,7 +497026,7 @@ fHB
 fZJ
 xre
 iDu
-pOO
+gvg
 iDu
 xre
 fZJ
@@ -497002,9 +497040,9 @@ iiT
 pZg
 fZJ
 fZJ
-cMC
-drT
-aLF
+sBp
+lKh
+cZw
 fZJ
 fZJ
 fZJ
@@ -497432,17 +497470,17 @@ vra
 vra
 mrB
 pZg
-vKJ
-czI
-rSD
-rSD
-dEE
-rXY
-rXY
-rXY
-rXY
-rXY
-oAJ
+fYp
+puo
+xxx
+xxx
+pMj
+drT
+drT
+drT
+drT
+drT
+teF
 pNY
 tvA
 hyc
@@ -497864,17 +497902,17 @@ pZg
 hWg
 xdj
 xre
-drT
-rXD
-oRc
+lKh
+nwa
+vXx
 fZJ
-mHQ
-drT
-kTi
-puo
-cMC
-drT
+tNh
+lKh
+qYZ
+sSO
 sBp
+lKh
+bLf
 vdf
 vdf
 vdf
@@ -498296,19 +498334,19 @@ fZJ
 fZJ
 fZJ
 fZJ
-wdm
-eIC
-tyQ
-tyQ
-cQz
-drT
-uuw
+alB
+tSx
+seO
+seO
+toA
+lKh
+mDb
 fZJ
-cMC
-drT
-pds
-jmq
-aLF
+sBp
+lKh
+cBC
+vmS
+cZw
 fZJ
 fZJ
 fZJ
@@ -498728,19 +498766,19 @@ pZg
 xre
 pZg
 pZg
-rBp
-puo
-puo
-gJx
+cQz
+sSO
+sSO
+ccp
+lKh
+lKh
 drT
 drT
-rXY
-rXY
-drT
-dHF
-drT
-drT
-aLF
+lKh
+nVM
+lKh
+lKh
+cZw
 fZJ
 fZJ
 fZJ
@@ -499163,16 +499201,16 @@ xqX
 kIY
 fZJ
 hox
-gvg
-gvg
-gvg
-gvg
-gvg
-nmP
+oPQ
+oPQ
+oPQ
+oPQ
+oPQ
+hUW
 jBi
-iLD
-feq
-aLF
+tCG
+mGd
+cZw
 fZJ
 fZJ
 eDa
@@ -499582,7 +499620,7 @@ pZg
 fhy
 tRs
 loY
-oPQ
+rSD
 pZg
 jqs
 fZJ
@@ -499603,7 +499641,7 @@ lDN
 hKm
 lVX
 fZJ
-puo
+sSO
 fZJ
 fZJ
 fZJ
@@ -503914,7 +503952,7 @@ fZJ
 cbg
 vBU
 wAo
-lKl
+xsp
 eBW
 eBW
 gdM

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -22294,8 +22294,8 @@
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/shelter/bog)
 "eVw" = (
-/obj/structure/fluff/railing/wood{
-	pixel_y = -4
+/obj/structure/fluff/railing/border{
+	dir = 6
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -22677,6 +22677,12 @@
 /obj/machinery/light/rogue/candle/red,
 /turf/open/floor/rogue/cobble/mossy,
 /area/rogue/indoors/town/bath)
+"fai" = (
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "faj" = (
 /obj/structure/table/wood,
 /obj/item/cooking/platter/gold,
@@ -53784,9 +53790,9 @@
 /area/rogue/indoors/town/manor/rockhill)
 "mjL" = (
 /obj/structure/chair/bench/couch/r{
-	pixel_x = -6;
 	pixel_y = 8
 	},
+/obj/machinery/light/rogue/candle,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "mjR" = (
@@ -55067,10 +55073,8 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/under/town/basement/keep)
 "mxM" = (
-/obj/structure/fluff/railing/wood{
-	dir = 8;
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/fluff/railing/border{
+	dir = 8
 	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
@@ -56951,6 +56955,12 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/town/church)
+"mUW" = (
+/obj/structure/fluff/railing/border{
+	dir = 5
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "mUX" = (
 /obj/item/natural/rock/iron,
 /obj/item/grown/log/tree/small,
@@ -60428,6 +60438,9 @@
 /area/rogue/outdoors/woodsrat/north)
 "nLe" = (
 /obj/machinery/light/rogue/candle/l,
+/obj/structure/fluff/railing/border{
+	dir = 9
+	},
 /turf/open/floor/rogue/woodturned,
 /area/rogue/indoors/town)
 "nLn" = (
@@ -60783,6 +60796,13 @@
 /obj/item/flint,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town/academy)
+"nQe" = (
+/obj/structure/stairs,
+/obj/structure/fluff/railing/border{
+	dir = 6
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "nQg" = (
 /obj/structure/mineral_door/wood/fancywood{
 	locked = 1;
@@ -61243,6 +61263,13 @@
 	},
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/inq)
+"nVk" = (
+/obj/structure/fluff/railing/border{
+	dir = 8;
+	layer = 2.05
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "nVm" = (
 /obj/structure/fluff/statue{
 	pixel_y = -15
@@ -62577,7 +62604,6 @@
 /area/rogue/outdoors/rtfield/rockhill)
 "olj" = (
 /obj/structure/chair/bench/couch{
-	pixel_x = -6;
 	pixel_y = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -93415,11 +93441,11 @@
 /turf/open/floor/rogue/ruinedwood/spiral,
 /area/rogue/outdoors/town/roofs)
 "vwN" = (
-/obj/structure/table/finer,
 /obj/item/reagent_containers/glass/cup/wooden{
 	pixel_x = -4;
 	pixel_y = 3
 	},
+/obj/structure/table/finestone,
 /turf/open/floor/carpet/royalblack,
 /area/rogue/indoors/town)
 "vwP" = (
@@ -95347,6 +95373,12 @@
 /obj/structure/chair/wood/rogue,
 /turf/open/floor/rogue/ruinedwood,
 /area/rogue/indoors/town/warden)
+"vUx" = (
+/obj/structure/fluff/railing/border{
+	dir = 10
+	},
+/turf/open/floor/rogue/woodturned,
+/area/rogue/indoors/town)
 "vUG" = (
 /turf/closed/wall/mineral/rogue/roofwall/middle,
 /area/rogue/outdoors/rtfield/rockhill/above)
@@ -98779,6 +98811,7 @@
 /area/rogue/outdoors/beach/harbor)
 "wIb" = (
 /obj/structure/table/wood/poor,
+/obj/item/rogueweapon/huntingknife/chefknife,
 /turf/open/floor/rogue/tile,
 /area/rogue/indoors/town)
 "wIh" = (
@@ -413245,7 +413278,7 @@ cWq
 bKn
 ryw
 ryw
-ryw
+eVw
 oHF
 xre
 kqo
@@ -413677,8 +413710,8 @@ cDn
 bKn
 ryw
 ryw
-ryw
-ryw
+vUx
+nVk
 nLe
 ryw
 pZg
@@ -523406,10 +523439,10 @@ inZ
 xrP
 cSf
 pZg
-eVw
+eVF
 oTD
-oHF
-ryw
+nQe
+mUW
 pZg
 izh
 xZg
@@ -523838,10 +523871,10 @@ aTy
 xrP
 xrP
 qZr
-ryw
+vUx
 mxM
-ryw
-ryw
+mxM
+fai
 pZg
 aYd
 ptM


### PR DESCRIPTION
## About The Pull Request
- Touched up on a single house in the southeast to make it a tad prettier and with a shelf, fireplace, some carpet and a rail.
- Reworked some southwest district houses.
- Added a communal area to the southwest district along with an upper boardwalk and fencing to make it similar to a gated community.
- Fixed a single border corner on the upper floor of the gate house where you drop rocks from. It was misaligned.

## Testing Evidence
<img width="1628" height="1971" alt="houses1" src="https://github.com/user-attachments/assets/6799ae5b-182e-474d-8153-13747dd232c5" />
<img width="1547" height="1317" alt="houses2" src="https://github.com/user-attachments/assets/3f87a3e8-3d89-4aa8-933b-0ede684ae357" />
<img width="1542" height="1219" alt="houses3" src="https://github.com/user-attachments/assets/ef7ffe72-96e5-40b5-9127-c9eafe44c2bb" />

## Why It's Good For The Game
Looks nicer. Discussed with Jam already.

## Changelog
:cl:
map: Touched up on a single house in the southeast to make it a tad prettier and with a shelf, fireplace, some carpet and a rail.
map: Reworked some southwest district houses.
map: Added a communal area to the southwest district along with an upper boardwalk and fencing to make it similar to a gated community.
map: Fixed a single border corner on the upper floor of the gate house where you drop rocks from. It was misaligned.
/:cl: