### PR TITLE
Migrant 2.0 [AP Port]

### DIFF
--- a/code/__DEFINES/migrants.dm
+++ b/code/__DEFINES/migrants.dm
@@ -1,17 +1,18 @@
 #define MIGRANT_ROLE(role_type) GLOB.migrant_roles[role_type]
 #define MIGRANT_WAVE(wave_type) GLOB.migrant_waves[wave_type]
 
+#define MIGRANT_TRACK_REGULAR "regular"
+#define MIGRANT_TRACK_SPECIAL "special"
+#define MIGRANT_TRACK_TRIUMPH "triumph"
+#define MIGRANT_TRACK_EVENT "event"
+
 #define MIGRANT_NOBILITY \
 	/datum/migrant_role/heartfelt/lord,\
-	/datum/migrant_role/heartfelt/lady,\
 	/datum/migrant_role/heartfelt/hand,\
 	/datum/migrant_role/heartfelt/knight,\
-	/datum/migrant_role/heartfelt/magos,\
-	/datum/migrant_role/heartfelt/prior,\
 
 #define MIGRANT_LORDS \
 	/datum/migrant_role/heartfelt/lord,\
-	/datum/migrant_role/heartfelt/lady
 
 #define MIGRANT_SLAVERS \
 	/datum/migrant_role/slaver/master,\

--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -3,140 +3,120 @@ SUBSYSTEM_DEF(migrants)
 	wait = 2 SECONDS
 	runlevels = RUNLEVEL_GAME
 	var/wave_number = 1
-	var/current_wave = null
-	var/time_until_next_wave = 90 SECONDS
-	var/wave_timer = 0
 
-	var/time_between_waves = 2 MINUTES
-	var/time_between_fail_wave = 90 SECONDS
-	var/wave_wait_time = 30 SECONDS
+	var/wave_wait_time = 3 MINUTES
+	var/regular_roll_interval = 5 MINUTES
+	var/special_roll_interval = 18 MINUTES
+	var/faction_fail_cooldown = 20 MINUTES
+	var/raid_fail_cooldown = 30 MINUTES
+	var/ooc_ping_interval = 5 MINUTES
+	var/last_ooc_ping = 0
+
+	var/list/track_forming = list()
+	var/list/track_arrival = list()
+	var/list/track_next_roll = list()
+	var/list/track_forced = list()
+	var/list/wave_cooldown = list()
 
 	var/list/spawned_waves = list()
-	/// Track triumph contributions across all waves
 	var/list/global_triumph_contributions = list()
-	/// Track parent wave for downgrades
-	var/current_parent_wave = null
 
 /datum/controller/subsystem/migrants/Initialize()
+	track_next_roll[MIGRANT_TRACK_REGULAR] = world.time + 2 MINUTES
+	track_next_roll[MIGRANT_TRACK_SPECIAL] = world.time + special_roll_interval
 	return ..()
 
 /datum/controller/subsystem/migrants/fire(resumed)
-	process_migrants(2 SECONDS)
+	process_track(MIGRANT_TRACK_REGULAR, regular_roll_interval, FALSE)
+	process_track(MIGRANT_TRACK_SPECIAL, special_roll_interval, TRUE)
+	process_triumph_track()
+	process_event_track()
 	update_ui()
 
-/datum/controller/subsystem/migrants/proc/set_current_wave(wave_type, time, parent_wave = -1)
-	current_wave = wave_type
-	wave_timer = time
-	if(parent_wave != -1)
-		current_parent_wave = parent_wave
-/datum/controller/subsystem/migrants/proc/process_migrants(dt)
-	if(current_wave)
-		process_current_wave(dt)
-	else
-		process_next_wave(dt)
-
-/datum/controller/subsystem/migrants/proc/process_current_wave(dt)
-	wave_timer -= dt
-	if(wave_timer > 0)
+/datum/controller/subsystem/migrants/proc/process_event_track()
+	if(!track_forming[MIGRANT_TRACK_EVENT])
 		return
-	// Try and spawn wave
-	var/success = try_spawn_wave()
-	if(success)
-		log_game("Migrants: Successfully spawned wave: [current_wave]")
-	else
-		log_game("Migrants: FAILED to spawn wave: [current_wave]")
+	if(world.time < track_arrival[MIGRANT_TRACK_EVENT])
+		return
+	resolve_forming_wave(MIGRANT_TRACK_EVENT)
 
-	// Handle downgrade logic
-	var/datum/migrant_wave/wave = MIGRANT_WAVE(current_wave)
-	var/parent_wave = current_parent_wave
+/datum/controller/subsystem/migrants/proc/process_track(track, roll_interval, announce)
+	var/forming = track_forming[track]
+	if(forming)
+		if(world.time < track_arrival[track])
+			return
+		resolve_forming_wave(track)
+		track_next_roll[track] = world.time + roll_interval
+		return
+	if(world.time < track_next_roll[track])
+		return
+	var/wave_type = roll_wave(track)
+	if(wave_type)
+		begin_forming(track, wave_type)
+		if(announce)
+			announce_special_wave(wave_type)
+	track_next_roll[track] = world.time + roll_interval
 
-	// Unset some values, increment wave number if success
+/datum/controller/subsystem/migrants/proc/process_triumph_track()
+	var/forming = track_forming[MIGRANT_TRACK_TRIUMPH]
+	if(forming)
+		if(world.time < track_arrival[MIGRANT_TRACK_TRIUMPH])
+			return
+		resolve_forming_wave(MIGRANT_TRACK_TRIUMPH)
+		return
+	var/wave_type = get_maxed_wave()
+	if(wave_type)
+		begin_forming(MIGRANT_TRACK_TRIUMPH, wave_type)
+		announce_special_wave(wave_type)
+
+/datum/controller/subsystem/migrants/proc/is_forced_forming(wave_type)
+	for(var/track in track_forced)
+		if(track_forced[track] && track_forming[track] == wave_type)
+			return TRUE
+	return FALSE
+
+/datum/controller/subsystem/migrants/proc/begin_forming(track, wave_type, forced = FALSE)
+	track_forming[track] = wave_type
+	track_arrival[track] = world.time + wave_wait_time
+	track_forced[track] = forced
+	log_game("Migrants: [track] track rolled wave: [wave_type][forced ? " (forced)" : ""]")
+
+/datum/controller/subsystem/migrants/proc/resolve_forming_wave(track)
+	var/wave_type = track_forming[track]
+	var/forced = track_forced[track]
+	track_forming[track] = null
+	track_arrival[track] = 0
+	track_forced[track] = FALSE
+	var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+	var/success = try_spawn_wave(wave, forced)
 	if(success)
+		log_game("Migrants: Successfully spawned wave: [wave_type]")
 		wave_number++
-		// Reset parent wave triumph if this was a downgrade that succeeded
-		if(parent_wave)
-			reset_wave_contributions(MIGRANT_WAVE(parent_wave))
-	set_current_wave(null, 0)
+		return
+	log_game("Migrants: FAILED to spawn wave: [wave_type]")
+	message_admins("MIGRANTS: Wave '[wave.name]' failed to assemble on the [track] track.")
+	wave_cooldown[wave_type] = world.time + get_fail_cooldown(wave)
+	for(var/client/client as anything in get_wave_candidates(wave_type))
+		to_chat(client, span_boldwarning("The wave you queued for, [wave.name], failed to gather enough people and scattered into the mist. You have left the queue."))
+	if(track == MIGRANT_TRACK_TRIUMPH)
+		refund_wave_contributions(wave)
+	reset_wave_queue(wave_type)
 
-	if(success)
-		time_until_next_wave = time_between_waves
-		current_parent_wave = null
-	else
-		if(wave.downgrade_wave)
-			// Apply triumph weighting to downgrade decision
-			var/datum/migrant_wave/downgrade_wave = MIGRANT_WAVE(wave.downgrade_wave)
-			var/downgrade_weight = calculate_triumph_weight(downgrade_wave)
-			// Use parent wave if this was already a downgrade, otherwise use current wave as parent
-			var/new_parent = parent_wave ? parent_wave : current_wave
-			set_current_wave(wave.downgrade_wave, wave_wait_time, new_parent)
-			log_game("Migrants: Downgrading to [wave.downgrade_wave] (parent: [new_parent]) with triumph weight [downgrade_weight]")
-		else
-			current_parent_wave = null
-			time_until_next_wave = time_between_fail_wave
+/datum/controller/subsystem/migrants/proc/get_fail_cooldown(datum/migrant_wave/wave)
+	return wave.is_raid ? raid_fail_cooldown : faction_fail_cooldown
 
-/datum/controller/subsystem/migrants/proc/try_spawn_wave()
-	var/datum/migrant_wave/wave = MIGRANT_WAVE(current_wave)
-	/// Create initial assignment list
-	var/list/assignments = list()
-	/// Populate it
-	for(var/role_type in wave.roles)
-		var/amount = wave.roles[role_type]
-		for(var/i in 1 to amount)
-			assignments += new /datum/migrant_assignment(role_type)
-	/// Shuffle assignments so role rolling is not consistent
-	assignments = shuffle(assignments)
-
-	var/list/active_migrants = get_active_migrants()
+/datum/controller/subsystem/migrants/proc/try_spawn_wave(datum/migrant_wave/wave, forced = FALSE)
+	var/list/active_migrants
+	active_migrants = get_wave_candidates(wave.type)
 	active_migrants = shuffle(active_migrants)
-
-	var/list/picked_migrants = list()
-
 	if(!length(active_migrants))
 		return FALSE
-	/// Try to assign priority players to positions
-	for(var/datum/migrant_assignment/assignment as anything in assignments)
-		if(!length(active_migrants))
-			break // Out of migrants, we're screwed and will fail
-		if(assignment.client)
-			continue
-		var/list/priority = get_priority_players(active_migrants, assignment.role_type, current_wave)
-		if(!length(priority))
-			continue
-		var/client/picked
-		priority = shuffle(priority)
-		for(var/client/client as anything in priority)
-			if(!can_be_role(client, assignment.role_type))
-				continue
-			picked = client
-			break
-		if(!picked)
-			continue
 
-		active_migrants -= picked
-		assignment.client = picked
-		picked_migrants += picked
+	var/list/picked_migrants = list()
+	var/list/assignments = assemble_role_wave(wave, active_migrants, picked_migrants)
+	if(isnull(assignments))
+		return FALSE
 
-	/// Assign rest of the players to positions
-	for(var/datum/migrant_assignment/assignment as anything in assignments)
-		if(!length(active_migrants))
-			break // Out of migrants, we're screwed and will fail
-		if(assignment.client)
-			continue
-
-		var/client/picked
-		for(var/client/client as anything in active_migrants)
-			if(!can_be_role(client, assignment.role_type))
-				continue
-			picked = client
-			break
-		if(!picked)
-			continue
-
-		active_migrants -= picked
-		assignment.client = picked
-		picked_migrants += picked
-
-	/// Find spawn points for the assignments
 	var/turf/spawn_location = get_spawn_turf_for_job(wave.spawn_landmark)
 	var/atom/fallback_location = spawn_location
 
@@ -148,24 +128,18 @@ SUBSYSTEM_DEF(migrants)
 		var/datum/migrant_assignment/assignment = assignments[i]
 		assignment.spawn_location = turf
 
-	/// See if anything went wrong and return FALSE if it did
 	for(var/datum/migrant_assignment/assignment as anything in assignments)
-		if(!assignment.client)
-			return FALSE
 		if(!assignment.spawn_location)
 			assignment.spawn_location = fallback_location
 
-	/// At this point everything is GOOD and SWELL, we want to spawn the wave
+	var/greet_text = pick_greet_text(wave, assignments.len)
 
-	/// Unset their pref so if they respawn they wont get yoinked into migrants immediately
 	for(var/client/client as anything in picked_migrants)
 		client.prefs.migrant.post_spawn()
 
-	/// Spawn the migrants, hooray
 	for(var/datum/migrant_assignment/assignment as anything in assignments)
-		spawn_migrant(wave, assignment, wave.spawn_on_location)
+		spawn_migrant(wave, assignment, wave.spawn_on_location, greet_text)
 
-	// Increment wave spawn counter
 	var/used_wave_type = wave.type
 	if(wave.shared_wave_type)
 		used_wave_type = wave.shared_wave_type
@@ -176,9 +150,74 @@ SUBSYSTEM_DEF(migrants)
 	reset_wave_contributions(wave)
 	message_admins("MIGRANTS: Spawned wave: [wave.name] (players: [assignments.len]) at [ADMIN_VERBOSEJMP(spawn_location)]")
 
-	unset_all_active_migrants()
-
 	return TRUE
+
+/datum/controller/subsystem/migrants/proc/pick_greet_text(datum/migrant_wave/wave, fill_count)
+	if(!length(wave.greet_text_by_fill))
+		return wave.greet_text
+	var/best_key = null
+	for(var/key in wave.greet_text_by_fill)
+		var/threshold = text2num(key)
+		if(threshold > fill_count)
+			continue
+		if(isnull(best_key) || threshold > text2num(best_key))
+			best_key = key
+	if(isnull(best_key))
+		return wave.greet_text
+	return wave.greet_text_by_fill[best_key]
+
+/datum/controller/subsystem/migrants/proc/assemble_role_wave(datum/migrant_wave/wave, list/active_migrants, list/picked_migrants)
+	var/list/required = list()
+	for(var/role_type in wave.required_roles)
+		for(var/i in 1 to wave.required_roles[role_type])
+			required += new /datum/migrant_assignment(role_type)
+	required = shuffle(required)
+
+	for(var/datum/migrant_assignment/assignment as anything in required)
+		fill_assignment(assignment, active_migrants, picked_migrants, wave.type, prefer = TRUE)
+		if(!assignment.client)
+			fill_assignment(assignment, active_migrants, picked_migrants, wave.type, prefer = FALSE)
+		if(!assignment.client)
+			return null
+
+	var/list/optional = list()
+	for(var/role_type in wave.optional_roles)
+		for(var/i in 1 to wave.optional_roles[role_type])
+			optional += new /datum/migrant_assignment(role_type)
+	optional = shuffle(optional)
+
+	for(var/datum/migrant_assignment/assignment as anything in optional)
+		fill_assignment(assignment, active_migrants, picked_migrants, wave.type, prefer = TRUE)
+	for(var/datum/migrant_assignment/assignment as anything in optional)
+		if(assignment.client)
+			continue
+		fill_assignment(assignment, active_migrants, picked_migrants, wave.type, prefer = FALSE)
+
+	var/list/filled_optional = list()
+	for(var/datum/migrant_assignment/assignment as anything in optional)
+		if(assignment.client)
+			filled_optional += assignment
+
+	if(length(filled_optional) < wave.min_optional_fills)
+		return null
+
+	return required + filled_optional
+
+/datum/controller/subsystem/migrants/proc/fill_assignment(datum/migrant_assignment/assignment, list/active_migrants, list/picked_migrants, wave_type, prefer = TRUE)
+	if(assignment.client || !length(active_migrants))
+		return
+	var/list/candidates
+	if(prefer)
+		candidates = get_priority_players(active_migrants, assignment.role_type, wave_type)
+	else
+		candidates = active_migrants
+	for(var/client/client as anything in candidates)
+		if(!can_be_role(client, assignment.role_type))
+			continue
+		assignment.client = client
+		active_migrants -= client
+		picked_migrants += client
+		return
 
 /datum/controller/subsystem/migrants/proc/get_influenceable_waves()
 	var/list/waves = list()
@@ -186,7 +225,6 @@ SUBSYSTEM_DEF(migrants)
 		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
 		if(!wave.can_roll)
 			continue
-		// Only show waves that haven't hit max spawns
 		if(!isnull(wave.max_spawns))
 			var/used_wave_type = wave.type
 			if(wave.shared_wave_type)
@@ -197,23 +235,17 @@ SUBSYSTEM_DEF(migrants)
 	return waves
 
 /datum/controller/subsystem/migrants/proc/get_status_line()
-	var/string = ""
-	if(current_wave)
-		var/datum/migrant_wave/wave = MIGRANT_WAVE(current_wave)
-		var/parent_info = ""
-		if(current_parent_wave)
-			var/datum/migrant_wave/parent = MIGRANT_WAVE(current_parent_wave)
-			parent_info = " (downgrade from [parent.name])"
-		string = "[wave.name][parent_info] ([get_active_migrant_amount()]/[wave.get_roles_amount()]) - [wave_timer / (1 SECONDS)]s"
-	else
-		string = "Mist - [time_until_next_wave / (1 SECONDS)]s"
-	return "Migrants: [string]"
-
-/datum/controller/subsystem/migrants/proc/unset_all_active_migrants()
-	var/list/active_migrants = get_active_migrants()
-	if(active_migrants)
-		for(var/client/client as anything in active_migrants)
-			client.prefs.migrant.set_active(FALSE)
+	var/list/parts = list()
+	for(var/track in list(MIGRANT_TRACK_REGULAR, MIGRANT_TRACK_SPECIAL, MIGRANT_TRACK_TRIUMPH, MIGRANT_TRACK_EVENT))
+		var/forming = track_forming[track]
+		if(forming)
+			var/datum/migrant_wave/wave = MIGRANT_WAVE(forming)
+			parts += "[track]: [wave.name] [(track_arrival[track] - world.time) / (1 SECONDS)]s"
+		else if(track_next_roll[track])
+			parts += "[track]: [(track_next_roll[track] - world.time) / (1 SECONDS)]s"
+		else
+			parts += "[track]: idle"
+	return "Migrants ([get_active_migrant_amount()] queued): [parts.Join(" | ")]"
 
 /datum/controller/subsystem/migrants/proc/get_safe_turfs_around_location(atom/location)
 	var/list/turfs = list()
@@ -229,7 +261,7 @@ SUBSYSTEM_DEF(migrants)
 	turfs = shuffle(turfs)
 	return turfs
 
-/datum/controller/subsystem/migrants/proc/spawn_migrant(datum/migrant_wave/wave, datum/migrant_assignment/assignment, spawn_on_location)
+/datum/controller/subsystem/migrants/proc/spawn_migrant(datum/migrant_wave/wave, datum/migrant_assignment/assignment, spawn_on_location, greet_text)
 	var/rank = "Migrant"
 	var/mob/dead/new_player/newplayer = assignment.client.mob
 
@@ -267,8 +299,11 @@ SUBSYSTEM_DEF(migrants)
 			fakekey = get_fake_key(character.ckey)
 		GLOB.character_list[character.mobid] = "[fakekey] was [character.real_name] ([rank])<BR>"
 		GLOB.character_ckey_list[character.real_name] = character.ckey
+		var/mob_name = character.real_name
+		var/mob_rank = rank
 		if(character.mind.special_role == "Court Agent")
-			GLOB.actors_list["Wanderers"] += list(character.mobid, "[character.real_name] as Adventurer<BR>")
+			mob_rank = "Adventurer"
+		GLOB.actors_list[character.mobid] = list("name" = mob_name, "rank" = mob_rank)
 		log_character("[character.ckey] ([fakekey]) - [character.real_name] - [rank]")
 	if(GLOB.respawncounts[character.ckey])
 		var/AN = GLOB.respawncounts[character.ckey]
@@ -282,10 +317,11 @@ SUBSYSTEM_DEF(migrants)
 		character.forceMove(assignment.spawn_location)
 
 	to_chat(character, span_alertsyndie("I am a [role.name]!"))
-	to_chat(character, span_notice(wave.greet_text))
-	to_chat(character, span_notice(role.greet_text))
-
-	ADD_TRAIT(character, TRAIT_OUTLANDER, TRAIT_GENERIC)
+	var/wave_greet = isnull(greet_text) ? wave.greet_text : greet_text
+	if(wave_greet)
+		to_chat(character, span_notice("[wave_greet]"))
+	if(role.greet_text)
+		to_chat(character, span_notice("[role.greet_text]"))
 
 	if(role.outfit)
 		var/datum/outfit/outfit = new role.outfit()
@@ -310,52 +346,31 @@ SUBSYSTEM_DEF(migrants)
 		try_apply_character_post_equipment(character, character.client)
 
 /datum/controller/subsystem/migrants/proc/get_priority_players(list/players, role_type, wave_type)
-	var/list/priority = list()
-	var/list/triumph_weighted = list()
-
+	var/list/weighted = list()
 	for(var/client/client as anything in players)
-		var/base_priority = 0
-		var/triumph_bonus = 0
-		//Standard role preference priority
-		if(role_type in client.prefs.migrant.role_preferences)
-			base_priority = 1
-			triumph_bonus = get_triumph_selection_bonus(client, wave_type) //Only gains the Triumph Bonus if they want that role.
+		if(client.prefs.migrant.queued_role != role_type)
+			continue
+		weighted[client] = get_triumph_selection_bonus(client, wave_type)
 
-		var/final_priority = base_priority + triumph_bonus
+	var/list/priority = list()
+	var/list/unpledged = list()
+	for(var/client/client in weighted)
+		if(weighted[client] <= 0)
+			unpledged += client
 
-		if(final_priority > 0)
-			triumph_weighted[client] = final_priority
-
-	//Check if all triumph_weighted values are equal
-	var/all_equal = TRUE
-	var/first_val = -1
-
-	if(length(triumph_weighted))
-		first_val = triumph_weighted[1]
-		for(var/client/client in triumph_weighted)
-			// Check if anything is not equal to the first value in the list
-			if(triumph_weighted[client] != first_val)
-				all_equal = FALSE
-				break
-
-	//Convert weighted list to prioritized list
-	while(length(triumph_weighted))
+	while(length(weighted) > length(unpledged))
 		var/client/highest = null
 		var/highest_priority = 0
-
-		for(var/client/client in triumph_weighted)
-			if(triumph_weighted[client] > highest_priority)
-				highest_priority = triumph_weighted[client]
+		for(var/client/client in weighted)
+			if(weighted[client] > highest_priority)
+				highest_priority = weighted[client]
 				highest = client
+		if(!highest)
+			break
+		priority += highest
+		weighted -= highest
 
-		if(highest)
-			priority += highest
-			triumph_weighted -= highest
-
-	//Shuffle only if all have equal priority
-	if(all_equal)
-		priority = shuffle(priority)
-
+	priority += shuffle(unpledged)
 	return priority
 
 /datum/controller/subsystem/migrants/proc/can_be_role(client/player, role_type)
@@ -365,8 +380,6 @@ SUBSYSTEM_DEF(migrants)
 	if(!player.prefs)
 		return FALSE
 	var/datum/preferences/prefs = player.prefs
-	if(role.allowed_races && !(prefs.pref_species.type in role.allowed_races))
-		return FALSE
 	if(role.disallowed_races && (prefs.pref_species.type in role.disallowed_races))
 		return FALSE
 	if(role.allowed_sexes && !(prefs.gender in role.allowed_sexes))
@@ -375,106 +388,65 @@ SUBSYSTEM_DEF(migrants)
 		return FALSE
 	return TRUE
 
-/datum/controller/subsystem/migrants/proc/process_next_wave(dt)
-	time_until_next_wave -= dt
-	if(time_until_next_wave > 0)
-		return
-	var/wave_type = roll_wave()
-	if(wave_type)
-		log_game("Migrants: Rolled wave: [wave_type]")
-		set_current_wave(wave_type, wave_wait_time, wave_type)
-
-	time_until_next_wave = time_between_fail_wave
-
-/datum/controller/subsystem/migrants/proc/roll_wave()
-	var/list/available_weighted_waves = list()
+/datum/controller/subsystem/migrants/proc/wave_eligible(datum/migrant_wave/wave)
+	if(!wave.can_roll)
+		return FALSE
 	var/active_migrants = get_active_migrant_amount()
 	var/active_players = get_round_active_players()
+	if(wave.min_round_time && (world.time - SSticker.round_start_time) < wave.min_round_time)
+		return FALSE
+	if(!isnull(wave.min_active) && active_migrants < wave.min_active)
+		return FALSE
+	if(!isnull(wave.max_active) && active_migrants > wave.max_active)
+		return FALSE
+	if(!isnull(wave.min_pop) && active_players < wave.min_pop)
+		return FALSE
+	if(!isnull(wave.max_pop) && active_players > wave.max_pop)
+		return FALSE
+	if(!isnull(wave.max_spawns))
+		var/used_wave_type = wave.shared_wave_type ? wave.shared_wave_type : wave.type
+		if(spawned_waves[used_wave_type] && spawned_waves[used_wave_type] >= wave.max_spawns)
+			return FALSE
+	return TRUE
 
-	// Check for auto-triggered waves first
-	var/auto_wave = check_triumph_threshold_waves()
-	if(auto_wave)
-		return auto_wave
-
-	// Build available waves with triumph-modified weights
+/datum/controller/subsystem/migrants/proc/roll_wave(track)
+	var/list/available_weighted_waves = list()
 	for(var/wave_type in GLOB.migrant_waves)
 		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
-		if(!wave.can_roll)
+		if(wave.track != track)
 			continue
-		if(!isnull(wave.min_active) && active_migrants < wave.min_active)
+		if(!wave_eligible(wave))
 			continue
-		if(!isnull(wave.max_active) && active_migrants > wave.max_active)
+		if(wave_cooldown[wave_type] && world.time < wave_cooldown[wave_type])
 			continue
-		if(!isnull(wave.min_pop) && active_players < wave.min_pop)
-			continue
-		if(!isnull(wave.max_pop) && active_players > wave.max_pop)
-			continue
-		if(!isnull(wave.max_spawns))
-			var/used_wave_type = wave.type
-			if(wave.shared_wave_type)
-				used_wave_type = wave.shared_wave_type
-			if(spawned_waves[used_wave_type] && spawned_waves[used_wave_type] >= wave.max_spawns)
-				continue
-		// Calculate triumph-modified weight
-		var/final_weight = calculate_triumph_weight(wave)
-		available_weighted_waves[wave_type] = final_weight
+		available_weighted_waves[wave_type] = calculate_triumph_weight(wave)
 
 	if(!length(available_weighted_waves))
 		return null
 	return pickweight(available_weighted_waves)
 
-/datum/controller/subsystem/migrants/proc/check_triumph_threshold_waves()
-	// Find waves that have hit their triumph threshold
-	var/list/threshold_waves = list()
-
-	for(var/wave_type in GLOB.migrant_waves)
-		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
-		if(!wave.can_roll)
-			continue
-		if(wave.triumph_total >= wave.triumph_threshold)
-			// Still need to check population/active requirements
-			var/active_migrants = get_active_migrant_amount()
-			var/active_players = get_round_active_players()
-
-			if(!isnull(wave.min_active) && active_migrants < wave.min_active)
-				continue
-			if(!isnull(wave.max_active) && active_migrants > wave.max_active)
-				continue
-			if(!isnull(wave.min_pop) && active_players < wave.min_pop)
-				continue
-			if(!isnull(wave.max_pop) && active_players > wave.max_pop)
-				continue
-			if(!isnull(wave.max_spawns))
-				var/used_wave_type = wave.type
-				if(wave.shared_wave_type)
-					used_wave_type = wave.shared_wave_type
-				if(spawned_waves[used_wave_type] && spawned_waves[used_wave_type] >= wave.max_spawns)
-					continue
-
-			threshold_waves[wave_type] = wave.triumph_total
-
-	if(!length(threshold_waves))
-		return null
-
-	// Return the wave with highest triumph investment if multiple hit threshold
+/datum/controller/subsystem/migrants/proc/get_maxed_wave()
 	var/chosen_wave = null
 	var/highest_triumph = 0
-	for(var/wave_type in threshold_waves)
-		if(threshold_waves[wave_type] > highest_triumph)
-			highest_triumph = threshold_waves[wave_type]
+	for(var/wave_type in GLOB.migrant_waves)
+		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+		if(wave.triumph_total < wave.triumph_threshold)
+			continue
+		if(!wave_eligible(wave))
+			continue
+		if(wave.triumph_total > highest_triumph)
+			highest_triumph = wave.triumph_total
 			chosen_wave = wave_type
-
 	return chosen_wave
 
 /datum/controller/subsystem/migrants/proc/calculate_triumph_weight(datum/migrant_wave/wave)
 	var/base_weight = wave.weight
 	var/triumph_bonus = wave.triumph_total
 
-	// Triumph provides a linear bonus to weight (configurable multiplier)
-	var/triumph_multiplier = 12 // Each triumph point adds 12x weight
+	var/triumph_multiplier = 6
 	var/final_weight = base_weight + (triumph_bonus * triumph_multiplier)
 
-	return max(final_weight, 1) // Ensure minimum weight of 1
+	return max(final_weight, 1)
 
 
 /datum/controller/subsystem/migrants/proc/contribute_triumph_to_wave(client/player, wave_type, amount)
@@ -485,22 +457,18 @@ SUBSYSTEM_DEF(migrants)
 	if(!wave)
 		return FALSE
 
-	// Check if player has enough triumph
 	var/current_triumph = SStriumphs.get_triumphs(player.ckey)
 	if(current_triumph < amount)
 		to_chat(player, span_warning("You don't have enough triumph! You have [current_triumph], need [amount]."))
 		return FALSE
 
-	// Deduct triumph from player
 	player.adjust_triumphs(-amount, TRUE, "Wave influence: [wave.name]")
 
-	// Add to wave contributions
 	if(!wave.triumph_contributions[player.ckey])
 		wave.triumph_contributions[player.ckey] = 0
 	wave.triumph_contributions[player.ckey] += amount
 	wave.triumph_total += amount
 
-	// Track globally for selection chances
 	if(!global_triumph_contributions[player.ckey])
 		global_triumph_contributions[player.ckey] = list()
 	if(!global_triumph_contributions[player.ckey][wave_type])
@@ -509,7 +477,6 @@ SUBSYSTEM_DEF(migrants)
 
 	to_chat(player, span_notice("You've contributed [amount] triumph to '[wave.name]'. Total: [wave.triumph_total]/[wave.triumph_threshold]"))
 
-	// Announce if threshold reached
 	if(wave.triumph_total >= wave.triumph_threshold)
 		message_admins("TRIUMPH: Wave '[wave.name]' has reached its triumph threshold ([wave.triumph_total]/[wave.triumph_threshold]) and will be prioritized!")
 		log_game("TRIUMPH: Wave '[wave.name]' reached triumph threshold via player contributions")
@@ -517,8 +484,6 @@ SUBSYSTEM_DEF(migrants)
 	return TRUE
 
 /datum/controller/subsystem/migrants/proc/get_triumph_selection_bonus(client/player, wave_type)
-	if(current_parent_wave)
-		wave_type = current_parent_wave
 	if(!player?.ckey)
 		return 0
 
@@ -534,24 +499,69 @@ SUBSYSTEM_DEF(migrants)
 	if(!wave.reset_contributions_on_spawn)
 		return
 
-	// Clear contributions for this wave
 	wave.triumph_contributions.Cut()
 	wave.triumph_total = 0
 
-	// Clear from global tracking
 	for(var/ckey in global_triumph_contributions)
 		if(global_triumph_contributions[ckey][wave.type])
 			global_triumph_contributions[ckey] -= wave.type
 
+/datum/controller/subsystem/migrants/proc/refund_wave_contributions(datum/migrant_wave/wave)
+	for(var/ckey in wave.triumph_contributions)
+		var/amount = wave.triumph_contributions[ckey]
+		if(amount <= 0)
+			continue
+		SStriumphs.triumph_adjust(amount, ckey)
+		var/client/client = GLOB.directory[ckey]
+		if(client)
+			to_chat(client, span_nicegreen("[wave.name] failed to arrive - your [amount] pledged triumph has been refunded."))
+	wave.triumph_contributions.Cut()
+	wave.triumph_total = 0
+	for(var/ckey in global_triumph_contributions)
+		if(global_triumph_contributions[ckey][wave.type])
+			global_triumph_contributions[ckey] -= wave.type
+
+/datum/controller/subsystem/migrants/proc/announce_special_wave(wave_type)
+	var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+	if(wave.hidden)
+		return
+	if(last_ooc_ping && (world.time - last_ooc_ping) < ooc_ping_interval)
+		return
+	last_ooc_ping = world.time
+
+	var/list/needs = list()
+	for(var/role_type in wave.required_roles)
+		var/datum/migrant_role/role = MIGRANT_ROLE(role_type)
+		needs += "[wave.required_roles[role_type]] [role.name]"
+	var/list/slots = list()
+	for(var/role_type in wave.optional_roles)
+		var/datum/migrant_role/role = MIGRANT_ROLE(role_type)
+		slots += "[wave.optional_roles[role_type]] [role.name]"
+
+	var/line = "<b>A wave is forming: [wave.name]</b>"
+	if(length(needs))
+		line += "<br>Needs: [needs.Join(", ")]."
+	if(length(slots))
+		line += "<br>Slots open for [slots.Join(", ")]."
+	line += "<br><a href='?src=[REF(src)];open_panel=1'>Click to join.</a> [wave_wait_time / (1 SECONDS)]s remaining."
+	for(var/mob/dead/new_player/lobby_nerd in GLOB.player_list)
+		if(!lobby_nerd.client)
+			continue
+		to_chat(lobby_nerd, "\n<font color='purple'>[line]</font>")
+
+/datum/controller/subsystem/migrants/Topic(href, list/href_list)
+	. = ..()
+	if(href_list["open_panel"])
+		var/mob/user = usr
+		if(user?.client?.prefs?.migrant)
+			user.client.prefs.migrant.show_ui()
+
 /datum/controller/subsystem/migrants/proc/update_ui()
-	var/countdown_text
-	if(!current_wave)
-		countdown_text = "The mist will clear out of the way in [time_until_next_wave / (1 SECONDS)] seconds..."
-	else
-		countdown_text = "They will arrive in [wave_timer / (1 SECONDS)] seconds..."
 	for(var/client/client as anything in get_all_migrants())
-		if(client?.mob)
-			client.mob << output(countdown_text, "migration.browser:update_migrant_countdown")
+		var/datum/migrant_pref/pref = client.prefs.migrant
+		var/datum/tgui/ui = SStgui.get_open_ui(client.mob, pref)
+		if(ui)
+			ui.send_update()
 
 /datum/controller/subsystem/migrants/proc/get_active_migrant_amount()
 	var/list/migrants = get_active_migrants()
@@ -561,13 +571,21 @@ SUBSYSTEM_DEF(migrants)
 
 /datum/controller/subsystem/migrants/proc/get_stars_on_role(role_type)
 	var/stars = 0
-	var/list/active_migrants = get_active_migrants()
-	if(active_migrants)
-		for(var/client/client as anything in active_migrants)
-			if(!(role_type in client.prefs.migrant.role_preferences))
-				continue
+	for(var/client/client as anything in get_active_migrants())
+		if(client.prefs.migrant.queued_role == role_type)
 			stars++
 	return stars
+
+/datum/controller/subsystem/migrants/proc/get_wave_candidates(wave_type)
+	var/list/candidates = list()
+	for(var/client/client as anything in get_active_migrants())
+		if(client.prefs.migrant.queued_wave == wave_type)
+			candidates += client
+	return candidates
+
+/datum/controller/subsystem/migrants/proc/reset_wave_queue(wave_type)
+	for(var/client/client as anything in get_wave_candidates(wave_type))
+		client.prefs.migrant.clear_queue(silent = TRUE)
 
 /datum/controller/subsystem/migrants/proc/get_round_active_players()
 	var/active = 0
@@ -583,7 +601,6 @@ SUBSYSTEM_DEF(migrants)
 		active++
 	return active
 
-/// Returns a list of all newplayer clients with active migrant pref
 /datum/controller/subsystem/migrants/proc/get_active_migrants()
 	var/list/migrants = list()
 	for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
@@ -591,12 +608,11 @@ SUBSYSTEM_DEF(migrants)
 			continue
 		if(!player.client.prefs)
 			continue
-		if(!player.client.prefs.migrant.active)
+		if(!player.client.prefs.migrant.queued_wave)
 			continue
 		migrants += player.client
 	return migrants
 
-/// Returns a list of all newplayer clients
 /datum/controller/subsystem/migrants/proc/get_all_migrants()
 	var/list/migrants = list()
 	for(var/mob/dead/new_player/player as anything in GLOB.new_player_list)
@@ -610,7 +626,7 @@ SUBSYSTEM_DEF(migrants)
 	return migrants
 
 /client/proc/admin_force_next_migrant_wave()
-	set category = "-Server-"
+	set category = "SERVER"
 	set name = "Force Migrant Wave"
 	if(!holder)
 		return
@@ -620,9 +636,10 @@ SUBSYSTEM_DEF(migrants)
 	var/picked_wave_type = input(user, "Choose migrant wave to force:", "Migrants")  as null|anything in GLOB.migrant_waves
 	if(!picked_wave_type)
 		return
-	message_admins("Admin [key_name_admin(user)] forced next migrant wave: [picked_wave_type] (Arrival: 1 Minute)")
-	log_game("Admin [key_name_admin(user)] forced next migrant wave: [picked_wave_type] (Arrival: 1 Minute)")
-	SSmigrants.set_current_wave(picked_wave_type, (1 MINUTES))
+	message_admins("Admin [key_name_admin(user)] forced next migrant wave: [picked_wave_type]")
+	log_game("Admin [key_name_admin(user)] forced next migrant wave: [picked_wave_type]")
+	var/datum/migrant_wave/wave = MIGRANT_WAVE(picked_wave_type)
+	SSmigrants.begin_forming(wave.track, picked_wave_type, forced = TRUE)
 
 /proc/get_spawn_turf_for_job(jobname)
 	var/list/landmarks = list()

--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -443,7 +443,7 @@ SUBSYSTEM_DEF(migrants)
 	var/base_weight = wave.weight
 	var/triumph_bonus = wave.triumph_total
 
-	var/triumph_multiplier = 6
+	var/triumph_multiplier = 20
 	var/final_weight = base_weight + (triumph_bonus * triumph_multiplier)
 
 	return max(final_weight, 1)

--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(migrants)
 
 	var/wave_wait_time = 3 MINUTES
 	var/regular_roll_interval = 5 MINUTES
-	var/special_roll_interval = 18 MINUTES
+	var/special_roll_interval = 12 MINUTES
 	var/faction_fail_cooldown = 20 MINUTES
 	var/raid_fail_cooldown = 30 MINUTES
 	var/ooc_ping_interval = 5 MINUTES

--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -626,7 +626,7 @@ SUBSYSTEM_DEF(migrants)
 	return migrants
 
 /client/proc/admin_force_next_migrant_wave()
-	set category = "SERVER"
+	set category = "-Server-"
 	set name = "Force Migrant Wave"
 	if(!holder)
 		return

