### PR TITLE
Bug fix to allow janissary standard bearer to actually use standard

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -784,7 +784,7 @@
 	if(active_item)
 		return
 	active_item = TRUE
-	if(user.job == "Man at Arms")
+	if(user.job == "Man at Arms" || user.job == "Janissary")
 		to_chat(user, span_suppradio("The standard's runes pulse, accepting me as its <b>master</b>."))
 		user.change_stat(STATKEY_LCK, 3)
 		user.add_stress(/datum/stressevent/keep_standard)
@@ -806,7 +806,7 @@
 	if(!active_item)
 		return
 	active_item = FALSE
-	if(user.job == "Man at Arms")
+	if(user.job == "Man at Arms" || user.job == "Janissary")
 		to_chat(user, span_monkeyhive("The standard's runes pulse, rhythmically, as if sad to see you release your control."))
 		user.change_stat(STATKEY_LCK, -3)
 		user.remove_stress(/datum/stressevent/keep_standard)


### PR DESCRIPTION
Changed 1 file to add janissary after maa as a job that is considered 'worthy' of the standard. Despite janissary standard bearer having the flag bearer trait this was ignored as was the janissary job entirely. 
This is my first PR, so do be kindly and review if necessary. Advice was given throughout the process.

Tested via VSC and confirmed, with some difficulty figuring out how to start the game (janissary on rockhill was cursed), that it works. 

Bug fix good. 

:cl:
fix: janissary standardbearer being unable to use their standard
/:cl:
