### PR TITLE
Oversight Fix, Eoran Bud Works on mask slot

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -20,7 +20,7 @@
 
 /obj/item/clothing/head/peaceflower/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
-	if(slot == SLOT_HEAD)
+	if(slot == SLOT_HEAD || slot = SLOT_MASK)
 		var/trait_given = user?.patron?.type == /datum/patron/divine/eora ? TRAIT_EORAN_CONTENTED : TRAIT_PACIFISM
 		ADD_TRAIT(user, trait_given, "peaceflower_[REF(src)]")
 		user.apply_status_effect(/datum/status_effect/buff/peaceflower)

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -20,7 +20,7 @@
 
 /obj/item/clothing/head/peaceflower/equipped(mob/living/carbon/human/user, slot)
 	. = ..()
-	if(slot == SLOT_HEAD || slot = SLOT_MASK)
+	if(slot == SLOT_HEAD || slot == SLOT_WEAR_MASK)
 		var/trait_given = user?.patron?.type == /datum/patron/divine/eora ? TRAIT_EORAN_CONTENTED : TRAIT_PACIFISM
 		ADD_TRAIT(user, trait_given, "peaceflower_[REF(src)]")
 		user.apply_status_effect(/datum/status_effect/buff/peaceflower)


### PR DESCRIPTION
## About The Pull Request

Makes Eoran Buds apply their buff in the mask slot

## Testing Evidence

yes

## Why It's Good For The Game

sacrificing mask protection (PLAP PLAP GET PEELED)

## Changelog


:cl:
fix: Eoran bud now works on mask slot
/:cl: