### PR TITLE
Replace warden master's generic axe with the special snowflake Oath Warden axe.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/wardenmaster.dm
@@ -117,7 +117,7 @@
 		switch(weapon_choice)//feel it'd be nice to have a sword version for a real Jeor Mormont?
 			if("Greataxe")			
 				backl = /obj/item/rogueweapon/scabbard/gwstrap
-				l_hand = /obj/item/rogueweapon/greataxe/steel
+				l_hand = /obj/item/rogueweapon/stoneaxe/oath
 			if("Javelins & Shield")
 				beltr = /obj/item/quiver/javelin/steel
 				backl = /obj/item/rogueweapon/shield/tower/


### PR DESCRIPTION
## About The Pull Request

- Gives the special warden his special axe
- Makes oath axe no longer unreachable dead code

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles. 1 line change. 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The cool special warden axe wasn't used anywhere, not even mapped, unlike the minotaur axe, which is on some spots. Its flavor all points to it being for the veteran warden, but instead, he got handed a normal steel greataxe. 

Our special little omnistat chud warden needs his special axe to larp has the milwood knigth captain from DS3 he was born to be. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: replaced the warden master's steel greataxe loadout option with the unique oath axe. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
