### PR TITLE
Fix flavortext color parsing

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -493,14 +493,9 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 	// Parse colour
 	if(!barebones)
-		var/regex/hexgex = regex(@"(?<=-=)(.{6})", "g")
-		while(hexgex.Find(t))
-			var/endblock = findtext(t, "=-", hexgex.index)
-			if(!endblock)
-				break
-			t = replacetext(t, "=-", "</font>", hexgex.index, endblock+2)
-			var/c_code = sanitize_hexcolor(hexgex.match)
-			t = replacetext(t, "-=[hexgex.match]", "<font color='[c_code]'>", hexgex.index-2, endblock+2)
+		var/regex/hexgex = regex(@"-=([A-Za-z0-9]{6})(.+?)=-", "g")
+		// group 1 - color. group 2 - affected text
+		t = hexgex.Replace_char(t, "<font color='$1'>$2</font>")
 
 	// Parse hr and small
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -493,7 +493,10 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 	// Parse colour
 	if(!barebones)
-		var/regex/hexgex = regex(@"-=([A-Za-z0-9]{6})(.+?)=-", "g")
+		// Because `[.\n]` would just match the literal . character and newlines,
+		// we have to use [\S\s\n] here to match all non-spaces, all spaces, and all newlines.
+		// Also if you try to add \r it explodes, don't do that.
+		var/regex/hexgex = regex(@"-=([A-Za-z0-9]{6})([\S\s\n]+?)=-", "g")
 		// group 1 - color. group 2 - affected text
 		t = hexgex.Replace_char(t, "<font color='$1'>$2</font>")
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -30,6 +30,7 @@
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ExaminePanel")
+		ui.set_autoupdate(FALSE) // this would not really ever need to autoupdate aside from maybe obscured stuff, but just re-examine at that point
 		ui.open()
 
 /datum/examine_panel/ui_data(mob/user)


### PR DESCRIPTION
Makes flavortext color parsing less laggy. Confirmed elaborate FTs that formerly caused lag still work and don't spike tidi on local:
<img width="619" height="510" alt="image" src="https://github.com/user-attachments/assets/14a2d861-bf9a-4fb7-a809-33b3704c31d6" />
