### PR TITLE
Fixes the royal blacksteel staff being unable to be upgraded

### DIFF
--- a/modular_azurepeak/code/game/objects/items/magic_staffs.dm
+++ b/modular_azurepeak/code/game/objects/items/magic_staffs.dm
@@ -125,6 +125,13 @@
 	max_integrity = 300 // 100 more integrity than a steel quarterstaff due to it's blacksteel nature. Can't smelt it down though :)
 	sellprice = 160
 
+/obj/item/rogueweapon/woodstaff/diamond/refinedblacksteelstaffroyal
+	name = "refined ducal blacksteel staff"
+	desc = "A mage's staff that has been reinforced with blacksteel rivets and plating. An extravagent gift for a precocious heir that serves as both casting implement and mark of station. Perched atop it is a new beautiful Dorpel that shimmers with magical energies."
+	icon_state = "blacksteelstaff"
+	max_integrity = 300
+	sellprice = 230
+
 /obj/item/rogueweapon/woodstaff/riddle_of_steel
 	name = "\improper Staff of the Riddle-Steel"
 	desc = "Flame dances within the focus-gem of this mighty staff at a rhythm and intensity to match the \
@@ -215,5 +222,12 @@
 	name = "Refined Blacksteel Staff"
 	result = /obj/item/rogueweapon/woodstaff/diamond/blacksteelstaff
 	reqs = list(/obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff = 1,
+				/obj/item/roguegem/diamond = 1)
+	craftdiff = 0
+
+/datum/crafting_recipe/gemstaff/ducalblacksteelstaffupgrade
+	name = "Refined Ducal Blacksteel Staff"
+	result = /obj/item/rogueweapon/woodstaff/diamond/refinedblacksteelstaffroyal
+	reqs = list(/obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff/royal = 1,
 				/obj/item/roguegem/diamond = 1)
 	craftdiff = 0

--- a/modular_azurepeak/code/game/objects/items/magic_staffs.dm
+++ b/modular_azurepeak/code/game/objects/items/magic_staffs.dm
@@ -125,11 +125,9 @@
 	max_integrity = 300 // 100 more integrity than a steel quarterstaff due to it's blacksteel nature. Can't smelt it down though :)
 	sellprice = 160
 
-/obj/item/rogueweapon/woodstaff/diamond/refinedblacksteelstaffroyal
+/obj/item/rogueweapon/woodstaff/diamond/blacksteelstaff/royal
 	name = "refined ducal blacksteel staff"
 	desc = "A mage's staff that has been reinforced with blacksteel rivets and plating. An extravagent gift for a precocious heir that serves as both casting implement and mark of station. Perched atop it is a new beautiful Dorpel that shimmers with magical energies."
-	icon_state = "blacksteelstaff"
-	max_integrity = 300
 	sellprice = 230
 
 /obj/item/rogueweapon/woodstaff/riddle_of_steel
@@ -227,7 +225,7 @@
 
 /datum/crafting_recipe/gemstaff/ducalblacksteelstaffupgrade
 	name = "Refined Ducal Blacksteel Staff"
-	result = /obj/item/rogueweapon/woodstaff/diamond/refinedblacksteelstaffroyal
+	result = /obj/item/rogueweapon/woodstaff/diamond/blacksteelstaff/royal
 	reqs = list(/obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff/royal = 1,
 				/obj/item/roguegem/diamond = 1)
 	craftdiff = 0


### PR DESCRIPTION

## About The Pull Request

All this does is add a subtype of the refined blacksteel staff for the ducal blacksteel staff.



## Testing Evidence

8 line change, compiles

## Why It's Good For The Game

So the original coder never added a refined version of the ducal blacksteel staff so when trying to upgrade it, it would just upgrade into nothing as it had nothing to upgrade to, this should fix that by adding a refined version so when you use a dorpel on the ducal blacksteel staff it will actually turn into its refined version 

## Changelog



:cl:
add: refined ducal blacksteel staff and the recipe for it
/:cl:

