### PR TITLE
Fixes "failure to fire" caused by beginning charge on Mob, moving cursor off Mob, then returning and upclicking on Mob

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -240,7 +240,7 @@
 
 	if(tcompare)
 		var/atom/target_atom = object
-		if(istype(target_atom) && tcompare != mob && (mob.atkswinging == "middle" || (mob.atkswinging && object != tcompare)))
+		if(istype(target_atom) && tcompare != mob && (mob.atkswinging == "middle" || mob.used_intent?.tranged || (mob.atkswinging && object != tcompare)))
 			target_atom.Click(location, control, params)
 		tcompare = null
 

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -238,6 +238,17 @@
 		mouse_pointer_icon = mouse_up_icon
 	selected_target[1] = null
 
+	// BYOND reads "cast started on mob, cursor left the mob" as a drag, so the finishing Click never
+	// fires even if you release back on the mob. Force the release cast ourselves.
+	if(mob.atkswinging == "middle" && mob.mmb_intent && istype(object, /atom) && !istype(object, /atom/movable/screen) && mob.next_move <= world.time && world.time > mob.next_click)
+		tcompare = null
+		if(mob.mmb_intent.no_early_release && chargedprog < 100)
+			mob.changeNext_move(mob.mmb_intent.clickcd)
+		else
+			mob.next_click = world.time + 1
+			mob.MiddleClickOn(object, params)
+		return
+
 	if(tcompare)
 		var/atom/target_atom = object
 		if(istype(target_atom) && tcompare != mob && (mob.atkswinging == "middle" || mob.used_intent?.tranged || (mob.atkswinging && object != tcompare)))


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
I ran into this bug on my bow hunter. When I started "charging" on a mob, and they or I moved and my cursor departed off of the sprite of the target mob, then I returned the cursor to the mob to "unclick" and release the arrow - nothing happened.

Further testing could reproduce this with any atom, turf etc. This also occurred with buff spells and invisibility. 

This PR puts a short circuit in MouseUp that should reliably bypass the mob-drag smear when using charged casts.

It also bypasses it if the mob is using a ranged attack. Seems to work ok in testing.
## Testing Evidence
https://cdn.discordapp.com/attachments/1338300314683441324/1521700483205435503/arrowtest2.mp4?ex=6a45c983&is=6a447803&hm=b6941e6e142f72e7a71dab7cda5e19e7995a57a1573a5e1ea7f9ccd21c19f70d&

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
disclosure, AI generated code (Opus 4.8). This can be done better by those more familiar
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed a bug where starting a spell on a mob, then the cursor moving off the mob, would cause that spell to no longer work when released on the mob.
fix: Same as above but also for arrow targets when firing a bow.
/:cl: