### PR TITLE
Increase the recharge time of raise lesser skeleton so one necromancer can't spawn 492 skeleton simple mobs in the span of maybe 4 skirmishes.

### DIFF
--- a/code/modules/spells/roguetown/necromancer.dm
+++ b/code/modules/spells/roguetown/necromancer.dm
@@ -84,7 +84,7 @@
 	chargedloop = /datum/looping_sound/invokegen
 	gesture_required = TRUE // Summon spell
 	associated_skill = /datum/skill/magic/arcane
-	recharge_time = 20 SECONDS
+	recharge_time = 60 SECONDS
 	var/cabal_affine = FALSE
 	var/is_summoned = FALSE
 	var/to_spawn = 4
@@ -136,7 +136,7 @@
 /obj/effect/proc_holder/spell/invoked/raise_undead_formation/necromancer
 	cabal_affine = TRUE
 	is_summoned = TRUE
-	recharge_time = 35 SECONDS
+	recharge_time = 60 SECONDS
 	to_spawn = 3
 
 


### PR DESCRIPTION
## About The Pull Request

- Upped recharge time for raise lesser skeleton formation from 20 seconds to 60

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
number change
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
<img width="288" height="46" alt="image_2026-07-03_200523220" src="https://github.com/user-attachments/assets/ea2b4d7d-6460-4324-b779-0acfb4e8d082" />

The above figure is from a recent round, maybe 3 big fights where the spell was used. Each summon is 3 simplemobs, so 492 skeletons were spawned over those three scuffles. 

Zizo's greatest bodyblockers can be spawned far faster and far more cheaply than the actual forcewall spells can, not to mention this wall fights back with mobs immune to sunder wounds. 

Also I died to it once. 


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: increased raise lesser undead spell recharge from 20 seconds to 60
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
