### PR TITLE
Noble Adventurers Re-Balanced

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/gambeson.dm
+++ b/code/modules/clothing/rogueclothes/armor/gambeson.dm
@@ -62,6 +62,9 @@
 	var/shifted = FALSE
 	cold_protection = CHEST | GROIN | ARM_RIGHT | ARM_LEFT
 	min_cold_protection_temperature = BODYTEMP_COLD_LEVEL_ONE_MAX
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/purple
+	color = CLOTHING_PURPLE
 	
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/attack_right(mob/user)
 	if(!shiftable)
@@ -182,6 +185,16 @@
 	altdetail_tag = "_detailalt"
 	shiftable = FALSE
 	var/picked = FALSE
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter/red
+	color = CLOTHING_RED
+	detail_color = CLOTHING_RED
+	altdetail_color = CLOTHING_RED
+
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter/white
+	color = CLOTHING_WHITE
+	detail_color = CLOTHING_WHITE
+	altdetail_color = CLOTHING_WHITE
 
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter/attack_right(mob/user)
 	..()

--- a/code/modules/clothing/rogueclothes/pants/heavy_leather.dm
+++ b/code/modules/clothing/rogueclothes/pants/heavy_leather.dm
@@ -50,6 +50,14 @@
 	heat_protection = GROIN | LEG_RIGHT | LEG_LEFT
 	max_heat_protection_temperature = 600
 
+/obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic/black
+	color = CLOTHING_BLACK
+	detail_color = CLOTHING_BLACK
+
+/obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic/brown
+	color = CLOTHING_BROWN
+	detail_color = CLOTHING_BROWN
+
 /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic/update_icon()
 	cut_overlays()
 	if(get_detail_tag())

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -41,14 +41,15 @@
 	backl = /obj/item/storage/backpack/rogue/satchel
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	id = /obj/item/clothing/ring/silver
-	beltl = /obj/item/rogueweapon/sword/sabre/dec
-	l_hand = /obj/item/rogueweapon/scabbard/sword
+	beltl = /obj/item/rogueweapon/scabbard/sword
+	l_hand = /obj/item/rogueweapon/sword/sabre/dec
 	if(should_wear_masc_clothes(H))
 		cloak = /obj/item/clothing/cloak/half/red
-		shirt = /obj/item/clothing/suit/roguetown/shirt/tunic/red
-		pants = /obj/item/clothing/under/roguetown/tights/black
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter/red
+		pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic/black
 	if(should_wear_femme_clothes(H))
-		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/gen/purple
+		armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/purple
+		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/purple
 		cloak = /obj/item/clothing/cloak/raincloak/purple
 	// backpack_contents = list(/obj/item/recipe_book/survival = 1)//superceded by tgui
 	H.set_blindness(0)
@@ -63,9 +64,9 @@
 	subclass_social_rank = SOCIAL_RANK_MINOR_NOBLE
 	traits_applied = list(TRAIT_NOBLE, TRAIT_HEAVYARMOR)
 	subclass_stats = list(
-		STATKEY_STR = 2,
-		STATKEY_CON = 1,
-		STATKEY_WIL = 1,
+		STATKEY_STR = 1,
+		STATKEY_CON = 2,
+		STATKEY_WIL = 2,
 		STATKEY_INT = 1,
 	)
 	subclass_skills = list(
@@ -114,54 +115,68 @@
 			"Brigandine"		= /obj/item/clothing/suit/roguetown/armor/brigandine,
 			"Coat of Plates"	= /obj/item/clothing/suit/roguetown/armor/brigandine/coatplates,
 			"Steel Cuirass"		= /obj/item/clothing/suit/roguetown/armor/plate/half,
+			"Fluted Cuirass"	= /obj/item/clothing/suit/roguetown/armor/plate/half/fluted,
 			)
 		var/armorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in armors
 		armor = armors[armorchoice]
 
-	gloves = /obj/item/clothing/gloves/roguetown/chain
-	pants = /obj/item/clothing/under/roguetown/chainlegs
+		var/underarmors = list("Steel Maille","Padded Cloth")
+		var/underarmorchoice = input(H, "Choose your armor.", "TAKE UP ARMOR") as anything in underarmors
+		switch(underarmorchoice)
+			if("Steel Maille")
+				gloves = /obj/item/clothing/gloves/roguetown/chain
+				shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+				pants = /obj/item/clothing/under/roguetown/chainlegs
+				shoes = /obj/item/clothing/shoes/roguetown/boots/armor
+			if("Padded Cloth")
+				gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
+				shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/freifechter/white
+				pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic/brown
+				shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
+
 	cloak = /obj/item/clothing/cloak/stabard
 	neck = /obj/item/clothing/neck/roguetown/bevor
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	wrists = /obj/item/clothing/wrists/roguetown/bracers
-	shoes = /obj/item/clothing/shoes/roguetown/boots/armor
 	belt = /obj/item/storage/belt/rogue/leather/steel/tasset
 	backl = /obj/item/storage/backpack/rogue/satchel
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backpack_contents = list(
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/storage/belt/rogue/pouch/coins/mid = 1,
 		)
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	H.set_blindness(0)
 	if(H.mind)
-		var/weapons = list("Longsword","Mace + Shield","Flail + Shield","Billhook","Battle Axe","Greataxe")
-		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
-		switch(weapon_choice)
+		var/sidearms = list("Longsword","Mace","Flail","Battle Axe")
+		var/sidearm_choice = input(H, "Choose your sidearm.", "TAKE UP ARMS") as anything in sidearms
+		switch(sidearm_choice)
 			if("Longsword")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltr = /obj/item/rogueweapon/sword/long
 				r_hand = /obj/item/rogueweapon/scabbard/sword
