### PR TITLE
Loose Straps Fix

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -14,6 +14,7 @@
 #define BLOCK_Z_IN_DOWN			(1<<10) // Should this object block z falling from above?
 #define BLOCK_Z_IN_UP			(1<<11) // Should this object block z uprise from below?
 #define IGNORE_SINK				(1<<12)
+#define CLAMP_BREAK				(1<<13)	// Should we bypass our break threshold to be destroyed if the damage is big enough? (Having the flag will clamp the damage)
 
 // If you add new ones, be sure to add them to /obj/Initialize as well for complete mapping support
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -13,6 +13,14 @@
 	if(damage_amount < DAMAGE_PRECISION)
 		return
 	. = damage_amount
+	if(obj_flags & CLAMP_BREAK)
+		var/break_threshold = (integrity_failure * max_integrity)
+		if(obj_integrity > break_threshold)
+			if((obj_integrity - damage_amount) <= break_threshold)
+				obj_integrity = break_threshold
+		if(obj_broken || (integrity_failure && obj_integrity == break_threshold))	// We're either broken or we will be broken
+			if(damage_type != BURN)
+				damage_amount = 1
 	obj_integrity = max(obj_integrity - damage_amount, 0)
 	if(animate_dmg)
 		var/oldx = pixel_x

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,9 +1,9 @@
 /obj/item/clothing
 	name = "clothing"
 	resistance_flags = FLAMMABLE
-	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME | CLAMP_BREAK
 	break_sound = 'sound/foley/cloth_rip.ogg'
-	blade_dulling = DULLING_CUT
+	blade_dulling = FALSE
 	max_integrity = 200
 	integrity_failure = 0.1
 	drop_sound = 'sound/foley/dropsound/cloth_drop.ogg'


### PR DESCRIPTION
## About The Pull Request
Currently, Loose Straps seemingly has the unintended side effect of allowing your armor to be destroyed if hit sufficiently hard whilst being flung at the same time. This should make it nigh-impossible to occur, by virtue of making clothing itself much more difficult to destroy save via fire.

Partial port of https://github.com/Azure-Peak/Azure-Peak/pull/6911, primarily just the aspect that clamps damage done to broken clothing.
## Testing Evidence
Attempted to replicate the issue described to me with regards to losing armor pieces after implementing changes, have not been successful. Will be happy to test further if deemed necessary.

## Why It's Good For The Game
In essence what it actually does is make it much harder to willfully destroy **broken** armor in general (again, save by fire.) But it also makes Loose Straps function as intended!