### PR TITLE
[TM ONLY] Make human limb icon cacheing actually work

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -57,12 +57,6 @@ There are several things that need to be remembered:
 			jazz += 2
 	return jazz
 
-//HAIR OVERLAY
-/mob/living/carbon/human/update_hair()
-	rebuild_obscured_flags()
-	update_body_parts(TRUE)
-	return
-
 /mob/living/carbon/human/update_body()
 	var/obj/item/bodypart/head/HD = get_bodypart(BODY_ZONE_HEAD)
 	var/new_cache_key = "[HD ? HD.skeletonized : "nohead"]|[HAS_TRAIT(src, TRAIT_HUSK)]|[lip_style]|[lip_color]|[gender]|[dna?.species?.hairyness]|[hair_color]"
@@ -926,7 +920,7 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/update_inv_wear_suit()
 	rebuild_obscured_flags()
-	update_body_parts(TRUE)
+	update_body()
 	return
 /*
 	remove_overlay(ARMOR_LAYER)
@@ -979,7 +973,6 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_wear_mask()
 	defer_overlay_vision_updates()
 	..()
-	update_body_parts(TRUE)
 	var/mutable_appearance/mask_overlay = overlays_standing[MASK_LAYER]
 	if(mask_overlay)
 		rebuild_obscured_flags()
@@ -995,6 +988,7 @@ There are several things that need to be remembered:
 		overlays_standing[MASK_LAYER] = mask_overlay
 		apply_overlay(MASK_LAYER)
 	resume_overlay_vision_updates()
+	update_body()
 
 /mob/living/carbon/human/update_inv_back(hide_experimental = FALSE)
 	queue_icon_update(PENDING_UPDATE_INV_BACK)
@@ -1282,7 +1276,6 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_inv_shirt_real()
 	remove_overlay(SHIRT_LAYER)
 	remove_overlay(SHIRTSLEEVE_LAYER)
-	update_body_parts(TRUE)
 
 	var/obj/item/bodypart/taur/taur = get_taur_tail()
 	var/icon/c_mask = taur?.clip_mask
@@ -1370,10 +1363,7 @@ There are several things that need to be remembered:
 				overlays_standing[SHIRTSLEEVE_LAYER] = sleeves
 
 	rebuild_obscured_flags()
-	if(gender == FEMALE && dna?.species)
-		update_body_parts(redraw = TRUE)
-		dna.species.handle_body(src)
-	update_hair()
+	update_body() // handles dna.species.handle_body() and update_body_parts() for us
 	// Note: wrists will update gloves in its own update
 
 	apply_overlay(SHIRT_LAYER)
@@ -1480,10 +1470,7 @@ There are several things that need to be remembered:
 				overlays_standing[ARMORSLEEVE_LAYER] = sleeves
 
 	rebuild_obscured_flags()
-	if(gender == FEMALE && dna?.species)
-		update_body_parts(redraw = TRUE)
-		dna.species.handle_body(src)
-	update_hair()
+	update_body()
 	update_inv_shirt() // fix boob
 
 	apply_overlay(ARMOR_LAYER)
@@ -1559,7 +1546,7 @@ There are several things that need to be remembered:
 				overlays_standing[LEGSLEEVE_LAYER] = sleeves
 
 	rebuild_obscured_flags()
-	update_hair()
+	update_body()
 	apply_overlay(PANTS_LAYER)
 	apply_overlay(LEGSLEEVE_LAYER)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -2036,12 +2036,6 @@ generate/load female uniform sprites matching all previously decided variables
 		. += "husk"
 	return jointext(., "-")
 
-/mob/living/carbon/human/load_limb_from_cache()
-	..()
-	update_hair()
-
-
-
 /mob/living/carbon/human/proc/update_observer_view(obj/item/I, inventory)
 	if(observers && observers.len)
 		for(var/M in observers)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -692,6 +692,11 @@ There are several things that need to be remembered:
 	apply_overlay(BELT_LAYER)*/
 	return
 
+//HAIR OVERLAY
+// NOTE Q2 2026 - REMOVE AND REPLACE WITH UPDATE_BODY EVENTUALLY
+/mob/living/carbon/human/update_hair()
+	rebuild_obscured_flags()
+	update_body()
 
 /mob/living/carbon/human/update_inv_head(hide_nonstandard = FALSE)
 	update_inv_head_real(hide_nonstandard)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -2003,19 +2003,7 @@ generate/load female uniform sprites matching all previously decided variables
 	. += obscured_flags
 
 	for(var/obj/item/bodypart/BP as anything in bodyparts)
-		. += BP.body_zone
-		. += (BP.status == BODYPART_ORGANIC) ? "organic" : "robotic"
-		switch(BP.use_digitigrade)
-			if(FULL_DIGITIGRADE)
-				. += "digitigrade_full"
-			if(SQUISHED_DIGITIGRADE)
-				. += "digitigrade_squashed"
-		if(BP.rotted)
-			. += "rotted"
-		if(BP.skeletonized)
-			. += "skeletonized"
-		if(BP.dmg_overlay_type)
-			. += BP.dmg_overlay_type
+		. += BP.generate_limb_cache_key()
 
 	if(HAS_TRAIT(src, TRAIT_HUSK))
 		. += "husk"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -60,13 +60,10 @@ There are several things that need to be remembered:
 /mob/living/carbon/human/update_body()
 	var/obj/item/bodypart/head/HD = get_bodypart(BODY_ZONE_HEAD)
 	var/new_cache_key = "[HD ? HD.skeletonized : "nohead"]|[HAS_TRAIT(src, TRAIT_HUSK)]|[lip_style]|[lip_color]|[gender]|[dna?.species?.hairyness]|[hair_color]"
-
-	if(body_overlay_cache_key == new_cache_key)
-		return
-	body_overlay_cache_key = new_cache_key
-
-	dna.species.handle_body(src)
-	..()
+	if(body_overlay_cache_key != new_cache_key)
+		dna.species.handle_body(src)
+		body_overlay_cache_key = new_cache_key
+	..() // always do update_body_parts when we call this
 
 #define SUNDER_FILTER "sunder_filter"
 
@@ -2003,6 +2000,7 @@ generate/load female uniform sprites matching all previously decided variables
 
 	. += gender
 	. += age
+	. += obscured_flags
 
 	for(var/obj/item/bodypart/BP as anything in bodyparts)
 		. += BP.body_zone

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -570,7 +570,6 @@
 		. += "husk"
 	return jointext(., "-")
 
-
 //change the mob's icon to the one matching its key
 /mob/living/carbon/proc/load_limb_from_cache()
 	if(limb_icon_cache[icon_render_key])

--- a/code/modules/mob/update_icons.dm
+++ b/code/modules/mob/update_icons.dm
@@ -47,6 +47,7 @@
 	return
 
 /mob/proc/update_hair()
+	// TODO: COMPLETELY REMOVE THIS PROC AND ALL CASES WHERE IT'S CALLED
 	return
 
 /mob/proc/update_fire()

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -611,6 +611,9 @@
 /// Generates a cache key for this limb's base appearance
 /obj/item/bodypart/proc/generate_limb_cache_key(dropped, hideaux)
 	var/list/key_parts = list(
+		type,
+		icon,
+		species_icon,
 		body_zone,
 		body_gender,
 		dropped,
@@ -709,7 +712,6 @@
 			if(marking_overlays)
 				. += marking_overlays
 
-	// These are not cached as they can change independently
 	var/draw_organ_features = TRUE
 	var/draw_bodypart_features = TRUE
 	if(owner?.dna?.species)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -632,6 +632,28 @@
 		skin_tone,
 		limb_material
 	)
+	// todo: cache these on the bodypart and update in set_species
+	var/draw_organ_features = TRUE
+	var/draw_bodypart_features = TRUE
+	if(owner?.dna?.species)
+		var/datum/species/owner_species = owner.dna.species
+		if(NO_ORGAN_FEATURES in owner_species.species_traits)
+			draw_organ_features = FALSE
+		if(NO_BODYPART_FEATURES in owner_species.species_traits)
+			draw_bodypart_features = FALSE
+	// Organ overlays
+	if(!skeletonized && draw_organ_features)
+		// i don't know if this will actually work since these aren't sorted?
+		for(var/obj/item/organ/organ as anything in get_organs())
+			if(organ.is_visible())
+				var/extra_keys = organ.get_icon_cache_key(src)
+				key_parts += extra_keys
+
+	if(!skeletonized && draw_bodypart_features)
+		for(var/datum/bodypart_feature/feature as anything in bodypart_features)
+			var/extra_keys = feature.get_icon_cache_key(src)
+			if(extra_keys)
+				key_parts += extra_keys
 	return key_parts.Join("-")
 
 /// Invalidates the cached limb appearance

--- a/code/modules/surgery/bodyparts/bodypart_features/_bodypart_feature.dm
+++ b/code/modules/surgery/bodyparts/bodypart_features/_bodypart_feature.dm
@@ -10,6 +10,12 @@
 	/// Slot of the bodypart feature
 	var/feature_slot
 
+/datum/bodypart_feature/proc/get_icon_cache_key(obj/item/bodypart/bodypart)
+	return jointext(list(
+		accessory_type,
+		accessory_colors
+	), "-")
+
 /// Proc to customize the base icon of the organ.
 /datum/bodypart_feature/proc/bodypart_icon(mutable_appearance/standing)
 	return

--- a/code/modules/surgery/bodyparts/taur.dm
+++ b/code/modules/surgery/bodyparts/taur.dm
@@ -61,6 +61,24 @@
 	if(clip_mask_legs_state)
 		clip_mask_legs = icon(icon = (clip_mask_icon || icon), icon_state = clip_mask_legs_state)
 
+/obj/item/bodypart/taur/generate_limb_cache_key(dropped, hideaux)
+	. = ..()
+	. += jointext(list(
+		taur_icon_state,
+		taur_markings_state,
+		taur_tertiary_state,
+		has_taur_color,
+		color_blend_mode,
+		taur_color,
+		taur_markings,
+		taur_tertiary,
+		taur_clothing_category,
+		tasset1_color,
+		tasset2_color,
+		clip_mask_icon,
+		clip_mask_state,
+		clip_mask_legs_state), "-")
+
 /obj/item/bodypart/taur/get_limb_icon(dropped, hideaux = FALSE)
 	// List of overlays
 	. = list()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -328,6 +328,16 @@
 		bodypart_overlays(organ_overlay)
 		return organ_overlay
 
+/obj/item/organ/proc/get_icon_cache_key(obj/item/bodypart/bodypart)
+	return jointext(list(
+		bodypart_icon,
+		bodypart_icon_state,
+		bodypart_layer,
+		color,
+		accessory_type,
+		accessory_colors
+	), "-")
+
 /// Proc to customize the base icon of the organ.
 /obj/item/organ/proc/bodypart_icon(mutable_appearance/standing)
 	return


### PR DESCRIPTION
EXTREMELY EXPERIMENTAL, MAY BREAK THINGS

Previously the icon cache was entirely redundant, for reasons you can see here. Trying to just naively re-enable it meant a bunch of bodypart features were broken, and that took a while to fix.

This will make icon cache keys for our sort of very-complex human mobs very long. That might not be worth it at highpop, it's really, REALLY hard to tell. I'd like to maybe try testing this on the secondary server to ensure nothing breaks, but literally no one plays it...