### PR TITLE
fixes a discrepancy that was making Wretches show as Heretics instead of Outlaws

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -88,7 +88,7 @@
 			H.change_stat("willpower", 1)
 			H.change_stat("speed", 1)
 			H.change_stat("fortune", 1)
-			if(bounty_poster == "The Justiciary of The Realm")
+			if(bounty_poster == "The Justiciary of [SSmapping.map_adjustment.realm_name]")
 				GLOB.outlawed_players += H.real_name
 			else
 				GLOB.excommunicated_players += H.real_name


### PR DESCRIPTION
## About The Pull Request

There was a typo I accidentally put in the code that determines what makes a wretch an Outlaw and it was instead defaulting to them being Heretics

## Testing Evidence

<img width="1084" height="558" alt="image" src="https://github.com/user-attachments/assets/509885fd-f8f1-4594-9205-5d5d81819cfe" />

## Why It's Good For The Game

bugfix

## Changelog

:cl:
fix: fixes wretches showing as Heretics when they should be Outlaws
/:cl:
