### PR TITLE
Fix duplicate lighting updates on move

### DIFF
--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -133,13 +133,7 @@
 		T.opaque_atom_count--
 	T.reconsider_lights()
 
-/atom/movable/Moved(atom/OldLoc, Dir)
-	. = ..()
-	var/datum/light_source/L
-	var/thing
-	for (thing in light_sources) // Cycle through the light sources on this atom and tell them to update.
-		L = thing
-		L.source_atom.update_light()
+// No /atom/movable/Moved override here, that's handled by a signal now.
 
 /atom/vv_edit_var(var_name, var_value)
 	switch (var_name)


### PR DESCRIPTION
We called update_light twice, once via signal and once via this. Waaaagh