### PR TITLE
Save one cast var assignment in is_species

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -454,12 +454,8 @@ GLOBAL_LIST_EMPTY(species_list)
 	if(progbar)
 		qdel(progbar)
 
-/proc/is_species(A, species_datum)
-	. = FALSE
-	if(ishuman(A))
-		var/mob/living/carbon/human/H = A
-		if(H.dna && istype(H.dna.species, species_datum))
-			. = TRUE
+/proc/is_species(mob/living/carbon/human/human, species_datum)
+	return ishuman(human) && istype(human.dna?.species, species_datum)
 
 /proc/spawn_atom_to_turf(spawn_type, target, amount, admin_spawn=FALSE, list/extra_args)
 	var/turf/T = get_turf(target)


### PR DESCRIPTION
This is the microopt to end all microopts. is_species gets called SO OFTEN due to dullahan code snowflakery in speech/hearing that it may actually be worth doing things like this. Needs a TM.

<img width="1030" height="41" alt="image" src="https://github.com/user-attachments/assets/8a13bff6-9061-482b-a13f-32601fdeab28" />
This just happened on the live server. It's being called excessively but we can at least try to microoptimize it until we figure out what the culprit is.