### PR TITLE
"Why didn't you EXPLODE?" - Makes bombs actually useful

### DIFF
--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -300,7 +300,7 @@
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5
 	throw_range = 3
-	var/fuze = 7.5 SECONDS
+	var/fuze = 5.5 SECONDS
 	var/lit = FALSE
 	var/prob2fail = 1
 
@@ -349,7 +349,7 @@
 			if(!skipprob && prob(prob2fail))
 				snuff()
 			else
-				explosion(T, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
+				explosion(T, devastation_range = 2, heavy_impact_range = 4, light_impact_range = 6, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
 				loud_message("A muted explosion echos in the ears of those whom hear it", hearing_distance = 14)
 				qdel(src) //IMPORTANT!! go into walls /turf/closed/wall/ and see /turf/closed/wall/ex_act. Its bounded with /proc/explosion. Same for /obj/structure and /obj/structure/ex_act because if you going to fuck intergity or whatever this shit called players will skin you alive for breaking their equipment and keys
 		else //also /turf/open/floor/ex_act for comment above
@@ -423,7 +423,7 @@
 			if(!skipprob && prob(prob2fail))
 				snuff()
 			else
-				explosion(T, devastation_range = 3, light_impact_range = 10, flame_range = 1, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
+				explosion(T, devastation_range = 5, heavy_impact_range = 6, light_impact_range = 10, flame_range = 2, smoke = TRUE, soundin = pick('sound/misc/explode/bottlebomb (1).ogg','sound/misc/explode/bottlebomb (2).ogg'))
 				loud_message("A loud explosion rings in the ears of those whom hear it", hearing_distance = 28)
 				qdel(src)
 

--- a/code/game/objects/items/rogueitems/bombs.dm
+++ b/code/game/objects/items/rogueitems/bombs.dm
@@ -299,7 +299,7 @@
 	throwforce = 0
 	slot_flags = ITEM_SLOT_HIP
 	throw_speed = 0.5
-	throw_range = 3
+	throw_range = 6
 	var/fuze = 5.5 SECONDS
 	var/lit = FALSE
 	var/prob2fail = 1


### PR DESCRIPTION
makes bombs less of a joke

## About The Pull Request

Be me

Make four Satchel bombs

Put them in a ring to explode someone

By some miracle they survive with zero damage done to them with zero armor.

## Testing Evidence

2 Line change, compiles on local host

## Why It's Good For The Game

Currently bombs kinda suck, they don't even delimb you while impact grenades will, this makes it so they WILL delimb you no matter what, if you get hit by a satchel bomb...I don't think you should shrug that off.

## Changelog


:cl:
fix: The supplier of gunpowder to the duchy has been executed for high treason following faulty gunpowder mix, satchel bombs and bomb sticks will now properly explode people
change: the supply of longer fuses has ran out resulting in shorter times to explode for blastsand sticks, a more volatile gunpowder mix has been included in the sticks, much lighter and able to be thrown farther
/:cl:


