### PR TITLE
Gives whips swift balance and heavy whips heavy balance.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/whip.dm
+++ b/code/game/objects/items/rogueweapons/melee/whip.dm
@@ -20,6 +20,7 @@
 	grid_width = 32
 	grid_height = 64
 	special = /datum/special_intent/whip_coil
+	wbalance = WBALANCE_SWIFT
 
 /obj/item/rogueweapon/whip/getonmobprop(tag)
 	. = ..()
@@ -127,6 +128,7 @@
 	wdefense = 0
 	anvilrepair = /datum/skill/craft/weaponsmithing
 	smeltresult = /obj/item/ingot/silver
+	wbalance = WBALANCE_HEAVY
 
 /obj/item/rogueweapon/whip/antique/psywhip/ComponentInitialize()
 	AddComponent(\
@@ -149,6 +151,7 @@
 	wdefense = 0
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silver
+	wbalance = WBALANCE_HEAVY
 
 /obj/item/rogueweapon/whip/silver/ComponentInitialize()
 	AddComponent(\
@@ -201,3 +204,4 @@
 	wdefense = 0
 	possible_item_intents = list(/datum/intent/whip/lash/holy, /datum/intent/whip/crack, /datum/intent/whip/punish) //Able to dismember at range. 'Holy' is a catchall term, in this case.
 	smeltresult = /obj/item/ingot/bronze
+	wbalance = WBALANCE_HEAVY


### PR DESCRIPTION
## About The Pull Request

- All light whips now have swift balance, making them better with speed
- The silver whip, bronze whip, and daybreak all have heavy balance to scale with strength better. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
simple var edit
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Better differentiates the whip classes and allows the weapons to play into their strengths. You should have an easier time whipping some big dumb bruiser with your light whip, as well as make said bruiser's stamina go out faster if you're slapping them with a massive silver chain. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Gave whips the wbalance var, with light whips getting swift and most of the heavier whips getting heavy balance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
