### PR TITLE
Make Zizite Knight Migrant able to properly train their squire. 

### DIFF
--- a/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
+++ b/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
@@ -110,7 +110,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/boots/blacksteel/modern/plateboots
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	belt = /obj/item/storage/belt/rogue/leather/steel/tasset
-	beltr = /obj/item/rogueweapon/scabbard/sword
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backr = /obj/item/storage/backpack/rogue/satchel
 	l_hand = /obj/item/rogueweapon/greatsword/grenz/flamberge/blacksteel
 
@@ -124,7 +124,7 @@
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/polearms, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-		H.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+		H.adjust_skillrank(/datum/skill/combat/swords, 5, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/whipsflails, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/axes, 3, TRUE)
 		H.adjust_skillrank(/datum/skill/combat/maces, 3, TRUE)


### PR DESCRIPTION
## About The Pull Request
Ziziod Knights get an objective to train their squire, the small issue being that they only have expert swords and thus cant actually train their squire to anything above journeyman... which is what they start with. This changes that and also swaps their scabbard from a longsword one to a greatweapon strap so they can actually store their flamberg. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
2 line change
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Makes the ziziod knight able to do their objective properly, brings them up to speed with the keep and other wretches skill-wise.  Also unfucks their loadout. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: increased Zizite Knight Migrant sword skill to 5, so they can train their squire. 
fix: changed the zizite knight's scabbard to a great weapon strap so they can store their sword properly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
