### PR TITLE
Adds Saddle to Loadout

### DIFF
--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -2288,6 +2288,11 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	path = /obj/item/storage/backpack/rogue/satchel/short
 	triumph_cost = 4
 
+/datum/loadout_item/saddle
+	name = "Saddle"
+	path = /obj/item/natural/saddle
+	triumph_cost = 4
+
 /datum/loadout_item/pouches
 	name = "Pouche"
 	path = /obj/item/storage/belt/rogue/pouch


### PR DESCRIPTION
## About The Pull Request
Title.

## Testing Evidence
<img width="246" height="155" alt="saddleloadout" src="https://github.com/user-attachments/assets/5ee27177-8b16-4032-a4a7-8cf1924baa70" />

## Why It's Good For The Game
A niche item that is mostly good for taur players, really. Costs 4 because it can be used like a bag for them, but its only as expensive as a satchel at the merchant, anyway. Saddles are easy to get regardless but since we already have satchels and the like as options, we may as well.

## Changelog
:cl:
add: Saddle in the loadout options.
/:cl: