### PR TITLE
Put catchpole maul option on equal grounds to cityguard maul. 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/gormless.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/gormless.dm
@@ -50,6 +50,9 @@
 			if("Maul - 14STR Minimum")
 				r_hand = /obj/item/rogueweapon/mace/maul
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				H.change_stat(STATKEY_STR, 1) /// so even without a strength-specific statpack, you can at least use the weapon. With one, it allows great maul just like on city guard.
+				H.change_stat(STATKEY_SPD, -1)
+				H.change_stat(STATKEY_INT, -1)
 
 	backpack_contents = list(//Iron dagger and ale instead of red.
 		/obj/item/rogueweapon/huntingknife/idagger = 1,


### PR DESCRIPTION
## About The Pull Request
City guard maul option allowed most players to take the maul option and not be immediately shafted because they didn't meet the 14 strength minimum by granting +1 strength to their 2 strength stat, which any player with a strength statpack could utilize to play with a maul or grand maul if taking muscular, thuggish, or struggler. 

Catchpole, on the contrary, has no such buff, meaning players had to choose the above three statpacks and couldn't use a grand maul unless playing as Drakian or Lamia. This PR tweaks the catchpole maul option to work much the same as cityguard's option does, giving +1 strength at the cost of -1 int and speed. 

TLDR:
Adjusted maul option for catchpole

- +1 strength
- -1 intelligence
- -1 speed
- can use grandmaul with +2 statpack

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
easy peasy 3 line change taken directly from townguard.dm

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Less statpack restrictions on catchpole, more variety for catchpole maul users.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Catchpole maul option gets +1 strength at the cost of -1 int and speed in line with cityguard's maul option.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