-			if("Mace + Shield")
+			if("Mace")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltr = /obj/item/rogueweapon/mace
-				backr = /obj/item/rogueweapon/shield/tower/metal
-			if("Flail + Shield")
+			if("Flail")
 				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				beltr = /obj/item/rogueweapon/flail
-				backr = /obj/item/rogueweapon/shield/tower/metal
-			if("Billhook")
-				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				r_hand = /obj/item/rogueweapon/spear/billhook
-				backr = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Battle Axe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				r_hand = /obj/item/rogueweapon/stoneaxe/battle
+
+		var/weapons = list("Billhook","Greataxe","Shield")
+		var/weapon_choice = input(H, "Choose your formation weapon.", "TAKE UP STRENGTH") as anything in weapons
+		switch(weapon_choice)
+			if("Billhook")
+				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				l_hand = /obj/item/rogueweapon/spear/billhook
+				backr = /obj/item/rogueweapon/scabbard/gwstrap
 			if("Greataxe")
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
-				r_hand = /obj/item/rogueweapon/greataxe
+				l_hand = /obj/item/rogueweapon/greataxe
 				backr = /obj/item/rogueweapon/scabbard/gwstrap
+			if("Shield")
+				H.adjust_skillrank_up_to(/datum/skill/combat/shields, SKILL_LEVEL_JOURNEYMAN, TRUE)
+				backr = /obj/item/rogueweapon/shield/tower/metal
 
 	if (H.mind && !H.mind.has_spell(/obj/effect/proc_holder/spell/self/choose_riding_virtue_mount))
 		H.AddSpell(new /obj/effect/proc_holder/spell/self/choose_riding_virtue_mount)
@@ -227,16 +242,25 @@
 				pants = /obj/item/clothing/under/roguetown/chainlegs/iron
 				gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 				ADD_TRAIT(H, TRAIT_MEDIUMARMOR, TRAIT_GENERIC)
+		var/masks = list("Wildguard","Simple Mask","Hound Mask")
+		var/mask_choice = input(H, "Choose your mask.", "WILL YOU DIE SMILING") as anything in masks
+		switch(mask_choice)
+			if("Wildguard")
+				mask = /obj/item/clothing/mask/rogue/wildguard
+			if("Simple Mask")
+				mask = /obj/item/clothing/mask/rogue/facemask
+			if("Hound Mask")
+				mask = /obj/item/clothing/mask/rogue/facemask/hound
 		var/weapons = list("Arming Sword","Shortsword + Shield","Bow & Arrow","Spear")
 		var/weapon_choice = input(H, "Choose your weapon.", "WHAT WILL YOU SWING BEFORE DEATH") as anything in weapons
 		switch(weapon_choice)
 			if("Arming Sword")
 				backl = /obj/item/rogueweapon/scabbard/sword
-				r_hand = /obj/item/rogueweapon/sword/iron
+				r_hand = /obj/item/rogueweapon/sword
 			if("Shortsword + Shield")
 				beltr = /obj/item/rogueweapon/scabbard/sword
 				backl = /obj/item/rogueweapon/shield/wood
-				r_hand = /obj/item/rogueweapon/sword/short/iron
+				r_hand = /obj/item/rogueweapon/sword/short
 			if("Bow & Arrow")
 				H.adjust_skillrank_up_to(/datum/skill/combat/bows, SKILL_LEVEL_JOURNEYMAN, TRUE)
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve


### PR DESCRIPTION
## About The Pull Request
Gives masculine aristocrats a fencing shirt and breeches for some survivability in the wilderness. Feminine aristocrats get a padded gambeson beneath their dress. You do only have apprentice sword-fighting and novice wrestling, so watch out still.

Gives knight errant an option between maille or padded armor beneath their cuirass. Takes 1 STR away to give +1 CON and +1 WIL for better survivability. Gave a fluted cuirass as a cuirass choice mainly for style. Separated their weapon choices into two lists, sidearms and primaries, for more versatility. Increased coin pouch from poor to mid.

Gives squire errant a steel arming sword and steel shortsword (from iron), and the choice of an iron mask to go with their iron maille coif.

## Testing Evidence

The loadouts and what they vaguely look like in-game (I threw off the surcoat from knight and squire errant, but they still spawn with them. The knight does still also spawn with a helmet.)
<img width="1131" height="620" alt="image" src="https://github.com/user-attachments/assets/0fcc2857-e1bb-4cbb-a124-75ca56b0c215" />

## Why It's Good For The Game
The noble adventurer classes are neat as a concept but comparatively weak versus "pay some triumphs and play a more combat capable class with nobility virtue". These changes hopefully make them slightly more appealing to play without making them overbearing; the only actual stat I changed was trading 1 of knight errant's 2  STR for another point in both CON and WIL. Knight errant getting two weapons might be stronger, but they're same weapons overall as before, and KE still only has journeyman skills in them.

As for squire errant, hopefully steel weapons and a mask will make it more equitable to playing as any other class with the failed squire virtue.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: adventurer aristocrat gets padded armor similar to previous non-padded outfit
balance: adventurer knight errant gets two weapons, a choice between maille or padded armor, a fluted cuirass added to the armor choices, and a chance to spawn with some silvers instead of just copper.
balance: adventurer knight errant also has traded 1 STR for another +1 CON and WIL, totaling 2 for each of those.
balance: adventurer squire errant's arming sword and short sword are steel now, and they also get an iron mask to compliment their iron coif.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
