### PR TITLE
Incredible Court Mage Powercreep (I gave them a crownstone)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -109,7 +109,7 @@
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
 	beltr = /obj/item/storage/keyring/mage
 	beltl = /obj/item/storage/magebag/associate
-	id = /obj/item/clothing/ring/gold
+	id = /obj/item/scomstone/garrison
 	r_hand = /obj/item/rogueweapon/woodstaff/riddle_of_steel/magos
 	backl = /obj/item/storage/backpack/rogue/satchel
 	if(SSmapping.config.map_name == "Desert Town")


### PR DESCRIPTION
## About The Pull Request

The Court Magos didn't have a crownstone before. Now they do.

## Testing Evidence

Literally a one-line change using copy-pasted code.

## Why It's Good For The Game

Playing a keep mage is already pretty disconnected from matters. The lackluster SCOM placement doesn't help things, nor does the court mage being utterly out of the loop if they don't go steal a Houndstone. This should, hopefully, encourage the court to bother the CM more and encourage CMs to directly interact with the keep more.

Not a perfect fix as the core issues lie with both the mageloop and the map design on every map but Desert Town, but it's a step in the right direction.

Also the CM has the same nobility tag as the Duke? Like, I genuinely did not know this and just thought it deserved being brought up here.

Tangentially: Technically a combat nerf as CMs are now discouraged from using Conjure Armor and wearing Heavy Padded Coifs (which, due to a bug are currently 100% incompat with Crownstones so you need to full remove the item to talk into the ring).

## Changelog

:cl:
balance: Gave the Court Magician a Crownstone instead of a generic gold ring.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
