### PR TITLE
Gives Estoc A Special Attack

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -1232,6 +1232,7 @@
 	)
 	bigboy = TRUE
 	gripsprite = TRUE
+	special = /datum/special_intent/piercing_lunge
 	wlength = WLENGTH_GREAT
 	w_class = WEIGHT_CLASS_BULKY
 	minstr = 8


### PR DESCRIPTION
## About The Pull Request

For some reason, the Estoc has no special attack! This PR slaps a bandaid on that by giving it the rapier's special attack. Not sure if there's another special attack that would suit it better, or if AP has one that we haven't ported yet or something, but this one seems appropriate for now.

## Testing Evidence

<img width="1248" height="547" alt="dreamseeker_2026-06-18_20-07-25" src="https://github.com/user-attachments/assets/d8f120cb-fc26-492d-8ad8-90723716bb66" />
<img width="399" height="197" alt="dreamseeker_2026-06-18_20-07-16" src="https://github.com/user-attachments/assets/77065c46-0ba3-4f8d-bd9c-adb2c0ea48bb" />


## Why It's Good For The Game

Better than nothing! Most other weapons have a special attack. If someone wants to add a better one, feel free to reach out to me or something- but I am talentless and lazy and this was easy to do.

## Changelog


:cl:
add: Gives the Estoc a special attack, in line with other weapons.
/:cl:
