### PR TITLE
Optimize sound loops

### DIFF
--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(soundloopers)
 	var/client_ticker = 0
 
 /datum/controller/subsystem/soundloopers/fire(resumed = 0)
+	MC_SPLIT_TICK_INIT(2)
+	MC_SPLIT_TICK
 	if (!resumed || !currentrun.len)
 		src.currentrun = processing.Copy()
 
@@ -29,7 +31,7 @@ SUBSYSTEM_DEF(soundloopers)
 		if (!thing || !istype(thing) || QDELETED(thing))
 			processing -= thing
 			if (MC_TICK_CHECK)
-				return
+				break
 			continue
 
 		if(world.time > thing.starttime + thing.mid_length) //Make sure we don't try to trigger it while a loop is playing
@@ -37,43 +39,51 @@ SUBSYSTEM_DEF(soundloopers)
 				continue
 
 		if(check_clients && thing.persistent_loop)
-			for(var/client/C in GLOB.clients)
-				if(C.mob) //Not in the lobby
-					C.update_sounds()
+			var/turf/parent_turf = get_turf(thing.parent)
+			for(var/mob/M in get_hearers_in_range(world.view + thing.extra_range, parent_turf, SPATIAL_GRID_CONTENTS_TYPE_CLIENTS))
+				M.client?.update_persistent_sound_loop(thing)
 
 		if (MC_TICK_CHECK)
-			return
+			break
+
+	MC_SPLIT_TICK
+
+	if(check_clients)
+		for(var/client/C in GLOB.clients)
+			if(!C.mob)
+				continue // no lobby
+			C.update_sounds()
+			if (MC_TICK_CHECK)
+				break
+
+/client/proc/update_persistent_sound_loop(datum/looping_sound/PS)
+	if(PS in played_loops) //Make sure it's not already on the list
+		return
+
+	if((istype(PS, /datum/looping_sound/instrument) || istype(PS, /datum/looping_sound/musloop) || istype(PS, /datum/looping_sound/dmusloop)) && !(prefs?.toggles & SOUND_INSTRUMENTS))
+		return
+
+	if(!PS.parent)
+		return
+
+	var/turf/parent_turf = get_turf(PS.parent)
+	var/turf/mob_turf = get_turf(mob)
+	if(get_dist(get_turf(mob),parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
+		return
+
+	if(mob_turf.z - parent_turf.z > 2 || mob_turf.z - parent_turf.z < -2) //for some reason get_dist not checking this properly
+		return
+
+	//otherwise add it to the client loops and off we go from there
+	var/sound/our_sound = PS.cursound
+	if(!istype(our_sound)) //somehow it doesn't have a correct sound
+		our_sound = sound(our_sound)
+	if(!our_sound)
+		return //something fucked up and the loop has no cursound, wups. this should basically never happen
+
+	mob.playsound_local(parent_turf, PS.cursound, PS.volume, PS.vary, PS.frequency, PS.falloff, PS.channel, FALSE, our_sound, repeat = PS)
 
 /client/proc/update_sounds()
-
-	//First we need to periodically scan if we moved into range of an already-playing sound
-	for(var/datum/looping_sound/PS in GLOB.persistent_sound_loops)
-		if(PS in played_loops) //Make sure it's not already on the list
-			continue
-
-		if((istype(PS, /datum/looping_sound/instrument) || istype(PS, /datum/looping_sound/musloop) || istype(PS, /datum/looping_sound/dmusloop)) && !(prefs?.toggles & SOUND_INSTRUMENTS))
-			continue
-
-		if(!PS.parent)
-			continue
-
-		var/turf/parent_turf = get_turf(PS.parent)
-		var/turf/mob_turf = get_turf(mob)
-		if(get_dist(get_turf(mob),parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
-			continue
-
-		if(mob_turf.z - parent_turf.z > 2 || mob_turf.z - parent_turf.z < -2) //for some reason get_dist not checking this properly
-			continue
-
-		//otherwise add it to the client loops and off we go from there
-		var/sound/our_sound = PS.cursound
-		if(!istype(our_sound)) //somehow it doesn't have a correct sound
-			our_sound = sound(our_sound)
-		if(!our_sound)
-			continue //something fucked up and the loop has no cursound, wups. this should basically never happen
-
-		mob.playsound_local(parent_turf, PS.cursound, PS.volume, PS.vary, PS.frequency, PS.falloff, PS.channel, FALSE, our_sound, repeat = PS)
-
 	//Now we check how far away etc we are
 	for(var/datum/looping_sound/loop in played_loops)
 		if (!loop)

--- a/code/controllers/subsystem/rogue/soundloopers.dm
+++ b/code/controllers/subsystem/rogue/soundloopers.dm
@@ -54,11 +54,10 @@ SUBSYSTEM_DEF(soundloopers)
 		if((istype(PS, /datum/looping_sound/instrument) || istype(PS, /datum/looping_sound/musloop) || istype(PS, /datum/looping_sound/dmusloop)) && !(prefs?.toggles & SOUND_INSTRUMENTS))
 			continue
 
-		var/atom/PS_parent = PS.parent.resolve()
-		if(!PS_parent)
+		if(!PS.parent)
 			continue
 
-		var/turf/parent_turf = get_turf(PS_parent)
+		var/turf/parent_turf = get_turf(PS.parent)
 		var/turf/mob_turf = get_turf(mob)
 		if(get_dist(get_turf(mob),parent_turf) > world.view + PS.extra_range) //Too far away. get_dist shouldn't be too awful for repeated calcs
 			continue
@@ -96,7 +95,7 @@ SUBSYSTEM_DEF(soundloopers)
 					mob.stop_sound_channel(muted_sound.channel)
 			continue
 		
-		var/atom/loop_parent = loop.parent?.resolve()
+		var/atom/loop_parent = loop.parent
 		if(!loop_parent)
 			// Parent is gone — stale entry. Remove it so its old channel number
 			// can't corrupt volume-update packets sent to a recycled channel.

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	direct			(bool)					If true plays directly to provided atoms instead of from them
 */
 /datum/looping_sound
-	var/datum/weakref/parent // weakref to the atom we belong to
+	var/atom/parent // the atom we belong to
 	var/mid_sounds
 	var/mid_length = 1
 	var/start_sound
@@ -112,7 +112,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 		group.last_iter++
 		channel = picked_channel
 
-	parent = WEAKREF(_parent)
+	parent = _parent
 	direct = _direct
 
 	if(_channel)
@@ -184,18 +184,17 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	if(direct)
 		S.channel = channel
 		S.volume = volume
-	var/atom/thing = parent.resolve()
-	if (!thing)
+	if (!parent)
 		return
 
 	starttime = world.time
 
 	if(direct)
-		if(ismob(thing))
-			var/mob/mob = thing
+		if(ismob(parent))
+			var/mob/mob = parent
 			mob.playsound_local(mob, S, volume, vary, frequency, falloff, repeat = src, channel = channel)
 	else
-		var/list/R = playsound(thing, S, volume, vary, extra_range, falloff, frequency, channel, ignore_walls = ignore_walls, repeat = src)
+		var/list/R = playsound(parent, S, volume, vary, extra_range, falloff, frequency, channel, ignore_walls = ignore_walls, repeat = src)
 		if(!R || !R.len)
 			R = list()
 		for(var/datum/weakref/listener_ref in thingshearing)
@@ -254,8 +253,8 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	if(persistent_loop)
 		attach_loop_to_all_clients()
 	addtimer(CALLBACK(src, PROC_REF(begin_loop)), start_wait, TIMER_CLIENT_TIME)
-	if(persistent_loop && !(src in GLOB.persistent_sound_loops))
-		GLOB.persistent_sound_loops += src
+	if(persistent_loop)
+		GLOB.persistent_sound_loops |= src
 
 /datum/looping_sound/proc/attach_loop_to_all_clients()
 	if(!persistent_loop)
@@ -296,20 +295,15 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 					M.client.played_loops -= src
 					thingshearing -= listener_ref
 	else
-		var/mob/P = parent.resolve()
+		var/mob/P = parent
 		if(P && P.client)
 			P.stop_sound_channel(channel) //This is mostly used for weather
 
 /datum/looping_sound/proc/set_parent(new_parent)
-	var/atom/real_parent = parent.resolve()
-
-	if(real_parent)
-		UnregisterSignal(real_parent, COMSIG_PARENT_QDELETING)
+	if(parent)
+		UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
 	if(new_parent)
-		if(istype(new_parent, /datum/weakref)) // probably shouldn't happen but it does, so?
-			var/datum/weakref/passed_weakref = new_parent
-			new_parent = passed_weakref.resolve()
-		parent = WEAKREF(new_parent)
+		parent = new_parent
 		RegisterSignal(new_parent, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_del))
 
 /datum/looping_sound/proc/handle_parent_del(datum/source)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -189,8 +189,7 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 	if(!channel)
 		channel = _get_sound_group()?.checkout_channel()
 		if(!channel)
-			var/atom/resolved_parent = parent?.resolve()
-			log_game("INSTRUMENT: All [/datum/sound_group/instruments::channel_count] instrument channels in use simultaneously - [resolved_parent]")
+			log_game("INSTRUMENT: All [/datum/sound_group/instruments::channel_count] instrument channels in use simultaneously - [parent]")
 			return FALSE
 	..()
 	return TRUE

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -213,6 +213,8 @@
 			if("hear_instruments")
 				owner.prefs.toggles ^= SOUND_INSTRUMENTS
 				owner.prefs.save_preferences()
+				for(var/datum/looping_sound/persistent_loop in GLOB.persistent_sound_loops)
+					owner.update_persistent_sound_loop(persistent_loop)
 				owner.update_sounds()
 				owner.sync_instrument_audio_toggle()
 			if("animal_emotes")


### PR DESCRIPTION
Alternative to #1885. A lot of the work being done was redundant, so I split it up to avoid that redundancy. It currently loops over every persistent sound loop, and then loops over every client for each persistent loop, and then loops over every persistent loop for each client. That means 20 persistent sound loops and 100 players means 20 * 100 * 20 = 40000 loops every 5 ticks (so akin to 8k per tick), whereas this should only do 20 * 100=2000 every 5 ticks (more like 400 per tick).

Also makes looping sounds not use weakrefs, because we already unregister on parent qdel, so it's just a ton of wasted lookups.