### PR TITLE
Untameable Drider Bug Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/game/drider.dm
+++ b/code/modules/mob/living/simple_animal/rogue/game/drider.dm
@@ -26,8 +26,19 @@
 	STACON = 8
 	STASTR = 10
 	tame = FALSE
-	tame_chance = 25
-	bonus_tame_chance = 15
+	food_type = list(
+		/obj/item/reagent_containers/food/snacks/rogue/meat/steak,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/fatty,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/bacon,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/spider,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/steak/wolf,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/crab,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/poultry,
+		/obj/item/reagent_containers/food/snacks/rogue/meat/rabbit,
+		/obj/item/reagent_containers/food/snacks/rogue/truffles,
+	)
+	tame_chance = 5
+	bonus_tame_chance = 5
 	can_saddle = TRUE
 	can_buckle = TRUE
 	aggressive = 1


### PR DESCRIPTION
## About The Pull Request
Drider spiders, usually only used by the drow merc advclass, had a tame chance var but no actual food_type list like their saiga counterparts do. Practically speaking, this meant they were unable to be easily healed like saiga and were impossible to tame in the wild. 

This fixes that by giving them a list of mostly raw meats they can eat, while lowering their tame chance from the saiga default to a 5% base, with a 5% bonus per failed attempt, given their robust statline compared to the other mounts. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Ignore me fucking up putting a saddle on a stationary spider please

https://github.com/user-attachments/assets/63315107-c041-4975-be62-6e8eea80680c


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Mercs can heal their mounts, and especially daring characters can gamble with the Underdark ambush pool for a wicked cool spider mount. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
fix: Fixed Drider simplemobs being untameable and unable to be food healed. Feed your new best friend some meat and truffles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
