### PR TITLE
Optimize progress bars via the spatial grid system

### DIFF
--- a/code/__DEFINES/spatial_gridmap.dm
+++ b/code/__DEFINES/spatial_gridmap.dm
@@ -14,10 +14,8 @@
 #define SPATIAL_GRID_CONTENTS_TYPE_HEARING RECURSIVE_CONTENTS_HEARING_SENSITIVE
 ///every movable that has a client in it is stored in this channel
 #define SPATIAL_GRID_CONTENTS_TYPE_CLIENTS RECURSIVE_CONTENTS_CLIENT_MOBS
-///all atmos machines are stored in this channel (I'm sorry kyler)
-#define SPATIAL_GRID_CONTENTS_TYPE_ATMOS "spatial_grid_contents_type_atmos"
 
-#define ALL_CONTENTS_OF_CELL(cell) (cell.hearing_contents | cell.client_contents | cell.atmos_contents)
+#define ALL_CONTENTS_OF_CELL(cell) (cell.hearing_contents | cell.client_contents)
 
 ///whether movable is itself or containing something which should be in one of the spatial grid channels.
 #define HAS_SPATIAL_GRID_CONTENTS(movable) (movable.spatial_grid_key)
@@ -51,5 +49,4 @@
 ///remove from every list
 #define GRID_CELL_REMOVE_ALL(cell, movable) \
 	GRID_CELL_REMOVE(cell.hearing_contents, movable) \
-	GRID_CELL_REMOVE(cell.client_contents, movable) \
-	GRID_CELL_REMOVE(cell.atmos_contents, movable)
+	GRID_CELL_REMOVE(cell.client_contents, movable)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -26,8 +26,6 @@
 	var/list/hearing_contents
 	///every client possessed mob inside this cell
 	var/list/client_contents
-	///every atmos machine inside this cell
-	var/list/atmos_contents
 
 /datum/spatial_grid_cell/New(cell_x, cell_y, cell_z)
 	. = ..()
@@ -42,7 +40,6 @@
 		stack_trace("SSspatial_grid.dummy_list had something inserted into it at some point! this is a problem as it is supposed to stay empty")
 	hearing_contents = dummy_list
 	client_contents = dummy_list
-	atmos_contents = dummy_list
 
 /datum/spatial_grid_cell/Destroy(force)
 	if(!force)//the response to someone trying to qdel this is a right proper fuck you
@@ -74,7 +71,7 @@
  *
  * The second pattern is more paired down, and supports more wide use.
  * Rather then the object and anything the object is in being sensitive, it's limited to just the object itself
- * Currently only [SPATIAL_GRID_CONTENTS_TYPE_ATMOS] uses this pattern. This is because it's far more common, and so worth optimizing
+ * Currently nothing uses this pattern. It should be used for things where optimisation is critical.
  *
  */
 SUBSYSTEM_DEF(spatial_grid)
@@ -84,7 +81,7 @@ SUBSYSTEM_DEF(spatial_grid)
 	///list of the spatial_grid_cell datums per z level, arranged in the order of y index then x index
 	var/list/grids_by_z_level = list()
 	///everything that spawns before us is added to this list until we initialize
-	var/list/waiting_to_add_by_type = list(SPATIAL_GRID_CONTENTS_TYPE_HEARING = list(), SPATIAL_GRID_CONTENTS_TYPE_CLIENTS = list(), SPATIAL_GRID_CONTENTS_TYPE_ATMOS = list())
+	var/list/waiting_to_add_by_type = list(SPATIAL_GRID_CONTENTS_TYPE_HEARING = list(), SPATIAL_GRID_CONTENTS_TYPE_CLIENTS = list())
 	///associative list of the form: movable.spatial_grid_key (string) -> inner list of spatial grid types for that key.
 	///inner lists contain contents channel types such as SPATIAL_GRID_CONTENTS_TYPE_HEARING etc.
 	///we use this to make adding to a cell static cost, and to save on memory
@@ -248,11 +245,6 @@ SUBSYSTEM_DEF(spatial_grid)
 
 					. += grid_level[row][x_index].hearing_contents
 
-		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			for(var/row in BOUNDING_BOX_MIN(center_y) to BOUNDING_BOX_MAX(center_y, cells_on_y_axis))
-				for(var/x_index in BOUNDING_BOX_MIN(center_x) to BOUNDING_BOX_MAX(center_x, cells_on_x_axis))
-					. += grid_level[row][x_index].atmos_contents
-
 	return .
 
 ///get the grid cell encomapassing targets coordinates
@@ -361,22 +353,17 @@ SUBSYSTEM_DEF(spatial_grid)
 	var/y_index = GET_SPATIAL_INDEX(target_turf.y)
 	var/z_index = target_turf.z
 
+	var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
 	var/datum/spatial_grid_cell/intersecting_cell = grids_by_z_level[z_index][y_index][x_index]
 	for(var/type in spatial_grid_categories[new_target.spatial_grid_key])
 		switch(type)
 			if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
-				var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
 				GRID_CELL_SET(intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
-				var/list/new_target_contents = new_target.important_recursive_contents
-				GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+				GRID_CELL_SET(intersecting_cell.hearing_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
-
-			if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-				GRID_CELL_SET(intersecting_cell.atmos_contents, new_target)
-				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), new_target)
 
 ///acts like enter_cell() but only adds the target to a specified type of grid cell contents list
 /datum/controller/subsystem/spatial_grid/proc/add_single_type(atom/movable/new_target, turf/target_turf, exclusive_type)
@@ -392,21 +379,16 @@ SUBSYSTEM_DEF(spatial_grid)
 	var/y_index = GET_SPATIAL_INDEX(target_turf.y)
 	var/z_index = target_turf.z
 
+	var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
 	var/datum/spatial_grid_cell/intersecting_cell = grids_by_z_level[z_index][y_index][x_index]
 	switch(exclusive_type)
 		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
-			var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
 			GRID_CELL_SET(intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
-			var/list/new_target_contents = new_target.important_recursive_contents
-			GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+			GRID_CELL_SET(intersecting_cell.hearing_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
-
-		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			GRID_CELL_SET(intersecting_cell.atmos_contents, new_target)
-			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), new_target)
 
 	return intersecting_cell
 
@@ -443,10 +425,6 @@ SUBSYSTEM_DEF(spatial_grid)
 				GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target_contents)
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(type), old_target_contents)
 
-			if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-				GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
-				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(type), old_target)
-
 	return TRUE
 
 ///acts like exit_cell() but only removes the target from the specified type of grid cell contents list
@@ -474,10 +452,6 @@ SUBSYSTEM_DEF(spatial_grid)
 			var/list/old_target_contents = old_target.important_recursive_contents?[exclusive_type] || old_target
 			GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target_contents)
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target_contents)
-
-		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
-			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target)
 
 	return TRUE
 
@@ -522,12 +496,6 @@ SUBSYSTEM_DEF(spatial_grid)
 						contents = "[contents], client"
 					else
 						contents = "client"
-
-				if(movable_to_check in cell.atmos_contents)
-					if(length(contents) > 0)
-						contents = "[contents], atmos"
-					else
-						contents = "atmos"
 
 				if(length(error_data) > 0)
 					error_data = "[error_data], {coords: [coords], within channels: [contents]}"
@@ -600,7 +568,7 @@ SUBSYSTEM_DEF(spatial_grid)
 	for(var/list/z_level_grid as anything in grids_by_z_level)
 		for(var/list/cell_row as anything in z_level_grid)
 			for(var/datum/spatial_grid_cell/cell as anything in cell_row)
-				if(to_remove in (cell.hearing_contents | cell.client_contents | cell.atmos_contents))
+				if(to_remove in (cell.hearing_contents | cell.client_contents))
 					containing_cells += cell
 					if(remove_from_cells)
 						force_remove_from_cell(to_remove, cell)
@@ -672,15 +640,12 @@ SUBSYSTEM_DEF(spatial_grid)
 /atom/proc/find_grid_statistics_for_z_level(insert_clients = 0)
 	var/raw_clients = 0
 	var/raw_hearables = 0
-	var/raw_atmos = 0
 
 	var/cells_with_clients = 0
 	var/cells_with_hearables = 0
-	var/cells_with_atmos = 0
 
 	var/list/client_list = list()
 	var/list/hearable_list = list()
-	var/list/atmos_list = list()
 
 	var/x_cell_count = world.maxx / SPATIAL_GRID_CELLSIZE
 	var/y_cell_count = world.maxy / SPATIAL_GRID_CELLSIZE
@@ -689,7 +654,6 @@ SUBSYSTEM_DEF(spatial_grid)
 
 	var/average_clients_per_cell = 0
 	var/average_hearables_per_cell = 0
-	var/average_atmos_mech_per_call = 0
 
 	var/hearable_min_x = x_cell_count
 	var/hearable_max_x = 1
@@ -702,12 +666,6 @@ SUBSYSTEM_DEF(spatial_grid)
 
 	var/client_min_y = y_cell_count
 	var/client_max_y = 1
-
-	var/atmos_min_x = x_cell_count
-	var/atmos_max_x = 1
-
-	var/atmos_min_y = y_cell_count
-	var/atmos_max_y = 1
 
 	var/list/inserted_clients = list()
 
@@ -726,11 +684,9 @@ SUBSYSTEM_DEF(spatial_grid)
 	for(var/datum/spatial_grid_cell/cell as anything in all_z_level_cells)
 		var/client_length = length(cell.client_contents)
 		var/hearable_length = length(cell.hearing_contents)
-		var/atmos_length = length(cell.atmos_contents)
 
 		raw_clients += client_length
 		raw_hearables += hearable_length
-		raw_atmos += atmos_length
 
 		if(client_length)
 			cells_with_clients++
@@ -766,30 +722,11 @@ SUBSYSTEM_DEF(spatial_grid)
 			if(cell.cell_y > hearable_max_y)
 				hearable_max_y = cell.cell_y
 
-		if(raw_atmos)
-			cells_with_atmos++
-
-			atmos_list += cell.atmos_contents
-
-			if(cell.cell_x < atmos_min_x)
-				atmos_min_x = cell.cell_x
-
-			if(cell.cell_x > atmos_max_x)
-				atmos_max_x = cell.cell_x
-
-			if(cell.cell_y < atmos_min_y)
-				atmos_min_y = cell.cell_y
-
-			if(cell.cell_y > atmos_max_y)
-				atmos_max_y = cell.cell_y
-
 	var/total_client_distance = 0
 	var/total_hearable_distance = 0
-	var/total_atmos_distance = 0
 
 	var/average_client_distance = 0
 	var/average_hearable_distance = 0
-	var/average_atmos_distance = 0
 
 	for(var/hearable in hearable_list)//n^2 btw
 		for(var/other_hearable in hearable_list)
@@ -803,36 +740,24 @@ SUBSYSTEM_DEF(spatial_grid)
 				continue
 			total_client_distance += get_dist(client, other_client)
 
-	for(var/atmos in atmos_list)//n^2 btw
-		for(var/other_atmos in atmos_list)
-			if(atmos == other_atmos)
-				continue
-			total_atmos_distance += get_dist(atmos, other_atmos)
-
 	if(length(hearable_list))
 		average_hearable_distance = total_hearable_distance / length(hearable_list)
 	if(length(client_list))
 		average_client_distance = total_client_distance / length(client_list)
-	if(length(atmos_list))
-		average_atmos_distance = total_atmos_distance / length(atmos_list)
 
 	average_clients_per_cell = raw_clients / total_cells
 	average_hearables_per_cell = raw_hearables / total_cells
