### PR TITLE
[TM ONLY] Remove update_body_parts_head_only

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/licker.dm
@@ -54,7 +54,6 @@
 /datum/reagent/vampsolution/on_mob_metabolize(mob/living/M, mob/living/S)
 	M.overlay_fullscreen("druqk", /atom/movable/screen/fullscreen/druqks)
 	M.set_drugginess(30)
-	M.update_body_parts_head_only()
 	if(M.client)
 		ADD_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.area_entered(get_area(M), M.client)
@@ -66,4 +65,3 @@
 	if(M.client)
 		REMOVE_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.play_area_sound(get_area(M), M.client)
-	M.update_body_parts_head_only()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -2083,44 +2083,12 @@ generate/load female uniform sprites matching all previously decided variables
 /mob/proc/update_body_parts_head_only()
 	return
 
+
 // Only renders the head of the human
+// TEMPORARILY REPLACED, this proc didn't properly use the overlays system
+// and also doesn't use the limb icon cache.
 /mob/living/carbon/human/update_body_parts_head_only()
-	if (!dna)
-		return
-
-	if (!dna.species)
-		return
-
-	var/obj/item/bodypart/HD = get_bodypart("head")
-
-	if (!istype(HD))
-		return
-
-	testing("ehadonly [src]")
-	HD.update_limb()
-
-	add_overlay(HD.get_limb_icon())
-	update_damage_overlays()
-
-	if(HD && !(HAS_TRAIT(src, TRAIT_HUSK)))
-
-		// lipstick
-		if(lip_style && (LIPS in dna.species.species_traits))
-			var/mutable_appearance/lip_overlay = mutable_appearance('icons/mob/human_face.dmi', "lips_[lip_style]", -BODY_LAYER)
-			lip_overlay.color = lip_color
-			if(gender == FEMALE)
-				if(OFFSET_FACE_F in dna.species.offset_features)
-					lip_overlay.pixel_x += dna.species.offset_features[OFFSET_FACE_F][1]
-					lip_overlay.pixel_y += dna.species.offset_features[OFFSET_FACE_F][2]
-			else
-				if(OFFSET_FACE in dna.species.offset_features)
-					lip_overlay.pixel_x += dna.species.offset_features[OFFSET_FACE][1]
-					lip_overlay.pixel_y += dna.species.offset_features[OFFSET_FACE][2]
-			add_overlay(lip_overlay)
-
-	update_inv_head()
-	update_inv_wear_mask()
-	update_inv_mouth()
+	return update_body_parts()
 
 /mob/living/carbon/proc/has_boobed_overlay()
 	var/obj/item/organ/breasts/boobs = getorganslot(ORGAN_SLOT_BREASTS)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -24,7 +24,6 @@
 
 /datum/reagent/drug/space_drugs/on_mob_end_metabolize(mob/living/M)
 	M.clear_fullscreen("weedsm")
-	M.update_body_parts_head_only()
 
 /*
 	if(M.client)
@@ -34,7 +33,6 @@
 /datum/reagent/drug/space_drugs/on_mob_metabolize(mob/living/M)
 	..()
 	M.set_drugginess(30)
-	M.update_body_parts_head_only()
 	M.overlay_fullscreen("weedsm", /atom/movable/screen/fullscreen/weedsm)
 
 /*

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -61,7 +61,6 @@
 /datum/reagent/druqks/on_mob_metabolize(mob/living/M)
 	M.overlay_fullscreen("druqk", /atom/movable/screen/fullscreen/druqks)
 	M.set_drugginess(30)
-	M.update_body_parts_head_only()
 	if(M.client)
 		ADD_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.area_entered(get_area(M), M.client)
@@ -76,7 +75,6 @@
 	if(M.client)
 		REMOVE_TRAIT(M, TRAIT_DRUQK, "based")
 		SSdroning.play_area_sound(get_area(M), M.client)
-	M.update_body_parts_head_only()
 //		if(M.client.screen && M.client.screen.len)
 ///			var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/game_world) in M.client.screen
 //			PM.backdrop(M.client.mob)
@@ -488,7 +486,6 @@
 	M.remove_status_effect(/datum/status_effect/buff/herozium)
 	if(M.client)
 		SSdroning.play_area_sound(get_area(M), M.client)
-	M.update_body_parts_head_only()
 
 /datum/reagent/herozium/overdose_process(mob/living/M)
 	if(prob(30))

--- a/code/modules/roguetown/roguemachine/heartbeast/heart_component.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_component.dm
@@ -1,3 +1,4 @@
+// why does this use a component, it should be on the heart beast type, this is dumb
 /datum/component/chimeric_heart_beast
 	var/obj/structure/roguemachine/chimeric_heart_beast/heart_beast
 	var/base_blood_output = 1
@@ -199,7 +200,7 @@
 
 /datum/component/chimeric_heart_beast/proc/update_blood_overlay()
 	var/blood_percent = blood_pool / max_blood_pool
-	heart_beast.cut_overlay("blood_pool")
+	heart_beast.cut_overlays()
 
 	var/chunk = round(blood_percent * 5) // This gives us 0-5
 	if(chunk >= 1)


### PR DESCRIPTION
Replaces `update_body_parts_head_only()` with `update_body()` temporarily. UBPHO doesn't use the limb cache, it doesn't get queued, it doesn't properly use apply_overlay or remove_overlay, it's just bad overall, boo, we don't like you, go home.

Also, removes those calls entirely from reagents, these don't modify your head icon so they shouldn't be called at all. It's probably just a holdover from a time where they did, and people copied the space drugs code not knowing why those lines existed.

Based on https://github.com/tgstation/tgstation/pull/89015, except our issue isn't from blinking, it's from space drugs. It's probably even worse for us given the limb cache and queueing.