### PR TITLE
Nerf human NPC processing

### DIFF
--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(pathfinder)
 	var/datum/flowcache/circuits
 
 /datum/controller/subsystem/pathfinder/Initialize()
-	mobs = new(20)
+	mobs = new(10)
 	circuits = new(3)
 	return ..()
 

--- a/code/controllers/subsystem/rogue/humannpc.dm
+++ b/code/controllers/subsystem/rogue/humannpc.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(humannpc)
 	name = "humannpc"
 	wait = 1 SECONDS
 	flags = SS_KEEP_TIMING
-	priority = 50
+	priority = FIRE_PRIORITY_NPC_ACTIONS
 	var/list/processing = list()
 	var/list/currentrun = list()
 	processing_flag = PROCESSING_HUMANNPC


### PR DESCRIPTION
We now have a max of 10 pathfinders at a time for mobs, rather than 20. I might actually make this even lower and increase humanNPC processing rate, because that will make ongoing movement/fighting faster while avoiding the excessive pathfinding lag.

Also, the human NPC subsystem runs at a lower priority now. It shouldn't be starving anything else for tick time.