### PR TITLE
Makes Pickpocketing Not Utter Bullshit

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -15,7 +15,7 @@
 	if(!isnum(range_add))
 		range_add = 0
 	var/steal_radius = 1 + range_add
-	var/list/stealablezones = list("chest", "neck", "groin", "r_hand", "l_hand")
+	var/list/stealablezones = list("chest", "neck", "groin", "r_hand", "l_hand", "r_leg", "l_leg")
 	// Pickpocketting checks
 	if(get_dist(thief, victim) > steal_radius)
 		to_chat(thief, span_warning("[victim] is too far away."))
@@ -43,7 +43,7 @@
 	var/list/mobsbehind = list()
 	var/exp_to_gain = thief.STAINT
 	to_chat(thief, span_notice("I try to steal from [victim]..."))	
-	if(!do_after(thief, 5, target = victim, progress = 0))
+	if(!do_after(thief, 1 SECONDS, target = victim, progress = 0))
 		return
 	// Pickpocketting checks after the channel in case something changed
 	if(get_dist(thief, victim) > steal_radius)
@@ -71,15 +71,26 @@
 					if (victim.get_item_by_slot(SLOT_NECK))
 						stealpos.Add(victim.get_item_by_slot(SLOT_NECK))
 				if("groin")
-					if (victim.get_item_by_slot(SLOT_BELT_R))
-						stealpos.Add(victim.get_item_by_slot(SLOT_BELT_R))
+					if (victim.get_item_by_slot(SLOT_BELT))
+						stealpos.Add(victim.get_item_by_slot(SLOT_BELT))
+				if("l_leg")
 					if (victim.get_item_by_slot(SLOT_BELT_L))
 						stealpos.Add(victim.get_item_by_slot(SLOT_BELT_L))
+				if("r_leg")
+					if (victim.get_item_by_slot(SLOT_BELT_R))
+						stealpos.Add(victim.get_item_by_slot(SLOT_BELT_R))
 				if("r_hand", "l_hand")
 					if (victim.get_item_by_slot(SLOT_RING))
 						stealpos.Add(victim.get_item_by_slot(SLOT_RING))
 			if(length(stealpos) > 0)
 				var/obj/item/picked = pick(stealpos)
+				if(istype(picked,/obj/item/storage))
+					var/obj/item/storage/container = picked
+					var/datum/component/storage/STR = container.GetComponent(/datum/component/storage)
+					var/list/stuff = STR.contents()
+					if(stuff.len > 0)
+						picked = pick(stuff)
+						STR.remove_from_storage(picked, get_turf(victim))
 				victim.dropItemToGround(picked)
 				thief.put_in_active_hand(picked)
 				to_chat(thief, span_green("I stole [picked]!"))


### PR DESCRIPTION
## About The Pull Request

pickpocketing a storage item now picks a random item from within to steal, instead of yoinking the whole container
increased pickpocketing delay from 0.5 secs to 1 second.
belts are now pickpocketing targets, by targetting groin
pickpocketing hip slots is now done by targeting the legs.

## Testing Evidence

<img width="325" height="430" alt="image" src="https://github.com/user-attachments/assets/5f2a5100-e6a2-4d96-abee-acc2a8d04f22" />
<img width="305" height="111" alt="image" src="https://github.com/user-attachments/assets/8371f140-82d2-45d4-8470-789c59d6529d" />


## Why It's Good For The Game

having your whole fucking satchel with your literal Everything is BULLSHIT.

## Changelog

:cl:
balance: Pickpocketing storaget items will now pick a random item from within it to steal.
balance: Belts are now pickpocketing targets, by targeting groin. Hip slots are leg targets.
balance: Pickpocketing delay increased from 0.5 seconds to 1 second.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
