### PR TITLE
More Knight Weapon Options + Tweaking the City Guard's Weapon Choices

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_foot.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_foot.dm
@@ -46,7 +46,7 @@
 				l_hand = /obj/item/rogueweapon/flail/sflail
 				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_MASTER, TRUE)
 			if ("Warhammer")
-				beltr = /obj/item/rogueweapon/mace/warhammer
+				beltr = /obj/item/rogueweapon/mace/warhammer/steel
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_MASTER, TRUE)
 			if("Sabre")
 				beltl = /obj/item/rogueweapon/scabbard/sword

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_heavy.dm
@@ -35,12 +35,16 @@
 
 	H.adjust_blindness(-3)
 	if(H.mind)
-		var/weapons = list("Claymore","Great Mace","Battle Axe","Greataxe","Estoc","Lucerne","Partizan")
+		var/weapons = list("Greatsword","Zweihander","Great Mace","Battle Axe","Greataxe","Estoc","Eagle's Beak","Partizan")
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		H.set_blindness(0)
 		switch(weapon_choice)
-			if("Claymore")
-				r_hand = /obj/item/rogueweapon/greatsword/zwei
+			if("Greatsword")
+				r_hand = /obj/item/rogueweapon/greatsword
+				backl = /obj/item/rogueweapon/scabbard/gwstrap
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_MASTER, TRUE)
+			if("Zweihander")
+				r_hand = /obj/item/rogueweapon/greatsword/grenz
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_MASTER, TRUE)
 			if("Great Mace")
@@ -57,8 +61,8 @@
 				r_hand = /obj/item/rogueweapon/estoc
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_MASTER, TRUE)
-			if("Lucerne")
-				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
+			if("Eagle's Beak")
+				r_hand = /obj/item/rogueweapon/eaglebeak
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_MASTER, TRUE)
 			if("Partizan")

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -115,7 +115,7 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)
 			if("Polehammer")
-				r_hand = /obj/item/rogueweapon/eaglebeak
+				r_hand = /obj/item/rogueweapon/eaglebeak/lucerne
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, 4, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 4, TRUE)


### PR DESCRIPTION
## About The Pull Request
Replaces Heavy Knights "Claymore" option with a choice of a greatsword or a zweihander. Also, upgrades the choice of a polehammer from a lucerne to a Eagle's Beak.

Foot Knight's warhammer choice is upgraded to steel as well.

Downgrades City Guards Polehammer choice from Eagle's Beak to Lucerne.

## Testing Evidence

I promise this works, it's a few string changes. I tested it myself regardless.

## Why It's Good For The Game

After playing both Knight and City Guard extensively I can clearly see there's some things that do not make very much sense.

Knights have a lot of great options to pick from when spawning in, however there's a few that give them iron weapons when other classes like mercenaries or even the run of the mill city guard get them on spawn. This seeks to change that, allowing heavy knights to select real steel greatswords or an eagle's beak instead of a lucerne.

There's no real reason that the elite warriors of the duchy should have worse weapon selection than some merc from grenzelhoft or even Ferentian mercs (who get steel greatswords already).

HOWEVER, as I mentioned the city guard getting the best polehammer in the game on spawn is really strange given that most of the rest of their weapons are iron. Compare them to the MAA who almost entirely get iron on spawn, and it makes even less sense. So as a sort of trade this PR downgrades their polehammer choice to a lucerne instead of an eagle's beak.

## Changelog

:cl:
balance: heavy knight's claymore weapon choice split into two steel options
balance: heavy knight's lucerne weapon choice changed to eagle's beak
balance: foot knight's warhammer weapon choice upgraded to steel to match all other options
balance: city guard's polehammer weapon choice downgraded to lucerne instead of the current eagle's beak
:cl: