### PR TITLE
Unrepentant soiler buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/peasant.dm
@@ -24,7 +24,7 @@
 		/datum/skill/combat/knives = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/slings = SKILL_LEVEL_APPRENTICE,
-
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/labor/farming = SKILL_LEVEL_EXPERT,
 		/datum/skill/labor/lumberjacking = SKILL_LEVEL_NOVICE,

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -81,7 +81,8 @@
 	if(H.age == AGE_OLD)//So ppl have reason to pick this I guess?
 		H.adjust_skillrank_up_to(/datum/skill/labor/farming, 6, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/labor/butchering, 6, TRUE)
-
+	if(H.patron?.type == /datum/patron/divine/dendor)
+		H.adjust_skillrank_up_to(/datum/skill/magic/druidic, 2, TRUE)
 	if(should_wear_femme_clothes(H))
 		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/random
 		shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/random

--- a/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/soilson.dm
@@ -38,11 +38,12 @@
 	subclass_stats = list(
 		STATKEY_WIL = 2,
 		STATKEY_STR = 1,
-		STATKEY_CON = 1,
+		STATKEY_CON = 2,
 		STATKEY_SPD = 1,
 		STATKEY_INT = -1,//simple and honest
 	)
 	subclass_skills = list(
+		/datum/skill/misc/athletics = SKILL_LEVEL_MASTER,
 		/datum/skill/combat/whipsflails = SKILL_LEVEL_NOVICE,
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,


### PR DESCRIPTION
## About The Pull Request

It is absolutely wild to me that Soilsons/Soilbrides don't have athletics. We're talking about corn-fed farmboys and farmgirls here, if anybody should be athletic it's the people who spend their whole lives tilling soil and working in the field.

So I gave them Master athletics. I believe they should have some of the best endurance of anyone around. For pulling plows, wrestling goats and ploughing... Fields. Yeah. Fields.

They also had a pathetic 6 weighted total statpoints. So I gave 'em an extra point of con to bump them up to 7, which is used for many slot-limited noncombat jobs. This should allow them to 1v10 the wretch squad, ruin antags forever, and win roguetown. Please look forward to it.

I also gave them apprentice Druidic Trickery if they worship Dendor. Druids have been muscling in on their turf for a while now, so I think it's only fair to let them do it back a little. This gives them a slight head start over other farmers in this area, and lets them do some cool stuff. Also, since farming gives druidic trickery XP now it represents them having been at it for a while before the round starts.

Also added expert athletics to non-soiler farmers, as a treat. They were completely lacking athletics as well.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

Playing a revenant with no statpack in this screenshot. Have the meal buff from readying up - Woops!

<img width="468" height="832" alt="image" src="https://github.com/user-attachments/assets/97764005-c93d-44af-a1a0-ef454e676b70" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Sovl. Farmers should have a lot of stamina.

Druidic Trickery allows for some cool gameplay that is very relevant to Soilsons, and they can already gain access. It's just a long grind. Giving them a small leg up helps them to become a relevant option for farming, something they struggle with.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Raised soilson con bonus to 2, from 1
balance: Raised soilson athletics to 5, from 0
balance: Added druidic trickery 2 to dendorite soilsons
balance: Raised pilgrim farmer athletics to 4, from 0
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
