### PR TITLE
Optimize get_slowdown(), get_heuristic_slowdown(), AStar, and heap structures

### DIFF
--- a/code/__HELPERS/AStar.dm
+++ b/code/__HELPERS/AStar.dm
@@ -98,10 +98,13 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 		return FALSE
 	if(maxnodes)
 		//if start turf is farther than maxnodes from end turf, no need to do anything
-		if(call(start, dist)(end, caller) > maxnodes)
+		//Yes, this is a hardcoded distance proc. If you want diagonal moves you'll need to change this,
+		//but otherwise this is fine.
+		// EVERYTHING ELSE SHOULD USE THE DIST PARAMETER, THOUGH!
+		if(start.Distance_cardinal_3d(end, caller) > maxnodes)
 			return FALSE
 		maxnodedepth = maxnodes //no need to consider path longer than maxnodes
-	var/datum/Heap/open = new /datum/Heap(/proc/HeapPathWeightCompare) //the open list
+	var/datum/path_minheap/open = new /datum/path_minheap() //the open list
 	var/list/openc = new() //open list for node check
 	var/list/path = null //the returned path, if any
 	//initialization
@@ -110,7 +113,7 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 	open.Insert(cur)
 	openc[start] = cur
 	//then run the main loop
-	while(caller && !open.IsEmpty() && !path)
+	while(caller && length(open.L) && !path)
 		cur = open.Pop() //get the lower f turf in the open list
 		//get the lower f node on the open list
 		//if we only want to get near the target, check if we're close enough
@@ -119,8 +122,6 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 			// I lied, this one is also hardcoded; we don't want to use the heuristic for our termination condition,
 			// only the actual distance.
 			closeenough = cur.source.Distance_cardinal_3d(end, caller) <= mintargetdist
-
-
 
 		//found the target turf (or close enough), let's create the path to it
 		if(cur.source == end || closeenough)
@@ -165,8 +166,9 @@ Also added 'exclude' turf to avoid travelling over; defaults to null
 		CHECK_TICK
 	//reverse the path to get it from start to finish
 	if(path)
-		for(var/i = 1 to round(0.5*path.len))
-			path.Swap(i,path.len-i+1)
+		var/path_len = length(path)
+		for(var/i = 1 to round(0.5*path_len))
+			path.Swap(i,path_len-i+1)
 	openc = null
 	//cleaning after us
 	return path

--- a/code/__HELPERS/heap.dm
+++ b/code/__HELPERS/heap.dm
@@ -1,76 +1,67 @@
 
 //////////////////////
-//datum/Heap object
+//datum/path_minheap object
 //////////////////////
 
-/datum/Heap
-	var/list/L
-	var/cmp
+/datum/path_minheap
+	var/list/datum/PathNode/L
 
-/datum/Heap/New(compare)
+/datum/path_minheap/New(compare)
 	L = new()
-	cmp = compare
-
-/datum/Heap/proc/IsEmpty()
-	return !L.len
 
 //Insert and place at its position a new node in the heap
-/datum/Heap/proc/Insert(atom/A)
+/datum/path_minheap/proc/Insert(atom/A)
 
 	L.Add(A)
-	Swim(L.len)
+	Swim(length(L))
 
 //removes and returns the first element of the heap
 //(i.e the max or the min dependant on the comparison function)
-/datum/Heap/proc/Pop()
-	if(!L.len)
+/datum/path_minheap/proc/Pop()
+	if(!length(L))
 		return 0
 	. = L[1]
 
-	L[1] = L[L.len]
-	L.Cut(L.len)
-	if(L.len)
+	L[1] = L[length(L)]
+	L.Cut(length(L))
+	if(length(L))
 		Sink(1)
 
 //Get a node up to its right position in the heap
-/datum/Heap/proc/Swim(index)
+/datum/path_minheap/proc/Swim(index)
 	var/parent = round(index * 0.5)
-
-	while(parent > 0 && (call(cmp)(L[index],L[parent]) > 0))
+	while(parent > 0 && ((L[parent].f - L[index].f) > 0))
 		L.Swap(index,parent)
 		index = parent
 		parent = round(index * 0.5)
 
 //Get a node down to its right position in the heap
-/datum/Heap/proc/Sink(index)
-	var/g_child = GetGreaterChild(index)
+/datum/path_minheap/proc/Sink(index)
+	. = index * 2
+	var/heap_len = length(L)
+	if(. > heap_len)
+		. = 0
+	else if(. + 1 > heap_len) { ;; } // . = index * 2, no-op
+	else if((L[. + 1].f - L[.].f) < 0)
+		. += 1
 
-	while(g_child > 0 && (call(cmp)(L[index],L[g_child]) < 0))
-		L.Swap(index,g_child)
-		index = g_child
-		g_child = GetGreaterChild(index)
-
-//Returns the greater (relative to the comparison proc) of a node children
-//or 0 if there's no child
-/datum/Heap/proc/GetGreaterChild(index)
-	if(index * 2 > L.len)
-		return 0
-
-	if(index * 2 + 1 > L.len)
-		return index * 2
-
-	if(call(cmp)(L[index * 2],L[index * 2 + 1]) < 0)
-		return index * 2 + 1
-	else
-		return index * 2
+	while(. > 0 && (L[.].f - L[index].f) < 0)
+		L.Swap(index,.) // preserves length so no need to recalculate heap_len
+		index = .
+		. = index * 2
+		if(. > heap_len)
+			. = 0
+		else if(. + 1 > heap_len) { ;; } // . = index * 2, no-op
+		else if((L[. + 1].f - L[.].f) < 0)
+			. += 1
 
 //Replaces a given node so it verify the heap condition
-/datum/Heap/proc/ReSort(atom/A)
+/datum/path_minheap/proc/ReSort(atom/A)
 	var/index = L.Find(A)
 
 	Swim(index)
 	Sink(index)
 
-/datum/Heap/proc/List()
+/datum/path_minheap/proc/List()
 	. = L.Copy()
 

--- a/code/controllers/subsystem/adjacent_air.dm
+++ b/code/controllers/subsystem/adjacent_air.dm
@@ -54,7 +54,6 @@ SUBSYSTEM_DEF(adjacent_air)
 	var/obj/effect/abstract/liquid_turf/liquids
 	var/liquid_height = 0
 	var/turf_height = 0
-	var/path_weight = 0
 
 /turf/open
 	var/obj/effect/hotspot/active_hotspot

--- a/code/datums/elements/mob_overlay_effect.dm
+++ b/code/datums/elements/mob_overlay_effect.dm
@@ -25,9 +25,11 @@
 	. = ..()
 	UnregisterSignal(get_turf(source), list(
 		COMSIG_TURF_EXITED,
-		COMSIG_TURF_ENTERED,
+		COMSIG_TURF_ENTERED))
+	UnregisterSignal(source, list(
 		COMSIG_MOB_OVERLAY_FORCE_REMOVE,
-		COMSIG_MOB_OVERLAY_FORCE_UPDATE
+		COMSIG_MOB_OVERLAY_FORCE_UPDATE,
+		COMSIG_PARENT_QDELETING
 	))
 
 /datum/element/mob_overlay_effect/proc/on_remove(datum/source, datum/target)
@@ -48,9 +50,9 @@
 /datum/element/mob_overlay_effect/proc/on_add(datum/source, datum/target)
 	SIGNAL_HANDLER
 	var/mob/mob = target
-	for(var/obj/structure/S in get_turf(target))
-		if(S.obj_flags & BLOCK_Z_OUT_DOWN)
-			return
+	var/turf/target_turf = get_turf(target)
+	if(target_turf.platform_atom_count > 0)
+		return
 
 	if(isobj(target))
 		var/obj/obj = target

--- a/code/datums/particle_weathers/datum_types/snow_storm.dm
+++ b/code/datums/particle_weathers/datum_types/snow_storm.dm
@@ -87,10 +87,3 @@
 
 /turf
 	var/turf_flags = TURF_EFFECT_AFFECTABLE
-
-/turf/Exited(atom/movable/gone, direction)
-	if(!istype(gone))
-		return
-	SEND_SIGNAL(src, COMSIG_TURF_EXITED, gone, direction)
-	SEND_SIGNAL(gone, COMSIG_MOVABLE_TURF_EXITED, src, direction)
-

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -171,7 +171,7 @@
 
 	if (opacity && isturf(loc))
 		var/turf/T = loc
-		T.has_opaque_atom = TRUE // No need to recalculate it in this case, it's guaranteed to be on afterwards anyways.
+		T.opaque_atom_count++
 
 	if (canSmoothWith)
 		canSmoothWith = typelist("canSmoothWith", canSmoothWith)

--- a/code/game/machinery/trams_and_elevators/industrial_lift.dm
+++ b/code/game/machinery/trams_and_elevators/industrial_lift.dm
@@ -484,7 +484,7 @@ GLOBAL_LIST_INIT(all_radial_directions, list(
 
 
 		if(mover_old_area != mover_new_area)
-			mover_old_area.Exited(mover, movement_direction)
+			mover_old_area.Exited(mover, mover_new_loc)
 			mover_new_area.Entered(mover, mover_new_area)
 
 		mover.Moved(mover_old_loc, movement_direction, TRUE, null, FALSE)

--- a/code/game/machinery/trams_and_elevators/lift_master.dm
+++ b/code/game/machinery/trams_and_elevators/lift_master.dm
@@ -575,7 +575,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 		platform.horizontal_speed = 0.1
 		base_horizontal_speed = 0.1
 		horizontal_speed = 0.1
-		platform.obj_flags &= ~BLOCK_Z_OUT_DOWN
+		platform.set_is_platform(FALSE)
 		platform.alpha = 0
 		for(var/atom/movable/movable in platform.lift_load)
 			if(ismob(movable))
@@ -589,7 +589,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 
 		for(var/obj/structure/industrial_lift/tram/moving_platform in platform.moving_lifts)
 			moving_platform.horizontal_speed = 0.1
-			moving_platform.obj_flags &= ~BLOCK_Z_OUT_DOWN
+			moving_platform.set_is_platform(FALSE)
 			moving_platform.alpha = 0
 
 /datum/lift_master/tram/proc/show_tram()
@@ -598,7 +598,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 		platform.horizontal_speed = 4
 		base_horizontal_speed = 4
 		horizontal_speed = 4
-		platform.obj_flags |= BLOCK_Z_OUT_DOWN
+		platform.set_is_platform(TRUE)
 		platform.alpha = 255
 		for(var/atom/movable/movable in objects_pre_alpha)
 			movable.alpha = objects_pre_alpha[movable]
@@ -608,7 +608,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 
 		for(var/obj/structure/industrial_lift/tram/moving_platform in platform.moving_lifts)
 			moving_platform.horizontal_speed = 4
-			moving_platform.obj_flags |= BLOCK_Z_OUT_DOWN
+			moving_platform.set_is_platform(TRUE)
 			moving_platform.alpha = 255
 
 /datum/lift_master/tram/proc/try_process_order()

--- a/code/game/objects/minecart_system/minecart.dm
+++ b/code/game/objects/minecart_system/minecart.dm
@@ -236,7 +236,7 @@
 	if(!on_rails || momentum > 0)
 		return
 
-	obj_flags |= BLOCK_Z_OUT_DOWN
+	set_is_platform(TRUE)
 	var/movedir = bumped_atom.dir
 	var/turf/next_turf = get_step(src, movedir)
 	if(!can_travel_on_turf(next_turf, movedir))
@@ -280,7 +280,7 @@
 	if(momentum <= 0)
 		stack_trace("Mine cart moving on 0 momentum!")
 		SSmove_manager.stop_looping(src, SSminecarts)
-		obj_flags &= ~BLOCK_Z_OUT_DOWN
+		set_is_platform(FALSE)
 		momentum = 0
 		return MOVELOOP_SKIP_STEP
 	// Forced to not move
@@ -334,7 +334,7 @@
 
 	// Can't go straight and cant turn = STOP
 	SSmove_manager.stop_looping(src, SSminecarts)
-	obj_flags &= ~BLOCK_Z_OUT_DOWN
+	set_is_platform(FALSE)
 	if(momentum >= 12)
 		visible_message(span_warning("[src] comes to a violent halt!"))
 		throw_contents()
@@ -355,7 +355,7 @@
 			else
 				visible_message(span_notice("[src] comes to a stop."))
 			SSmove_manager.stop_looping(src, SSminecarts)
-			obj_flags &= ~BLOCK_Z_OUT_DOWN
+			set_is_platform(FALSE)
 			momentum = 0
 			return
 		check_powered()
@@ -364,7 +364,7 @@
 	// No more momentum = STOP
 	if(momentum <= 0)
 		SSmove_manager.stop_looping(src, SSminecarts)
-		obj_flags &= ~BLOCK_Z_OUT_DOWN
+		set_is_platform(FALSE)
 		momentum = 0
 		visible_message(span_notice("[src] comes to a slow stop."))
 		return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -98,7 +98,7 @@
 				obj_flags |= string_to_objflag[flag]
 	var/turf/our_turf = get_turf(src)
 	// if the turf is uninitialized it'll just call Entered on us
-	if((our_turf.flags_1 & INITIALIZED_1) && (obj_flags & BLOCK_Z_OUT_DOWN))
+	if(our_turf && (our_turf.flags_1 & INITIALIZED_1) && (obj_flags & BLOCK_Z_OUT_DOWN))
 		our_turf.platform_atom_count++
 
 /obj/Destroy(force=FALSE)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -271,6 +271,17 @@
 /obj/proc/dump_contents()
 	CRASH("Unimplemented.")
 
+/// Sets the BLOCK_Z_OUT_DOWN obj_flag and runs associated updates.
+/obj/proc/set_is_platform(new_platform_status)
+	if((obj_flags & BLOCK_Z_OUT_DOWN) == new_platform_status)
+		return
+	var/turf/our_turf = get_turf(src)
+	obj_flags ^= BLOCK_Z_OUT_DOWN
+	if(new_platform_status)
+		our_turf.platform_atom_count++
+	else
+		our_turf.platform_atom_count--
+
 /obj/merge_conflict_marker
 	name = "---Merge Conflict Marker---"
 	desc = "Mapping helper."

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -96,6 +96,10 @@
 				obj_flags &= ~string_to_objflag[flag]
 			else
 				obj_flags |= string_to_objflag[flag]
+	var/turf/our_turf = get_turf(src)
+	// if the turf is uninitialized it'll just call Entered on us
+	if((our_turf.flags_1 & INITIALIZED_1) && (obj_flags & BLOCK_Z_OUT_DOWN))
+		our_turf.platform_atom_count++
 
 /obj/Destroy(force=FALSE)
 	if(!ismachinery(src))

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -297,3 +297,13 @@
 				return  "It appears heavily damaged."
 			if(1 to 25)
 				return  span_warning("It's falling apart!")
+
+/obj/structure/proc/set_climbable(new_climbable)
+	if(new_climbable == climbable)
+		return
+	var/turf/our_turf = get_turf(src)
+	climbable = new_climbable
+	if(climbable)
+		our_turf.climbable_atom_count++
+	else
+		our_turf.climbable_atom_count--

--- a/code/game/objects/structures/fence.dm
+++ b/code/game/objects/structures/fence.dm
@@ -78,11 +78,11 @@
 					if(MEDIUM_HOLE)
 						visible_message(span_notice("\The [user] cuts into \the [src] some more."))
 						to_chat(user, span_info("I could probably fit myself through that hole now. Although climbing through would be much faster if it was even bigger."))
-						climbable = TRUE
+						set_climbable(TRUE)
 					if(LARGE_HOLE)
 						visible_message(span_notice("\The [user] completely cuts through \the [src]."))
 						to_chat(user, span_info("The hole in \the [src] is now big enough to walk through."))
-						climbable = FALSE
+						set_climbable(FALSE)
 
 				update_cut_status()
 

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -519,7 +519,8 @@
 	if(togg)
 		testing("togge1")
 		icon_state = "floorgrilleopen"
-		obj_flags = CAN_BE_HIT
+		set_is_platform(FALSE)
+		obj_flags &= ~BLOCK_Z_IN_UP
 		var/turf/T = loc
 		if(istype(T))
 			for(var/mob/living/M in loc)
@@ -527,7 +528,8 @@
 	else
 		testing("togge2")
 		icon_state = "floorgrille"
-		obj_flags = CAN_BE_HIT | BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
+		set_is_platform(TRUE)
+		obj_flags |= BLOCK_Z_IN_UP
 
 /obj/structure/bars/grille/attackby(obj/item/I, mob/user, params)
 	. = ..()

--- a/code/game/objects/structures/roguetown/newtree.dm
+++ b/code/game/objects/structures/roguetown/newtree.dm
@@ -31,7 +31,7 @@
 /obj/structure/flora/newtree/obj_destruction(damage_flag)//this proc is stupidly long for a destruction proc
 	var/turf/NT = get_turf(src)
 	var/turf/UPNT = get_step_multiz(src, UP)
-	src.obj_flags = CAN_BE_HIT | BLOCK_Z_IN_UP //so the logs actually fall when pulled by zfall
+	set_is_platform(FALSE) //so the logs actually fall when pulled by zfall
 	if(burnt)
 		damage_flag = "fire"
 
@@ -47,13 +47,13 @@
 				var/turf/BI = get_step(B, DI)
 				for(var/obj/structure/flora/newbranch/bi in BI)//2 tile end branch
 					if(bi.dir == DI)
-						bi.obj_flags = CAN_BE_HIT
+						bi.set_is_platform(FALSE)
 						bi.obj_destruction(damage_flag)
 					for(var/atom/bio in BI)
 						BI.zFall(bio)
 				for(var/obj/structure/flora/newleaf/bil in BI)//2 tile end leaf
 					bil.obj_destruction(damage_flag)
-				BRANCH.obj_flags = CAN_BE_HIT 
+				BRANCH.set_is_platform(FALSE)
 				BRANCH.obj_destruction(damage_flag)
 			for(var/atom/BRA in B)//unload a sack of rocks on a branch and stand under it, it'll be funny bro
 				B.zFall(BRA)

--- a/code/game/objects/structures/roguetown/newtreealt.dm
+++ b/code/game/objects/structures/roguetown/newtreealt.dm
@@ -31,7 +31,7 @@
 /obj/structure/flora/newtreealt/obj_destruction(damage_flag)//this proc is stupidly long for a destruction proc
 	var/turf/NT = get_turf(src)
 	var/turf/UPNT = get_step_multiz(src, UP)
-	src.obj_flags = CAN_BE_HIT | BLOCK_Z_IN_UP //so the logs actually fall when pulled by zfall
+	set_is_platform(FALSE) //so the logs actually fall when pulled by zfall
 	if(burnt)
 		damage_flag = "fire"
 
@@ -47,13 +47,13 @@
 				var/turf/BI = get_step(B, DI)
 				for(var/obj/structure/flora/newbranchalt/bi in BI)//2 tile end branch
 					if(bi.dir == DI)
-						bi.obj_flags = CAN_BE_HIT
+						bi.set_is_platform(FALSE)
 						bi.obj_destruction(damage_flag)
 					for(var/atom/bio in BI)
 						BI.zFall(bio)
 				for(var/obj/structure/flora/newleafalt/bil in BI)//2 tile end leaf
 					bil.obj_destruction(damage_flag)
-				BRANCH.obj_flags = CAN_BE_HIT 
+				BRANCH.set_is_platform(FALSE)
 				BRANCH.obj_destruction(damage_flag)
 			for(var/atom/BRA in B)//unload a sack of rocks on a branch and stand under it, it'll be funny bro
 				B.zFall(BRA)

--- a/code/game/objects/structures/roguetown/redstone.dm
+++ b/code/game/objects/structures/roguetown/redstone.dm
@@ -618,7 +618,8 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	return ..()
 */
 /obj/structure/floordoor/obj_break(damage_flag)
-	obj_flags = null
+	set_is_platform(FALSE)
+	obj_flags &= ~BLOCK_Z_IN_UP
 	..()
 
 /obj/structure/floordoor/redstone_triggered(mob/user)
@@ -627,20 +628,22 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	togg = !togg
 	if(togg)
 		icon_state = "[base_state]0"
-		obj_flags = null
+		set_is_platform(FALSE)
+		obj_flags &= ~BLOCK_Z_IN_UP
 		var/turf/T = loc
 		if(istype(T))
 			for(var/atom/movable/M in loc)
 				T.Entered(M)
 	else
 		icon_state = "[base_state]1"
-		obj_flags = BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
+		set_is_platform(TRUE)
+		obj_flags |= BLOCK_Z_IN_UP
 
 /obj/structure/floordoor/open
-		icon_state = "floorhatch0"
-		base_state = "floorhatch"
-		togg = TRUE
-		obj_flags = null
+	icon_state = "floorhatch0"
+	base_state = "floorhatch"
+	togg = TRUE
+	obj_flags = null
 
 /obj/structure/floordoor/gatehatch
 	name = ""
@@ -668,7 +671,8 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	if(togg)
 		sleep(delay2open)
 		icon_state = "[base_state]0"
-		obj_flags = null
+		set_is_platform(FALSE)
+		obj_flags &= ~BLOCK_Z_IN_UP
 		var/turf/T = loc
 		if(istype(T))
 			for(var/atom/movable/M in loc)
@@ -678,7 +682,8 @@ GLOBAL_LIST_EMPTY(redstone_objs)
 	else
 		sleep(delay2close)
 		icon_state = "[base_state]1"
-		obj_flags = BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
+		set_is_platform(TRUE)
+		obj_flags |= BLOCK_Z_IN_UP
 		sleep(40-delay2close)
 		changing_state = FALSE
 

--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -68,7 +68,7 @@
 				playsound(user, 'sound/misc/wood_saw.ogg', 100, TRUE)
 				icon_state = "[base_state]"
 				density = TRUE
-				climbable = FALSE
+				set_climbable(FALSE)
 				brokenstate = FALSE
 				obj_broken = FALSE
 				opacity = initial(opacity)
@@ -295,7 +295,7 @@
 					new /obj/item/natural/glass_shard (get_turf(src))
 					new /obj/effect/decal/cleanable/debris/glassy(get_turf(src))
 					brokenstate = TRUE
-					climbable = TRUE
+					set_climbable(TRUE)
 					opacity = FALSE
 					update_icon()
 					var/obj/effect/track/structure/new_track = new(get_turf(src))
@@ -324,20 +324,20 @@
 /obj/structure/roguewindow/proc/open_up(mob/user)
 	visible_message(span_info("[user] opens [src]."))
 	playsound(src, 'sound/foley/doors/windowup.ogg', 100, FALSE)
-	climbable = TRUE
+	set_climbable(TRUE)
 	opacity = FALSE
 	update_icon()
 
 /obj/structure/roguewindow/proc/force_open()
 	playsound(src, 'sound/foley/doors/windowup.ogg', 100, FALSE)
-	climbable = TRUE
+	set_climbable(TRUE)
 	opacity = FALSE
 	update_icon()
 
 /obj/structure/roguewindow/proc/close_up(mob/user)
 	visible_message(span_info("[user] closes [src]."))
 	playsound(src, 'sound/foley/doors/windowdown.ogg', 100, FALSE)
-	climbable = FALSE
+	set_climbable(FALSE)
 	opacity = TRUE
 	update_icon()
 
@@ -413,7 +413,7 @@
 		loud_message("A loud crash of a window getting broken rings out", hearing_distance = 14)
 		new /obj/item/natural/glass_shard (get_turf(src))
 		new /obj/effect/decal/cleanable/debris/glassy(get_turf(src))
-		climbable = TRUE
+		set_climbable(TRUE)
 		brokenstate = TRUE
 		opacity = FALSE
 	update_icon()

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -18,12 +18,11 @@
 	return 0
 
 /turf/open/get_slowdown(mob/user)
-	var/total_slowdown = slowdown
+	. = slowdown
+	if(platform_atom_count > 0)
+		return
 	for(var/obj/obj in contents)
-		if(obj.obj_flags & BLOCK_Z_OUT_DOWN)
-			return slowdown
-		total_slowdown += obj.object_slowdown
-	return total_slowdown
+		. += obj.object_slowdown
 
 /turf
 	var/landsound = null

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -84,10 +84,9 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 		return FALSE
 	if(direction == DOWN)
 		testing("dir=down")
-		for(var/obj/O in contents)
-			if(O.obj_flags & BLOCK_Z_OUT_DOWN)
-				testing("noout")
-				return FALSE
+		if(platform_atom_count > 0)
+			testing("noout")
+			return FALSE
 		return TRUE
 	if(direction == UP)
 		for(var/obj/O in contents)

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -88,9 +88,8 @@
 	if(isliving(AM) && !AM.throwing)
 		var/mob/living/user = AM
 		if(isliving(user) && !user.is_floor_hazard_immune())
-			for(var/obj/structure/S in src)
-				if(S.obj_flags & BLOCK_Z_OUT_DOWN)
-					return
+			if(platform_atom_count > 0)
+				return
 			if(water_overlay)
 				if((get_dir(src, newloc) == SOUTH))
 					water_overlay.layer = BELOW_MOB_LAYER
@@ -154,9 +153,8 @@
 	if(!swimmer.check_armor_skill())
 		. += UNSKILLED_ARMOR_PENALTY
 	if(.) // this check is expensive so we only run it if we do expect to use stamina
-		for(var/obj/structure/S in src)
-			if(S.obj_flags & BLOCK_Z_OUT_DOWN)
-				return 0
+		if(platform_atom_count > 0)
+			return 0
 		for(var/D in GLOB.cardinals) //adjacent to a floor to hold onto
 			if(istype(get_step(src, D), /turf/open/floor))
 				return 0
@@ -194,9 +192,8 @@
 
 /turf/open/water/Entered(atom/movable/AM, atom/oldLoc)
 	. = ..()
-	for(var/obj/structure/S in src)
-		if(S.obj_flags & BLOCK_Z_OUT_DOWN)
-			return
+	if(platform_atom_count > 0)
+		return
 	if(istype(AM, /obj/item/reagent_containers/food/snacks/fish))
 		var/obj/item/reagent_containers/food/snacks/fish/F = AM
 		if (F.sinkable)
@@ -607,7 +604,8 @@
 
 /turf/open/water/river/Entered(atom/movable/AM, atom/oldLoc)
 	. = ..()
-	START_PROCESSING(SSrivers, src)
+	if(platform_atom_count <= 0)
+		START_PROCESSING(SSrivers, src)
 
 /turf/open/water/river/get_heuristic_slowdown(mob/traverser, travel_dir)
 	var/const/UPSTREAM_PENALTY = 2 //Ratwood edit, Azure: 4
@@ -616,9 +614,8 @@
 	. = ..()
 	if(traverser.is_floor_hazard_immune())
 		return
-	for(var/obj/structure/S in src)
-		if(S.obj_flags & BLOCK_Z_OUT_DOWN)
-			return
+	if(platform_atom_count > 0)
+		return
 	if(travel_dir == dir) // downriver
 		. += DOWNSTREAM_BONUS // faster!
 	else if(travel_dir == GLOB.reverse_dir[dir]) // upriver
@@ -627,16 +624,18 @@
 		. += SIDESTREAM_PENALTY // sidestream walking isn't free, bro
 
 /turf/open/water/river/proc/process_river()
+	if(platform_atom_count > 0)
+		STOP_PROCESSING(SSrivers, src)
+		return
 	var/found_movable = FALSE
 	for(var/atom/movable/A in contents)
-		found_movable = TRUE
-		for(var/obj/structure/S in src)
-			if(S.obj_flags & BLOCK_Z_OUT_DOWN)
-				return
-		if((A.loc == src))
-			A.ConveyorMove(dir)
+		if(!A.anchored)
+			found_movable = TRUE
+			if((A.loc == src))
+				A.ConveyorMove(dir)
 
-	if(found_movable)
+	// stop processing once there's nothing left to move
+	if(!found_movable)
 		STOP_PROCESSING(SSrivers, src)
 		return
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -55,6 +55,13 @@
 	var/neighborlay_override
 	var/teleport_restricted = FALSE //whether turf teleport spells are forbidden from teleporting to this turf
 
+	// Pathfinding variables.
+	var/path_weight = 0
+	/// How many dense climbable atoms does this turf have?
+	var/climbable_atom_count = 0
+	/// How many atoms on this turf act as platforms (have BLOCK_Z_OUT_DOWN)?
+	var/platform_atom_count = 0
+
 	vis_flags = VIS_INHERIT_PLANE|VIS_INHERIT_ID
 
 /turf/vv_edit_var(var_name, new_value)
@@ -107,7 +114,7 @@
 		reassess_stack()
 
 	if (opacity)
-		has_opaque_atom = TRUE
+		opaque_atom_count = 1 // we count ourselves
 
 	ComponentInitialize()
 
@@ -401,18 +408,37 @@
 		if(QDELETED(mover))
 			return FALSE		//We were deleted.
 
-/turf/Entered(atom/movable/AM)
+/turf/Entered(atom/movable/entered_movable)
 	..()
-	SEND_SIGNAL(src, COMSIG_TURF_ENTERED, AM)
-	SEND_SIGNAL(AM, COMSIG_MOVABLE_TURF_ENTERED, src)
-
-	if(explosion_level && AM.ex_check(explosion_id))
-		AM.ex_act(explosion_level)
-
+	SEND_SIGNAL(src, COMSIG_TURF_ENTERED, entered_movable)
+	SEND_SIGNAL(entered_movable, COMSIG_MOVABLE_TURF_ENTERED, src)
+	if(explosion_level && entered_movable.ex_check(explosion_id))
+		entered_movable.ex_act(explosion_level)
 	// If an opaque movable atom moves around we need to potentially update visibility.
-	if (AM.opacity)
-		has_opaque_atom = TRUE // Make sure to do this before reconsider_lights(), incase we're on instant updates. Guaranteed to be on in this case.
+	if (entered_movable.opacity)
+		opaque_atom_count++ // Make sure to do this before reconsider_lights(), incase we're on instant updates.
 		reconsider_lights()
+	if(isstructure(entered_movable))
+		var/obj/structure/entered_structure = entered_movable
+		if(entered_structure.density && entered_structure.climbable)
+			climbable_atom_count += 1
+		if(entered_structure.obj_flags & BLOCK_Z_OUT_DOWN)
+			platform_atom_count += 1
+
+/turf/Exited(atom/movable/gone, atom/newloc)
+	if(!istype(gone))
+		return
+	SEND_SIGNAL(src, COMSIG_TURF_EXITED, gone, newloc)
+	SEND_SIGNAL(gone, COMSIG_MOVABLE_TURF_EXITED, src, newloc)
+	if (gone?.opacity)
+		opaque_atom_count-- // Make sure to do this before reconsider_lights(), incase we're on instant updates.
+		reconsider_lights()
+	if(isstructure(gone))
+		var/obj/structure/exited_structure = gone
+		if(exited_structure.density && exited_structure.climbable)
+			climbable_atom_count -= 1
+		if(exited_structure.obj_flags & BLOCK_Z_OUT_DOWN)
+			platform_atom_count -= 1
 
 /turf/open/Entered(atom/movable/AM)
 	..()
@@ -531,22 +557,19 @@
 		return FALSE
 	return abs(x - T.x) + abs(y - T.y) + abs(z - T.z)
 
+// TODO: cache certain parts of this per-tile and update on /entered and /exited
+// that way we can avoid iterating contents
 /// Returns an additional distance factor based on slowdown and other factors.
 /turf/proc/get_heuristic_slowdown(mob/traverser, travel_dir)
 	. = get_slowdown(traverser)
-	// add cost from climbable obstacles
-	for(var/obj/structure/some_object in src)
-		if(some_object.density && some_object.climbable)
-			. += 1 // extra tile penalty
-			break
 	var/obj/structure/mineral_door/door = locate() in src
 	if(door && door.density && !door.locked && door.anchored) // door will have to be opened
 		. += 2 // try to avoid closed doors where possible
-
-	for(var/obj/structure/O in contents)
-		if(O.obj_flags & BLOCK_Z_OUT_DOWN)
-			return
-	. += path_weight
+	// add cost from climbable obstacles
+	if(climbable_atom_count > 0)
+		. += 1 // extra tile penalty
+	if(platform_atom_count <= 0)
+		. += path_weight
 
 // Like Distance_cardinal, but includes additional weighting to make A* prefer turfs that are easier to pass through.
 /turf/proc/Heuristic_cardinal(turf/T, mob/traverser)

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -113,10 +113,8 @@
 	var/turf/T = loc
 	. = ..()
 	if (opacity && istype(T))
-		var/old_has_opaque_atom = T.has_opaque_atom
-		T.recalc_atom_opacity()
-		if (old_has_opaque_atom != T.has_opaque_atom)
-			T.reconsider_lights()
+		T.opaque_atom_count--
+		T.reconsider_lights()
 
 // Should always be used to change the opacity of an atom.
 // It notifies (potentially) affected light sources so they can update (if needed).
@@ -129,14 +127,11 @@
 	if (!isturf(T))
 		return
 
-	if (new_opacity == TRUE)
-		T.has_opaque_atom = TRUE
-		T.reconsider_lights()
+	if (new_opacity)
+		T.opaque_atom_count++
 	else
-		var/old_has_opaque_atom = T.has_opaque_atom
-		T.recalc_atom_opacity()
-		if (old_has_opaque_atom != T.has_opaque_atom)
-			T.reconsider_lights()
+		T.opaque_atom_count--
+	T.reconsider_lights()
 
 /atom/movable/Moved(atom/OldLoc, Dir)
 	. = ..()

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -7,7 +7,7 @@
 	var/tmp/list/datum/light_source/affecting_lights       // List of light sources affecting this turf.
 	var/tmp/atom/movable/lighting_object/lighting_object // Our lighting object.
 	var/tmp/list/datum/lighting_corner/corners
-	var/tmp/has_opaque_atom = FALSE // Not to be confused with opacity, this will be TRUE if there's any opaque atom on the tile.
+	var/tmp/opaque_atom_count = 0 // Not to be confused with opacity, this is the number of opaque atoms on the tile.
 
 // Causes any affecting light sources to be queued for a visibility update, for example a door got opened.
 /turf/proc/reconsider_lights()
@@ -94,21 +94,12 @@
 
 	return !lighting_object.luminosity
 
-// Can't think of a good name, this proc will recalculate the has_opaque_atom variable.
+// Can't think of a good name, this proc will recalculate the opaque_atom_count variable.
 /turf/proc/recalc_atom_opacity()
-	has_opaque_atom = opacity
-	if (!has_opaque_atom)
-		for (var/atom/A in src.contents) // Loop through every movable atom on our tile PLUS ourselves (we matter too...)
-			if (A.opacity)
-				has_opaque_atom = TRUE
-				break
-
-/turf/Exited(atom/movable/Obj, atom/newloc)
-	. = ..()
-
-	if (Obj && Obj.opacity)
-		recalc_atom_opacity() // Make sure to do this before reconsider_lights(), incase we're on instant updates.
-		reconsider_lights()
+	opaque_atom_count = 0
+	for (var/atom/A in src.contents) // Loop through every movable atom on our tile
+		if (A.opacity)
+			opaque_atom_count++
 
 /turf/proc/change_area(area/old_area, area/new_area)
 	GLOB.SUNLIGHT_QUEUE_WORK += src
@@ -126,7 +117,7 @@
 		return null
 	if (!lighting_corners_initialised)
 		generate_missing_corners()
-	if (has_opaque_atom)
+	if (opacity || (opaque_atom_count > 0))
 		return null // Since this proc gets used in a for loop, null won't be looped though.
 
 	return corners

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -418,7 +418,7 @@
 				pathing_frustration++
 				sleep(time_to_wait)
 			continue
-		else if(!step(src, move_dir, cached_multiplicative_slowdown)) // try to move onto or along our path
+		else if(!step(src, move_dir, cached_multiplicative_slowdown) && (next_step.climbable_atom_count > 0)) // try to move onto or along our path
 			for(var/obj/structure/O in next_step)
 				if(O.density && O.climbable)
 					NPC_THINK("MOVEMENT TURN [movement_turn]: Trying to climb over [O]!")

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -95,9 +95,9 @@
 		return
 	if(SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_TURF_MOVESPEED) & TURF_MOVESPEED_BLOCKED)
 		return
-	var/usedslow = T.get_slowdown(src)
-	if(HAS_TRAIT(src, TRAIT_TRAM_MOVER))
-		usedslow = 0
+	var/usedslow = 0
+	if(!HAS_TRAIT(src, TRAIT_TRAM_MOVER))
+		usedslow = T.get_slowdown(src)
 	if(usedslow != 0)
 		add_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD, update=TRUE, priority=100, multiplicative_slowdown=usedslow, movetypes=GROUND)
 	else

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -405,7 +405,7 @@
 	on_mob.forceMove(scanning)
 	for(var/i in 1 to light_beam_distance)
 		scanning = get_step(scanning, scandir)
-		if(scanning.opacity || scanning.has_opaque_atom)
+		if(scanning.opacity || (scanning.opaque_atom_count > 0))
 			stop = TRUE
 		var/obj/effect/abstract/eye_lighting/L = LAZYACCESS(eye_lighting, i)
 		if(stop)


### PR DESCRIPTION
A bunch of changes to pathfinding-related stuff to hopefully make the game faster. Had a huge improvement in local with a stress test (100 NPC goblins vs 20 NPC skeletons with crazy gear/stats) but needs a testmerge to see if it helps on the live server too.

Also contains some slightly-invasive changes to opacity bookkeeping code, to hopefully reduce turf opaque atom recalculations by just letting us use an opaque atom count. Maybe. Should save us some loops over turf contents. This same principle was used for vars to track things like climbables and platforms, and so setters are used to toggle platform/climbable status to ensure it's updated properly.

THIS MUST BE TESTMERGED BEFORE IT CAN BE FULLMERGED.