### PR TITLE
Fix map template runtimes

### DIFF
--- a/_maps/dungeon_generator/room/TownRuins.dmm
+++ b/_maps/dungeon_generator/room/TownRuins.dmm
@@ -1344,7 +1344,7 @@
 "Bc" = (
 /obj/structure/curtain/brown,
 /obj/structure/curtain/brown,
-/turf/closed/indestructible/rock,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/tomb/indoors)
 "By" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1415,7 +1415,7 @@
 /area/rogue/under/tomb/indoors)
 "CZ" = (
 /obj/structure/curtain/brown,
-/turf/closed/indestructible/rock,
+/turf/closed/mineral/rogue/bedrock,
 /area/rogue/under/tomb/indoors)
 "Db" = (
 /obj/item/natural/stone{

--- a/_maps/dungeon_generator/room/sewers.dmm
+++ b/_maps/dungeon_generator/room/sewers.dmm
@@ -132,7 +132,7 @@
 /area/rogue/under/tomb/sewer)
 "Ry" = (
 /turf/open/water/sewer,
-/area/centcom/supplypod/loading/ert)
+/area/rogue/under/tomb/sewer)
 
 (1,1,1) = {"
 aW


### PR DESCRIPTION
This causes those runtimes that always happen every time the map loads with the dungeon on.