### PR TITLE
Invalid Accent Runtime Fix

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3287,7 +3287,11 @@ Slots: [job.spawn_positions] [job.round_contrib_points ? "RCP: +[job.round_contr
 		character.update_hair()
 		character.update_body_parts(redraw = TRUE)
 
-	character.char_accent = char_accent
+	if (character.char_accent in GLOB.character_accents)
+		character.char_accent = char_accent
+	else
+		char_accent = "No accent"
+		character.char_accent = char_accent
 
 	if(culinary_preferences)
 		apply_culinary_preferences(character)


### PR DESCRIPTION
## About The Pull Request

Currently, if a character has an accent set in their save file that is invalid- be it through admin shenanigans or via accents getting removed from the code (e.g. SCUM accent, Valley accent)- and the accent selection is unchanged by the player following the removal, the character will create a few runtimes whenever they speak, as the game tries to look up the corresponding accent files and finds all of them to not exist.

This PR adds a simple if-else to the logic that assigns characters their accent when they spawn in. If their selection is valid, let them spawn with it normally. If it's invalid (not in the global list of accents), then give them no accent.

## Testing Evidence

This was tested both with a character spawning in with a valid accent, and a character spawning in with an invalid accent. Both cases worked as expected.

<img width="1201" height="725" alt="dreamseeker_2026-06-18_11-26-27" src="https://github.com/user-attachments/assets/2b452eb3-8947-44a6-b504-55be6dee5c06" />
<img width="1194" height="708" alt="dreamseeker_2026-06-18_11-28-11" src="https://github.com/user-attachments/assets/2e4a7321-2283-4655-8d37-21bab9212340" />


## Why It's Good For The Game

Less runtimes good. This could also have been addressed by directly modifying the save files of affected players (or asking them to modify it themselves), but this is less intrusive and also future-proofs in case we remove or rename any other existing accents.
