### PR TITLE
CON affects bleed rate less strongly

### DIFF
--- a/code/__DEFINES/roguetown/combat.dm
+++ b/code/__DEFINES/roguetown/combat.dm
@@ -11,8 +11,8 @@
 Medical defines
 */
 #define ARTERY_LIMB_BLEEDRATE 20	//This is used as a reference point for dynamic wounds, so it's better off as a define.
-#define CONSTITUTION_BLEEDRATE_MOD 0.1	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
-#define CONSTITUTION_BLEEDRATE_CAP 15	//The CON value up to which we get a bleedrate reduction.
+#define CONSTITUTION_BLEEDRATE_MOD 0.05	//How much slower we'll be bleeding for every CON point. 0.1 = 10% slower.
+#define CONSTITUTION_BLEEDRATE_CAP 20	//The CON value up to which we get a bleedrate reduction.
 
 /*
 Misc. Category. Spin it out if needed


### PR DESCRIPTION
## About The Pull Request
PREVIOUSLY:

- Each point of CON above or below 10 affects your bleed rate by 10%, capping out at 5/15 CON (50%/150% bleed rate).

NOW:

- Each point of CON above or below 10 affects your bleed rate by 5%, capping out at 1/20 CON (50%/150% bleed rate).

Azure changed this all the way back on [February 25th](https://github.com/Azure-Peak/Azure-Peak/pull/5977).
<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/79217e40-9034-4f10-8e8c-e2a51fcd280b" />

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
I hosted a local, gave myself exactly 15 CON and 10 FOR, put on a timer, cut myself a bit. Recorded the time it took me to get the 1st blood loss penalty.
Then I made the changes, rehosted, gave myself 15 CON and 10 FOR, put on a timer, cut myself a bit. It took less time to get the 1st blood loss penalty.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The original bleed rate scaling (1 point per 10% change) was a band-aid solution for the initial introduction of omniwounds, when people bled out far harder. Now that omniwounds cause less bleed, this scaling is excessive.

This change makes CON below 10 _less_ oppressive and CON above 10 _less_ powerful.

CON is weighted like any non-STR/non-SPD stat, yet it affects just about almost everything related to not dying. Probably shouldn't make it more powerful than it has to be.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: CON influence on bleedrate reduced by half (5% per point). Its cap has been raised to 20.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