--- a/code/datums/migrants/migrant_pref.dm
+++ b/code/datums/migrants/migrant_pref.dm
@@ -1,334 +1,202 @@
 /datum/migrant_pref
-	/// Reference to our prefs
 	var/datum/preferences/prefs
-	/// Whether the user wants to be a migrant
-	var/active = FALSE
-	/// Role preferences of the user, the things he clicks on to be preferred to be
-	var/list/role_preferences = list()
-	///are we viewing the page?
+	/// Wave typepath the player is queued for, or null.
+	var/queued_wave = null
+	/// Role typepath within the queued wave the player wants, or null for any.
+	var/queued_role = null
 	var/viewer = FALSE
 
 /datum/migrant_pref/New(datum/preferences/passed_prefs)
 	. = ..()
 	prefs = passed_prefs
 
-/datum/migrant_pref/proc/set_active(new_state, silent = FALSE)
-	if(active == new_state)
+/datum/migrant_pref/proc/queue_for(wave_type, role_type)
+	var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+	if(!wave)
 		return
-	active = new_state
-	role_preferences.Cut()
+	// Hidden waves are only queueable while an admin has them forced and forming.
+	if(wave.hidden && !SSmigrants.is_forced_forming(wave_type))
+		return
+	if(role_type && !SSmigrants.can_be_role(prefs.parent, role_type))
+		to_chat(prefs.parent, span_warning("You can't be this role. (Wrong species, gender, or age.)"))
+		return
+	queued_wave = wave_type
+	queued_role = role_type
+	if(prefs.parent)
+		var/datum/migrant_role/role = role_type ? MIGRANT_ROLE(role_type) : null
+		to_chat(prefs.parent, span_nicegreen("You are queued for [wave.name][role ? " as the [role.name]" : ""]. This does not guarantee a slot."))
+
+/datum/migrant_pref/proc/clear_queue(silent = FALSE)
+	if(!queued_wave)
+		return
+	queued_wave = null
+	queued_role = null
 	if(!silent && prefs.parent)
-		if(new_state)
-			to_chat(prefs.parent, span_notice("You are now in the migrant queue, and will join the game with them when they arrive"))
-		else
-			to_chat(prefs.parent, span_boldwarning("You are no longer in the migrant queue"))
-
-/datum/migrant_pref/proc/toggle_role_preference(role_type)
-	if(role_type in role_preferences)
-		role_preferences -= role_type
-	else
-		// Currently only allow 1 role preffed up for clarity
-		role_preferences.Cut()
-
-		if(SSmigrants.can_be_role(prefs.parent, role_type))
-			role_preferences += role_type
-			var/datum/migrant_role/role = MIGRANT_ROLE(role_type)
-			to_chat(prefs.parent, span_nicegreen("You have prioritized the [role.name]. This does not guarantee getting the role."))
-		else
-			to_chat(prefs.parent, span_warning("You can't be this role. (Wrong species, gender, or age.)"))
+		to_chat(prefs.parent, span_boldwarning("You are no longer in the migrant queue."))
 
 /datum/migrant_pref/proc/post_spawn()
-	set_active(FALSE, TRUE)
+	clear_queue(silent = TRUE)
 	hide_ui()
+
+/datum/migrant_pref/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/migrant_pref/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "MigrantPanel")
+		ui.open()
+	viewer = TRUE
+
+/datum/migrant_pref/ui_close(mob/user)
+	viewer = FALSE
+
+/datum/migrant_pref/ui_data(mob/user)
+	var/client/client = prefs.parent
+	var/list/data = list()
+	data["server_time"] = world.time
+	data["wave_number"] = SSmigrants.wave_number
+	data["player_triumph"] = client ? SStriumphs.get_triumphs(client.ckey) : 0
+	data["active_migrants"] = SSmigrants.get_active_migrant_amount()
+	data["round_time"] = world.time - SSticker.round_start_time
+	data["queued_wave"] = queued_wave ? "[queued_wave]" : null
+	data["queued_role"] = queued_role ? "[queued_role]" : null
+
+	var/list/forming = list()
+	for(var/track in list(MIGRANT_TRACK_REGULAR, MIGRANT_TRACK_SPECIAL, MIGRANT_TRACK_TRIUMPH, MIGRANT_TRACK_EVENT))
+		var/wave_type = SSmigrants.track_forming[track]
+		if(!wave_type)
+			continue
+		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+		var/is_forced = SSmigrants.track_forced[track]
+		// Hidden waves stay out of the panel unless an admin forced them (then they're shown + queueable).
+		if(wave.hidden && !is_forced)
+			continue
+		forming += list(list(
+			"track" = track,
+			"ref" = "[wave_type]",
+			"name" = wave.name,
+			"arrival_at" = SSmigrants.track_arrival[track],
+			"queued" = (queued_wave == wave_type),
+			"min_optional_fills" = wave.min_optional_fills,
+			"roles" = build_role_data(wave),
+		))
+	data["forming"] = forming
+	data["next_regular_at"] = SSmigrants.track_next_roll[MIGRANT_TRACK_REGULAR]
+	data["next_special_at"] = SSmigrants.track_next_roll[MIGRANT_TRACK_SPECIAL]
+
+	var/list/track_total_weight = list()
+	for(var/wave_type in GLOB.migrant_waves)
+		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+		if(wave.hidden || !wave.can_roll || wave.is_raid)
+			continue
+		track_total_weight[wave.track] += SSmigrants.calculate_triumph_weight(wave)
+
+	var/list/waves = list()
+	for(var/wave_type in GLOB.migrant_waves)
+		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+		if(wave.hidden || !wave.can_roll || wave.is_raid)
+			continue
+		var/maxed = FALSE
+		if(!isnull(wave.max_spawns))
+			var/used_wave_type = wave.shared_wave_type ? wave.shared_wave_type : wave.type
+			if(SSmigrants.spawned_waves[used_wave_type] && SSmigrants.spawned_waves[used_wave_type] >= wave.max_spawns)
+				maxed = TRUE
+		var/locked_until = 0
+		if(wave.min_round_time && (world.time - SSticker.round_start_time) < wave.min_round_time)
+			locked_until = SSticker.round_start_time + wave.min_round_time
+		var/total = track_total_weight[wave.track]
+		var/roll_chance = total ? round((SSmigrants.calculate_triumph_weight(wave) / total) * 100, 0.1) : 0
+		waves += list(list(
+			"ref" = "[wave_type]",
+			"name" = wave.name,
+			"track" = wave.track,
+			"weight" = wave.weight,
+			"roll_chance" = roll_chance,
+			"triumph_total" = wave.triumph_total,
+			"triumph_threshold" = wave.triumph_threshold,
+			"my_contribution" = client ? (wave.triumph_contributions[client.ckey] || 0) : 0,
+			"maxed" = maxed,
+			"locked_until" = locked_until,
+			"queued" = (queued_wave == wave_type),
+			"min_optional_fills" = wave.min_optional_fills,
+			"roles" = build_role_data(wave),
+		))
+	data["waves"] = waves
+	return data
+
+/datum/migrant_pref/proc/build_role_data(datum/migrant_wave/wave)
+	var/list/rows = list()
+	for(var/role_type in wave.required_roles)
+		rows += list(build_role_entry(role_type, wave.required_roles[role_type], "required"))
+	for(var/role_type in wave.optional_roles)
+		rows += list(build_role_entry(role_type, wave.optional_roles[role_type], "optional"))
+	return rows
+
+/datum/migrant_pref/proc/build_role_entry(role_type, amount, kind)
+	var/datum/migrant_role/role = MIGRANT_ROLE(role_type)
+	return list(
+		"ref" = "[role_type]",
+		"name" = role.name,
+		"amount" = amount,
+		"kind" = kind,
+		"stars" = SSmigrants.get_stars_on_role(role_type),
+		"queued" = (queued_role == role_type),
+		"can_be" = SSmigrants.can_be_role(prefs.parent, role_type),
+		"desc" = role.greet_text,
+	)
+
+/datum/migrant_pref/ui_act(action, list/params)
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("queue_role")
+			var/wave_type = text2path(params["wave"])
+			var/role_type = text2path(params["role"])
+			if(!wave_type)
+				return TRUE
+			if(queued_wave == wave_type && queued_role == role_type)
+				clear_queue()
+			else
+				queue_for(wave_type, role_type)
+			return TRUE
+		if("clear_queue")
+			clear_queue()
+			return TRUE
+		if("buy_wave")
+			var/wave_type = text2path(params["wave"])
+			if(wave_type)
+				handle_triumph_contribution(wave_type)
+			return TRUE
+
+/datum/migrant_pref/proc/handle_triumph_contribution(wave_type)
+	var/client/client = prefs.parent
+	if(!client)
+		return
+	var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
+	if(!wave || wave.hidden || !wave.can_roll || wave.is_raid)
+		return
+	var/current_triumph = SStriumphs.get_triumphs(client.ckey)
+	if(current_triumph <= 0)
+		to_chat(client, span_warning("You don't have any triumph to contribute!"))
+		return
+	var/player_contribution = wave.triumph_contributions[client.ckey] ? wave.triumph_contributions[client.ckey] : 0
+	var/max_contribute = min(current_triumph, 25)
+	var/amount = tgui_input_number(client, "Contribute triumph to '[wave.name]'?\n\nYour triumph: [current_triumph]\nYour contribution: [player_contribution]\nWave total: [wave.triumph_total]/[wave.triumph_threshold]", "Triumph Contribution", max_value = max_contribute, min_value = 1)
+	if(!amount || amount <= 0 || amount > max_contribute)
+		return
+	SSmigrants.contribute_triumph_to_wave(client, wave_type, amount)
 
 /datum/migrant_pref/proc/show_ui()
 	var/client/client = prefs.parent
 	if(!client)
 		return
-
-	var/current_migrants = SSmigrants.get_active_migrant_amount()
-	var/player_triumph = SStriumphs.get_triumphs(client.ckey)
-
-	// Build main content (left side)
-	var/list/main_dat = list()
-	main_dat += "<div style='padding: 10px;'>"
-	main_dat += "<div style='text-align: center; font-weight: bold; margin-bottom: 10px;'>WAVE: \Roman[SSmigrants.wave_number] | TRIUMPH: [player_triumph]</div>"
-	main_dat += "<div style='text-align: center; margin-bottom: 10px;'><b>BE A MIGRANT: <a href='byond://?src=[REF(src)];task=toggle_active'>[active ? "YES" : "NO"]</a></b></div>"
-	main_dat += "<div style='text-align: center; margin-bottom: 15px;'>Wandering fools: [current_migrants ? "\Roman[current_migrants]" : "None"]</div>"
-
-	if(!SSmigrants.current_wave)
-		main_dat += "<div style='text-align: center; margin-bottom: 15px;' id='migrant_countdown'>The mist will clear out of the way in [(SSmigrants.time_until_next_wave / (1 SECONDS))] seconds...</div>"
-	else
-		var/datum/migrant_wave/wave = MIGRANT_WAVE(SSmigrants.current_wave)
-		main_dat += "<div style='text-align: center; font-weight: bold; margin-bottom: 10px;'>[wave.name]</div>"
-
-		// Show if this wave was triumph-influenced
-		if(wave.triumph_total > 0)
-			var/player_contribution = wave.triumph_contributions[client.ckey] ? wave.triumph_contributions[client.ckey] : 0
-			if(player_contribution > 0)
-				main_dat += "<div style='text-align: center; color: cyan; margin-bottom: 10px;'>You influenced this wave! ([player_contribution] triumph)</div>"
-			else
-				main_dat += "<div style='text-align: center; color: yellow; margin-bottom: 10px;'>This wave was influenced by triumph!</div>"
-		for(var/role_type in wave.roles)
-			var/datum/migrant_role/role = MIGRANT_ROLE(role_type)
-			var/role_amount = wave.roles[role_type]
-			var/role_name = role.name
-			if(active  && (role_type in role_preferences))
-				role_name = "<u><b>[role_name]</b></u>"
-			var/stars_amount = SSmigrants.get_stars_on_role(role_type)
-			var/stars_string = ""
-			if(stars_amount)
-				stars_string = "(*\Roman[stars_amount])"
-
-			// Show triumph bonus for selection
-			var/triumph_bonus = SSmigrants.get_triumph_selection_bonus(client, SSmigrants.current_wave)
-			var/triumph_bonus_string = ""
-			if(triumph_bonus > 0)
-				triumph_bonus_string = " <span style='color: gold;'>(+[triumph_bonus])</span>"
-
-			main_dat += "<div style='text-align: center; margin: 5px 0;'><a href='byond://?src=[REF(src)];task=toggle_role_preference;role=[role_type]'>[role_name]</a> - \Roman[role_amount] [stars_string][triumph_bonus_string]</div>"
-		main_dat += "<div style='text-align: center; margin-top: 15px;' id='migrant_countdown'>They will arrive in [(SSmigrants.wave_timer / (1 SECONDS))] seconds...</div>"
-
-	main_dat += "</div>"
-
-	// Build wave influence sidebar (right side)
-	var/list/sidebar_dat = list()
-	sidebar_dat += "<div style='padding: 10px; background-color: #1a1a1a; height: 100%; overflow-y: auto;' id='wave-sidebar'>"
-	sidebar_dat += "<div style='text-align: center; font-weight: bold; margin-bottom: 10px; color: #cccccc;'>WAVE INFLUENCE</div>"
-
-	// Calculate total weights for percentage calculation
-	var/list/wave_weights = list()
-	var/total_weight = 0
-	var/list/available_waves = SSmigrants.get_influenceable_waves()
-
-	for(var/wave_type in available_waves)
-		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
-		var/weight = SSmigrants.calculate_triumph_weight(wave)
-		wave_weights[wave_type] = weight
-		total_weight += weight
-
-	for(var/wave_type in available_waves)
-		var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
-		var/triumph_display = "[wave.triumph_total]/[wave.triumph_threshold]"
-		var/threshold_reached = wave.triumph_total >= wave.triumph_threshold
-		var/player_contribution = wave.triumph_contributions[client.ckey] ? wave.triumph_contributions[client.ckey] : 0
-
-		// Check if wave has hit max spawns
-		var/is_maxed_out = FALSE
-		if(!isnull(wave.max_spawns))
-			var/used_wave_type = wave.type
-			if(wave.shared_wave_type)
-				used_wave_type = wave.shared_wave_type
-			if(SSmigrants.spawned_waves[used_wave_type] && SSmigrants.spawned_waves[used_wave_type] >= wave.max_spawns)
-				is_maxed_out = TRUE
-
-		var/wave_color = "#ffffff"
-		var/wave_name = wave.name
-		if(is_maxed_out)
-			wave_color = "#666666"
-			wave_name = "[wave.name] (MAXED)"
-		else if(threshold_reached)
-			wave_color = "gold"
-			wave_name = "[wave.name] (READY!)"
-		else if(player_contribution > 0)
-			wave_color = "cyan"
-			wave_name = "[wave.name] ([player_contribution])"
-
-		// Progress bar
-		var/progress_percent = min((wave.triumph_total / wave.triumph_threshold) * 100, 100)
-
-		// Calculate roll percentage
-		var/roll_percentage = 0
-		if(is_maxed_out)
-			roll_percentage = "0% (Maxed)"
-		else if(threshold_reached)
-			roll_percentage = "100% (Guaranteed)"
-		else if(total_weight > 0)
-			var/wave_weight = wave_weights[wave_type]
-			roll_percentage = "[round((wave_weight / total_weight) * 100, 0.1)]%"
-		else
-			roll_percentage = "0%"
-
-		sidebar_dat += "<div style='margin-bottom: 12px; padding: 8px; border: 1px solid #444; border-radius: 4px;' title='Roll Chance: [roll_percentage] (Base: [wave.weight], Triumph: +[wave.triumph_total * 6])'>"
-		sidebar_dat += "<div style='color: [wave_color]; font-weight: bold; margin-bottom: 4px;'>[wave_name]</div>"
-		sidebar_dat += "<div style='background-color: #333; height: 12px; border-radius: 6px; margin-bottom: 4px;'>"
-		sidebar_dat += "<div style='background-color: [threshold_reached ? "gold" : (is_maxed_out ? "#666666" : "cyan")]; height: 100%; width: [progress_percent]%; border-radius: 6px;'></div>"
-		sidebar_dat += "</div>"
-		sidebar_dat += "<div style='display: flex; justify-content: space-between; align-items: center; font-size: 12px;'>"
-		sidebar_dat += "<span>[triumph_display]</span>"
-
-		// Only show contribution button if wave isn't maxed out
-		if(!is_maxed_out)
-			sidebar_dat += "<a href='byond://?src=[REF(src)];task=contribute_triumph;wave=[wave_type]' style='background-color: #4a4a4a; color: white; text-decoration: none; padding: 2px 6px; border-radius: 3px; font-size: 11px;'>+T</a>"
-		else
-			sidebar_dat += "<span style='background-color: #333; color: #666; padding: 2px 6px; border-radius: 3px; font-size: 11px;'>MAX</span>"
-
-		sidebar_dat += "</div>"
-		sidebar_dat += "</div>"
-
-	sidebar_dat += "</div>"
-
-	// Combine into two-column layout
-	var/list/dat = list()
-	dat += {"<style>
-		body { margin: 0; padding: 0; font-family: monospace; background-color: #2a2a2a; color: #ffffff; }
-		.container { display: flex; height: 100vh; }
-		.main-content { flex: 1; overflow-y: auto; }
-		.sidebar { width: 280px; border-left: 1px solid #444; }
-		a { color: #88aaff; }
-		a:hover { color: #aaccff; }
-
-		/* Tooltip styling */
-		\[title\] {
-			position: relative;
-			cursor: help;
-		}
-		\[title\]:hover::after {
-			content: attr(title);
-			position: absolute;
-			bottom: 100%;
-			left: 50%;
-			transform: translateX(-50%);
-			background-color: #1a1a1a;
-			color: #ffffff;
-			padding: 8px 12px;
-			border-radius: 6px;
-			white-space: nowrap;
-			font-size: 12px;
-			border: 1px solid #555;
-			z-index: 1000;
-			box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-		}
-
-		\[title\]:hover::before {
-			content: '';
-			position: absolute;
-			bottom: 100%;
-			left: 50%;
-			transform: translateX(-50%) translateY(1px);
-			border: 5px solid transparent;
-			border-top-color: #555;
-			z-index: 1000;
-		}
-	</style>
-	<div class='container'>
-		<div class='main-content' id='main-content'>
-			[main_dat.Join()]
-		</div>
-		<div class='sidebar'>
-			[sidebar_dat.Join()]
-		</div>
-	</div>
-	<script>
-		function update_migrant_countdown(text) {
-			var el = document.getElementById("migrant_countdown");
-			if (el) el.innerHTML = text;
-		}
-
-		// Cookie functions
-		function setCookie(name, value, days) {
-			var expires = "";
-			if (days) {
-				var date = new Date();
-				date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-				expires = "; expires=" + date.toUTCString();
-			}
-			document.cookie = name + "=" + (value || "") + expires + "; path=/";
-		}
-
-		function getCookie(name) {
-			var nameEQ = name + "=";
-			var ca = document.cookie.split(';');
-			for(var i = 0; i < ca.length; i++) {
-				var c = ca\[i\];
-				while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-				if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
-			}
-			return null;
-		}
-
-		// Restore scroll position from cookie
-		var mainContent = document.getElementById('main-content');
-		var sidebar = document.getElementById('wave-sidebar');
-
-		if(mainContent) {
-			var savedScroll = getCookie('migrant_scroll');
-			if(savedScroll) {
-				mainContent.scrollTop = parseInt(savedScroll);
-			}
-
-			// Save scroll position to cookie when scrolling
-			mainContent.addEventListener('scroll', function() {
-				setCookie('migrant_scroll', this.scrollTop, 1); // Save for 1 day
-			});
-		}
-
-		if(sidebar) {
-			var savedSidebarScroll = getCookie('migrant_sidebar_scroll');
-			if(savedSidebarScroll) {
-				sidebar.scrollTop = parseInt(savedSidebarScroll);
-			}
-
-			// Save sidebar scroll position too
-			sidebar.addEventListener('scroll', function() {
-				setCookie('migrant_sidebar_scroll', this.scrollTop, 1);
-			});
-		}
-	</script>"}
-
-	var/datum/browser/popup = new(client.mob, "migration", "<center>Find a purpose</center>", 650, 500, src)
-	popup.set_content(dat.Join())
-	popup.open()
-	client.prefs.migrant.viewer = TRUE
-
-/datum/migrant_pref/Topic(href, href_list)
-	var/client/client = prefs.parent
-	if(!client)
-		return
-
-	if(href_list["close"])
-		if(active)
-			client.prefs.migrant.set_active(FALSE)
-		hide_ui()
-		return
-
-	switch(href_list["task"])
-		if("toggle_active")
-			set_active(!active)
-		if("toggle_role_preference")
-			var/role_type = text2path(href_list["role"])
-			toggle_role_preference(role_type)
-		if("contribute_triumph")
-			var/wave_type = text2path(href_list["wave"])
-			handle_triumph_contribution(wave_type)
-	show_ui()
-/datum/migrant_pref/proc/handle_triumph_contribution(wave_type)
-	var/client/client = prefs.parent
-	if(!client)
-		return
-
-	var/datum/migrant_wave/wave = MIGRANT_WAVE(wave_type)
-	if(!wave)
-		return
-
-	var/current_triumph = SStriumphs.get_triumphs(client.ckey)
-	if(current_triumph <= 0)
-		to_chat(client, span_warning("You don't have any triumph to contribute!"))
-		return
-
-	var/player_contribution = wave.triumph_contributions[client.ckey] ? wave.triumph_contributions[client.ckey] : 0
-	var/max_contribute = min(current_triumph, 25) // Cap individual contributions
-
-	var/amount = input(client, "Contribute triumph to '[wave.name]'?\n\nYour triumph: [current_triumph]\nYour contribution: [player_contribution]\nWave total: [wave.triumph_total]/[wave.triumph_threshold]\n\nAmount to contribute (1-[max_contribute]):", "Triumph Contribution") as null|num
-
-	if(!amount || amount <= 0 || amount > max_contribute)
-		return
-
-	SSmigrants.contribute_triumph_to_wave(client, wave_type, amount)
+	ui_interact(client.mob)
 
 /datum/migrant_pref/proc/hide_ui()
 	var/client/client = prefs.parent
 	if(!client)
 		return
-	client.mob << browse(null, "window=migration")
-	client.prefs.migrant.viewer = FALSE
+	SStgui.close_uis(src)
+	viewer = FALSE

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -2,8 +2,22 @@
 	abstract_type = /datum/migrant_wave
 	/// Name of the wave
 	var/name = "MIGRANT WAVE"
-	/// Assoc list of roles types to amount
-	var/list/roles = list()
+	/// Which roll track this wave belongs to.
+	var/track = MIGRANT_TRACK_REGULAR
+	/// Assoc list of role type -> count that must all fill, or the wave aborts.
+	var/list/required_roles = list()
+	/// Assoc list of role type -> count, filled demand-driven by player preference. Unfilled slots vanish.
+	var/list/optional_roles = list()
+	/// Wave aborts if fewer than this many optional slots fill.
+	var/min_optional_fills = 0
+	/// Assoc list of headcount (as text key, e.g. "5") -> greet text. Pick the highest key <= final fill. Falls back to greet_text.
+	var/list/greet_text_by_fill = null
+	/// Earliest round time (world.time - round_start_time) this wave may roll.
+	var/min_round_time = 0
+	/// If TRUE, this wave is hidden from the migrant panel (rolls naturally but isn't advertised or triumph-buyable).
+	var/hidden = FALSE
+	/// If TRUE, this is a hostile raid (longer fail cooldown).
+	var/is_raid = FALSE
 	/// If defined, this is the minimum active migrants required to roll the wave
 	var/min_active = null
 	/// If defined, this is the maximum active migrants required to roll the wave
@@ -20,10 +34,8 @@
 	var/spawn_landmark = "Pilgrim"
 	/// Text to greet all players in the wave with
 	var/greet_text
-	/// Whether this wave can roll at all. If not, it can still be forced to be ran, or used as "downgrade" wave
+	/// Whether this wave can roll at all. If not, it can still be forced to be ran.
 	var/can_roll = TRUE
-	/// What type of wave to downgrade to on failure
-	var/downgrade_wave
 	/// If defined, this will be the wave type to increment for purposes of checking `max_spawns`
 	var/shared_wave_type = null
 	/// Whether we want to spawn people on the rolled location, this may not be desired for bandits or other things that set the location
@@ -39,128 +51,81 @@
 
 /datum/migrant_wave/proc/get_roles_amount()
 	var/amount = 0
-	for(var/role_type in roles)
-		amount += roles[role_type]
+	for(var/role_type in required_roles)
+		amount += required_roles[role_type]
+	for(var/role_type in optional_roles)
+		amount += optional_roles[role_type]
 	return amount
+
+/datum/migrant_wave/proc/get_all_role_types()
+	. = list()
+	for(var/role_type in required_roles)
+		. |= role_type
+	for(var/role_type in optional_roles)
+		. |= role_type
 
 /datum/migrant_wave/pilgrim
 	name = "Pilgrimage"
-	downgrade_wave = /datum/migrant_wave/pilgrim_down_one
-	roles = list(
-		/datum/migrant_role/pilgrim = 4,
-	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
-
-/datum/migrant_wave/pilgrim_down_one
-	name = "Pilgrimage"
-	downgrade_wave = /datum/migrant_wave/pilgrim_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/pilgrim = 3,
-	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
-
-/datum/migrant_wave/pilgrim_down_two
-	name = "Pilgrimage"
-	downgrade_wave = /datum/migrant_wave/pilgrim_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/pilgrim = 2,
-	)
-	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
-
-/datum/migrant_wave/pilgrim_down_three
-	name = "Pilgrimage"
-	can_roll = FALSE
-	roles = list(
+	track = MIGRANT_TRACK_REGULAR
+	weight = 100 // It is a "default" wave
+	triumph_threshold = 10
+	required_roles = list(
 		/datum/migrant_role/pilgrim = 1,
+	)
+	optional_roles = list(
+		/datum/migrant_role/pilgrim = 3,
 	)
 	greet_text = "Fleeing from misfortune and hardship, you and a handful of survivors get closer to the realm, looking for refuge and work, finally almost being there, almost..."
 
 /datum/migrant_wave/adventurer
 	name = "Adventure Party"
-	downgrade_wave = /datum/migrant_wave/adventurer_down_one
-	roles = list(
-		/datum/migrant_role/adventurer = 4,
-	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
-
-/datum/migrant_wave/adventurer_down_one
-	name = "Adventure Party"
-	downgrade_wave = /datum/migrant_wave/adventurer_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/adventurer = 3,
-	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
-
-/datum/migrant_wave/adventurer_down_two
-	name = "Adventure Party"
-	downgrade_wave = /datum/migrant_wave/adventurer_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/adventurer = 2,
-	)
-	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
-
-/datum/migrant_wave/adventurer_down_three
-	name = "Adventure Party"
-	can_roll = FALSE
-	roles = list(
+	track = MIGRANT_TRACK_REGULAR
+	weight = 100 // Adventurers is the default spillover role and instead of just setting adventurers slots up high at roundstart we'll let people join in gradually through the round
+	triumph_threshold = 15
+	required_roles = list(
 		/datum/migrant_role/adventurer = 1,
+	)
+	optional_roles = list(
+		/datum/migrant_role/adventurer = 3,
 	)
 	greet_text = "Together with a party of trusted friends we decided to venture out, seeking thrills, glory and treasure, ending up on a dark and lonesome road, perhaps getting ourselves into more than what we bargained for."
 
 /datum/migrant_wave/bandit
 	name = "Bandit Raid"
-	downgrade_wave = /datum/migrant_wave/bandit_down_one
-	can_roll = FALSE
+	track = MIGRANT_TRACK_SPECIAL
 	weight = 16
+	min_round_time = 45 MINUTES
+	is_raid = TRUE
 	spawn_landmark = "Bandit"
-	roles = list(
-		/datum/migrant_role/bandit = 4,
-	)
-
-/datum/migrant_wave/bandit_down_one
-	name = "Bandit Raid"
-	downgrade_wave = /datum/migrant_wave/bandit_down_two
-	can_roll = FALSE
-	spawn_landmark = "Bandit"
-	roles = list(
-		/datum/migrant_role/bandit = 3,
-	)
-
-/datum/migrant_wave/bandit_down_two
-	name = "Bandit Raid"
-	downgrade_wave = /datum/migrant_wave/bandit_down_three
-	can_roll = FALSE
-	spawn_landmark = "Bandit"
-	roles = list(
-		/datum/migrant_role/bandit = 2,
-	)
-
-/datum/migrant_wave/bandit_down_three
-	name = "Bandit Raid"
-	can_roll = FALSE
-	spawn_landmark = "Bandit"
-	roles = list(
+	required_roles = list(
 		/datum/migrant_role/bandit = 1,
+	)
+	optional_roles = list(
+		/datum/migrant_role/bandit = 2,
 	)
 
 /datum/migrant_wave/assassin
 	name = "Assassin Hit"
-	downgrade_wave = /datum/migrant_wave/assassin
-	can_roll = FALSE
+	track = MIGRANT_TRACK_SPECIAL
 	weight = 12
-	roles = list(
-		/datum/migrant_role/assassin = 4,
+	min_round_time = 60 MINUTES
+	is_raid = TRUE
+	required_roles = list(
+		/datum/migrant_role/assassin = 1,
+	)
+	optional_roles = list(
+		/datum/migrant_role/assassin = 3,
 	)
 
 /datum/migrant_wave/gnolls
 	name = "Gnoll raid"
-	downgrade_wave = /datum/migrant_wave/gnolls
-	can_roll = FALSE
+	track = MIGRANT_TRACK_SPECIAL
 	weight = 12
-	roles = list(
-		/datum/migrant_role/gnoll = 4,
+	min_round_time = 45 MINUTES
+	is_raid = TRUE
+	required_roles = list(
+		/datum/migrant_role/gnoll = 1,
+	)
+	optional_roles = list(
+		/datum/migrant_role/gnoll = 3,
 	)

--- a/code/datums/migrants/migrant_wave.dm
+++ b/code/datums/migrants/migrant_wave.dm
@@ -93,8 +93,8 @@
 /datum/migrant_wave/bandit
 	name = "Bandit Raid"
 	track = MIGRANT_TRACK_SPECIAL
-	weight = 16
-	min_round_time = 45 MINUTES
+	weight = 0
+	min_round_time = 300 MINUTES
 	is_raid = TRUE
 	spawn_landmark = "Bandit"
 	required_roles = list(
@@ -107,8 +107,8 @@
 /datum/migrant_wave/assassin
 	name = "Assassin Hit"
 	track = MIGRANT_TRACK_SPECIAL
-	weight = 12
-	min_round_time = 60 MINUTES
+	weight = 0
+	min_round_time = 300 MINUTES
 	is_raid = TRUE
 	required_roles = list(
 		/datum/migrant_role/assassin = 1,
@@ -120,8 +120,8 @@
 /datum/migrant_wave/gnolls
 	name = "Gnoll raid"
 	track = MIGRANT_TRACK_SPECIAL
-	weight = 12
-	min_round_time = 45 MINUTES
+	weight = 0
+	min_round_time = 300 MINUTES
 	is_raid = TRUE
 	required_roles = list(
 		/datum/migrant_role/gnoll = 1,

--- a/code/datums/migrants/migrant_waves/117th_crusade_wave.dm
+++ b/code/datums/migrants/migrant_waves/117th_crusade_wave.dm
@@ -1,44 +1,13 @@
 /datum/migrant_wave/crusade
 	name = "The 117th Holy Crusade"
-	shared_wave_type = /datum/migrant_wave/crusade
-	downgrade_wave = /datum/migrant_wave/crusade_down_one
 	weight = 20
 	max_spawns = 1
-	roles = list(
-		/datum/migrant_role/crusader = 5)
-	greet_text = "Psydon's holy chalice must be found! Rockhill, a faithful land? Bah, Why let that get in the way of a good crusade! Plenty of looting and pillaging to be done- all in service to Astrata."
-
-/datum/migrant_wave/crusade_down_one
-	name = "The 117th Holy Crusade"
-	shared_wave_type = /datum/migrant_wave/crusade
-	downgrade_wave = /datum/migrant_wave/crusade_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/crusader = 4)
-	greet_text = "Psydon's holy chalice must be found! Rockhill, a faithful land? Bah, Why let that get in the way of a good crusade! Plenty of looting and pillaging to be done- all in service to Astrata."
-
-/datum/migrant_wave/crusade_down_two
-	name = "The 117th Holy Crusade"
-	shared_wave_type = /datum/migrant_wave/crusade
-	downgrade_wave = /datum/migrant_wave/crusade_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/crusader = 3)
-	greet_text = "Psydon's holy chalice must be found! Rockhill, a faithful land? Bah, Why let that get in the way of a good crusade! Plenty of looting and pillaging to be done- all in service to Astrata."
-
-/datum/migrant_wave/crusade_down_three
-	name = "The 117th Holy Crusade"
-	shared_wave_type = /datum/migrant_wave/crusade
-	downgrade_wave = /datum/migrant_wave/crusade_down_four
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/crusader = 2)
-	greet_text = "Psydon's holy chalice must be found! Rockhill, a faithful land? Bah, Why let that get in the way of a good crusade! Plenty of looting and pillaging to be done- all in service to Astrata."
-
-/datum/migrant_wave/crusade_down_four
-	name = "The 117th One-Man Crusade"
-	shared_wave_type = /datum/migrant_wave/crusade
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/crusader = 1)
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
+		/datum/migrant_role/crusader = 1,
+	)
+	optional_roles = list(
+		/datum/migrant_role/crusader = 4
+	)
+	min_optional_fills = 0
 	greet_text = "Psydon's holy chalice must be found! Rockhill, a faithful land? Bah, Why let that get in the way of a good crusade! Plenty of looting and pillaging to be done- all in service to Astrata."

--- a/code/datums/migrants/migrant_waves/czwarteki_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/czwarteki_noble_wave.dm
@@ -1,130 +1,16 @@
 /datum/migrant_wave/czwarteki_noble
 	name = "Czwarteki Retinue"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
 	weight = 50
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/czwarteki/lord = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/czwarteki/heir = 1,
 		/datum/migrant_role/czwarteki/hussar = 2,
 		/datum/migrant_role/czwarteki/retainer = 4,
 		/datum/migrant_role/czwarteki/servant = 2,
 	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_one
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_two
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 2,
-		/datum/migrant_role/czwarteki/retainer = 3,
-		/datum/migrant_role/czwarteki/servant = 2,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_two
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_three
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 2,
-		/datum/migrant_role/czwarteki/retainer = 2,
-		/datum/migrant_role/czwarteki/servant = 2,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_three
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_four
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 2,
-		/datum/migrant_role/czwarteki/retainer = 2,
-		/datum/migrant_role/czwarteki/servant = 1,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_four
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_five
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 2,
-		/datum/migrant_role/czwarteki/retainer = 2,
-		/datum/migrant_role/czwarteki/servant = 1,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_five
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_six
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 1,
-		/datum/migrant_role/czwarteki/retainer = 1,
-		/datum/migrant_role/czwarteki/servant = 1,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_six
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_seven
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 1,
-		/datum/migrant_role/czwarteki/retainer = 1,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_seven
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_eight
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/heir = 1,
-		/datum/migrant_role/czwarteki/hussar = 1,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-
-/datum/migrant_wave/czwarteki_noble_down_eight
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/czwarteki_noble_down_nine
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-		/datum/migrant_role/czwarteki/hussar = 1,
-	)
-	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."
-
-/datum/migrant_wave/czwarteki_noble_down_nine
-	name = "Czwarteki Retinue"
-	shared_wave_type = /datum/migrant_wave/czwarteki_noble
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/czwarteki/lord = 1,
-	)
+	min_optional_fills = 0
 	greet_text = "You are a Retinue under a Czwarteki Lord, be it diplomacy, war, or simple passing through the realm to see or assist an old alliance."

--- a/code/datums/migrants/migrant_waves/fablefield wave.dm
+++ b/code/datums/migrants/migrant_waves/fablefield wave.dm
@@ -1,41 +1,13 @@
 /datum/migrant_wave/fablefield
 	name = "The Fablefield Troupe"
+	track = MIGRANT_TRACK_SPECIAL
 	max_spawns = 1
 	weight = 20
-	downgrade_wave = /datum/migrant_wave/fablefield_down_one
-	roles = list(
+	required_roles = list(
 		/datum/migrant_role/fablefield/goliard = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/fablefield/troubadour = 3,
 	)
+	min_optional_fills = 0
 	greet_text = "A troupe of troubadours from fair Fablefield, you travel to these lands seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
-
-/datum/migrant_wave/fablefield_down_one
-	name = "The Fablefield Troupe"
-	shared_wave_type = /datum/migrant_wave/fablefield
-	downgrade_wave = /datum/migrant_wave/fablefield_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/fablefield/goliard = 1,
-		/datum/migrant_role/fablefield/troubadour = 2,
-	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to these lands seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
-
-/datum/migrant_wave/fablefield_down_two
-	name = "The Fablefield Troupe"
-	shared_wave_type = /datum/migrant_wave/fablefield
-	downgrade_wave = /datum/migrant_wave/fablefield_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/fablefield/goliard = 1,
-		/datum/migrant_role/fablefield/troubadour = 1,
-	)
-	greet_text = "A troupe of troubadours from fair Fablefield, you travel to these lands seeking inspiration, drawn at every step seemingly by the whims of Xylix. The people here look like they could do with a good show, give them one they'll remember!"
-
-/datum/migrant_wave/fablefield_down_three
-	name = "The Fablefield Goliard"
-	shared_wave_type = /datum/migrant_wave/fablefield
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/fablefield/goliard = 1
-	)
-	greet_text = "Your friends have abandoned you - lost to the whims of lyfe as Xylix taught you. Yet you march on into these lands. The people here look like they could do with a good show, give them one they'll remember - for your comrades!"

--- a/code/datums/migrants/migrant_waves/goldcaravan_wave.dm
+++ b/code/datums/migrants/migrant_waves/goldcaravan_wave.dm
@@ -2,31 +2,13 @@
 	name = "EA-Hasir's Gold Caravan"
 	max_spawns = 1
 	weight = 40
-	downgrade_wave = /datum/migrant_wave/fablefield_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/ea_hasir/merchant = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/ea_hasir/guard = 2,
 	)
-	greet_text = "The esteemed EA Hasir sent your gold caravan forth, Promising only the finest quality gold in grimoria\
-	Sell your golden riches and wonders- at a high price."
-
-/datum/migrant_wave/goldcaravan_down_one
-	name = "EA-Hasir's Gold Caravan"
-	shared_wave_type = /datum/migrant_wave/goldcaravan
-	downgrade_wave = /datum/migrant_wave/goldcaravan_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/ea_hasir/merchant = 1,
-		/datum/migrant_role/ea_hasir/guard = 1,
-	)
-	greet_text = "The esteemed EA Hasir sent your gold caravan forth, Promising only the finest quality gold in grimoria\
-	Sell your golden riches and wonders- at a high price."
-/datum/migrant_wave/goldcaravan_down_two
-	name = "EA-Hasir's Gold Caravan"
-	shared_wave_type = /datum/migrant_wave/goldcaravan
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/ea_hasir/merchant = 1,
-	)
+	min_optional_fills = 0
 	greet_text = "The esteemed EA Hasir sent your gold caravan forth, Promising only the finest quality gold in grimoria\
 	Sell your golden riches and wonders- at a high price."

--- a/code/datums/migrants/migrant_waves/grenzel_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/grenzel_noble_wave.dm
@@ -1,66 +1,14 @@
 /datum/migrant_wave/grenzel_envoy
 	name = "Grenzelhoftian Envoy"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/grenzel_envoy
 	weight = 50
-	downgrade_wave = /datum/migrant_wave/grenzel_envoy_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/grenzel/envoy = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/grenzel/bodyguard = 2,
 		/datum/migrant_role/grenzel/priest = 1,
 	)
+	min_optional_fills = 0
 	greet_text = "You are a Grenzelhoftian envoy, traveling with bodyguards and a priest to represent your homeland."
-
-/datum/migrant_wave/grenzel_envoy_down_one
-	name = "Grenzelhoftian Envoy"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/grenzel_envoy
-	downgrade_wave = /datum/migrant_wave/grenzel_envoy_down_two
-	roles = list(
-		/datum/migrant_role/grenzel/envoy = 1,
-		/datum/migrant_role/grenzel/bodyguard = 1,
-		/datum/migrant_role/grenzel/priest = 1,
-	)
-	greet_text = "You are a Grenzelhoftian envoy, traveling with bodyguards and a priest to represent your homeland."
-
-/datum/migrant_wave/grenzel_envoy_down_two
-	name = "Grenzelhoftian Envoy"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/grenzel_envoy
-	downgrade_wave = /datum/migrant_wave/grenzel_envoy_down_three
-	roles = list(
-		/datum/migrant_role/grenzel/envoy = 1,
-		/datum/migrant_role/grenzel/bodyguard = 2,
-	)
-	greet_text = "You are a Grenzelhoftian envoy, traveling with bodyguards and a priest to represent your homeland."
-
-/datum/migrant_wave/grenzel_envoy_down_three
-	name = "Grenzelhoftian Envoy"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/grenzel_envoy
-	downgrade_wave = /datum/migrant_wave/grenzel_envoy_down_four
-	roles = list(
-		/datum/migrant_role/grenzel/envoy = 1,
-		/datum/migrant_role/grenzel/bodyguard = 1,
-	)
-	greet_text = "You are a Grenzelhoftian envoy, traveling with bodyguards and a priest to represent your homeland."
-
-/datum/migrant_wave/grenzel_envoy_down_four
-	name = "Grenzelhoftian Envoy"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/grenzel_envoy
-	downgrade_wave = /datum/migrant_wave/grenzel_envoy_down_five
-	roles = list(
-		/datum/migrant_role/grenzel/envoy = 1,
-		/datum/migrant_role/grenzel/priest = 1,
-	)
-	greet_text = "You are a Grenzelhoftian envoy, traveling with a priest to represent your homeland."
-
-/datum/migrant_wave/grenzel_envoy_down_five
-	name = "Grenzelhoftian Envoy"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/grenzel_envoy
-	roles = list(
-		/datum/migrant_role/grenzel/envoy = 1,
-	)
-	greet_text = "You are a Grenzelhoftian envoy, traveling alone to represent your homeland."

--- a/code/datums/migrants/migrant_waves/gronn_wave.dm
+++ b/code/datums/migrants/migrant_waves/gronn_wave.dm
@@ -1,87 +1,16 @@
 /datum/migrant_wave/gronn
 	name = "Gronn Raiding Party"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/gronn
 	weight = 40
-	downgrade_wave = /datum/migrant_wave/gronn_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/gronn/chieftain = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/gronn/shaman = 1,
-		/datum/migrant_role/gronn/warrior = 2,
+		/datum/migrant_role/gronn/warrior = 3,
 		/datum/migrant_role/gronn/tribal = 4,
-		/datum/migrant_role/gronn/slave = 4
+		/datum/migrant_role/gronn/slave = 4,
 	)
+	min_optional_fills = 0
 	greet_text = "You're a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, on this odd place, could you hope to survive, and, perhaps, thrive?"
-
-/datum/migrant_wave/gronn_down_one
-	name = "Gronn Raiding Party"
-	shared_wave_type = /datum/migrant_wave/gronn
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/gronn_down_two
-	roles = list(
-		/datum/migrant_role/gronn/chieftain = 1,
-		/datum/migrant_role/gronn/shaman = 1,
-		/datum/migrant_role/gronn/warrior = 2,
-		/datum/migrant_role/gronn/tribal = 2,
-		/datum/migrant_role/gronn/slave = 2
-	)
-	greet_text = "You're a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, on this odd place, you've lost a handful of men. Things are starting to look sour."
-
-/datum/migrant_wave/gronn_down_two
-	name = "Gronn Raiding Party"
-	shared_wave_type = /datum/migrant_wave/gronn
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/gronn_down_three
-	roles = list(
-		/datum/migrant_role/gronn/chieftain = 1,
-		/datum/migrant_role/gronn/shaman = 1,
-		/datum/migrant_role/gronn/warrior = 1,
-		/datum/migrant_role/gronn/tribal = 1,
-		/datum/migrant_role/gronn/slave = 1
-	)
-	greet_text = "You're a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, on this odd place, you've lost many. Could you hope to survive?"
-
-/datum/migrant_wave/gronn_down_three
-	name = "Gronn Raiding Party"
-	shared_wave_type = /datum/migrant_wave/gronn
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/gronn_down_four
-	roles = list(
-		/datum/migrant_role/gronn/chieftain = 1,
-		/datum/migrant_role/gronn/shaman = 1,
-		/datum/migrant_role/gronn/warrior = 1,
-		/datum/migrant_role/gronn/slave = 1
-	)
-	greet_text = "You're a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, on this odd place, you've lost most of your party. What chance do you have?"
-
-/datum/migrant_wave/gronn_down_four
-	name = "Gronn Raiding Party"
-	shared_wave_type = /datum/migrant_wave/gronn
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/gronn_down_five
-	roles = list(
-		/datum/migrant_role/gronn/chieftain = 1,
-		/datum/migrant_role/gronn/shaman = 1,
-		/datum/migrant_role/gronn/warrior = 1
-	)
-	greet_text = "You're a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, on this odd place, you've lost most of your party. Now, it's just the three of you."
-
-/datum/migrant_wave/gronn_down_five
-	name = "Gronn Raiding Party"
-	shared_wave_type = /datum/migrant_wave/gronn
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/gronn_down_six
-	roles = list(
-		/datum/migrant_role/gronn/chieftain = 1,
-		/datum/migrant_role/gronn/shaman = 1
-	)
-	greet_text = "You're a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, on this odd place, you've lost most of your party. Now, it's just the two of you."
-
-/datum/migrant_wave/gronn_down_six
-	name = "Gronn Raiding Party"
-	shared_wave_type = /datum/migrant_wave/gronn
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/gronn/chieftain = 1
-	)
-	greet_text = "You were a scouting party sent directly from the steppes of Gronn itself. Without the main support of your warband, all but you have fallen. For what little hope there is, perhaps Graggah himself could guide you."

--- a/code/datums/migrants/migrant_waves/heartfelt wave.dm
+++ b/code/datums/migrants/migrant_waves/heartfelt wave.dm
@@ -1,130 +1,19 @@
 /datum/migrant_wave/heartfelt
 	name = "The Court of Heartfelt"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/heartfelt
 	weight = 50
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/heartfelt/lord = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/heartfelt/hand = 1,
 		/datum/migrant_role/heartfelt/knight = 1,
-		/datum/migrant_role/heartfelt/retinue = 4,
+		/datum/migrant_role/heartfelt/retinue = 5,
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes!"
-
-/datum/migrant_wave/heartfelt_down_one
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_two
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/hand = 1,
-		/datum/migrant_role/heartfelt/knight = 1,
-		/datum/migrant_role/heartfelt/retinue = 3,
+	min_optional_fills = 0
+	greet_text = "You're the mighty Baron of Heartfelt, a Border-Vassal of the Vale. Whether compelled by an invasion at the border, a sheer desire to sightsee and visit the Realm, or some political plot known only to you and your court, you have come to visit the Realm with a small, elite picked retinue."
+	greet_text_by_fill = list(
+		"5" = "You're the mighty Baron of Heartfelt, a Border-Vassal of the Vale. Whether compelled by an invasion at the border, a sheer desire to sightsee and visit the Realm, or some political plot known only to you and your court, you have come to visit the Realm with a small, elite picked retinue.",
+		"3" = "You're the mighty Baron of Heartfelt, a Border-Vassal of the Vale. Whether compelled by an invasion at the border, a sheer desire to sightsee and visit the Realm, or some political plot known only to you and your court, you have come to visit the Realm with a small, elite picked retinue. Unfortunately, a few of your retinue seems to have forgotten their luggage and had to turn back.",
 	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
-
-/datum/migrant_wave/heartfelt_down_two
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_three
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/hand = 1,
-		/datum/migrant_role/heartfelt/knight = 1,
-		/datum/migrant_role/heartfelt/retinue = 2,
-	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
-
-
-/datum/migrant_wave/heartfelt_down_three
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_four
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/hand = 1,
-		/datum/migrant_role/heartfelt/knight = 1,
-		/datum/migrant_role/heartfelt/retinue = 1,
-	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
-
-/datum/migrant_wave/heartfelt_down_four
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_five
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/hand = 1,
-		/datum/migrant_role/heartfelt/knight = 1,
-	)
-	greet_text = "Fleeing disaster, you have come together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
-
-/datum/migrant_wave/heartfelt_down_five
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_six
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/hand = 1,
-		/datum/migrant_role/heartfelt/retinue = 1,
-	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
-
-/datum/migrant_wave/heartfelt_down_six
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_seven
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/retinue = 2,
-	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Stay close and watch out for each other, for all of your sakes! Some of you already did not make it on the way here..."
-
-/datum/migrant_wave/heartfelt_down_seven
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_eight
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/knight = 1,
-	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their trusty knight left on their lonesome..."
-
-/datum/migrant_wave/heartfelt_down_eight
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_nine
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/hand = 1,
-	)
-	greet_text = "Fleeing disaster, you came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their trusty Hand left on their lonesome..."
-
-/datum/migrant_wave/heartfelt_down_nine
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	downgrade_wave = /datum/migrant_wave/heartfelt_down_ten
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-		/datum/migrant_role/heartfelt/retinue = 1,
-	)
-	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. Now, in the end, it is only the Lord and their last loyal follower left on their lonesome..."
-
-/datum/migrant_wave/heartfelt_down_ten
-	name = "The Court of Heartfelt"
-	shared_wave_type = /datum/migrant_wave/heartfelt
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/heartfelt/lord = 1,
-	)
-	greet_text = "Fleeing disaster, you have came together as a court, united in a final effort to restore the former glory and promise of Heartfelt. It was all for naught - in the end, only you are left, bereft of your family and men. How the mighty have fallen..."

--- a/code/datums/migrants/migrant_waves/knightly_journey_wave.dm
+++ b/code/datums/migrants/migrant_waves/knightly_journey_wave.dm
@@ -1,29 +1,9 @@
 /datum/migrant_wave/knightly_journey
 	name = "The Knightly journey"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/knightly_journey
-	downgrade_wave = /datum/migrant_wave/knightly_journey_down_one
 	weight = 50
-	roles = list(
-		/datum/migrant_role/kj_knight = 1,
-		/datum/migrant_role/kj_squire = 1,
-	)
-
-/datum/migrant_wave/knightly_journey_down_one
-	name = "The Knightly journey"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/knightly_journey
-	downgrade_wave = /datum/migrant_wave/knightly_journey_down_two
-	roles = list(
-		/datum/migrant_role/kj_knight = 1,
-		/datum/migrant_role/kj_squire = 1,
-	)
-
-/datum/migrant_wave/knightly_journey_down_two
-	name = "The Knightly journey"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/knightly_journey
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/kj_knight = 1,
 		/datum/migrant_role/kj_squire = 1,
 	)

--- a/code/datums/migrants/migrant_waves/otavan_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/otavan_noble_wave.dm
@@ -1,96 +1,16 @@
 /datum/migrant_wave/otavan_envoy
 	name = "Otavan Emissary"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
 	weight = 50
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/otavan/envoy = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/otavan/knight = 1,
 		/datum/migrant_role/otavan/guard = 1,
 		/datum/migrant_role/otavan/scribe = 1,
 		/datum/migrant_role/otavan/preacher = 1,
 	)
+	min_optional_fills = 0
 	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland."
-
-/datum/migrant_wave/otavan_envoy_down_one
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_two
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-		/datum/migrant_role/otavan/knight = 1,
-		/datum/migrant_role/otavan/guard = 1,
-		/datum/migrant_role/otavan/scribe = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. The Psydonite is dead - you must carry on."
-
-/datum/migrant_wave/otavan_envoy_down_two
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_three
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-		/datum/migrant_role/otavan/knight = 1,
-		/datum/migrant_role/otavan/guard = 1,
-		/datum/migrant_role/otavan/preacher = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. The Scribe was swallowed by a troll - nothing is left."
-
-/datum/migrant_wave/otavan_envoy_down_three
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_four
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-		/datum/migrant_role/otavan/knight = 1,
-		/datum/migrant_role/otavan/guard = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. The Scribe died to illness, and the Psydonite stayed behind to bury the body."
-
-/datum/migrant_wave/otavan_envoy_down_four
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_five
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-		/datum/migrant_role/otavan/knight = 1,
-		/datum/migrant_role/otavan/preacher = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. The Scribe and the Crossbowman fell to brigands - you are almost there!"
-
-/datum/migrant_wave/otavan_envoy_down_five
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_six
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-		/datum/migrant_role/otavan/preacher = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. Your Knight and Crossbowman died attempting to aid the Scribe from a wave of Deadites - you must ENDURE."
-
-/datum/migrant_wave/otavan_envoy_down_six
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	downgrade_wave = /datum/migrant_wave/otavan_envoy_down_seven
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-		/datum/migrant_role/otavan/knight = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. The Crossbowman and the Scribe died in a horrible carriage accident, and the Psydonite drunk himself to dead. Keep your noble cause alive."
-
-/datum/migrant_wave/otavan_envoy_down_seven
-	name = "Otavan Emissary"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/otavan_envoy
-	roles = list(
-		/datum/migrant_role/otavan/envoy = 1,
-	)
-	greet_text = "You are part of an Otavan diplomatic mission: a small retinue and a Psydonite preacher, ready to represent your homeland. The Knight drowned, the Crossbowman starved, the Scribe broke his neck and the Psydonite turned to Zizo and died - it's only you."
-

--- a/code/datums/migrants/migrant_waves/runaway_prisoners.dm
+++ b/code/datums/migrants/migrant_waves/runaway_prisoners.dm
@@ -3,39 +3,16 @@
 /datum/migrant_wave/runaway_prisoners
 	name = "Runaway Prisoners"
 	max_spawns = 1
-	shared_wave_type = /datum/migrant_wave/runaway_prisoners
-	downgrade_wave = /datum/migrant_wave/runaway_prisoners_down_one
 	weight = 50
-	roles = list(
-		/datum/migrant_role/runaway_prisoner = 4
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
+		/datum/migrant_role/runaway_prisoner = 1,
 	)
+	optional_roles = list(
+		/datum/migrant_role/runaway_prisoner = 4,
+	)
+	min_optional_fills = 0
 	greet_text = "You've been rotting for years in a cell. Though you escaped, you have nothing - your body atrophied, your mind dulled. But one thing you kknow clearlyu - you are not going back." 
-
-/datum/migrant_wave/runaway_prisoners_down_one
-	name = "Runaway Prisoners"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/runaway_prisoners
-	downgrade_wave = /datum/migrant_wave/runaway_prisoners_down_two
-	roles = list(
-		/datum/migrant_role/runaway_prisoner = 3
-	)
-
-/datum/migrant_wave/runaway_prisoners_down_two
-	name = "Runaway Prisoners"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/runaway_prisoners
-	downgrade_wave = /datum/migrant_wave/runaway_prisoners_down_three
-	roles = list(
-		/datum/migrant_role/runaway_prisoner = 2
-	)
-
-/datum/migrant_wave/runaway_prisoners_down_three
-	name = "Runaway Prisoners"
-	can_roll = FALSE
-	shared_wave_type = /datum/migrant_wave/runaway_prisoners
-	roles = list(
-		/datum/migrant_role/runaway_prisoner = 1
-	)
 
 /datum/migrant_role/runaway_prisoner
 	name = "Escaped Prisoner"

--- a/code/datums/migrants/migrant_waves/slaver wave.dm
+++ b/code/datums/migrants/migrant_waves/slaver wave.dm
@@ -2,102 +2,13 @@
 	name = "The Zybantine Slavers"
 	max_spawns = 1
 	weight = 60
-	downgrade_wave = /datum/migrant_wave/slaver_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/slaver/master = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/slaver/slavemerc = 6,
-		/datum/migrant_role/slaver/slavez = 2,
+		/datum/migrant_role/slaver/slavez = 4,
 	)
+	min_optional_fills = 1
 	greet_text = "A troop of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_one
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_two
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavemerc = 5,
-		/datum/migrant_role/slaver/slavez = 2,
-	)
-	greet_text = "A troop of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_two
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_three
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavemerc = 4,
-		/datum/migrant_role/slaver/slavez = 1,
-	)
-	greet_text = "A troop of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_three
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_four
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavemerc = 3,
-		/datum/migrant_role/slaver/slavez = 1,
-	)
-	greet_text = "A troop of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_four
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_five
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavemerc = 2,
-		/datum/migrant_role/slaver/slavez = 2,
-	)
-	greet_text = "A troop of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers. Yours got away - so you'll need new flesh."
-
-/datum/migrant_wave/slaver_down_five
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_six
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavemerc = 2,
-		/datum/migrant_role/slaver/slavez = 1,
-	)
-	greet_text = "A troop of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_six
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_seven
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavemerc = 1,
-		/datum/migrant_role/slaver/slavez = 1,
-	)
-	greet_text = "A duo of slavers coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_seven
-	name = "The Zybantine Slavers"
-	shared_wave_type = /datum/migrant_wave/slaver
-	downgrade_wave = /datum/migrant_wave/slaver_down_eight
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1,
-		/datum/migrant_role/slaver/slavez = 1
-	)
-	greet_text = "A single slave master coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."
-
-/datum/migrant_wave/slaver_down_eight
-	name = "The Zybantine Slaver"
-	shared_wave_type = /datum/migrant_wave/slaver
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/slaver/master = 1
-	)
-	greet_text = "A single slave master coming to the mainland from the deserts of Zybantine in the hopes of gathering wealth through the trade unfortunate laborers."

--- a/code/datums/migrants/migrant_waves/zybantine_noble_wave.dm
+++ b/code/datums/migrants/migrant_waves/zybantine_noble_wave.dm
@@ -3,114 +3,14 @@
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/zybantine_noble
 	weight = 40
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_one
-	roles = list(
+	track = MIGRANT_TRACK_SPECIAL
+	required_roles = list(
 		/datum/migrant_role/zybantine/emir = 1,
+	)
+	optional_roles = list(
 		/datum/migrant_role/zybantine/amirah = 1,
 		/datum/migrant_role/zybantine/janissary = 2,
 		/datum/migrant_role/zybantine/advisor = 1,
 	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_one
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_two
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/amirah = 1,
-		/datum/migrant_role/zybantine/janissary = 1,
-		/datum/migrant_role/zybantine/advisor = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_two
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_three
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/amirah = 1,
-		/datum/migrant_role/zybantine/janissary = 2,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_three
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_four
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/janissary = 2,
-		/datum/migrant_role/zybantine/advisor = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_four
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_five
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/janissary = 1,
-		/datum/migrant_role/zybantine/advisor = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_five
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_six
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/amirah = 1,
-		/datum/migrant_role/zybantine/janissary = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_six
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_seven
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/amirah = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_seven
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_eight
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/advisor = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_eight
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	downgrade_wave = /datum/migrant_wave/zybantine_noble_down_nine
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-		/datum/migrant_role/zybantine/janissary = 1,
-	)
-	greet_text = "You are far from home on missive from the Zybantine Empire."
-
-/datum/migrant_wave/zybantine_noble_down_nine
-	name = "Zybantine Emir"
-	shared_wave_type = /datum/migrant_wave/zybantine_noble
-	can_roll = FALSE
-	roles = list(
-		/datum/migrant_role/zybantine/emir = 1,
-	)
+	min_optional_fills = 0
 	greet_text = "You are far from home on missive from the Zybantine Empire."

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2971,7 +2971,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 					user << browse(null, "window=preferences") //closes job selection
 					user << browse(null, "window=mob_occupation")
 					user << browse(null, "window=latechoices") //closes late job selection
-					user << browse(null, "window=migration") // Closes migrant menu
+					migrant.hide_ui() // Closes migrant menu
 
 					SStriumphs.remove_triumph_buy_menu(user.client)
 
@@ -3385,7 +3385,7 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 /datum/preferences/proc/is_active_migrant()
 	if(!migrant)
 		return FALSE
-	if(!migrant.active)
+	if(!migrant.queued_wave)
 		return FALSE
 	return TRUE
 

--- a/code/modules/events/antagonist/migrant_waves/_base.dm
+++ b/code/modules/events/antagonist/migrant_waves/_base.dm
@@ -16,4 +16,6 @@
 
 /datum/round_event/migrant_wave/start()
 	. = ..()
-	SSmigrants.set_current_wave(wave_type, 1 MINUTES)
+	if(SSmigrants.track_forming[MIGRANT_TRACK_EVENT])
+		return
+	SSmigrants.begin_forming(MIGRANT_TRACK_EVENT, wave_type)

--- a/code/modules/events/antagonist/migrant_waves/dark_itinerant_knight_wave.dm
+++ b/code/modules/events/antagonist/migrant_waves/dark_itinerant_knight_wave.dm
@@ -18,7 +18,7 @@
 	max_spawns = 1
 	shared_wave_type = /datum/migrant_wave/evil_knight
 	weight = 8
-	roles = list(
+	required_roles = list(
 		/datum/migrant_role/dark_itinerant_knight = 1,
 		/datum/migrant_role/dark_itinerant_squire = 1,
 	)

--- a/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
+++ b/code/modules/events/antagonist/migrant_waves/exiled_adventurer.dm
@@ -15,13 +15,14 @@
 
 /datum/migrant_wave/werewolf
 	name = "Exiled Adventurer (Verevolf)"
-	roles = list(
+	track = MIGRANT_TRACK_EVENT
+	required_roles = list(
 		/datum/migrant_role/werewolf = 1,
 	)
 	can_roll = FALSE
 
 /datum/migrant_role/werewolf
-	name = "Adventurer"
+	name = "Verevolf"
 	antag_datum = /datum/antagonist/werewolf
 	advclass_cat_rolls = list(CTAG_ADVENTURER = 5)
 
@@ -42,18 +43,19 @@
 
 /datum/migrant_wave/vampire
 	name = "Exiled Adventurer (Vampire)"
-	roles = list(
+	track = MIGRANT_TRACK_EVENT
+	required_roles = list(
 		/datum/migrant_role/vampire = 1,
 	)
 	can_roll = FALSE
 
 /datum/migrant_role/vampire
-	name = "Adventurer"
+	name = "Vampire"
 	antag_datum = /datum/antagonist/vampire
 	advclass_cat_rolls = list(CTAG_ADVENTURER = 5)
 
 /datum/round_event_control/antagonist/migrant_wave/unbound_death_knight
-	name = "Death knight (Unbound)"
+	name = "Death Knight (Unbound)"
 	wave_type = /datum/migrant_wave/unbound_death_knight
 
 	weight = 6
@@ -69,12 +71,13 @@
 
 /datum/migrant_wave/unbound_death_knight
 	name = "Death knight (Unbound)"
-	roles = list(
+	track = MIGRANT_TRACK_EVENT
+	required_roles = list(
 		/datum/migrant_role/unbound_death_knight = 1,
 	)
 	can_roll = FALSE
 
 /datum/migrant_role/unbound_death_knight
-	name = "Adventurer"
+	name = "Death Knight"
 	antag_datum = /datum/antagonist/unbound_death_knight
 	advclass_cat_rolls = null

--- a/code/modules/events/antagonist/migrant_waves/gnolls.dm
+++ b/code/modules/events/antagonist/migrant_waves/gnolls.dm
@@ -2,9 +2,9 @@
 	name = "Gnolls Migration"
 	typepath = /datum/round_event/migrant_wave/gnolls
 	wave_type = /datum/migrant_wave/gnolls
-	max_occurrences = 2
-	weight = 5
-	earliest_start = 0 SECONDS
+	max_occurrences = 0
+	weight = 0
+	earliest_start = 150 MINUTES
 	tags = list(
 		TAG_COMBAT,
 		TAG_VILLIAN,

--- a/code/modules/events/antagonist/migrant_waves/lich.dm
+++ b/code/modules/events/antagonist/migrant_waves/lich.dm
@@ -15,7 +15,8 @@
 
 /datum/migrant_wave/lich
 	name = "Wandering Lich"
-	roles = list(
+	track = MIGRANT_TRACK_EVENT
+	required_roles = list(
 		/datum/migrant_role/lich = 1,
 	)
 	can_roll = FALSE

--- a/code/modules/events/antagonist/migrant_waves/lich.dm
+++ b/code/modules/events/antagonist/migrant_waves/lich.dm
@@ -3,9 +3,9 @@
 	wave_type = /datum/migrant_wave/lich
 
 	weight = 6
-	max_occurrences = 1
+	max_occurrences = 0
 
-	earliest_start = 15 MINUTES
+	earliest_start = 180 MINUTES
 
 	tags = list(
 		TAG_HAUNTED,

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -803,7 +803,8 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	src << browse(null, "window=preferences") //closes job selection
 	src << browse(null, "window=mob_occupation")
 	src << browse(null, "window=latechoices") //closes late job selection
-	src << browse(null, "window=migration") // Closes migrant menu
+	if(client?.prefs?.migrant)
+		client.prefs.migrant.hide_ui() // Closes migrant menu
 	src << browse(null, "window=familiar_prefs") // Closes familiar prefs menu
 
 	SStriumphs.remove_triumph_buy_menu(client)

--- a/tgui/packages/tgui/interfaces/MigrantPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MigrantPanel.tsx
@@ -1,0 +1,470 @@
+import { useState } from 'react';
+import type { BooleanLike } from 'tgui-core/react';
+
+import { useBackend } from '../backend';
+import { Window } from '../layouts';
+import {
+  cardStyle,
+  INK,
+  INK_FAINT,
+  INK_SOFT,
+  inkButtonStyle,
+  pageStyle,
+  PARCHMENT_SHADOW,
+  rulerStyle,
+  SEAL_AMBER,
+  SEAL_BLUE,
+  SEAL_GREEN,
+  SEAL_RED,
+  sectionHeaderStyle,
+  SERIF,
+  subtitleStyle,
+  tabBarStyle,
+  tabStyle,
+  titleStyle,
+} from './common/parchment';
+
+type Role = {
+  ref: string;
+  name: string;
+  amount: number;
+  kind: 'required' | 'optional';
+  stars: number;
+  queued: BooleanLike;
+  can_be: BooleanLike;
+  desc: string;
+};
+
+const KIND_LABEL: Record<Role['kind'], string> = {
+  required: 'REQUIRED',
+  optional: 'OPTIONAL',
+};
+
+type WaveInfo = {
+  ref: string;
+  name: string;
+  track: string;
+  weight: number;
+  roll_chance: number;
+  triumph_total: number;
+  triumph_threshold: number;
+  my_contribution: number;
+  maxed: BooleanLike;
+  locked_until: number;
+  queued: BooleanLike;
+  min_optional_fills: number;
+  roles: Role[];
+};
+
+type FormingWave = {
+  track: string;
+  ref: string;
+  name: string;
+  arrival_at: number;
+  queued: BooleanLike;
+  min_optional_fills: number;
+  roles: Role[];
+};
+
+type Data = {
+  server_time: number;
+  wave_number: number;
+  player_triumph: number;
+  active_migrants: number;
+  round_time: number;
+  queued_wave: string | null;
+  queued_role: string | null;
+  forming: FormingWave[];
+  next_regular_at: number;
+  next_special_at: number;
+  waves: WaveInfo[];
+};
+
+type ActFn = (action: string, params?: Record<string, unknown>) => void;
+
+const TRACK_REGULAR = 'regular';
+const TRACK_SPECIAL = 'special';
+const TRACK_TRIUMPH = 'triumph';
+const TRACK_EVENT = 'event';
+
+const fmtClock = (deciseconds: number): string => {
+  const total = Math.max(0, Math.round(deciseconds / 10));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+};
+
+const kindColor = (kind: Role['kind']): string =>
+  kind === 'required' ? SEAL_AMBER : SEAL_BLUE;
+
+const roleTooltip = (role: Role): string =>
+  role.desc ? `[${KIND_LABEL[role.kind]}] ${role.desc}` : '';
+
+const QueueRoleRow = (props: {
+  waveRef: string;
+  waveQueued: BooleanLike;
+  role: Role;
+  act: ActFn;
+}) => {
+  const { waveRef, waveQueued, role, act } = props;
+  const claimed = !!waveQueued && !!role.queued;
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: '6px',
+        padding: '2px 4px',
+        fontFamily: SERIF,
+      }}
+    >
+      <button
+        type="button"
+        title={roleTooltip(role)}
+        style={{
+          ...inkButtonStyle({ disabled: !role.can_be, color: claimed ? SEAL_GREEN : INK }),
+          flex: 1,
+          textAlign: 'left',
+          fontWeight: claimed ? 'bold' : 'normal',
+        }}
+        disabled={!role.can_be}
+        onClick={() => act('queue_role', { wave: waveRef, role: role.ref })}
+      >
+        {claimed ? '✓ ' : ''}
+        {role.name} <span style={{ color: INK_SOFT }}>x{role.amount}</span>
+      </button>
+      {role.stars > 0 && (
+        <span style={{ color: SEAL_AMBER, fontSize: '11px' }}>
+          {'★'.repeat(Math.min(role.stars, 5))}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const StaticRoleLine = (props: { roles: Role[] }) => {
+  const { roles } = props;
+  return (
+    <div style={{ fontSize: '11px', color: INK_SOFT, lineHeight: 1.4 }}>
+      {roles.map((r, i) => (
+        <span
+          key={r.ref}
+          title={roleTooltip(r)}
+          style={{ cursor: r.desc ? 'help' : 'default' }}
+        >
+          {i > 0 && ', '}
+          <span style={{ color: kindColor(r.kind) }}>{r.name}</span>
+          {r.amount > 1 ? ` x${r.amount}` : ''}
+        </span>
+      ))}
+    </div>
+  );
+};
+
+const sectionLabelStyle = (color: string) => ({
+  fontSize: '13px',
+  fontVariant: 'small-caps' as const,
+  fontWeight: 'bold' as const,
+  color: color,
+  marginTop: '4px',
+});
+
+const noteStyle = {
+  fontSize: '12px',
+  color: INK_SOFT,
+  marginBottom: '2px',
+};
+
+const FormingRoster = (props: {
+  forming: FormingWave;
+  now: number;
+  act: ActFn;
+}) => {
+  const { forming, now, act } = props;
+  const required = forming.roles.filter((r) => r.kind === 'required');
+  const optional = forming.roles.filter((r) => r.kind !== 'required');
+  const hasFloor = forming.min_optional_fills > 0;
+  const rowFor = (r: Role) => (
+    <QueueRoleRow
+      key={r.ref}
+      waveRef={forming.ref}
+      waveQueued={forming.queued}
+      role={r}
+      act={act}
+    />
+  );
+  return (
+    <div style={{ ...cardStyle, marginBottom: 0, padding: '6px 8px' }}>
+      <div style={{ fontWeight: 'bold', color: INK, fontSize: '13px' }}>
+        {forming.name}
+      </div>
+      <div style={{ color: SEAL_GREEN, fontSize: '12px', marginBottom: '3px' }}>
+        Arrives in {fmtClock(forming.arrival_at - now)}
+      </div>
+      {required.length > 0 && (
+        <>
+          <div style={sectionLabelStyle(SEAL_AMBER)}>Required</div>
+          <div style={noteStyle}>Must be filled or the wave will not arrive.</div>
+          {required.map(rowFor)}
+        </>
+      )}
+      {optional.length > 0 && (
+        <>
+          <div style={sectionLabelStyle(SEAL_BLUE)}>
+            {hasFloor ? 'Required-Optional' : 'Optional'}
+          </div>
+          <div style={noteStyle}>
+            {hasFloor
+              ? `At least ${forming.min_optional_fills} of these must join, but specific slots may stay empty.`
+              : 'Extra companions - empty slots are fine.'}
+          </div>
+          {optional.map(rowFor)}
+        </>
+      )}
+    </div>
+  );
+};
+
+const FormingCard = (props: {
+  label: string;
+  color: string;
+  forming: FormingWave | undefined;
+  emptyText: string;
+  now: number;
+  act: ActFn;
+}) => {
+  const { label, color, forming, emptyText, now, act } = props;
+  return (
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div
+        style={{
+          textAlign: 'center',
+          fontVariant: 'small-caps',
+          fontWeight: 'bold',
+          color: color,
+          borderBottom: `1px solid ${color}`,
+          marginBottom: '4px',
+        }}
+      >
+        {label}
+      </div>
+      {forming ? (
+        <FormingRoster forming={forming} now={now} act={act} />
+      ) : (
+        <div
+          style={{
+            ...cardStyle,
+            marginBottom: 0,
+            color: INK_FAINT,
+            textAlign: 'center',
+            padding: '6px 8px',
+          }}
+        >
+          {emptyText}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ProgressBar = (props: { value: number; max: number; color: string }) => {
+  const { value, max, color } = props;
+  const pct = Math.min((value / max) * 100, 100);
+  return (
+    <div
+      style={{
+        background: PARCHMENT_SHADOW,
+        height: '6px',
+        borderRadius: '2px',
+        margin: '2px 0',
+      }}
+    >
+      <div
+        style={{ background: color, width: `${pct}%`, height: '100%', borderRadius: '2px' }}
+      />
+    </div>
+  );
+};
+
+const PurchaseCard = (props: { wave: WaveInfo; now: number; act: ActFn }) => {
+  const { wave, now, act } = props;
+  const ready = wave.triumph_total >= wave.triumph_threshold;
+  const locked = wave.locked_until > now;
+  const pledged = wave.triumph_total > 0;
+  return (
+    <div style={{ ...cardStyle, marginBottom: '8px', padding: '6px 8px' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+        <span style={{ fontWeight: 'bold', color: ready ? SEAL_AMBER : INK, fontSize: '13px' }}>
+          {wave.name}
+          {!!wave.maxed && <span style={{ color: INK_FAINT }}> (maxed)</span>}
+          {ready && !wave.maxed && <span style={{ color: SEAL_AMBER }}> (ready!)</span>}
+        </span>
+        <span style={{ fontSize: '11px', color: INK_SOFT }}>
+          {locked ? `locked ${fmtClock(wave.locked_until - now)}` : `${wave.roll_chance}%`}
+        </span>
+      </div>
+      <div style={{ minHeight: '32px' }}>
+        <StaticRoleLine roles={wave.roles} />
+      </div>
+      <ProgressBar
+        value={wave.triumph_total}
+        max={wave.triumph_threshold}
+        color={ready ? SEAL_AMBER : SEAL_BLUE}
+      />
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span style={{ fontSize: '11px', color: INK_SOFT }}>
+          {wave.triumph_total}/{wave.triumph_threshold}
+          {wave.my_contribution > 0 ? ` (you: ${wave.my_contribution})` : ''}
+          {wave.min_optional_fills > 0
+            ? ` · Min. Optionals: ${wave.min_optional_fills}`
+            : ''}
+        </span>
+        <button
+          type="button"
+          style={{ ...inkButtonStyle({ disabled: !!wave.maxed }), padding: '1px 8px', fontSize: '11px' }}
+          disabled={!!wave.maxed}
+          onClick={() => act('buy_wave', { wave: wave.ref })}
+        >
+          Pledge
+        </button>
+      </div>
+    </div>
+  );
+};
+
+type PurchaseTab = 'regular' | 'special';
+
+export const MigrantPanel = () => {
+  const { act, data } = useBackend<Data>();
+  const [now, setNow] = useState(data.server_time);
+  const [tab, setTab] = useState<PurchaseTab>('regular');
+
+  if (now < data.server_time) {
+    setNow(data.server_time);
+  }
+
+  const formingRegular = data.forming.find((f) => f.track === TRACK_REGULAR);
+  const formingSpecial = data.forming.find((f) => f.track === TRACK_SPECIAL);
+  const formingTriumph = data.forming.find((f) => f.track === TRACK_TRIUMPH);
+  const formingEvent = data.forming.find((f) => f.track === TRACK_EVENT);
+
+  const tabWaves = data.waves.filter(
+    (w) => w.track === (tab === 'special' ? TRACK_SPECIAL : TRACK_REGULAR),
+  );
+
+  const queuedWave = data.queued_wave
+    ? data.waves.find((w) => w.ref === data.queued_wave)
+    : undefined;
+
+  return (
+    <Window width={760} height={680} theme="parchment">
+      <Window.Content scrollable>
+        <div style={pageStyle}>
+          <div style={titleStyle}>Find a Purpose</div>
+          <div style={subtitleStyle}>
+            The mist parts, and travellers find their way to Azure Peak.
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: '8px',
+            }}
+          >
+            <span>
+              Wave {data.wave_number} &middot; Triumph: {data.player_triumph}
+            </span>
+            {queuedWave ? (
+              <button
+                type="button"
+                style={inkButtonStyle({ color: SEAL_GREEN })}
+                onClick={() => act('clear_queue')}
+              >
+                Queued: {queuedWave.name} (leave)
+              </button>
+            ) : (
+              <span style={{ color: INK_FAINT }}>
+                Pick a role on a forming wave to queue
+              </span>
+            )}
+            <span style={{ color: INK_SOFT }}>Queued: {data.active_migrants}</span>
+          </div>
+
+          <div style={rulerStyle} />
+
+          <div style={sectionHeaderStyle}>Active Tracks - Queue Here</div>
+          <div style={{ display: 'flex', gap: '8px', marginBottom: '10px', alignItems: 'flex-start' }}>
+            <FormingCard
+              label="Regular"
+              color={SEAL_BLUE}
+              forming={formingRegular}
+              emptyText={`Next in ${fmtClock(data.next_regular_at - now)}`}
+              now={now}
+              act={act}
+            />
+            <FormingCard
+              label="Special"
+              color={SEAL_AMBER}
+              forming={formingSpecial}
+              emptyText={`Next in ${fmtClock(data.next_special_at - now)}`}
+              now={now}
+              act={act}
+            />
+            <FormingCard
+              label="Triumph"
+              color={SEAL_GREEN}
+              forming={formingTriumph}
+              emptyText="Pledge to call a wave"
+              now={now}
+              act={act}
+            />
+            {formingEvent && (
+              <FormingCard
+                label="Event"
+                color={SEAL_RED}
+                forming={formingEvent}
+                emptyText=""
+                now={now}
+                act={act}
+              />
+            )}
+          </div>
+
+          <div style={rulerStyle} />
+
+          <div style={tabBarStyle}>
+            <div style={tabStyle(tab === 'regular')} onClick={() => setTab('regular')}>
+              Regular Migrants
+            </div>
+            <div style={tabStyle(tab === 'special')} onClick={() => setTab('special')}>
+              Special Arrivals
+            </div>
+          </div>
+
+          <div style={subtitleStyle}>
+            Pledge triumph to weight or guarantee a wave&apos;s arrival.
+          </div>
+          {tabWaves.length === 0 ? (
+            <div style={{ ...cardStyle, color: INK_SOFT, textAlign: 'center' }}>
+              None available.
+            </div>
+          ) : (
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                columnGap: '8px',
+              }}
+            >
+              {tabWaves.map((w) => (
+                <PurchaseCard key={w.ref} wave={w} now={now} act={act} />
+              ))}
+            </div>
+          )}
+        </div>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/MigrantPanel.tsx
+++ b/tgui/packages/tgui/interfaces/MigrantPanel.tsx
@@ -362,7 +362,7 @@ export const MigrantPanel = () => {
         <div style={pageStyle}>
           <div style={titleStyle}>Find a Purpose</div>
           <div style={subtitleStyle}>
-            The mist parts, and travellers find their way to Azure Peak.
+            The mist parts, and travellers find their way to Rotwood Vale.
           </div>
 
           <div

--- a/tgui/packages/tgui/interfaces/common/WaxSeal.tsx
+++ b/tgui/packages/tgui/interfaces/common/WaxSeal.tsx
@@ -1,0 +1,171 @@
+import type { CSSProperties } from 'react';
+
+export type WaxSealColor = 'red' | 'green' | 'blue' | 'amber';
+
+type Palette = {
+  outer: string;
+  inner: string;
+  highlight: string;
+  rim: string;
+  detail: string;
+  glyph: string;
+  shine: string;
+};
+
+const PALETTES: Record<WaxSealColor, Palette> = {
+  red: {
+    outer: '#8b1a1a',
+    inner: '#b42a24',
+    highlight: '#f0a08a',
+    rim: '#5c0c0c',
+    detail: '#5c0c0c',
+    glyph: '#f3c164',
+    shine: '#ffd2bc',
+  },
+  green: {
+    outer: '#2f5a2c',
+    inner: '#4a7d3f',
+    highlight: '#a8d098',
+    rim: '#1d3a1a',
+    detail: '#1d3a1a',
+    glyph: '#f3c164',
+    shine: '#d8efc8',
+  },
+  blue: {
+    outer: '#1f3a6b',
+    inner: '#2e4a78',
+    highlight: '#9ab4d8',
+    rim: '#0e1f3a',
+    detail: '#0e1f3a',
+    glyph: '#f3c164',
+    shine: '#cfdcef',
+  },
+  amber: {
+    outer: '#7a5616',
+    inner: '#a37522',
+    highlight: '#e7c890',
+    rim: '#3a2a08',
+    detail: '#3a2a08',
+    glyph: '#fff3d4',
+    shine: '#fbe6b8',
+  },
+};
+
+type WaxSealProps = {
+  label: string;
+  mark?: string;
+  royal?: boolean;
+  color?: WaxSealColor;
+  size?: number;
+  style?: CSSProperties;
+};
+
+export const WaxSeal = (props: WaxSealProps) => {
+  const {
+    label,
+    mark,
+    royal = false,
+    color = 'red',
+    size = 54,
+    style,
+  } = props;
+  const palette = PALETTES[color];
+  const glyph = mark ?? label.trim().charAt(0).toUpperCase();
+
+  const baseStyle: CSSProperties = {
+    width: `${size}px`,
+    height: `${size}px`,
+    transform: 'rotate(-8deg)',
+    filter: `drop-shadow(0 1px 2px ${palette.rim}59)`,
+    ...style,
+  };
+
+  return (
+    <svg
+      aria-label={`Seal: ${label}`}
+      role="img"
+      style={baseStyle}
+      viewBox="0 0 80 80"
+    >
+      <path
+        d="M39 4 C45 2 48 8 53 8 C61 8 61 17 68 20 C75 23 70 32 74 38 C79 47 69 51 68 58 C67 67 56 64 51 72 C45 80 38 72 31 75 C22 79 20 68 13 66 C5 63 11 52 6 47 C-1 39 9 34 8 28 C7 19 18 19 22 12 C27 4 33 8 39 4 Z"
+        fill={palette.outer}
+      />
+      <path
+        d="M40 9 C46 7 49 12 54 13 C60 14 61 21 66 25 C70 29 66 36 69 41 C72 48 64 52 62 58 C60 65 52 63 47 68 C41 74 35 67 29 68 C21 69 20 60 15 57 C9 53 14 45 11 40 C7 33 15 29 15 23 C16 16 24 17 28 12 C32 8 36 11 40 9 Z"
+        fill={palette.inner}
+        opacity="0.72"
+      />
+      <circle
+        cx="40"
+        cy="40"
+        fill="none"
+        r="26"
+        stroke={palette.highlight}
+        strokeWidth="2"
+      />
+      <circle
+        cx="40"
+        cy="40"
+        fill="none"
+        opacity="0.55"
+        r="20"
+        stroke={palette.detail}
+        strokeDasharray="2 3"
+        strokeWidth="1.5"
+      />
+      <path
+        d="M21 38 C27 27 33 25 40 31 C47 25 54 27 59 38"
+        fill="none"
+        opacity="0.65"
+        stroke={palette.detail}
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+      <path
+        d="M21 45 C28 55 35 56 40 50 C46 56 53 55 59 45"
+        fill="none"
+        opacity="0.65"
+        stroke={palette.detail}
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+      {royal ? (
+        <g
+          fill={palette.glyph}
+          stroke={palette.detail}
+          strokeLinejoin="round"
+          strokeWidth="2"
+        >
+          <path d="M22 48 L25 28 L34 40 L40 24 L47 40 L56 28 L59 48 Z" />
+          <path d="M24 51 H58 V57 H24 Z" />
+          <circle cx="25" cy="27" r="3" />
+          <circle cx="40" cy="23" r="3" />
+          <circle cx="56" cy="27" r="3" />
+        </g>
+      ) : (
+        <text
+          fill={palette.glyph}
+          fontFamily='"Lora", Georgia, serif'
+          fontSize="30"
+          fontWeight="700"
+          stroke={palette.detail}
+          strokeWidth="0.9"
+          textAnchor="middle"
+          x="40"
+          y="51"
+        >
+          {glyph}
+        </text>
+      )}
+      <path
+        d="M19 22 C14 29 13 36 15 44 M61 22 C66 29 67 36 65 44 M22 61 C30 67 50 67 58 61"
+        fill="none"
+        opacity="0.38"
+        stroke={palette.shine}
+        strokeLinecap="round"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+};

--- a/tgui/packages/tgui/interfaces/common/parchment.tsx
+++ b/tgui/packages/tgui/interfaces/common/parchment.tsx
@@ -1,0 +1,308 @@
+import type { CSSProperties } from 'react';
+
+export const FONT_TINY = 'var(--p-font-tiny)';
+export const FONT_SMALL = 'var(--p-font-small)';
+export const FONT_BODY = 'var(--p-font-body)';
+export const FONT_LEAD = 'var(--p-font-lead)';
+export const FONT_TITLE = 'var(--p-font-title)';
+export const FONT_HEAD = 'var(--p-font-head)';
+
+export const INK = 'var(--p-ink)';
+export const INK_SOFT = 'var(--p-ink-soft)';
+export const INK_FAINT = 'var(--p-ink-faint)';
+export const PARCHMENT = 'var(--p-bg)';
+export const PARCHMENT_DEEP = 'var(--p-bg-deep)';
+export const PARCHMENT_SHADOW = 'var(--p-bg-shadow)';
+export const SEAL_RED = 'var(--p-seal-red)';
+export const SEAL_RED_SOFT = 'var(--p-seal-red-soft)';
+export const SEAL_GREEN = 'var(--p-seal-green)';
+export const SEAL_BLUE = 'var(--p-seal-blue)';
+export const SEAL_AMBER = 'var(--p-seal-amber)';
+export const BUTTON_BG = 'var(--p-button-bg)';
+export const TITLE = 'var(--p-title)';
+export const TITLE_FONT = 'var(--p-title-font)';
+
+export const SERIF = '"Lora", Georgia, serif';
+
+export const pageStyle: CSSProperties = {
+  position: 'relative',
+  minHeight: '100%',
+  padding: '18px 28px 28px 28px',
+  fontFamily: SERIF,
+  color: INK,
+  fontSize: FONT_BODY,
+  lineHeight: 1.5,
+};
+
+export const titleStyle: CSSProperties = {
+  textAlign: 'center',
+  fontSize: '22px',
+  fontWeight: 'bold',
+  fontFamily: TITLE_FONT,
+  color: TITLE,
+  margin: '0 0 4px 0',
+};
+
+export const subtitleStyle: CSSProperties = {
+  textAlign: 'center',
+  color: INK_SOFT,
+  fontStyle: 'italic',
+  fontSize: FONT_BODY,
+  marginBottom: '10px',
+};
+
+export const rulerStyle: CSSProperties = {
+  height: '1px',
+  background: `linear-gradient(90deg, transparent 0%, ${INK_FAINT} 20%, ${INK_FAINT} 80%, transparent 100%)`,
+  border: 'none',
+  margin: '8px 0 14px 0',
+};
+
+export const sectionHeaderStyle: CSSProperties = {
+  fontSize: FONT_TITLE,
+  color: TITLE,
+  fontWeight: 'bold',
+  borderBottom: `1px solid ${INK_FAINT}`,
+  paddingBottom: '2px',
+  marginTop: '10px',
+  marginBottom: '8px',
+};
+
+export const tabBarStyle: CSSProperties = {
+  display: 'flex',
+  gap: '6px',
+  justifyContent: 'center',
+  margin: '10px 0 6px 0',
+};
+
+export const tabStyle = (active: boolean): CSSProperties => ({
+  fontFamily: SERIF,
+  fontSize: FONT_BODY,
+  padding: '4px 18px',
+  color: active ? INK : INK_FAINT,
+  background: active ? 'var(--p-tab-active-bg)' : 'transparent',
+  border: `1px solid ${active ? INK_SOFT : 'transparent'}`,
+  borderRadius: '2px',
+  cursor: 'pointer',
+  fontWeight: active ? 'bold' : 'normal',
+});
+
+export const subTabBarStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '4px',
+  justifyContent: 'flex-start',
+  margin: '6px 0',
+};
+
+export const subTabStyle = (active: boolean): CSSProperties => ({
+  fontFamily: SERIF,
+  fontSize: FONT_BODY,
+  padding: '3px 10px',
+  color: active ? INK : INK_FAINT,
+  background: active ? 'var(--p-tab-active-bg)' : 'transparent',
+  border: `1px solid ${active ? INK_SOFT : INK_FAINT}`,
+  borderRadius: '2px',
+  cursor: 'pointer',
+  fontWeight: active ? 'bold' : 'normal',
+  whiteSpace: 'nowrap',
+});
+
+/// Wiki-style table-of-contents link. Renders as plain text with a dashed separator
+/// between rows, a subtle background tint when selected, and a hover underline.
+/// Apply via `style={tocLinkStyle(active)} className="toc-link"` on a button or anchor.
+/// Hover style lives in parchment.scss (and variants) keyed off the .toc-link class.
+export const tocLinkStyle = (active: boolean): CSSProperties => ({
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  background: active ? 'var(--p-tab-active-bg)' : 'transparent',
+  border: 'none',
+  borderBottom: `1px dashed ${INK_FAINT}`,
+  padding: '4px 8px',
+  fontFamily: SERIF,
+  fontSize: FONT_TITLE,
+  color: active ? INK : INK_SOFT,
+  fontWeight: active ? 'bold' : 'normal',
+  cursor: 'pointer',
+  whiteSpace: 'normal',
+  lineHeight: 1.3,
+});
+
+export const cardStyle: CSSProperties = {
+  background: 'var(--p-card-bg)',
+  border: `1px solid ${INK_FAINT}`,
+  borderRadius: '2px',
+  padding: '8px 12px',
+  marginBottom: '10px',
+  boxShadow: '1px 1px 4px var(--p-card-shadow)',
+};
+
+export const dashedFrameStyle: CSSProperties = {
+  padding: '8px 10px',
+  border: `1px dashed ${INK_FAINT}`,
+  textAlign: 'left',
+  fontSize: FONT_BODY,
+  lineHeight: 1.4,
+  color: INK_SOFT,
+};
+
+export const stickyLeftCellStyle: CSSProperties = {
+  position: 'sticky',
+  left: 0,
+  background: 'var(--p-card-bg)',
+};
+
+export const badgeStyle = (color: string): CSSProperties => ({
+  display: 'inline-block',
+  fontFamily: SERIF,
+  fontSize: FONT_BODY,
+  padding: '1px 7px',
+  marginLeft: '6px',
+  color: 'var(--p-badge-text)',
+  background: color,
+  border: `1px solid ${color}`,
+  borderRadius: '2px',
+  verticalAlign: 'middle',
+});
+
+export const inkButtonStyle = (opts: {
+  color?: string;
+  disabled?: boolean;
+} = {}): CSSProperties => {
+  const col = opts.color || INK;
+  return {
+    fontFamily: SERIF,
+    fontSize: FONT_BODY,
+    fontWeight: 'bold',
+    padding: '2px 10px',
+    color: col,
+    background: opts.disabled ? 'transparent' : BUTTON_BG,
+    border: opts.disabled
+      ? `1px dashed ${INK_FAINT}`
+      : `1px solid ${col}`,
+    borderRadius: '2px',
+    cursor: opts.disabled ? 'default' : 'pointer',
+    opacity: opts.disabled ? 0.7 : 1,
+    transition: 'background-color 80ms linear',
+  };
+};
+
+export const inkInputStyle: CSSProperties = {
+  fontFamily: SERIF,
+  fontSize: FONT_BODY,
+  color: INK,
+  background: BUTTON_BG,
+  border: `1px solid ${INK_FAINT}`,
+  borderRadius: '2px',
+  padding: '2px 6px',
+  outline: 'none',
+};
+
+export const fieldRowStyle: CSSProperties = {
+  display: 'flex',
+  padding: '5px 0',
+  borderBottom: `1px dashed ${PARCHMENT_SHADOW}`,
+  fontSize: FONT_BODY,
+};
+
+export const fieldLabelStyle: CSSProperties = {
+  flex: '0 0 145px',
+  fontWeight: 500,
+  color: SEAL_AMBER,
+};
+
+export const fieldValueStyle: CSSProperties = {
+  color: INK,
+  flex: 1,
+  fontFamily: SERIF,
+  fontSize: FONT_BODY,
+};
+
+export const bannerStyle = (color: string, soft: boolean = false): CSSProperties => ({
+  background: soft
+    ? 'var(--p-banner-bg-soft)'
+    : 'var(--p-banner-bg)',
+  border: `1px solid ${color}`,
+  color: color,
+  padding: '6px 12px',
+  marginBottom: '10px',
+  textAlign: 'center',
+  fontWeight: 'bold',
+});
+
+export const denseRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  padding: '4px 6px',
+  borderBottom: `1px dashed ${PARCHMENT_SHADOW}`,
+  fontFamily: SERIF,
+  lineHeight: 1.3,
+};
+
+export const ellipsisCellStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+export const compactButtonStyle = (opts: {
+  color?: string;
+  disabled?: boolean;
+} = {}): CSSProperties => ({
+  ...inkButtonStyle(opts),
+  padding: '1px 7px',
+  fontSize: FONT_LEAD,
+});
+
+export const PriceTag = (props: {
+  price: number;
+  tariff?: number;
+  cantAfford?: boolean;
+  title?: string;
+  strikethrough?: number;
+}) => {
+  const { price, tariff, cantAfford, title, strikethrough } = props;
+  const hasTariff = !!tariff && tariff > 0;
+  const hasStrike = !!strikethrough && strikethrough > price;
+  return (
+    <div
+      style={{
+        fontSize: FONT_LEAD,
+        color: cantAfford ? INK_FAINT : INK,
+        flexShrink: 0,
+        whiteSpace: 'nowrap',
+      }}
+      title={title}
+    >
+      {hasStrike && (
+        <span
+          style={{
+            color: INK_FAINT,
+            textDecoration: 'line-through',
+            marginRight: '4px',
+            fontSize: FONT_BODY,
+          }}
+        >
+          {strikethrough}m
+        </span>
+      )}
+      <span style={{ color: hasStrike ? SEAL_GREEN : 'inherit' }}>{price}</span>
+      {hasTariff && (
+        <span
+          style={{
+            color: SEAL_AMBER,
+            fontSize: FONT_BODY,
+            marginLeft: '2px',
+          }}
+        >
+          +{tariff}
+        </span>
+      )}
+      <span style={{ color: INK_SOFT, fontSize: FONT_SMALL }}>m</span>
+    </div>
+  );
+};

--- a/tgui/packages/tgui/styles/themes/azure_ascendant.scss
+++ b/tgui/packages/tgui/styles/themes/azure_ascendant.scss
@@ -1,0 +1,25 @@
+@use 'azure_base' as *;
+
+// New Ascendant — warm chant-inspired palette with gradients and glow
+.theme-azure_ascendant:root {
+  @include azure-theme((
+    'base':            #140a0a,
+    'base-light':      #1a0e0e,
+    'base-dark':       #0a0505,
+    'section':         rgba(42, 16, 16, 0.45),
+    'section-title':   #c96e6e,
+    'text':            #d4a0a0,
+    'label':           #b08080,
+    'accent':          #8b5555,
+    'accent-bright':   #a06060,
+    'border':          #5a3030,
+    'btn-text':        #d4a0a0,
+    'btn-selected':    #7b4040,
+    'btn-disabled':    #5e4040,
+    'scrollbar-thumb': #8b5555,
+    'glow':            rgba(139, 85, 85, 0.2),
+    'link':            #c96e6e,
+    'link-visited':    #e0b0b0,
+    'link-hover':      #d4a0a0,
+  ), '../assets/azure_default/topbar_red.svg');
+}

--- a/tgui/packages/tgui/styles/themes/azure_lingyue.scss
+++ b/tgui/packages/tgui/styles/themes/azure_lingyue.scss
@@ -1,0 +1,25 @@
+@use 'azure_base' as *;
+
+// Lingyue — Chinese-inspired palette (cinnabar red & gold)
+.theme-azure_lingyue:root {
+  @include azure-theme((
+    'base':            #140a0a,
+    'base-light':      #221210,
+    'base-dark':       #0e0606,
+    'section':         rgba(48, 18, 18, 0.45),
+    'section-title':   #c8a040,
+    'text':            #d4c8b0,
+    'label':           #b0a088,
+    'accent':          #8b3535,
+    'accent-bright':   #a04040,
+    'border':          #4a2520,
+    'btn-text':        #d4c8b0,
+    'btn-selected':    #6b2828,
+    'btn-disabled':    #584040,
+    'scrollbar-thumb': #8b3535,
+    'glow':            rgba(139, 53, 53, 0.2),
+    'link':            #c8a040,
+    'link-visited':    #e0d0a0,
+    'link-hover':      #d4c8b0,
+  ), '../assets/azure_default/topbar_red.svg');
+}

--- a/tgui/packages/tgui/styles/themes/azure_psydonic.scss
+++ b/tgui/packages/tgui/styles/themes/azure_psydonic.scss
@@ -1,0 +1,25 @@
+@use 'azure_base' as *;
+
+// Psydonic — primordial god palette (cold stone silver)
+.theme-azure_psydonic:root {
+  @include azure-theme((
+    'base':            #0e0e12,
+    'base-light':      #161620,
+    'base-dark':       #0a0a0e,
+    'section':         rgba(30, 30, 42, 0.45),
+    'section-title':   #a0a8b8,
+    'text':            #c0c4d0,
+    'label':           #909498,
+    'accent':          #606878,
+    'accent-bright':   #788090,
+    'border':          #3a3a48,
+    'btn-text':        #c0c4d0,
+    'btn-selected':    #505868,
+    'btn-disabled':    #484850,
+    'scrollbar-thumb': #606878,
+    'glow':            rgba(96, 104, 120, 0.2),
+    'link':            #a0a8b8,
+    'link-visited':    #d0d4e0,
+    'link-hover':      #c0c4d0,
+  ), '../assets/azure_default/topbar_red.svg');
+}

--- a/tgui/packages/tgui/styles/themes/parchment.scss
+++ b/tgui/packages/tgui/styles/themes/parchment.scss
@@ -1,0 +1,137 @@
+@use 'azure_base' as *;
+
+.theme-parchment:root {
+  @include azure-theme((
+    'base':            #c2ad7c,
+    'base-light':      #ceba8c,
+    'base-dark':       #a8915f,
+    'section':         rgba(230, 210, 165, 0.3),
+    'section-title':   #281a07,
+    'text':            #281a07,
+    'label':           #563d1e,
+    'accent':          rgba(122, 86, 22, 0.35),
+    'accent-bright':   rgba(181, 148, 64, 0.65),
+    'border':          rgba(138, 114, 80, 0.45),
+    'btn-text':        #3a2a14,
+    'btn-selected':    rgba(122, 86, 22, 0.25),
+    'btn-disabled':    #a89677,
+    'scrollbar-thumb': rgba(122, 86, 22, 0.45),
+    'glow':            rgba(181, 148, 64, 0.18),
+    'link':            #6e1414,
+    'link-visited':    #8b1a1a,
+    'link-hover':      #b42a24,
+  ), '../assets/azure_default/topbar_red.svg');
+
+  --font-family: 'Lora', Georgia, serif;
+
+  --p-font-tiny: 12px;
+  --p-font-small: 12px;
+  --p-font-body: 13px;
+  --p-font-lead: 13px;
+  --p-font-title: 14px;
+  --p-font-head: 15px;
+
+  --p-title: #58180d;
+  --p-title-font: 'MedievalSharp', Georgia, serif;
+
+  --p-bg: #c2ad7c;
+  --p-bg-deep: #a8915f;
+  --p-bg-shadow: #8a7444;
+  --p-ink: #281a07;
+  --p-ink-soft: #4a3416;
+  --p-ink-faint: #6b5128;
+  --p-seal-red: #8b2020;
+  --p-seal-red-soft: #a8433a;
+  --p-seal-green: #3b6a35;
+  --p-seal-blue: #2e4a78;
+  --p-seal-amber: #7a5616;
+  --p-button-bg: rgba(245, 230, 190, 0.35);
+  --p-tab-active-bg: rgba(200, 170, 100, 0.25);
+  --p-card-bg: rgba(230, 210, 165, 0.3);
+  --p-card-shadow: rgba(80, 50, 10, 0.12);
+  --p-banner-bg: rgba(180, 60, 40, 0.18);
+  --p-banner-bg-soft: rgba(180, 60, 40, 0.12);
+  --p-badge-text: #f7eccb;
+
+  &, .Window, .Layout, .Layout__content, .Window__rest, .Window__content,
+  .Window__contentPadding {
+    background: #c2ad7c !important;
+    background-image: none !important;
+  }
+  .Window__contentPadding {
+    margin: 0;
+    height: 100%;
+  }
+
+
+  .TitleBar {
+    background-color: #a8915f;
+    border-bottom: 1px solid rgba(122, 86, 22, 0.4);
+    box-shadow: 0 2px 8px rgba(80, 50, 10, 0.18);
+  }
+
+  .TitleBar__title {
+    color: var(--p-title);
+    font-size: 14px;
+    letter-spacing: 1px;
+    font-weight: bold;
+  }
+
+  .TitleBar__close {
+    color: rgba(110, 20, 20, 0.55);
+
+    &:hover {
+      color: rgba(180, 42, 36, 0.95);
+      background-color: rgba(180, 42, 36, 0.18);
+    }
+  }
+
+  .Section {
+    background: rgba(230, 210, 165, 0.3);
+    border: 1px solid rgba(122, 86, 22, 0.35);
+    box-shadow: inset 0 0 24px rgba(181, 148, 64, 0.09);
+  }
+
+  .Section__title {
+    color: var(--p-title);
+    letter-spacing: 1px;
+    font-weight: bold;
+    border-bottom: 1px solid rgba(122, 86, 22, 0.4);
+  }
+
+  .Button {
+    font-size: 14px;
+    border: 1px solid rgba(122, 86, 22, 0.45);
+    background: rgba(122, 86, 22, 0.12);
+    color: #281a07;
+    box-shadow: none;
+    margin: 1px 2px;
+
+    &:hover {
+      border-color: rgba(110, 20, 20, 0.65);
+      background: rgba(122, 86, 22, 0.22);
+    }
+
+    &:active {
+      background: rgba(122, 86, 22, 0.32);
+    }
+
+    &.Button--selected {
+      background: rgba(122, 86, 22, 0.35);
+      border-color: rgba(80, 50, 10, 0.6);
+    }
+  }
+
+  .LabeledList__label {
+    color: #563d1e;
+  }
+
+  .LabeledList__content {
+    color: #281a07;
+  }
+
+  .toc-link:hover {
+    text-decoration: underline;
+    color: var(--p-ink);
+  }
+}

--- a/tgui/packages/tgui/styles/themes/parchment_leatherbound.scss
+++ b/tgui/packages/tgui/styles/themes/parchment_leatherbound.scss
@@ -1,0 +1,151 @@
+@use 'azure_base' as *;
+
+.theme-parchment-leatherbound:root {
+  @include azure-theme((
+    'base':            #2a2118,
+    'base-light':      #332a1e,
+    'base-dark':       #1f1810,
+    'section':         rgba(60, 48, 32, 0.30),
+    'section-title':   #d4c090,
+    'text':            #d4c090,
+    'label':           #a89060,
+    'accent':          rgba(160, 130, 80, 0.35),
+    'accent-bright':   rgba(200, 170, 100, 0.55),
+    'border':          rgba(160, 130, 80, 0.35),
+    'btn-text':        #d4c090,
+    'btn-selected':    rgba(180, 145, 85, 0.55),
+    'btn-disabled':    #6a5a40,
+    'scrollbar-thumb': rgba(160, 130, 80, 0.45),
+    'glow':            rgba(200, 170, 100, 0.15),
+    'link':            #c8a050,
+    'link-visited':    #b08840,
+    'link-hover':      #e6c270,
+  ), '../assets/azure_default/topbar_red.svg');
+
+  --font-family: 'Lora', Georgia, serif;
+
+  --p-font-tiny: 12px;
+  --p-font-small: 12px;
+  --p-font-body: 13px;
+  --p-font-lead: 13px;
+  --p-font-title: 14px;
+  --p-font-head: 15px;
+
+  --p-title: #b5654a;
+  --p-title-font: 'MedievalSharp', Georgia, serif;
+
+  --p-bg: #2a2118;
+  --p-bg-deep: #332a1e;
+  --p-bg-shadow: #4a3a24;
+  --p-ink: #d4c090;
+  --p-ink-soft: #a89060;
+  --p-ink-faint: #7a6444;
+  --p-seal-red: #a04848;
+  --p-seal-red-soft: #8a3c3c;
+  --p-seal-green: #6a9560;
+  --p-seal-blue: #5a7ca8;
+  --p-seal-amber: #c8a050;
+  --p-button-bg: rgba(80, 64, 40, 0.28);
+  --p-tab-active-bg: rgba(180, 145, 85, 0.55);
+  --p-card-bg: rgba(60, 48, 32, 0.40);
+  --p-card-shadow: rgba(0, 0, 0, 0.45);
+  --p-banner-bg: rgba(160, 72, 72, 0.20);
+  --p-banner-bg-soft: rgba(160, 72, 72, 0.12);
+  --p-badge-text: #f7eccb;
+
+  &, .Window, .Layout, .Layout__content, .Window__rest, .Window__content,
+  .Window__contentPadding {
+    background: #2a2118 !important;
+    background-image: none !important;
+  }
+
+  .Window__contentPadding {
+    margin: 0;
+    height: 100%;
+  }
+
+  .TitleBar {
+    background-color: #1f1810;
+    border-bottom: 1px solid rgba(160, 130, 80, 0.40);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.50);
+  }
+
+  .TitleBar__title {
+    color: var(--p-title);
+    font-size: 14px;
+    letter-spacing: 1px;
+    font-weight: bold;
+  }
+
+  .TitleBar__close {
+    color: rgba(200, 170, 100, 0.55);
+
+    &:hover {
+      color: rgba(220, 120, 120, 0.95);
+      background-color: rgba(160, 72, 72, 0.25);
+    }
+  }
+
+  .Section {
+    background: rgba(60, 48, 32, 0.40);
+    border: 1px solid rgba(160, 130, 80, 0.30);
+    box-shadow: inset 0 0 24px rgba(0, 0, 0, 0.25);
+  }
+
+  .Section__title {
+    color: var(--p-title);
+    letter-spacing: 1px;
+    font-weight: bold;
+    border-bottom: 1px solid rgba(160, 130, 80, 0.40);
+  }
+
+  .Button {
+    border-color: rgba(160, 130, 80, 0.45);
+    background: rgba(80, 64, 40, 0.28);
+    color: #d4c090;
+    box-shadow: none;
+
+    &:hover {
+      border-color: rgba(200, 170, 100, 0.65);
+      background: rgba(100, 80, 50, 0.45);
+      box-shadow: 0 0 6px rgba(200, 170, 100, 0.20);
+    }
+
+    &:active {
+      box-shadow: inset 1px 1px 3px rgba(0, 0, 0, 0.55);
+    }
+  }
+
+  .LabeledList__label {
+    color: #a89060;
+  }
+
+  .LabeledList__content {
+    color: #d4c090;
+  }
+
+  .Input {
+    background-color: #1a1410;
+    border: 2px solid rgba(200, 170, 100, 0.55);
+    outline: 1px solid rgba(0, 0, 0, 0.6);
+    color: #f0dca8;
+
+    &:focus-within {
+      border-color: #e6c270;
+      box-shadow:
+        inset 2px 2px 4px rgba(0, 0, 0, 0.5),
+        inset -1px -1px 0 rgba(255, 255, 255, 0.05),
+        0 0 5px rgba(230, 194, 112, 0.45);
+    }
+  }
+
+  .Input__input::placeholder,
+  .Input input::placeholder {
+    color: rgba(212, 192, 144, 0.45);
+  }
+
+  .toc-link:hover {
+    text-decoration: underline;
+    color: var(--p-ink);
+  }
+}

--- a/tgui/packages/tgui/styles/themes/parchment_vellum.scss
+++ b/tgui/packages/tgui/styles/themes/parchment_vellum.scss
@@ -1,0 +1,131 @@
+@use 'azure_base' as *;
+
+.theme-parchment-vellum:root {
+  @include azure-theme((
+    'base':            #f4e7c6,
+    'base-light':      #faf2dc,
+    'base-dark':       #e6d4a3,
+    'section':         rgba(255, 248, 220, 0.45),
+    'section-title':   #281a07,
+    'text':            #281a07,
+    'label':           #563d1e,
+    'accent':          rgba(122, 86, 22, 0.35),
+    'accent-bright':   rgba(181, 148, 64, 0.65),
+    'border':          rgba(138, 114, 80, 0.45),
+    'btn-text':        #281a07,
+    'btn-selected':    rgba(122, 86, 22, 0.25),
+    'btn-disabled':    #a89677,
+    'scrollbar-thumb': rgba(122, 86, 22, 0.45),
+    'glow':            rgba(181, 148, 64, 0.18),
+    'link':            #6e1414,
+    'link-visited':    #8b1a1a,
+    'link-hover':      #b42a24,
+  ), '../assets/azure_default/topbar_red.svg');
+
+  --font-family: 'Lora', Georgia, serif;
+
+  --p-font-tiny: 12px;
+  --p-font-small: 12px;
+  --p-font-body: 13px;
+  --p-font-lead: 13px;
+  --p-font-title: 14px;
+  --p-font-head: 15px;
+
+  --p-title: #58180d;
+  --p-title-font: 'MedievalSharp', Georgia, serif;
+
+  --p-bg: #f4e7c6;
+  --p-bg-deep: #e6d4a3;
+  --p-bg-shadow: #c7a86a;
+  --p-ink: #281a07;
+  --p-ink-soft: #4a3416;
+  --p-ink-faint: #6b5128;
+  --p-seal-red: #8b2020;
+  --p-seal-red-soft: #a8433a;
+  --p-seal-green: #3b6a35;
+  --p-seal-blue: #2e4a78;
+  --p-seal-amber: #7a5616;
+  --p-button-bg: rgba(255, 248, 220, 0.6);
+  --p-tab-active-bg: rgba(200, 170, 100, 0.25);
+  --p-card-bg: rgba(255, 248, 220, 0.45);
+  --p-card-shadow: rgba(80, 50, 10, 0.12);
+  --p-banner-bg: rgba(180, 60, 40, 0.18);
+  --p-banner-bg-soft: rgba(180, 60, 40, 0.12);
+  --p-badge-text: #f7eccb;
+
+  &, .Window, .Layout, .Layout__content, .Window__rest, .Window__content,
+  .Window__contentPadding {
+    background: #f4e7c6 !important;
+    background-image: none !important;
+  }
+
+  .Window__contentPadding {
+    margin: 0;
+    height: 100%;
+  }
+
+  .TitleBar {
+    background-color: #e6d4a3;
+    border-bottom: 1px solid rgba(122, 86, 22, 0.4);
+    box-shadow: 0 2px 8px rgba(80, 50, 10, 0.18);
+  }
+
+  .TitleBar__title {
+    color: var(--p-title);
+    font-size: 14px;
+    letter-spacing: 1px;
+    font-weight: bold;
+  }
+
+  .TitleBar__close {
+    color: rgba(110, 20, 20, 0.55);
+
+    &:hover {
+      color: rgba(180, 42, 36, 0.95);
+      background-color: rgba(180, 42, 36, 0.18);
+    }
+  }
+
+  .Section {
+    background: rgba(255, 248, 220, 0.5);
+    border: 1px solid rgba(122, 86, 22, 0.35);
+    box-shadow: inset 0 0 24px rgba(181, 148, 64, 0.09);
+  }
+
+  .Section__title {
+    color: var(--p-title);
+    letter-spacing: 1px;
+    font-weight: bold;
+    border-bottom: 1px solid rgba(122, 86, 22, 0.4);
+  }
+
+  .Button {
+    border-color: rgba(122, 86, 22, 0.45);
+    background: rgba(255, 248, 220, 0.6);
+    color: #281a07;
+    box-shadow: none;
+
+    &:hover {
+      border-color: rgba(110, 20, 20, 0.65);
+      background: rgba(255, 248, 220, 0.85);
+      box-shadow: 0 0 6px rgba(181, 148, 64, 0.25);
+    }
+
+    &:active {
+      box-shadow: inset 1px 1px 3px rgba(80, 50, 10, 0.35);
+    }
+  }
+
+  .LabeledList__label {
+    color: #563d1e;
+  }
+
+  .LabeledList__content {
+    color: #281a07;
+  }
+
+  .toc-link:hover {
+    text-decoration: underline;
+    color: var(--p-ink);
+  }
+}


### PR DESCRIPTION

## About The Pull Request

Ports Migrant Rework from AP. While not as pretty, is MUCH MUCH more functional than our system.
Also changes: Adds an extra warrior and retinue slot to Gronn and Heartfelt.
Adds more slave slots to Slavers since it's easier to roll.
Adds a bunch of TGUI themes from AP
Increases Triumph-Weight
Im so fucking happy. 

## Testing Evidence

<details> <summary>Image Testing</summary>
<img width="651" height="501" alt="Screenshot 2026-06-14 184003" src="https://github.com/user-attachments/assets/6ac93f0f-6f22-4b97-9f6f-afc90953a812" />
<img width="1110" height="840" alt="Screenshot 2026-06-14 183854" src="https://github.com/user-attachments/assets/8acc0e2d-7cb8-4e90-a835-391f2c80ab40" />
<img width="1817" height="798" alt="Screenshot 2026-06-14 184641" src="https://github.com/user-attachments/assets/7ea08bb3-f57b-40a7-8b87-6f6727c39baa" />
<img width="1210" height="571" alt="Screenshot 2026-06-14 184514" src="https://github.com/user-attachments/assets/a928849c-b622-4ff3-abe9-94c0b99f088a" />
<img width="1172" height="602" alt="image" src="https://github.com/user-attachments/assets/745606ba-ce1d-46f4-87e8-dda84f0e6c3c" />

</details>

## Why It's Good For The Game

Makes it infinitely fucking easier to roll ANY fucking Migrant. It also should help with announcing migrant waves.

## Changelog

:cl: Gorap
add: A bunch of TGUI Themes from AP
qol: Makes Migrant waves easier to do.
balance: Adds 1 more retinue role on HF
balance: Adds 1 more warrior role on Gronn
balance: Adds 2 more Slave role on Slavers
/:cl: