### PR TITLE
Optimize sound loop handling

### DIFF
--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -7,21 +7,24 @@ SUBSYSTEM_DEF(soundloopers)
 	var/list/processing = list()
 	var/list/currentrun = list()
 	var/client_ticker = 0
+	var/list/client_run = list()
+	var/update_clients = FALSE
+	var/has_persistent = FALSE
 
 /datum/controller/subsystem/soundloopers/fire(resumed = 0)
-	if (!resumed || !currentrun.len)
+	if (!resumed)
 		src.currentrun = processing.Copy()
+		has_persistent = FALSE
+		client_ticker++
+		if(client_ticker >= 5)
+			client_ticker = 0
+			update_clients = TRUE
+			src.client_run = GLOB.clients.Copy()
+		else
+			update_clients = FALSE
 
 	//cache for sanic speed (lists are references anyways)
 	var/list/current = src.currentrun
-	var/check_clients = FALSE
-	client_ticker++
-
-	if(client_ticker>=5) //this is dumb but necessary- clients update every half tick but sounds themselves need to be updated regularly
-		client_ticker = 0
-		check_clients = TRUE
-	else
-		check_clients = FALSE
 
 	while (current.len)
 		var/datum/looping_sound/thing = current[current.len]
@@ -36,11 +39,20 @@ SUBSYSTEM_DEF(soundloopers)
 			if(thing.sound_loop()) //returns 1 if it fails for some reason
 				continue
 
-		if(check_clients && thing.persistent_loop)
-			for(var/client/C in GLOB.clients)
-				if(C.mob) //Not in the lobby
-					C.update_sounds()
+		if(thing.persistent_loop)
+			has_persistent = TRUE
 
+		if (MC_TICK_CHECK)
+			return
+
+	if(!update_clients || !has_persistent)
+		return
+	var/list/client_run = src.client_run
+	while (client_run.len)
+		var/client/C = client_run[client_run.len]
+		client_run.len--
+		if(C && C.mob) //Not in the lobby
+			C.update_sounds()
 		if (MC_TICK_CHECK)
 			return
 
@@ -73,7 +85,7 @@ SUBSYSTEM_DEF(soundloopers)
 		if(!our_sound)
 			continue //something fucked up and the loop has no cursound, wups. this should basically never happen
 
-		mob.playsound_local(parent_turf, PS.cursound, PS.volume, PS.vary, PS.frequency, PS.falloff, PS.channel, FALSE, our_sound, repeat = PS)
+		mob.playsound_local(parent_turf, PS.cursound, PS.volume, PS.vary, PS.frequency, PS.falloff, resolve_sound_channel(mob, PS.channel, PS), FALSE, our_sound, repeat = PS)
 
 	//Now we check how far away etc we are
 	for(var/datum/looping_sound/loop in played_loops)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,6 +1,15 @@
 /client
 	var/list/played_loops = list() //uses dlink to link to the sound
 
+/proc/resolve_sound_channel(mob/M, channel, datum/looping_sound/repeat)
+	if(!repeat || !M.client)
+		return channel
+	for(var/datum/looping_sound/existing_loop in M.client.played_loops)
+		if(existing_loop == repeat)
+			continue
+		if(existing_loop.channel == channel)
+			return null
+	return channel
 
 /proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, frequency = null, channel, pressure_affected = FALSE, ignore_walls = TRUE, soundping = FALSE, repeat, animal_pref = FALSE)
 	if(isarea(source))
@@ -72,7 +81,7 @@
 			if(animal_pref)
 				if(M.client?.prefs?.mute_animal_emotes)
 					continue
-			if(M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, repeat))
+			if(M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, resolve_sound_channel(M, channel, repeat), pressure_affected, S, repeat))
 				. += M
 	//This never runs because muffled listeners will always be empty and instead muffling runs on playsound_local
 	/*for(var/mob/M as anything in muffled_listeners)
@@ -81,7 +90,7 @@
 				if(M.client?.prefs?.mute_animal_emotes)
 					continue
 			if(M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, repeat, muffled = TRUE))
-				. += M*/ 
+				. += M*/
 
 
 /proc/ping_sound(atom/A)


### PR DESCRIPTION
## About The Pull Request

Issue: The soundlooper subsystem calls `C.update_sounds()` for every client inside its persistent-loop iteration. Since `update_sounds()` also iterates over every active loop, the total cost grows quadratically: active loops² ×  (clients) every half-second.

- Reduces unnecessary sound update calls.
- Prevents looping sounds from overwriting each other on the same channel.

## Testing Evidence

## Before:
<img width="1349" height="759" alt="image" src="https://github.com/user-attachments/assets/d4872818-b9ce-499f-b659-f14345118d9a" />
<img width="598" height="412" alt="image" src="https://github.com/user-attachments/assets/c578828a-5771-4932-a520-dd1965316bca" />


## After:

<img width="1397" height="813" alt="image" src="https://github.com/user-attachments/assets/cb5d2f51-ed88-4b3a-b49d-85256b277b54" />
<img width="1379" height="545" alt="image" src="https://github.com/user-attachments/assets/b9328cbe-66d9-4538-b612-0faaf865deb0" />

## Why It's Good For The Game

Improves performance and prevents broken volume or mute behavior.

## Changelog

:cl:
fix: Fixed looping sounds conflicting with each other
/:cl: