### PR TITLE
Gnoll Scent Buff

### DIFF
--- a/code/datums/sexcon/sexcon.dm
+++ b/code/datums/sexcon/sexcon.dm
@@ -405,9 +405,9 @@
 		if(!splashed_type)
 			splashed_user.apply_status_effect(status_type)
 			if(oral)
-				splashed_user.visible_message(span_love("[splashed_user] takes a load down their throat!"), span_love("I take a load down my throat!"))
+				splashed_user.visible_message(span_love("[splashed_user] takes a load down [splashed_user.p_their()] throat!"), span_love("I take a load down my throat!"))
 			else
-				splashed_user.visible_message(span_love("[splashed_user] takes a load inside them!"), span_love("I take a load inside me!"))
+				splashed_user.visible_message(span_love("[splashed_user] takes a load inside [splashed_user.p_them()]!"), span_love("I take a load inside me!"))
 		else
 			splashed_type.refresh_cum()
 		if(oral && splashed_user.reagents) //cum fills hunger if taking it orally
@@ -416,8 +416,10 @@
 			else
 				splashed_user.reagents.add_reagent(/datum/reagent/erpjuice/femcum, 2)
 			apply_cum_consumed_buff(splashed_user)
-		if(!oral && user?.dna?.species?.id == "gnoll")
+		if(user?.dna?.species?.id == "gnoll" && splashed_user?.dna?.species?.id != "gnoll")
 			splashed_user.has_gnoll_scent_this_round = TRUE
+		if(splashed_user?.dna?.species?.id == "gnoll" && user?.dna?.species?.id != "gnoll")
+			user.has_gnoll_scent_this_round = TRUE
 		modular_record_collar_receive_event(splashed_user, user)
 		if(!oral)
 			var/obj/item/organ/testicles/testes = user.getorganslot(ORGAN_SLOT_TESTICLES)

--- a/modular/code/modules/mob/living/carbon/examine_hooks.dm
+++ b/modular/code/modules/mob/living/carbon/examine_hooks.dm
@@ -17,16 +17,16 @@
 		if(user_is_gnoll)
 			var/datum/antagonist/gnoll/gnoll_antag = H.mind?.has_antag_datum(/datum/antagonist/gnoll)
 			if(gnoll_antag?.is_examine_marked_target(src))
-				lines += span_cultsmall("Graggar has marked them!")
+				lines += span_cultsmall("Graggar has marked [src.p_them()]!")
 			if(src.has_gnoll_scent_this_round)
-				lines += span_cultsmall("They have gnoll scent, a breeder!")
+				lines += span_cultsmall("[src.p_they(TRUE)] have gnoll scent, a breeder!")
 	if(src.has_gnoll_scent_this_round && !user_is_gnoll)
 		if(user_is_inquisition)
-			lines += span_warning("They reek of profane beast-taint. This demands scrutiny.")
+			lines += span_warning("[src.p_they(TRUE)] reek of profane beast-taint. This demands scrutiny.")
 		else if(user_is_clergy)
-			lines += span_warning("A profane, feral scent clings to them.")
+			lines += span_warning("A profane, feral scent clings to [src.p_them()].")
 		else
-			lines += span_warning("They have a strange scent about them...")
+			lines += span_warning("[src.p_they(TRUE)] have a strange scent about [src.p_them()]...")
 	var/perception_level = 15
 	if(isliving(user))
 		var/mob/living/L = user


### PR DESCRIPTION
## About The Pull Request
Topping a gnoll (or being dominated by one that lacks a pintle) now marks you, same as being topped. I also changed various examine messages to check for the character's pronouns rather than just defaulting to they/them. Gnolls don't mark each other because they already smell like gnolls.

## Testing Evidence
Dominating a male target
<img width="476" height="326" alt="image" src="https://github.com/user-attachments/assets/1fe875e7-6677-4532-aed2-b670eb3f8c51" />

The target's perspective
<img width="475" height="286" alt="image" src="https://github.com/user-attachments/assets/a52a38ad-405a-4469-9d40-68ace953e8d7" />

Two gnolls, not marking each other
<img width="476" height="326" alt="image" src="https://github.com/user-attachments/assets/91eed836-90b3-4886-9f74-0c3e0338dd13" />

## Why It's Good For The Game
If you lay with a gnoll you should smell like a gnoll, no matter what position you take.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: You now get the gnoll's strange scent if you top them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
