### PR TITLE
Fixes the Janissary not spawning with their mace & Makes their loadout match their description

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -51,14 +51,15 @@
 		/obj/item/rogueweapon/scabbard/sheath,
 		/obj/item/storage/belt/rogue/pouch/coins/poor
 		)
-	var/weapons = list("Heavy Mace","Shamshir and Shield","Spear and Shield","Axe and Shield")
+	var/weapons = list("Mace and Shield","Shamshir and Shield","Spear and Shield","Axe and Shield")
 	if(H.mind)
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
 		switch(weapon_choice)
-			if("Heavy Mace")
+			if("Mace and Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
-				backl = /obj/item/rogueweapon/mace/goden
+				backl = /obj/item/rogueweapon/shield/tower/zyb
+				beltr = /obj/item/rogueweapon/mace/steel
 			if("Shamshir and Shield")
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 				backl = /obj/item/rogueweapon/shield/tower/zyb


### PR DESCRIPTION
## About The Pull Request
Previously the 'mace' class for the Desert Rider Janissary did not spawn with a mace (See: https://github.com/Rotwood-Vale/Ratwood-2.0/issues/1920#issue-4679517795). Currently the class whose description reads "we fight with shield and mace" spawns with neither a shield nor a mace.

## Testing Evidence

https://github.com/user-attachments/assets/7fffd6cc-d173-451e-9219-cce4f111b4ee



## Why It's Good For The Game
The class should spawn with their equipment as advertised by the class description and specialisation selection. Presently they simply spawn without a primary weapon.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added back the Janissary's mace
add: Added a shield to the class to match its' description
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
