### PR TITLE
Stun/Immobilize Var to end stuns early from dropped pins

### DIFF
--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -343,6 +343,10 @@
 				var/stun_dur = max(((65 + (skill_diff * 10) + (user.STASTR * 5) - (M.STASTR * 5)) * combat_modifier), 20)
 				var/pincount = 0
 				user.stamina_add(rand(1,3))
+				var/pin_stun_baseline = M.AmountStun()
+				var/pin_stun_applied = FALSE
+				var/pin_immob_baseline = M.AmountImmobilized()
+				var/pin_immob_applied = FALSE
 				while(M == grabbed && !(M.mobility_flags & MOBILITY_STAND) && (src in M.grabbedby))
 					if(M.IsStun())
 						if(!do_after(user, stun_dur + 1, needhand = 0, target = M))
@@ -354,17 +358,26 @@
 							qdel(src)
 							break
 						M.Stun(stun_dur - pincount * 2)
-						M.Immobilize(stun_dur)	//Made immobile for the whole do_after duration, though
+						pin_stun_applied = TRUE
+						M.Immobilize(stun_dur)
+						pin_immob_applied = TRUE
 						user.stamina_add(rand(1,3) + abs(skill_diff) + stun_dur / 1.5)
 						M.visible_message(span_danger("[user] keeps [M] pinned to the ground!"))
 						pincount += 2
 					else if(src in M.grabbedby)
 						M.Stun(stun_dur - 10)
+						pin_stun_applied = TRUE
 						M.Immobilize(stun_dur)
+						pin_immob_applied = TRUE
 						user.stamina_add(rand(1,3) + abs(skill_diff) + stun_dur / 1.5)
 						pincount += 2
 						M.visible_message(span_danger("[user] pins [M] to the ground!"), \
 							span_userdanger("[user] pins me to the ground!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
+				if(!(src in M.grabbedby))
+					if(pin_stun_applied)
+						M.SetStun(pin_stun_baseline)
+					if(pin_immob_applied)
+						M.SetImmobilized(pin_immob_baseline)
 			else
 				if(user.badluck(4))
 					badluckmessage(user)


### PR DESCRIPTION
## About The Pull Request

Adds a `var` to store any existing stun/immobilize durations (likely zero), so that when a pin is ended early by letting it go in some way, the duration is put back to what it was prior to the pin (still likely zero.)

## Testing Evidence

<img width="292" height="38" alt="dreamseeker_Zv8LyR4Dd7" src="https://github.com/user-attachments/assets/54c53947-b2bf-4e82-b935-2426cd6c1c44" />

Hard to show this directly, but the gist of testing was:

Made two mobs, first tested the pin working period by grabbing the other, pinning it, and direct controlling while the pin was held. Worked.

Then, tested the pin stun ending early if let go by doing the same thing, but letting go before direct controlling. Also worked. _Mostly._ The visual indicator still shows it being there, but the stun effect itself stops.

## Why It's Good For The Game

With a combination of high STR and Wrestling skill, it became possible to effectively do upwards of an *eight* second "ghost" pin where by starting a pin and immediately dropping it, the person would be stuck to the ground while their 'pinner' was free to do anything else. Just a weird interaction overall.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Pins no longer magically 'held' long after the grab is let go
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
