### PR TITLE
Pestranjak

### DIFF
--- a/code/datums/skills/misc.dm
+++ b/code/datums/skills/misc.dm
@@ -100,7 +100,7 @@
 		"...a student to your left pales, her queasiness overwhelming before she faints. You steel yourself, and look at the voidlike ribcage in the torso before you. Well-preserved chunks of flesh lie beside it, waiting for you to restore them to their rightful places..."
 	)
 	expert_name = "Barber"
-	max_untraited_level = SKILL_LEVEL_EXPERT // We'll let people get to Expert as an exception because reviving someone is very important to keep players in round
+	max_untraited_level = SKILL_LEVEL_JOURNEYMAN // No longer expert because miracles exist and the woefully underpaid physicians are getting cucked by the meta
 	trait_uncap = list(TRAIT_MEDICINE_EXPERT = SKILL_LEVEL_LEGENDARY)
 
 /datum/skill/misc/tracking

--- a/code/datums/skills/misc.dm
+++ b/code/datums/skills/misc.dm
@@ -100,7 +100,7 @@
 		"...a student to your left pales, her queasiness overwhelming before she faints. You steel yourself, and look at the voidlike ribcage in the torso before you. Well-preserved chunks of flesh lie beside it, waiting for you to restore them to their rightful places..."
 	)
 	expert_name = "Barber"
-	max_untraited_level = SKILL_LEVEL_JOURNEYMAN // No longer expert because miracles exist and the woefully underpaid physicians are getting cucked by the meta
+	max_untraited_level = SKILL_LEVEL_EXPERT // We'll let people get to Expert as an exception because reviving someone is very important to keep players in round
 	trait_uncap = list(TRAIT_MEDICINE_EXPERT = SKILL_LEVEL_LEGENDARY)
 
 /datum/skill/misc/tracking

--- a/code/modules/jobs/job_types/roguetown/church/monk.dm
+++ b/code/modules/jobs/job_types/roguetown/church/monk.dm
@@ -250,6 +250,7 @@
 		H.adjust_skillrank_up_to(/datum/skill/misc/medicine, 4, TRUE)
 		H.adjust_skillrank(/datum/skill/craft/alchemy, 1, TRUE)
 		ADD_TRAIT(H, TRAIT_NOSTINK, TRAIT_GENERIC)
+		ADD_TRAIT(H, TRAIT_MEDICINE_EXPERT, TRAIT_GENERIC)
 	if(H.patron?.type == /datum/patron/divine/eora) // Beauty and Love - beautiful and can read people pretty well.
 		ADD_TRAIT(H, TRAIT_BEAUTIFUL, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_EMPATH, TRAIT_GENERIC)

--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -379,7 +379,7 @@
 	speed_mod *= get_speed_location_modifier(target)
 	var/medskill = user.get_skill_level(/datum/skill/misc/medicine)
 	if(medskill == SKILL_LEVEL_EXPERT)
-		speed_mod -= 0.2
+		speed_mod -= 0.3
 	else if(medskill == SKILL_LEVEL_MASTER)
 		speed_mod -= 0.4
 	else if(medskill == SKILL_LEVEL_LEGENDARY)

--- a/code/modules/surgery/_surgery_step.dm
+++ b/code/modules/surgery/_surgery_step.dm
@@ -378,10 +378,12 @@
 			speed_mod *= implements_speed[implement_type] || 1
 	speed_mod *= get_speed_location_modifier(target)
 	var/medskill = user.get_skill_level(/datum/skill/misc/medicine)
-	if(medskill == SKILL_LEVEL_MASTER)
+	if(medskill == SKILL_LEVEL_EXPERT)
 		speed_mod -= 0.2
-	else if(medskill == SKILL_LEVEL_LEGENDARY)
+	else if(medskill == SKILL_LEVEL_MASTER)
 		speed_mod -= 0.4
+	else if(medskill == SKILL_LEVEL_LEGENDARY)
+		speed_mod -= 0.6
 
 	return speed_mod
 

--- a/code/modules/surgery/surgeries/healing.dm
+++ b/code/modules/surgery/surgeries/healing.dm
@@ -112,8 +112,8 @@
 /********************BRUTE STEPS********************/
 /datum/surgery_step/heal/brute/basic
 	name = "Tend bruises"
-	brutehealing = 10
-	missinghpbonus = 6
+	brutehealing = 15
+	missinghpbonus = 7
 	requires_tech = FALSE
 	replaced_by = /datum/surgery_step/heal/brute/upgraded
 
@@ -126,7 +126,7 @@
 
 /datum/surgery_step/heal/brute/upgraded/femto
 	name = "Tend bruises (Exp.)"
-	brutehealing = 30
+	brutehealing = 20
 	missinghpbonus = 2
 	requires_tech = TRUE
 	replaced_by = null
@@ -134,47 +134,47 @@
 /********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/basic
 	name = "Tend burns"
-	burnhealing = 10
-	missinghpbonus = 7.5
+	burnhealing = 15
+	missinghpbonus = 7
 	requires_tech = FALSE
 	replaced_by = /datum/surgery_step/heal/burn/upgraded
 
 /datum/surgery_step/heal/burn/upgraded
 	name = "Tend burns (Adv.)"
-	burnhealing = 10
-	missinghpbonus = 5
+	burnhealing = 20
+	missinghpbonus = 4
 	requires_tech = TRUE
 	replaced_by = /datum/surgery_step/heal/burn/upgraded/femto
 
 /datum/surgery_step/heal/burn/upgraded/femto
 	name = "Tend burns (Exp.)"
-	burnhealing = 10
-	missinghpbonus = 2.5
+	burnhealing = 20
+	missinghpbonus = 2
 	requires_tech = TRUE
 	replaced_by = null
 
 /********************COMBO STEPS********************/
 /datum/surgery_step/heal/combo
 	name = "Tend damage"
-	brutehealing = 6
-	burnhealing = 6
-	missinghpbonus = 7.5
+	brutehealing = 7
+	burnhealing = 7
+	missinghpbonus = 7
 	requires_tech = FALSE
 	replaced_by = /datum/surgery_step/heal/combo/upgraded
 
 /datum/surgery_step/heal/combo/upgraded
 	name = "Tend damage (Adv.)"
-	brutehealing = 6
-	burnhealing = 6
-	missinghpbonus = 5
+	brutehealing = 7
+	burnhealing = 7
+	missinghpbonus = 4
 	requires_tech = TRUE
 	replaced_by = /datum/surgery_step/heal/combo/upgraded/femto
 
 /datum/surgery_step/heal/combo/upgraded/femto
 	name = "Tend damage (Exp.)"
-	brutehealing = 6
-	burnhealing = 6
-	missinghpbonus = 2.5
+	brutehealing = 7
+	burnhealing = 7
+	missinghpbonus = 2
 	requires_tech = TRUE
 	replaced_by = null
 

--- a/code/modules/surgery/surgeries/mouth_to_mouth.dm
+++ b/code/modules/surgery/surgeries/mouth_to_mouth.dm
@@ -6,7 +6,7 @@
 	name = "Mouth to Mouth"
 
 	possible_locs = list(BODY_ZONE_HEAD)
-	time = 4 SECONDS
+	time = 3 SECONDS
 	accept_hand = TRUE
 	accept_any_item = TRUE
 	possible_intents = list(
@@ -24,7 +24,7 @@
 	repeating = TRUE
 
 	// How much oxy damage we heal per completion
-	var/oxyhealing = 10
+	var/oxyhealing = 15
 
 /datum/surgery_step/mouth_to_mouth/validate_target(mob/user, mob/living/target, target_zone, datum/intent/intent)
 	. = ..()

--- a/code/modules/surgery/surgeries_hearth/extract_lux.dm
+++ b/code/modules/surgery/surgeries_hearth/extract_lux.dm
@@ -21,7 +21,7 @@
 	time = 8 SECONDS
 	surgery_flags = SURGERY_BLOODY | SURGERY_INCISED | SURGERY_CLAMPED | SURGERY_RETRACTED | SURGERY_BROKEN
 	surgery_flags_blocked = SURGERY_CONSTRUCT
-	skill_min = SKILL_LEVEL_JOURNEYMAN
+	skill_min = SKILL_LEVEL_EXPERT
 	preop_sound = 'sound/surgery/organ2.ogg'
 	success_sound = 'sound/surgery/organ1.ogg'
 	possible_locs = list(BODY_ZONE_CHEST)


### PR DESCRIPTION
## About The Pull Request
This is a series of small number and line changes.
- Adjusted surgery speeds based off skill level. Even expert is a bit faster now.
- Tending surgeries should heal some more too. Brought brute and burn surgeries more in-line with each other as well. They are the better choice to pick if a person has one specific type of damage only.
- CPR is a bit shorter and gives some more oxygen.
- Pestran acolytes get medicine expert trait.
- Bumped extract lux surgery to expert requirement to be the same as lux revival's tier. If people hate this enough it'll get changed back but for now I want to see the state of medicine when you must rely on physicians for this.

## Testing Evidence
It's kinda the same as it was but a bit better. I fiddled around with it and it felt slightly better than it currently is. There are so many factors that affect surgery too so I made sure to do it on top of a bedroll at the very least.
<img width="1192" height="721" alt="surgery1" src="https://github.com/user-attachments/assets/03ab6fb3-7074-432a-88d0-27293bece6cf" />

## Why It's Good For The Game
Some of these changes were requested the most or sought after for physician players. As a person who has played a ton of acolyte/missionary and also the other side of the coin as a physician and alchemy, these were much needed and will (hopefully) be sufficient enough for now.

This PR is also part of a series of PRs I am atomizing for which I plan on making to try and balance out the medicine and miracles in this game. Currently miracles are just way too strong and no one pays physicians the light of day they deserve. They just get relegated to potion pushers and honestly I'd rather see them be relied upon for surgeries more instead of the guys casting miracles. Maybe even have them work together if they need lux revivals.

With this PR, physicians will probably not be completely relied on for healing but they will be noticeably better at doing so in comparison to miracles. Legendary physicians will definitely outpace any healing done by miracles as well. If you want to be an acolyte and do surgery stuff past jman level (IE lux extractions and revivals) you will have to ask the apothecary, archivist or court physician to give you an apprenticeship. Or you know, just be a pestran!

See this thread on the discord if you want to add ideas or see what may be planned:
https://discord.com/channels/1240735983276654733/1520548701624340571

## Changelog
:cl:
qol: Makes surgery speeds a bit faster.
qol: Made surgeries heal a bit more based off skill and base values.
qol: Adjusted CPR to be a bit more rewarding on success.
qol: Makes physicians kinda better than miracles now. Surgeries heal a bit more too.
add: Pestran acolytes get medicine expert trait.
add: Bumped extract lux surgery to expert requirement.
/:cl: