### PR TITLE
Removes the Forced Outlander Trait on Migrants

### DIFF
--- a/code/controllers/subsystem/migrants.dm
+++ b/code/controllers/subsystem/migrants.dm
@@ -285,7 +285,6 @@ SUBSYSTEM_DEF(migrants)
 	to_chat(character, span_notice(wave.greet_text))
 	to_chat(character, span_notice(role.greet_text))
 
-	ADD_TRAIT(character, TRAIT_OUTLANDER, TRAIT_GENERIC)
 
 	if(role.outfit)
 		var/datum/outfit/outfit = new role.outfit()

--- a/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
+++ b/code/modules/antagonists/roguetown/villain/dark_itinerant.dm
@@ -97,6 +97,7 @@
 	H.cmode_music = 'sound/music/combat_heretic.ogg'
 	ADD_TRAIT(H, TRAIT_SQUIRE_REPAIR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_OUTLANDER, TRAIT_GENERIC)
 	wretch_select_bounty(H)
 
 /datum/outfit/job/dark_itinerant_knight/pre_equip(mob/living/carbon/human/H)
@@ -147,6 +148,7 @@
 
 	H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
 	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
+	ADD_TRAIT(H, TRAIT_OUTLANDER, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_STEELHEARTED, TRAIT_GENERIC)
 	ADD_TRAIT(H, TRAIT_RITUALIST, TRAIT_GENERIC)


### PR DESCRIPTION
Some Migrants are part of Ferencia and should probably not have it.

This is literally just for I believe Heartfelt and Fablefield.

## About The Pull Request

Some Migrants are part of Ferencia and should probably not have it.

This is literally just for I believe Heartfelt and Fablefield.

## Testing Evidence

3 Line Change

## Why It's Good For The Game

Expectations

## Changelog

:cl:
fix: Migrants being forced to be Outlanders
/:cl:
