### PR TITLE
Removes target.death( ) from Max Power Churn

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/matthios.dm
@@ -294,5 +294,4 @@
 						if(limb_turf)
 							new /obj/effect/decal/cleanable/blood/gibs/limb(limb_turf)
 
-			target.death()
 			return


### PR DESCRIPTION
## About The Pull Request

Removes the `target.death( )` proc at the end of the highest power stage for Churn Wealthy, where on top of already quad-delimbing the target, also immediately kills them.

## Testing Evidence

<img width="324" height="35" alt="dreamseeker_nLUYstFLwQ" src="https://github.com/user-attachments/assets/02e66280-2dc4-4468-a5b8-8e675ea1bc50" />
<img width="317" height="331" alt="dreamseeker_ZMPz8JXe78" src="https://github.com/user-attachments/assets/00633f69-3e6e-4b92-b026-37438026a7d3" />
<img width="642" height="119" alt="dreamseeker_iF2xQsF4uO" src="https://github.com/user-attachments/assets/771042d3-13ad-44d3-8496-9550ed444aa3" />
Your chicken nugget, sire.

## Why It's Good For The Game

Churn Wealthy in a perfect world can be used to threaten or coerce, but instead, is often used to reduce the bulk of an interaction (with the duke, typically) to "You let me get near you, DEATH.", whether it's the Duke trying to come see a captured Iconoclast (a thing that happened), the Duke stepping outside the manor to hold a conversation in any way and getting jumped with it after a one-liner (a thing that happened), or being assassinated by a bird with fo*w*l intentions (a thing that also, happened).

All these interactions tend to simply boil down to "You counter it by doing this very specific meta-knowledge/game-y thing to avoid the instant death move", and multiple times now, I've seen it used on people who are just unaware of how the mechanic works period... Because why would they? 

Players shouldn't be punished on a role that's already punished enough with `TRAIT_DNR` by also being immediately taken out of the round for having the audacity to try and even engage with (typically) prisoners in roleplay who just so happen to be capable of casting "Power Word: Kill" on the duke.

...Also, now casting churn on the duke turns them into a nugget, forced to live with a lack of limbs, which, admittedly, STILL SETS THEM UP TO BE QUITE KILLABLE (they can easily hit about 300 something burn damage, and are now incapable of defending themselves).

It's also just really funny to see a guy get turned into a nugget.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed the target.death() from 1001+ value churn wealthy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
