### PR TITLE
Virtue Restriction Fixing, Lunacy Embracer Virtue Restriction, TRAIT_RITUALIST to select LE Patrons

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -175,6 +175,11 @@
 		if(total_slots_occupied >= maximum_possible_slots)
 			return FALSE
 
+	if(length(virtue_restrictions) && H.client)
+	for(var/virtuetype in virtue_restrictions)
+		if(istype(H.client.prefs?.virtue, virtuetype) || istype(H.client.prefs?.virtuetwo, virtuetype))
+			return FALSE
+
 	#ifdef USES_PQ
 	if(min_pq != -100) // If someone sets this we actually do the check.
 		if(!(get_playerquality(H.client.ckey) >= min_pq))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -176,9 +176,9 @@
 			return FALSE
 
 	if(length(virtue_restrictions) && H.client)
-	for(var/virtuetype in virtue_restrictions)
-		if(istype(H.client.prefs?.virtue, virtuetype) || istype(H.client.prefs?.virtuetwo, virtuetype))
-			return FALSE
+		for(var/virtuetype in virtue_restrictions)
+			if(istype(H.client.prefs?.virtue, virtuetype) || istype(H.client.prefs?.virtuetwo, virtuetype))
+				return FALSE
 
 	#ifdef USES_PQ
 	if(min_pq != -100) // If someone sets this we actually do the check.

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -27,7 +27,9 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/music = SKILL_LEVEL_NOVICE,
 	)
-	
+
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)
@@ -83,7 +85,9 @@
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 	)
-	
+
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -33,6 +33,8 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -82,6 +82,8 @@
 		H.adjust_skillrank_up_to(/datum/skill/craft/cooking, SKILL_LEVEL_MASTER, TRUE) // holy shit they can COOK
 		ADD_TRAIT(H, TRAIT_GOODLOVER, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_ALCHEMY_EXPERT, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)//please don't let me regret doing this
+		H.put_in_hands(new /obj/item/ritechalk(H))
 	// if(H.patron?.type == /datum/patron/divine/astrata) I'm too lasy to ban Astratan LE but I'm certainly not dumb enough to give them +1 holy
 	//	H.adjust_skillrank(/datum/skill/magic/holy, 1, TRUE)
 	if(H.patron?.type == /datum/patron/divine/dendor)
@@ -112,6 +114,8 @@
 	if(H.patron?.type == /datum/patron/divine/eora)
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
+		H.put_in_hands(new /obj/item/ritechalk(H))
 	if(H.patron?.type == /datum/patron/divine/malum) // lol, lmao
 		H.adjust_skillrank_up_to(/datum/skill/craft/blacksmithing, SKILL_LEVEL_NOVICE, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/craft/armorsmithing, SKILL_LEVEL_NOVICE, TRUE)
@@ -123,7 +127,7 @@
 		H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, SKILL_LEVEL_NOVICE, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/music, SKILL_LEVEL_NOVICE, TRUE)
-		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC) //please, god, be funny
 		H.put_in_hands(new /obj/item/ritechalk(H))
 	// -- End of section for god specific bonuses --
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/lunacyembracer.dm
@@ -23,14 +23,13 @@
 		TRAIT_CALTROPIMMUNE,
 		TRAIT_LONGSTRIDER,
 		TRAIT_OUTDOORSMAN,
-		TRAIT_WOODSMAN
+		TRAIT_WOODSMAN,
 	)
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_CON = 2,
 		STATKEY_WIL = 2,
 		STATKEY_SPD = 2,
-		STATKEY_LCK = 2,
 		STATKEY_INT = -2,
 		STATKEY_PER = -2
 	)
@@ -55,8 +54,14 @@
 		/datum/skill/magic/holy = SKILL_LEVEL_JOURNEYMAN,
 	)
 
+	extra_context = "This class is restricted from using the Natural Armor virtue."
+
+	virtue_restrictions = list(
+		/datum/virtue/combat/tough_hide,
+	)
+
 /datum/outfit/job/roguetown/wretch/lunacyembracer/pre_equip(mob/living/carbon/human/H)
-	// -- Start of section for god specific bonuses --
+	// -- Start of section for god specific bonuses --	
 	if(H.patron?.type == /datum/patron/inhumen/graggar)
 		ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC) //no athletics for you
@@ -83,6 +88,8 @@
 	//	H.adjust_skillrank(/datum/skill/labor/farming, 1, TRUE) LE already has master farming for some reason? I'm not going to add to it.
 		H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 		H.grant_language(/datum/language/beast) //dendor antags can talk to WWs and druids
+		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
+		H.put_in_hands(new /obj/item/ritechalk(H))
 	if(H.patron?.type == /datum/patron/divine/noc)
 		H.adjust_skillrank_up_to(/datum/skill/misc/reading, SKILL_LEVEL_JOURNEYMAN, TRUE) // Really good at reading... almost actually useful for LE.
 		H.adjust_skillrank_up_to(/datum/skill/craft/alchemy, SKILL_LEVEL_EXPERT, TRUE)
@@ -92,6 +99,8 @@
 		H.adjust_skillrank_up_to(/datum/skill/labor/fishing, SKILL_LEVEL_MASTER, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/swimming, SKILL_LEVEL_EXPERT, TRUE)
 		ADD_TRAIT(H, TRAIT_WATERBREATHING, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
+		H.put_in_hands(new /obj/item/ritechalk(H))
 	if(H.patron?.type == /datum/patron/divine/necra)
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_SOUL_EXAMINE, TRAIT_GENERIC)
@@ -114,6 +123,8 @@
 		H.adjust_skillrank_up_to(/datum/skill/misc/climbing, SKILL_LEVEL_EXPERT, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/lockpicking, SKILL_LEVEL_NOVICE, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/misc/music, SKILL_LEVEL_NOVICE, TRUE)
+		ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)
+		H.put_in_hands(new /obj/item/ritechalk(H))
 	// -- End of section for god specific bonuses --
 
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_champion.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_champion.dm
@@ -30,6 +30,8 @@
 		/datum/skill/misc/tracking = SKILL_LEVEL_APPRENTICE,
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
@@ -31,6 +31,8 @@
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/cavalry.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/cavalry.dm
@@ -32,6 +32,8 @@
 		/datum/skill/misc/tracking = SKILL_LEVEL_JOURNEYMAN,	//Best tracker. Might as well give it something to stick-out utility wise.
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/steppesman.dm
@@ -24,6 +24,8 @@
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/vaquero.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/vaquero.dm
@@ -30,6 +30,8 @@
 		/datum/skill/misc/music = SKILL_LEVEL_EXPERT,
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -30,6 +30,10 @@
 		/datum/advclass/captain/infantry
 	)
 
+	virtue_restrictions = list(
+		/datum/virtue/utility/riding,
+	)
+
 /datum/outfit/job/roguetown/captain
 	head = /obj/item/clothing/head/roguetown/helmet/heavy/captain
 	neck = /obj/item/clothing/neck/roguetown/bevor
@@ -102,9 +106,6 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
 	)
 
-	virtue_restrictions = list(
-		/datum/virtue/utility/riding
-	)
 	extra_context = "This class gains Master skill in their weapon of choice."
 
 /datum/outfit/job/roguetown/captain/infantry/pre_equip(mob/living/carbon/human/H)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/goatherd.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/goatherd.dm
@@ -21,6 +21,8 @@
 		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
 	)
 
+	extra_context = "This class is restricted from using the Equestrian virtue."
+
 	virtue_restrictions = list(
 		/datum/virtue/utility/riding
 	)


### PR DESCRIPTION


## About The Pull Request

This one's a doozy.

First off, properly implements an attempt to add `virtue_restrictions`, allowing advclasses to be restricted based on virtues, in the same way they can be restricted based on race (removing them from selection entirely).

Then does so by incorporating some intended advclass restrictions based on equestrian, notably roles that already get access to the virtue innately, as well as adding a virtue restriction to Lunacy Embracer to prevent the use of Natural Armor.

This goes hand in hand with the other nerf to the role, removing its far-over-the-average stat total by stripping it of +2 FOR, which permitted taking (and still does) permit the predominant statpack choice of Struggler on the role.

In return, Dendor, Abyssor, and Xylixian LEs are getting access to `TRAIT_RITUALIST`, and the chalk to use them.

## Testing Evidence

<img width="400" height="100
/" alt="K1nGjdd7oY" src="https://github.com/user-attachments/assets/fd7f831e-d208-4206-aab1-fd70a2cd711c" />
<img width="123" height="177" alt="fpDaAcpTFS" src="https://github.com/user-attachments/assets/6be619df-ae1f-40c4-9a45-910e73dff061" />
<img width="179" height="96" alt="QqdmGR7n8i" src="https://github.com/user-attachments/assets/e7e49fda-b99a-4323-acab-36b472e7aa50" />
<img width="175" height="14" alt="MyXhLJjoBl" src="https://github.com/user-attachments/assets/243f580e-a577-4799-bc73-7e76778ec31c" />
<img width="162" height="87" alt="dreamseeker_zAtkvInx6m" src="https://github.com/user-attachments/assets/709f0956-bd92-43a9-8303-3fd7264bb6cf" />

## Why It's Good For The Game

Originally, LE was *supposed* to be implemented with changes to begin with, but it was not, so here's some of them. I was  going to go through with the slated patron locks on the LE, but have decided against it for now, since the original scope of this was simply to nip a recurring trend of how the role is used in the bud.

The role as a whole was intentionally statted in such a way that Struggler (and its adjacent packs) are by and far some of the best options for it when picked alongside a virtue that did not exist or conceptually exist in its original inception. It disobeys the stat weighting every other wretch has, with its 'drawback' stats being ones it cares utterly little about to begin with, as its typical gameplan for engagements that involve combat is to remove the need for feinting or accuracy altogether.

In return, I want to encourage LEs that play off of their nature as wildmen, freaks, outcasts. Dendor, Abyssor, and *to some degree*, Xylix fit the bill, so I'm giving them `TRAIT_RITUALIST` and the chalk to use it. If it turns out okay, maybe a curated list of access to rituals could be implemented for other patrons. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Properly implemented a way to restrict advclasses based on virtue selection
code: Adjusted the layout of existing virtue_restrictions on advclasses that had it
code: Implemented some context descriptions for existing class previews that have virtue restrictions on subclasses
balance: Removed access to Natural Armor virtue on Lunacy Embracers
balance: Removed +2 FOR from Lunacy Embracers stat block
balance: Added TRAIT_RITUALIST to Dendor, Abyssor, Xylix Lunacy Embracers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