-	average_atmos_mech_per_call = raw_atmos / total_cells
 
 	for(var/mob/inserted_client as anything in inserted_clients)
 		qdel(inserted_client)
 
 	message_admins("on z level [z] there are [raw_clients] clients ([insert_clients] of whom are fakes inserted to random station turfs)\
-	, [raw_hearables] hearables, and [raw_atmos] atmos machines. all of whom are inside the bounding box given by \
+	, and [raw_hearables] hearables. all of whom are inside the bounding box given by \
 	clients: ([client_min_x], [client_min_y]) x ([client_max_x], [client_max_y]), \
-	hearables: ([hearable_min_x], [hearable_min_y]) x ([hearable_max_x], [hearable_max_y]) \
-	and atmos machines: ([atmos_min_x], [atmos_min_y]) x ([atmos_max_x], [atmos_max_y]), \
-	on average there are [average_clients_per_cell] clients per cell, [average_hearables_per_cell] hearables per cell, \
-	and [average_atmos_mech_per_call] per cell, \
-	[cells_with_clients] cells have clients, [cells_with_hearables] have hearables, and [cells_with_atmos] have atmos machines \
-	the average client distance is: [average_client_distance], the average hearable_distance is [average_hearable_distance], \
-	and the average atmos distance is [average_atmos_distance] ")
+	and hearables: ([hearable_min_x], [hearable_min_y]) x ([hearable_max_x], [hearable_max_y]) \
+	on average there are [average_clients_per_cell] clients per cell, and [average_hearables_per_cell] hearables per cell, \
+	[cells_with_clients] cells have clients, and [cells_with_hearables] have hearables \
+	the average client distance is: [average_client_distance], and the average hearable_distance is [average_hearable_distance] ")
 
 #undef BOUNDING_BOX_MAX
 #undef BOUNDING_BOX_MIN

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -8,7 +8,8 @@
 	var/shown = 0
 	var/mob/user
 	var/listindex
-	var/list/tracked_clients
+	/// our current cell grid
+	var/datum/cell_tracker/our_cells
 
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
@@ -20,6 +21,12 @@
 	bar.plane = ABOVE_HUD_PLANE
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	user = User
+	our_cells = new(world.view, world.view, 1)
+	set_new_cells()
+	// late log-ins or walking into the range afterwards are handled by the cell tracker
+	for(var/mob/M in our_cells.get_type_members(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS))
+		if(M.client)
+			M.client.images |= bar
 
 	LAZYINITLIST(user.progressbars)
 	LAZYINITLIST(user.progressbars[bar.loc])
@@ -31,13 +38,6 @@
 	animate(bar, pixel_y = 32 + (PROGRESSBAR_HEIGHT * (listindex - 1)), alpha = 255, time = PROGRESSBAR_ANIMATION_TIME, easing = SINE_EASING)
 
 /datum/progressbar/proc/update(progress)
-	if(!tracked_clients)
-		tracked_clients = list()
-	for(var/mob/M in viewers(user, null))
-		if(M.client)
-			M.client.images |= bar
-			tracked_clients |= M.client
-
 	progress = CLAMP(progress, 0, goal)
 	last_progress = progress
 	bar.icon_state = "prog_bar_[round(((progress / goal) * 100), 5)]"
@@ -64,14 +64,37 @@
 		LAZYREMOVE(user.progressbars, bar.loc)
 
 	animate(bar, alpha = 0, time = PROGRESSBAR_ANIMATION_TIME)
-	addtimer(CALLBACK(src, PROC_REF(remove_from_client)), PROGRESSBAR_ANIMATION_TIME, TIMER_CLIENT_TIME)
+	addtimer(CALLBACK(src, PROC_REF(remove_from_clients)), PROGRESSBAR_ANIMATION_TIME, TIMER_CLIENT_TIME)
+	// this may not be necessary but i'm not sure
+	var/list/cell_collection = our_cells.member_cells
+	for(var/datum/grid as anything in cell_collection)
+		UnregisterSignal(grid, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS))
+	our_cells = null
 	return ..()
 
-/datum/progressbar/proc/remove_from_client()
-	for(var/client/C in tracked_clients)
+/datum/progressbar/proc/set_new_cells()
+	var/turf/our_turf = get_turf(bar.loc)
+	if(isnull(our_turf))
+		return
+
+	var/list/cell_collections = our_cells.recalculate_cells(our_turf)
+
+	for(var/datum/old_grid as anything in cell_collections[2])
+		UnregisterSignal(old_grid, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS))
+
+	for(var/datum/spatial_grid_cell/new_grid as anything in cell_collections[1])
+		RegisterSignal(new_grid, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), PROC_REF(on_client_enter))
+
+// we never remove these when clients exit, they all get cleaned up when the mob leaves
+/datum/progressbar/proc/on_client_enter(datum/source, mob/client_holder)
+	if(!istype(client_holder) || !client_holder.client)
+		return
+	client_holder.client.images |= bar
+
+/datum/progressbar/proc/remove_from_clients()
+	for(var/client/C in GLOB.clients) // this is genuinely faster than tracking clients we've sent it to
 		C.images -= bar
 	bar = null
-	tracked_clients = null
 
 #undef PROGRESSBAR_ANIMATION_TIME
 #undef PROGRESSBAR_HEIGHT

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -27,6 +27,7 @@
 	for(var/mob/M in our_cells.get_type_members(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS))
 		if(M.client)
 			M.client.images |= bar
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(set_new_cells))
 
 	LAZYINITLIST(user.progressbars)
 	LAZYINITLIST(user.progressbars[bar.loc])
@@ -73,6 +74,7 @@
 	return ..()
 
 /datum/progressbar/proc/set_new_cells()
+	SIGNAL_HANDLER
 	var/turf/our_turf = get_turf(bar.loc)
 	if(isnull(our_turf))
 		return
@@ -87,6 +89,7 @@
 
 // we never remove these when clients exit, they all get cleaned up when the mob leaves
 /datum/progressbar/proc/on_client_enter(datum/source, mob/client_holder)
+	SIGNAL_HANDLER
 	if(!istype(client_holder) || !client_holder.client)
 		return
 	client_holder.client.images |= bar
@@ -94,6 +97,8 @@
 /datum/progressbar/proc/remove_from_clients()
 	for(var/client/C in GLOB.clients) // this is genuinely faster than tracking clients we've sent it to
 		C.images -= bar
+	if(bar?.loc)
+		UnregisterSignal(bar.loc, COMSIG_MOVABLE_MOVED, PROC_REF(set_new_cells))
 	bar = null
 
 #undef PROGRESSBAR_ANIMATION_TIME

--- a/code/modules/spatial_grid/cell_tracking.dm
+++ b/code/modules/spatial_grid/cell_tracking.dm
@@ -72,6 +72,19 @@
 
 	return list(new_members, former_members)
 
+
+/// Returns a list of spatial grid managed objects of type [type] in our tracked cells
+/datum/cell_tracker/proc/get_type_members(type)
+	. = list()
+	/// Pull out all the members we want
+	switch(type)
+		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
+			for(var/datum/spatial_grid_cell/cell as anything in member_cells)
+				. += cell.client_contents
+		if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
+			for(var/datum/spatial_grid_cell/cell as anything in member_cells)
+				. += cell.hearing_contents
+
 /// Recalculates our member list, returns a list in the form list(new members, old members) for reaction
 /// Accepts the turf to use as our "center"
 /datum/cell_tracker/proc/recalculate_cells(turf/center)


### PR DESCRIPTION
Instead of sending progress bars to mobs in view every single update call, we just send it once when created and to anyone who enters the range after. We don't remove it from people who exit either, because that's pointless since it's offscreen anyway. This is similar to #1488 but fixes some of the issues with that approach, like people walking onscreen.

Removes the bookkeeping to only remove it from tracked clients, `images += foo` is expensive because `foo` is an appearance that has to get sent to clients, `images -= foo` doesn't require sending anything so it should be cheaper. Besides, it happens once, as opposed to the `|=` that was happening EVERY UPDATE CALL.

Also removes atmos contents from the spatial grid system, we don't use them at all because we do not. HAVE. Atmos.

Demonstration of progress bars still working. I'm unable to test it with high player count conditions because obviously.
<img width="347" height="303" alt="5wveiHBZDf" src="https://github.com/user-attachments/assets/a5fc36c6-6672-4a92-8c73-d2f38ec1fe02" />

This needs a testmerge before it can be merged.