### PR TITLE
Hotfix: Allows Eora Trees to Bear Gold Fruit + Snip QoL

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -533,7 +533,7 @@
 		update_icon()
 		return TRUE
 
-	if(istype(I, /obj/item/rogueweapon/huntingknife/scissors))
+	if(istype(I, /obj/item/rogueweapon/huntingknife/scissors) || (istype(I, /obj/item/rogueweapon/huntingknife/throwingknife/bauernwehr) && user.used_intent.type == /datum/intent/snip))
 		if(prune_count >= 1)
 			to_chat(user, span_warning("The tree has been fully pruned already!"))
 			return TRUE
@@ -556,7 +556,7 @@
 
 	if(istype(I, /obj/item/reagent_containers) && !istype(I, /obj/item/reagent_containers/food/snacks))
 		var/obj/item/reagent_containers/container = I
-		if(water_happiness >= 25)
+		if(water_happiness >= 40)
 			to_chat(user, span_warning("The tree can't absorb any more water right now!"))
 			return TRUE
 
@@ -570,7 +570,7 @@
 			to_chat(user, span_warning("The tree accepts only fresh, clean or blessed water."))
 			return
 
-		var/remaining_cap = 25 - water_happiness
+		var/remaining_cap = 40 - water_happiness
 		var/actual_gain = remaining_cap
 
 		if(do_after(user, 1 SECONDS, target = src))
@@ -677,7 +677,7 @@
 	else if(happiness_tier == 4)
 		. += span_good("The tree bustles with an incandescent light. You feel... perfection.")
 
-	if(water_happiness < 25)
+	if(water_happiness < 40)
 		. += span_info("It could use more water.")
 	else
 		. += span_info("It is fully slaked.")
@@ -688,7 +688,7 @@
 		. += span_info("It is fully sated.")
 
 	if(prune_count < 1)
-		. += span_info("The branches look messy. Perhaps a scissor can right this mess.")
+		. += span_info("The branches look messy. Perhaps something to snip them can right this mess.")
 	else
 		. += span_info("The branches are elaborately pruned.")
 


### PR DESCRIPTION
## About The Pull Request
- Fixes a fuckup where I didn't account for happiness values. Because of how I changed nutrition and water intake, I forgot about the total happiness. This caused a value that couldn't be reached (100), and thus I had to bump up the water total to get to that value.
- Allows the bauernwehr on snip intent to prune the trees too!

## Testing Evidence
<img width="355" height="626" alt="treefix" src="https://github.com/user-attachments/assets/446cae0b-9603-4990-9456-c664b9d5920b" />

## Why It's Good For The Game
Trying to get the game to work as it did before is good! Also, a bonus QoL for those who lost their scissors.

## Changelog
:cl:
fix: Fixes eora trees not producing golden fruits at max happiness.
qol: Allows the bauernwehr on snip intent to prune the trees too!
/:cl: