### PR TITLE
Look at how the man-eater have grown

### DIFF
--- a/code/game/objects/structures/maneater.dm
+++ b/code/game/objects/structures/maneater.dm
@@ -201,7 +201,7 @@
 
 /obj/structure/flora/roguegrass/maneater/real/juvenile/Initialize(mapload)
 	..()
-	transform = transform.Scale(0.5, 0.5)  // Start at half size
+	transform = transform.Scale(0.75, 0.75)  // Start larger than an kobold.
 	addtimer(CALLBACK(src, PROC_REF(try_grow)), growth_time)
 
 /obj/structure/flora/roguegrass/maneater/real/juvenile/Crossed(atom/movable/AM)
@@ -224,8 +224,8 @@
 /obj/structure/flora/roguegrass/maneater/real/juvenile/proc/try_grow()
 	if(growth_stage < max_growth_stage)
 		growth_stage++
-		// We end up at 1.0 size by final stage
-		transform = transform.Scale(1.26, 1.26)
+		// Largest juvenile stage stays under the adult's 1.0 size
+		transform = transform.Scale(1.1, 1.1)
 		visible_message(span_warning("[src] grows bigger!"))
 		playsound(loc, list('sound/vo/mobs/plant/attack (1).ogg','sound/vo/mobs/plant/attack (2).ogg','sound/vo/mobs/plant/attack (3).ogg','sound/vo/mobs/plant/attack (4).ogg'), 100, FALSE, -1)
 		addtimer(CALLBACK(src, PROC_REF(try_grow)), growth_time)


### PR DESCRIPTION
## About The Pull Request
Changed the baseline size of man-eater to 0.75

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Before
<img width="228" height="191" alt="image" src="https://github.com/user-attachments/assets/ea0e2391-05c8-4b65-bce6-5d28a003e9ca" />
Now

https://github.com/user-attachments/assets/66c382db-49ca-4ec1-bd56-a5911d4b27c6

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Kobolds, humans, etc, could not even hit the damn thing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Juvenile size increases to 0.75 the size of a normal man eater.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
