### PR TITLE
Updating Zizo Knight and Squire

### DIFF
--- a/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
+++ b/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
@@ -36,7 +36,8 @@
 	belt = /obj/item/storage/belt/rogue/leather
 	gloves = /obj/item/clothing/gloves/roguetown/angle
 	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather/heavy
-	backr = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
+	backr = /obj/item/storage/backpack/rogue/backpack
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	r_hand = /obj/item/rogueweapon/spear
 	backpack_contents = list(
@@ -45,6 +46,8 @@
 		/obj/item/rogueweapon/hammer/iron = 1, 
 		/obj/item/rogueweapon/tongs = 1, 
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1, 
+		/obj/item/polishing_cream = 1, 
+		/obj/item/armor_brush = 1, 
 	)
 	if(H.mind)
 		H.adjust_skillrank(/datum/skill/combat/bows, 3, TRUE)
@@ -111,6 +114,7 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	belt = /obj/item/storage/belt/rogue/leather/steel/tasset
 	beltr = /obj/item/rogueweapon/scabbard/sword
+	backl = /obj/item/rogueweapon/scabbard/gwstrap
 	backr = /obj/item/storage/backpack/rogue/satchel
 	l_hand = /obj/item/rogueweapon/greatsword/grenz/flamberge/blacksteel
 


### PR DESCRIPTION
Spawning people with two-handed weapons and no strap is silly. A travelling squire should also have his polishing tools and real storage.

## About The Pull Request

- Added great weapon strap to both Zizo Knight and Zizo Squire
- Traded Zizo Squire's satchel for a backpack
- Added polishing cream and brush to Zizo Squire inventory

## Testing Evidence

I followed the exact syntax of other classes to add the items. No major changes were made.

## Why It's Good For The Game

Zizo Knight/Squire hasn't seen an update in 9 months. This brings them up to date and gives the Squire a tiny bit of love. Ye olde forgotten code is olde. Squires carry things for knights, this is known. Squires polish weapons and armor, this is known. This allows both and helps them stay independent.

## Changelog

:cl:
add: Added greatweapon straps to Zizo Knight and Squire duo 
add: Traded satchel for backpack on Zizo Squire, gave polishing tools to Squire
/:cl: