### PR TITLE
Woe: Ducal colors upon ye

### DIFF
--- a/code/__HELPERS/cloaksetup.dm
+++ b/code/__HELPERS/cloaksetup.dm
@@ -26,16 +26,49 @@
 			allowed_cloaks = list(
 			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
 			"Tabard" = 			/obj/item/clothing/cloak/stabard/guard,
-			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood
-			)
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
 		if("Sergeant")
 			name_index = "sergeant"
 			allowed_cloaks = list(
 			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
 			"Tabard" = 			/obj/item/clothing/cloak/stabard/guard,
 			"Cape" = 			/obj/item/clothing/cloak/cape/guard,
-			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood
-			)
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
+		if("Vanguard")
+			name_index = "vanguard"
+			allowed_cloaks = list(
+			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
+			"Tabard" = 			/obj/item/clothing/cloak/stabard/guard,
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
+		if("Warden")
+			name_index = "warden"
+			allowed_cloaks = list(
+			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
+			"Tabard" = 			/obj/item/clothing/cloak/stabard/guard,
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
+		if("City Guard")
+			name_index = "city guard"
+			allowed_cloaks = list(
+			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
+			"Tabard" = 			/obj/item/clothing/cloak/stabard/guard,
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
+		if("Watch Captain")
+			name_index = "watch captain"
+			allowed_cloaks = list(
+			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
+			"Cape" = 			/obj/item/clothing/cloak/cape/guard,
+			"Long tabard" =		/obj/item/clothing/cloak/tabard/retinue,
+			"Short tabard" = 	/obj/item/clothing/cloak/stabard/guard,
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
+		if("Warden Master")
+			name_index = "warden master"
+			allowed_cloaks = list(
+			"Jupon" = 			/obj/item/clothing/cloak/stabard/surcoat/guard,
+			"Cape" = 			/obj/item/clothing/cloak/cape/guard,
+			"Long tabard" =		/obj/item/clothing/cloak/tabard/retinue,
+			"Short tabard" = 	/obj/item/clothing/cloak/stabard/guard,
+			"Guard hood" = 		/obj/item/clothing/cloak/stabard/guardhood)
+
 
 	var/choive_key = input(src, "Choose your cloak", "IDENTIFY YOURSELF") as anything in allowed_cloaks
 	var/typepath = allowed_cloaks[choive_key]

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -32,7 +32,7 @@
 /datum/outfit/job/roguetown/guardsman
 	job_bitflag = BITFLAG_GARRISON
 
-/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/townguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -32,18 +32,10 @@
 /datum/outfit/job/roguetown/guardsman
 	job_bitflag = BITFLAG_GARRISON
 
-/datum/job/roguetown/guardsman/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
-		var/mob/living/carbon/human/H = L
-		if(istype(H.cloak, /obj/item/clothing/cloak/citywatch))
-			var/obj/item/clothing/S = H.cloak
-			var/index = findtext(H.real_name, " ")
-			if(index)
-				index = copytext(H.real_name, 1,index)
-			if(!index)
-				index = H.real_name
-			S.name = "watchman halfcloak ([index])"
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
 
 /datum/outfit/job/roguetown/guardsman
 	neck = /obj/item/clothing/neck/roguetown/gorget

--- a/code/modules/jobs/job_types/roguetown/garrison/vanguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/vanguard.dm
@@ -32,10 +32,14 @@
 		/datum/advclass/vanguard/archer
 	)
 
+/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+
 /datum/outfit/job/roguetown/vanguard
 	backr = /obj/item/storage/backpack/rogue/satchel
 	head = /obj/item/clothing/head/roguetown/helmet/skullcap
-	cloak = /obj/item/clothing/cloak/shadowcloak
 	neck = /obj/item/clothing/neck/roguetown/chaincoif
 	gloves = /obj/item/clothing/gloves/roguetown/leather/black
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather

--- a/code/modules/jobs/job_types/roguetown/garrison/vanguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/vanguard.dm
@@ -32,7 +32,7 @@
 		/datum/advclass/vanguard/archer
 	)
 
-/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/vanguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -31,7 +31,7 @@
 		/datum/advclass/warden/forester
 	)
 
-/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/warden/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -31,9 +31,13 @@
 		/datum/advclass/warden/forester
 	)
 
+/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+
 /datum/outfit/job/roguetown/warden
 	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
-	cloak = /obj/item/clothing/cloak/wardencloak
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel

--- a/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
@@ -29,6 +29,11 @@
 		/datum/advclass/wardenmaster/wardenmaster
 	)
 
+/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+
 /datum/outfit/job/roguetown/wardenmaster
 	job_bitflag = BITFLAG_GARRISON
 

--- a/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
@@ -29,7 +29,7 @@
 		/datum/advclass/wardenmaster/wardenmaster
 	)
 
-/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/wardenmaster/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)

--- a/code/modules/jobs/job_types/roguetown/garrison/watchcaptain.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/watchcaptain.dm
@@ -30,7 +30,7 @@
 /datum/outfit/job/roguetown/watchcaptain
 	job_bitflag = BITFLAG_GARRISON
 
-/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+/datum/job/roguetown/watchcaptain/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)

--- a/code/modules/jobs/job_types/roguetown/garrison/watchcaptain.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/watchcaptain.dm
@@ -30,10 +30,14 @@
 /datum/outfit/job/roguetown/watchcaptain
 	job_bitflag = BITFLAG_GARRISON
 
+/datum/job/roguetown/manorguard/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
+	. = ..()
+	if(ishuman(L))
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+
 /datum/outfit/job/roguetown/watchcaptain
 	head = /obj/item/clothing/head/roguetown/helmet/citywatch
 	neck = /obj/item/clothing/neck/roguetown/bevor
-	cloak = /obj/item/clothing/cloak/citywatchcaptain
 	armor = /obj/item/clothing/suit/roguetown/armor/plate/citywatch
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 	belt = /obj/item/storage/belt/rogue/leather


### PR DESCRIPTION
## About The Pull Request

Makes vanguards, city guards, watch captain, wardens, and the master warden start with tabards of the ducal colors

## Testing Evidence

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/88313ecb-5260-49bf-a169-c3b554bd1796" />

## Why It's Good For The Game

In lore it makes sense for the duke to give their colors to the soldiers of their domain, even the lower ones. It makes it easier in combat to identify who is pro or anti-duchy.

## Changelog

:cl:
balance: all soldiers of the duchy now start with ducal colored tabards.
/:cl: