### PR TITLE
Make lighting effect objects use the movable light system

### DIFF
--- a/code/datums/components/movable_lighting.dm
+++ b/code/datums/components/movable_lighting.dm
@@ -267,14 +267,13 @@
 
 
 ///Changes the range which the light reaches. 0 means no light, 6 is the maximum value.
-/datum/component/overlay_lighting/proc/set_range(atom/source, old_inner_range, old_outer_range)
+/datum/component/overlay_lighting/proc/set_range(atom/source, new_inner_range, new_outer_range)
 	SIGNAL_HANDLER
-	var/new_range = source.light_outer_range
-	if(range == new_range)
+	if(range == new_outer_range)
 		return
 	if(range == 0)
 		turn_off()
-	range = clamp(CEILING(new_range, 0.5), 1, 6)
+	range = clamp(CEILING(new_outer_range, 0.5), 1, 6)
 	var/pixel_bounds = ((range - 1) * 64) + 32
 	lumcount_range = CEILING(range, 1)
 	visible_mask.icon = light_overlays["[pixel_bounds]"]

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -73,6 +73,7 @@
 	light_color = "#FFFFFF"
 	light_outer_range =  MINIMUM_USEFUL_LIGHT_RANGE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	light_system = MOVABLE_LIGHT
 
 /obj/effect/dummy/lighting_obj/Initialize(mapload, _color, _range, _power, _duration)
 	. = ..()

--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -77,7 +77,13 @@
 
 /obj/effect/dummy/lighting_obj/Initialize(mapload, _color, _range, _power, _duration)
 	. = ..()
-	set_light(_range ? _range : light_outer_range, light_inner_range, _power ? _power : light_power, l_color = _color ? _color : light_color)
+	set_light_on(TRUE)
+	if(_range)
+		set_light_range(null, _range)
+	if(_power)
+		set_light_power(_power)
+	if(_color)
+		set_light_color(_color)
 	if(_duration)
 		QDEL_IN(src, _duration)
 


### PR DESCRIPTION
~~Entirely untested~~ emergency fix. This seemed to be a big cause of unnecessary lighting updates on the live server and, assuming the movable lights system actually works right, this should be fine.

it did not actually work right, i fixed set_light_range not working but this entire component needs to be ripped out and replaced with TG's or CM's.

<img width="561" height="426" alt="pW816Rz4uY" src="https://github.com/user-attachments/assets/ada65361-79f4-4561-bb88-efc50d48246c" />

greater fireball light glow works. please testmerge this in case it's actually one billion times worse on live or something