### PR TITLE
Overlooked Bedbreaker Interaction

### DIFF
--- a/code/datums/sexcon/sex_actions/deviant/scissoring.dm
+++ b/code/datums/sexcon/sex_actions/deviant/scissoring.dm
@@ -33,6 +33,10 @@
 	user.sexcon.outercourse_noise(target, TRUE)
 	user.sexcon.do_thrust_animate(target)
 
+	if(HAS_TRAIT(user, TRAIT_DEATHBYSNUSNU) || (user.STASTR > 12))
+		if(istype(user.rmb_intent, /datum/rmb_intent/strong))
+			user.sexcon.try_pelvis_crush(target)
+
 	user.sexcon.perform_sex_action(user, 1, 4, TRUE)
 	user.sexcon.handle_passive_ejaculation()
 


### PR DESCRIPTION
## About The Pull Request
It has been reported to me that I overlooked giving bedbreaker functionality to when two people want to scissor, so now it does.

## Testing Evidence

<img width="434" height="222" alt="image" src="https://github.com/user-attachments/assets/082f701e-2045-4838-bf67-fbbcef57b1a9" />


## Why It's Good For The Game

Those who choose to not have a dick should be able to make their partners walk funny still (but watch out, scissoring also causes YOU pain)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: I forgot that scissoring was a thing, now bedbreaker applies to it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
