### PR TITLE
[Admin Balance Change] Remove Rontz Ring spawn from Contraband

### DIFF
--- a/code/game/objects/effects/spawners/equipment_spawners.dm
+++ b/code/game/objects/effects/spawners/equipment_spawners.dm
@@ -523,7 +523,7 @@
 	name = "confiscated item spawner"
 	icon_state = "heresy"
 	loot = list(
-		/obj/item/mattcoin = 5,
+		///obj/item/mattcoin = 5, Removing this for now. We don't want the garrison potentially getting access to bandit secure comms round start
 		/obj/item/reagent_containers/powder/herozium = 5,
 		/obj/item/reagent_containers/powder/starsugar = 5,
 		/obj/item/roguestatue/gold/loot = 5,

--- a/code/game/objects/effects/spawners/equipment_spawners.dm
+++ b/code/game/objects/effects/spawners/equipment_spawners.dm
@@ -523,7 +523,6 @@
 	name = "confiscated item spawner"
 	icon_state = "heresy"
 	loot = list(
-		///obj/item/mattcoin = 5, Removing this for now. We don't want the garrison potentially getting access to bandit secure comms round start
 		/obj/item/reagent_containers/powder/herozium = 5,
 		/obj/item/reagent_containers/powder/starsugar = 5,
 		/obj/item/roguestatue/gold/loot = 5,


### PR DESCRIPTION
## About The Pull Request

Did you know the contra spawner in the town watch can spawn a rontz ring roundstart? And if you're a matthiosite you can just pick it up and use it to listen in to the bandits with no chance they could know? Yeah, we didn't either. 

## Testing Evidence

Built, ran, seems fine. It's one line so should be good

## Why It's Good For The Game

This is far too easy to abuse and has no real right being in the game as agreed upon by several admins 

## Changelog

:cl:
fix: Removed rontz ring from the contraband spawner
/:cl:
