### PR TITLE
Remove the sensory effect system

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -607,25 +607,3 @@
 	if(!ckey || !istext(ckey))
 		return "some invalid"
 	return ckey
-
-/// Shows a sensory effect (IE: footstep, attack) to all mobs in range who are unconscious or blind.
-/proc/show_sensory_effect(atom/source, duration = 5, icon_state = "footstep", dir = null, ignore_self = FALSE)
-	var/turf/T = get_turf(source)
-	if (!isturf(T))
-		return FALSE
-
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(display_sensory_effect), source, T, duration, icon_state, dir, ignore_self), 0.5 SECONDS)
-
-/proc/display_sensory_effect(atom/source, turf/T, duration, icon_state, dir, ignore_self)
-	for(var/mob/living/M in hearers(7, T))
-		if(!M || (ignore_self && (M == source)))
-			continue
-
-		if(M.stat != UNCONSCIOUS && !is_blind(M)) // If the mob is not unconscious and not blind, we don't show the effect.
-			continue
-
-		var/image/I = image('icons/effects/fov/fov_effects.dmi', T, icon_state, SENSORY_LAYER)
-		I.plane = SENSORY_PLANE
-		if(dir)
-			I.dir = dir
-		flick_overlay(I, list(M.client), duration)

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -135,5 +135,3 @@
 		volume * used_volume,
 		do_vary,
 		used_extra_range + e_range)
-	if(ismovableatom(parent))
-		show_sensory_effect(parent, 5, "footstep", human_parent.dir, ignore_self = TRUE)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -775,7 +775,7 @@ GLOBAL_VAR_INIT(pixel_diff_time, 1)
 	animate(src, pixel_x = pixel_x + pixel_x_diff, pixel_y = pixel_y + pixel_y_diff, transform=rotated_transform, time = GLOB.pixel_diff_time, easing=LINEAR_EASING, flags = ANIMATION_PARALLEL)
 	animate(pixel_x = pixel_x - pixel_x_diff, pixel_y = pixel_y - pixel_y_diff, transform=initial_transform, time = GLOB.pixel_diff_time * 2, easing=SINE_EASING, flags = ANIMATION_PARALLEL)
 
-/atom/movable/proc/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect, item_animation_override = null, datum/intent/used_intent = null, simplified = FALSE, fov_effect = TRUE)
+/atom/movable/proc/do_attack_animation(atom/A, visual_effect_icon, obj/item/used_item, no_effect, item_animation_override = null, datum/intent/used_intent = null, simplified = FALSE)
 	if(used_item || !simplified)
 		var/animation_type = item_animation_override || used_intent?.get_attack_animation_type()
 		if(used_intent?.swingdelay)
@@ -787,8 +787,6 @@ GLOBAL_VAR_INIT(pixel_diff_time, 1)
 		else
 			do_item_attack_animation(A, visual_effect_icon, used_item, animation_type = animation_type, used_intent = used_intent)
 			return
-	if(fov_effect)
-		show_sensory_effect(A, 5, "attack")
 	wiggle(A)
 
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -68,7 +68,6 @@
 		shake_camera(user, recoil + 1, recoil)
 
 	playsound(user, fire_sound, fire_sound_volume, vary_fire_sound)
-	show_sensory_effect(user, 5, "gunfire", user.dir)
 	if(message)
 		user.visible_message("<span class='danger'>[user] shoots [src]!</span>", \
 						"<span class='danger'>I shoot [src]!</span>", \


### PR DESCRIPTION
It doesn't work well, doesn't work at all for blind characters unless their eyes are closed, and causes a bunch of lag. It's one of the top 5 items by self-cpu on the profiler, both the BYOND profiler and the Tracy one.