### PR TITLE
Fix sound datum churn in looping sounds

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -111,6 +111,11 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 		var/picked_channel = group.reserved_channels[group.last_iter]
 		group.last_iter++
 		channel = picked_channel
+	
+	if(start_sound && !istype(start_sound, /sound))
+		start_sound = sound(start_sound)
+	
+	mid_sounds = canonize_sounds(mid_sounds)
 
 	parent = _parent
 	direct = _direct
@@ -122,6 +127,21 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 
 	if(start_immediately)
 		start()
+
+/// Takes in a list of sound files, returns a list of corresponding sound datums.
+/datum/looping_sound/proc/canonize_sounds(list/input_sounds)
+	. = list()
+	for(var/sound_candidate in input_sounds)
+		if(isfile(sound_candidate))
+			. += sound(sound_candidate)
+		else if(istype(sound_candidate, /sound))
+			. += sound_candidate
+		else if(islist(sound_candidate))
+			. += list(canonize_sounds(sound_candidate))
+
+/datum/looping_sound/proc/set_mid_sounds(list/new_mid_sounds)
+	mid_sounds = canonize_sounds(new_mid_sounds)
+	cursound = null
 
 /datum/looping_sound/Destroy()
 	stop()
@@ -178,12 +198,6 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 //		timerid = addtimer(CALLBACK(src, PROC_REF(sound_loop), world.time), mid_length, TIMER_CLIENT_TIME | TIMER_STOPPABLE | TIMER_LOOP)
 
 /datum/looping_sound/proc/play(soundfile)
-	var/sound/S = soundfile
-	if(!istype(S))
-		S = sound(soundfile)
-	if(direct)
-		S.channel = channel
-		S.volume = volume
 	if (!parent)
 		return
 
@@ -192,32 +206,30 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 	if(direct)
 		if(ismob(parent))
 			var/mob/mob = parent
-			mob.playsound_local(mob, S, volume, vary, frequency, falloff, repeat = src, channel = channel)
-	else
-		var/list/R = playsound(parent, S, volume, vary, extra_range, falloff, frequency, channel, ignore_walls = ignore_walls, repeat = src)
-		if(!R || !R.len)
-			R = list()
-		for(var/datum/weakref/listener_ref in thingshearing)
-			var/mob/M = listener_ref.resolve()
-			if(!M || !M.client)
-				thingshearing -= listener_ref
-				continue
-			if(!(M in R) || M.IsSleeping())// they are out of range
-				var/list/L = M.client.played_loops[src]
-				if(L)
-					var/sound/SD = L["SOUND"]
-					if(SD)
-						if(persistent_loop)
-							L["MUTESTATUS"] = TRUE
-							L["VOL"] = 0
-							M.mute_sound(SD)
-							//M.play_ambience()
-						else
-							M.client.played_loops -= src
-							thingshearing -= listener_ref
-							M.stop_sound_channel(SD.channel)
-			else
-				on_hear_sound(M)
+			mob.playsound_local(mob, soundfile, volume, vary, frequency, falloff, repeat = src, channel = channel)
+		return
+	var/list/R = playsound(parent, soundfile, volume, vary, extra_range, falloff, frequency, channel, ignore_walls = ignore_walls, repeat = src)
+	for(var/datum/weakref/listener_ref in thingshearing)
+		var/mob/M = listener_ref.resolve()
+		if(!M?.client)
+			thingshearing -= listener_ref
+			continue
+		if(!(M in R) || M.IsSleeping())// they are out of range
+			var/list/L = M.client.played_loops[src]
+			if(L)
+				var/sound/SD = L["SOUND"]
+				if(SD)
+					if(persistent_loop)
+						L["MUTESTATUS"] = TRUE
+						L["VOL"] = 0
+						M.mute_sound(SD)
+						//M.play_ambience()
+					else
+						M.client.played_loops -= src
+						thingshearing -= listener_ref
+						M.stop_sound_channel(SD.channel)
+		else
+			on_hear_sound(M)
 
 /datum/looping_sound/proc/on_hear_sound(mob/M)
 	if(!persistent_loop || !M?.client)
@@ -242,7 +254,7 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 
 /datum/looping_sound/proc/get_sound(starttime, _mid_sounds)
 	. = _mid_sounds || mid_sounds
-	while(!isfile(.) && !isnull(.))
+	while(islist(.) && !isnull(.))
 		. = pickweight(.)
 
 /datum/looping_sound/proc/on_start()

--- a/code/game/objects/items/rogueitems/dmusicbox.dm
+++ b/code/game/objects/items/rogueitems/dmusicbox.dm
@@ -161,7 +161,7 @@ GLOBAL_VAR_INIT(musicboxes_last_play, 0) //last time of the last played track, t
 			GLOB.musicboxes_last_play = world.time
 			playing = TRUE
 			soundloop.channel = new_channel
-			soundloop.mid_sounds = list(curfile)
+			soundloop.set_mid_sounds(list(curfile))
 			soundloop.cursound = null
 			soundloop.start()
 			user.log_message("played jukebox song: [curfile]", LOG_GAME)

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -442,8 +442,7 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 				user.remove_status_effect(/datum/status_effect/buff/playing_music)
 				return
 			if(curfile)
-				soundloop.mid_sounds = list(curfile)
-				soundloop.cursound = null
+				soundloop.set_mid_sounds(list(curfile))
 				soundloop.volume = clamp(curvol, 10, 100)
 				soundloop.repeat_sound = loop_enabled
 				if(!soundloop.start(user))
@@ -620,8 +619,7 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 				var/mob/living/band_mob = instrument_to_bandmate[band_instrument]
 				if(band_mob)
 					play_source = band_mob
-			band_instrument.soundloop.mid_sounds = list(band_instrument.curfile)
-			band_instrument.soundloop.cursound = null
+			band_instrument.soundloop.set_mid_sounds(list(band_instrument.curfile))
 			band_instrument.soundloop.volume = clamp(band_instrument.curvol, 10, 100)
 			band_instrument.soundloop.repeat_sound = band_instrument.loop_enabled
 			if(!band_instrument.soundloop.start(play_source, sync_anchor))

--- a/code/game/objects/structures/roguetown/musicbox.dm
+++ b/code/game/objects/structures/roguetown/musicbox.dm
@@ -82,8 +82,7 @@
 
 /obj/structure/roguemachine/musicbox/proc/start_playing()
 	playing = TRUE
-	soundloop.mid_sounds = list(curfile)
-	soundloop.cursound = null
+	soundloop.set_mid_sounds(list(curfile))
 	soundloop.volume = curvol
 	soundloop.start()
 	testing("Music: V[soundloop.volume] C[soundloop.cursound] T[soundloop.thingshearing]")

--- a/code/game/objects/structures/roguetown/musicbox.dm
+++ b/code/game/objects/structures/roguetown/musicbox.dm
@@ -1,34 +1,3 @@
-#define MUSIC_TAVCAT_OTHERWORLDLY list(\
-	"Lore" = 'sound/music/jukeboxes/otherworld/ac-ler.ogg',\
-	"Landmarks of Lullabies" = 'sound/music/jukeboxes/otherworld/ac-lol.ogg',\
-	"Waters of Sacrifice" = 'sound/music/jukeboxes/otherworld/acn-wos.ogg',\
-	"Solar Wind" = 'sound/music/jukeboxes/otherworld/av_solar.ogg',\
-	"Balthasar" = 'sound/music/jukeboxes/otherworld/ac-balthasar.ogg',\
-	"Dead Windmills" = 'sound/music/jukeboxes/otherworld/dead_windmills.ogg',\
-	"In Heaven Everythin" = 'sound/music/jukeboxes/otherworld/in_heaven_eif.ogg',\
-	"Jazznocn" = 'sound/music/jukeboxes/otherworld/jazznocn.ogg',\
-	"Vivalaluna-Damla" = 'sound/music/jukeboxes/otherworld/vivalaluna-damla.ogg',\
-	"Shades of Futility" = 'sound/music/jukeboxes/otherworld/fb-sofutile.ogg',\
-	"Mr Doubt" = 'sound/music/jukeboxes/otherworld/mr_doubt.ogg'\
-)
-#define MUSIC_TAVCAT_GENERIC list(\
-	"Song 1" = 'sound/music/jukeboxes/gen/tavern1.ogg',\
-	"Song 2" = 'sound/music/jukeboxes/gen/tavern2.ogg',\
-	"Song 3" = 'sound/music/jukeboxes/gen/tavern3.ogg'\
-)
-#define MUSIC_TAVCAT_OLDSCHOOL list(\
-	"Autumn Voyage" = 'sound/music/jukeboxes/oldschool/Autumn_Voyage.ogg',\
-	"Fanfare" = 'sound/music/jukeboxes/oldschool/Fanfare.ogg',\
-	"Greatness" = 'sound/music/jukeboxes/oldschool/Greatness.ogg',\
-	"Medieval" = 'sound/music/jukeboxes/oldschool/Medieval.ogg',\
-	"Sea Shanty2" = 'sound/music/jukeboxes/oldschool/Sea_Shanty2.ogg',\
-	"Shine" = 'sound/music/jukeboxes/oldschool/Shine.ogg',\
-	"Spirit" = 'sound/music/jukeboxes/oldschool/Spirit.ogg',\
-	"Still Night" = 'sound/music/jukeboxes/oldschool/Still_Night.ogg',\
-	"Venture" = 'sound/music/jukeboxes/oldschool/Venture.ogg',\
-	"Yesteryear" = 'sound/music/jukeboxes/oldschool/Yesteryear.ogg'\
-)
-
 /datum/looping_sound/musloop
 	mid_sounds = list()
 	mid_length = 2400 // Whoever wrote this is giving me an aneurism
@@ -60,6 +29,36 @@
 	var/playing = FALSE // If music is playing or not. playmusic() deals with this don't mess with it.
 	var/curvol = 50 // The current volume at which audio is played. MAPPERS MAY TOUCH THIS.
 	var/playuponspawn = FALSE // Does the music box start playing music when it first spawns in? MAPPERS MAY TOUCH THIS.
+	var/list/static/songlist_otherworldly = list(
+		"Lore" = 'sound/music/jukeboxes/otherworld/ac-ler.ogg',
+		"Landmarks of Lullabies" = 'sound/music/jukeboxes/otherworld/ac-lol.ogg',
+		"Waters of Sacrifice" = 'sound/music/jukeboxes/otherworld/acn-wos.ogg',
+		"Solar Wind" = 'sound/music/jukeboxes/otherworld/av_solar.ogg',
+		"Balthasar" = 'sound/music/jukeboxes/otherworld/ac-balthasar.ogg',
+		"Dead Windmills" = 'sound/music/jukeboxes/otherworld/dead_windmills.ogg',
+		"In Heaven Everythin" = 'sound/music/jukeboxes/otherworld/in_heaven_eif.ogg',
+		"Jazznocn" = 'sound/music/jukeboxes/otherworld/jazznocn.ogg',
+		"Vivalaluna-Damla" = 'sound/music/jukeboxes/otherworld/vivalaluna-damla.ogg',
+		"Shades of Futility" = 'sound/music/jukeboxes/otherworld/fb-sofutile.ogg',
+		"Mr Doubt" = 'sound/music/jukeboxes/otherworld/mr_doubt.ogg'
+	)
+	var/list/static/songlist_generic = list(\
+		"Song 1" = 'sound/music/jukeboxes/gen/tavern1.ogg',
+		"Song 2" = 'sound/music/jukeboxes/gen/tavern2.ogg',
+		"Song 3" = 'sound/music/jukeboxes/gen/tavern3.ogg'
+	)
+	var/list/static/songlist_oldschool = list(\
+		"Autumn Voyage" = 'sound/music/jukeboxes/oldschool/Autumn_Voyage.ogg',
+		"Fanfare" = 'sound/music/jukeboxes/oldschool/Fanfare.ogg',
+		"Greatness" = 'sound/music/jukeboxes/oldschool/Greatness.ogg',
+		"Medieval" = 'sound/music/jukeboxes/oldschool/Medieval.ogg',
+		"Sea Shanty2" = 'sound/music/jukeboxes/oldschool/Sea_Shanty2.ogg',
+		"Shine" = 'sound/music/jukeboxes/oldschool/Shine.ogg',
+		"Spirit" = 'sound/music/jukeboxes/oldschool/Spirit.ogg',
+		"Still Night" = 'sound/music/jukeboxes/oldschool/Still_Night.ogg',
+		"Venture" = 'sound/music/jukeboxes/oldschool/Venture.ogg',
+		"Yesteryear" = 'sound/music/jukeboxes/oldschool/Yesteryear.ogg'
+	)
 
 /obj/structure/roguemachine/musicbox/Initialize(mapload)
 	. = ..()
@@ -115,16 +114,17 @@
 		toggle_music()
 
 	if(button_selection=="Change Song")
-		var/songlists_selection = input(user, "Which song list?", "\The [src]") as null | anything in list("OTHERWORLDLY"=MUSIC_TAVCAT_OTHERWORLDLY, "GENERIC"=MUSIC_TAVCAT_GENERIC, "OLDSCHOOL"=MUSIC_TAVCAT_OLDSCHOOL)
+		var/songlists_selection = input(user, "Which song list?", "\The [src]") as null | anything in list("OTHERWORLDLY", "GENERIC", "OLDSCHOOL")
 		playsound(loc, pick('sound/misc/keyboard_select (1).ogg','sound/misc/keyboard_select (2).ogg','sound/misc/keyboard_select (3).ogg','sound/misc/keyboard_select (4).ogg'), 100, FALSE, -1)
 		user.visible_message(span_info("[user] presses a button on \the [src]."),span_info("I press a button on \the [src]."))
 		var/chosen_songlists_selection = null
-		if(songlists_selection=="OTHERWORLDLY")
-			chosen_songlists_selection = MUSIC_TAVCAT_OTHERWORLDLY
-		if(songlists_selection=="GENERIC")
-			chosen_songlists_selection = MUSIC_TAVCAT_GENERIC
-		if(songlists_selection=="OLDSCHOOL")
-			chosen_songlists_selection = MUSIC_TAVCAT_OLDSCHOOL
+		switch(songlists_selection)
+			if("OTHERWORLDLY")
+				chosen_songlists_selection = songlist_otherworldly
+			if("GENERIC")
+				chosen_songlists_selection = songlist_generic
+			if("OLDSCHOOL")
+				chosen_songlists_selection = songlist_oldschool
 		var/song_selection = input(user, "Which song do I play?", "\The [src]") as null | anything in chosen_songlists_selection
 		if(!Adjacent(user))
 			return
@@ -159,13 +159,13 @@
 		start_playing()
 
 /obj/structure/roguemachine/musicbox/tavern
-	init_curfile = list(\
-		'sound/music/jukeboxes/gen/tavern1.ogg',\
-		'sound/music/jukeboxes/gen/tavern2.ogg',\
-		'sound/music/jukeboxes/gen/tavern3.ogg',\
+	init_curfile = list(
+		'sound/music/jukeboxes/gen/tavern1.ogg',
+		'sound/music/jukeboxes/gen/tavern2.ogg',
+		'sound/music/jukeboxes/gen/tavern3.ogg',
 		'sound/music/jukeboxes/otherworld/ac-lol.ogg',
-		'sound/music/jukeboxes/otherworld/ac-balthasar.ogg',\
-		'sound/music/jukeboxes/otherworld/vivalaluna-damla.ogg',\
+		'sound/music/jukeboxes/otherworld/ac-balthasar.ogg',
+		'sound/music/jukeboxes/otherworld/vivalaluna-damla.ogg',
 	)
 	curvol = 65
 	playuponspawn = TRUE


### PR DESCRIPTION
Looping sounds would create the same sound datum every time they played, even though they can be reused. This makes them reused.

Also rewrites the music box code while I'm in the area.

https://github.com/user-attachments/assets/019844b3-7311-4f6e-a3f1-fd7c29f80175

^ has sound