### PR TITLE
Fixes berserker loadout choices for Punch Dagger and Grand Mace

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/berserker.dm
@@ -70,13 +70,14 @@
 				beltr = /obj/item/rogueweapon/knuckles
 			if("Punch Dagger")
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, SKILL_LEVEL_MASTER, TRUE)
-				beltr = /obj/item/rogueweapon/katar/punchdagger
+				r_hand = /obj/item/rogueweapon/katar/punchdagger
 			if("Battle Axe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/stoneaxe/battle
 			if("Grand Mace")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_EXPERT, TRUE)
-				beltr = /obj/item/rogueweapon/mace/goden/steel
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				r_hand = /obj/item/rogueweapon/mace/goden/steel
 			if("Falx")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
 				beltr = /obj/item/rogueweapon/scabbard/sword


### PR DESCRIPTION
## About The Pull Request

Presently, if you choose punch dagger or grand mace, you get the skill increase, but no weapon. From what I can see, this is because it's trying to equip the grand mace and punch dagger to beltr, which is an invalid slot, so it just doesn't do it. Easy enough fix... Just put it in their hand. (And give grand mace a greatweapon strap, since they need that now).

## Testing Evidence

<img width="274" height="434" alt="dreamseeker_o7R9B4lNY7" src="https://github.com/user-attachments/assets/26a266da-8864-4810-a611-d9d6aa922487" />
Simple enough. Spawned in as Grand Mace loadout, it properly gives you the weapon (and new strap) accordingly. Punch dagger uses the same method to fix (putting it into your hand), and works the same.

## Why It's Good For The Game

A fix to loadout wonkiness. Came up in a few tickets, just going ahead and fixing it to prevent further instances of it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Grand Mace and Punch Dagger loadout choices for Berserker now work.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
