### PR TITLE
Removes Barbarian and Amazon from Licker Choices

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -198,6 +198,7 @@
 	outfit = /datum/outfit/job/roguetown/adventurer/barbarian
 	cmode_music = 'sound/music/cmode/antag/combat_darkstar.ogg'
 	traits_applied = list(TRAIT_STEELHEARTED, TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN)
+	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	subclass_stats = list(
 		STATKEY_STR = 3,
 		STATKEY_CON = 2,
@@ -581,6 +582,7 @@
 	tutorial = "Fierce warrior women from distant lands, Amazons choose their armor based on their preferred fighting style - from light and agile to heavily protected."
 	outfit = /datum/outfit/job/adventurer/amazon
 	traits_applied = list(TRAIT_STEELHEARTED)
+	category_tags = list(CTAG_ADVENTURER, CTAG_COURTAGENT)
 	subclass_stats = list()
 	subclass_social_rank = SOCIAL_RANK_DIRT
 


### PR DESCRIPTION
## About The Pull Request

See title. This is a balancejak. All my homies hate licker barbarians. They are too dominant and frankly too foolproof- from an administrative perspective, a lot of people often use them to go on killing sprees. This PR just removes Barbarian (and Amazon) from the list of licker options.

## Testing Evidence

<img width="544" height="305" alt="dreamseeker_2026-06-23_15-44-27" src="https://github.com/user-attachments/assets/db771b4f-7b8d-40ea-9ccf-41e028054735" />


## Why It's Good For The Game

The guy who in-general gets vampyric superpowers and giga-healing in the form of blood heal, and so on- doesn't really need stats and skills juiced towards grappling, nor does it need access to crit resist. It's strong enough already. Perhaps with this we'll get vampires that are literally any other class instead of 99% barbarians that wage war on the town-- which aren't very flavorful. More roleplay-oriented vampires that try to blend in with the town or feed more subtly would be nice.

## Changelog

:cl:
del: Removed Barbarian and Amazon from the list of possible Licker subclasses.
/:cl:
