### PR TITLE
Fountains can fill any liquid container. Plus more drinking fixes.

### DIFF
--- a/code/game/objects/structures/well.dm
+++ b/code/game/objects/structures/well.dm
@@ -26,6 +26,8 @@
 			to_chat(user, "<span class='notice'>I fill [W] from [src].</span>")
 			playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 80, FALSE)
 			return
+	else if(istype(I, /obj/item/reagent_containers/glass))
+		to_chat(user, span_warning("I need a bucket."))
 	else ..()
 
 /obj/structure/well/poisoned
@@ -48,12 +50,14 @@
 		if(W.reagents.holder_full())
 			to_chat(user, span_warning("[W] is full."))
 			return
-		if(do_after(user, 30, target = src))
+		if(do_after(user, 3 SECONDS, target = src))
 			var/list/waterl = list(/datum/reagent/water = 50, /datum/reagent/organpoison = 50)
 			W.reagents.add_reagent_list(waterl)
 			to_chat(user, "<span class='notice'>I fill [W] from [src]. The water looks vile, am I really going to drink this?</span>")
 			playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 80, FALSE)
 			return
+	else if(istype(I, /obj/item/reagent_containers/glass))
+		to_chat(user, span_warning("I need a bucket."))
 	else ..()
 
 /obj/structure/well/fountain
@@ -65,6 +69,20 @@
 	plane = GAME_PLANE_UPPER
 	pixel_x = -15
 
+/obj/structure/well/fountain/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers/glass))
+		var/obj/item/reagent_containers/glass/W = I
+		if(W.reagents.holder_full())
+			to_chat(user, span_warning("[W] is full."))
+			return
+		playsound(user, 'sound/foley/drawwater.ogg', 100, FALSE)
+		if(do_after(user, 1 SECONDS, target = src))
+			var/list/waterl = list(/datum/reagent/water = 250)
+			W.reagents.add_reagent_list(waterl)
+			to_chat(user, "<span class='notice'>I fill [W] from [src].</span>")			
+			return
+	else ..()
+
 /obj/structure/well/fountain/onbite(mob/user)
 	if(isliving(user))
 		var/mob/living/L = user
@@ -75,15 +93,15 @@
 			if(C.is_mouth_covered())
 				return
 		user.visible_message(span_info("[user] starts to drink from [src]."))
+		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		drink_act(user, L)
 		return
 	..()
 
 /obj/structure/well/fountain/proc/drink_act(mob/user, mob/living/L)
-	playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 	if(L.stat != CONSCIOUS)
 		return
-	if(do_after(L, 25, target = src))
+	if(do_after(L, 2.5 SECONDS, target = src))
 		var/list/waterl = list(/datum/reagent/water = 5)
 		var/datum/reagents/reagents = new()
 		reagents.add_reagent_list(waterl)
@@ -103,6 +121,20 @@
 	plane = GAME_PLANE_UPPER
 	pixel_x = -15
 
+/obj/structure/well/fountainswamp/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/reagent_containers/glass))
+		var/obj/item/reagent_containers/glass/W = I
+		if(W.reagents.holder_full())
+			to_chat(user, span_warning("[W] is full."))
+			return
+		playsound(user, 'sound/foley/drawwater.ogg', 100, FALSE)
+		if(do_after(user, 1 SECONDS, target = src))
+			var/list/waterl = list(/datum/reagent/water/gross = 250)
+			W.reagents.add_reagent_list(waterl)
+			to_chat(user, "<span class='notice'>I fill [W] from [src].</span>")			
+			return
+	else ..()
+
 /obj/structure/well/fountainswamp/onbite(mob/user)
 	if(isliving(user))
 		var/mob/living/L = user
@@ -113,15 +145,15 @@
 			if(C.is_mouth_covered())
 				return
 		user.visible_message(span_info("[user] starts to drink from [src]."))
+		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		drink_act(user, L)
 		return
 	..()
 
 /obj/structure/well/fountainswamp/proc/drink_act(mob/user, mob/living/L)
-	playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 	if(L.stat != CONSCIOUS)
 		return
-	if(do_after(L, 25, target = src))
+	if(do_after(L, 2.5 SECONDS, target = src))
 		var/list/waterl = list(/datum/reagent/water/gross = 5)
 		var/datum/reagents/reagents = new()
 		reagents.add_reagent_list(waterl)

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -248,8 +248,7 @@
 				to_chat(user, span_warning("[C] is full."))
 				return
 			playsound(user, 'sound/foley/drawwater.ogg', 100, FALSE)
-			if(do_after(user, 8, target = src))
-				user.changeNext_move(CLICK_CD_MELEE)
+			if(do_after(user, 0.8 SECONDS, target = src))
 				C.reagents.add_reagent(water_reagent, 300)
 				to_chat(user, span_notice("I fill [C] from [src]."))
 				// If the user is filling a water purifier and the water isn't already clean...
@@ -312,7 +311,7 @@
 
 		else
 			user.visible_message(span_info("[user] starts to wash [item2wash] in [src]."))
-			if(do_after(L, 30, target = src))
+			if(do_after(L, 3 SECONDS, target = src))
 				if(wash_in)
 					wash_atom(item2wash, CLEAN_STRONG)
 					L.update_inv_hands()
@@ -335,19 +334,20 @@
 			if(C.is_mouth_covered())
 				return
 		user.visible_message(span_info("[user] starts to drink from [src]."))
+		if(istype(src, /turf/open/water/sewer))
+			to_chat(user, span_userdanger("Have I gone mad!? Why am I drinking sewage?"))
+		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		drink_act(user, L)
 		return
 	..()
 
 /turf/open/water/proc/drink_act(mob/user, mob/living/L)
-	playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 	if(L.stat != CONSCIOUS)
 		return
-
-	if(do_after(L, 25, target = src))
+	if(do_after(L, 2.5 SECONDS, target = src))
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			if(H.dna?.species?.id == "gnoll" && ispath(water_reagent, /datum/reagent/blood))
+			if(ispath(water_reagent, /datum/reagent/blood) && (H.dna?.species?.id == "gnoll"))
 				if(!H.gnoll_bloodpool_feed())
 					return
 				playsound(src, 'sound/misc/drink_blood.ogg', 100, FALSE, -4)
@@ -356,8 +356,6 @@
 					if(water_volume <= 0)
 						water_reagent = water_reagent_purified
 				return
-		if (istype(src,/turf/open/water/sewer))
-			to_chat(user, span_userdanger("Have I gone mad!? Why am I drinking sewage!?"))
 		var/list/waterl = list(src.water_reagent = 5)
 		var/datum/reagents/reagents = new()
 		reagents.add_reagent_list(waterl)

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -334,8 +334,6 @@
 			if(C.is_mouth_covered())
 				return
 		user.visible_message(span_info("[user] starts to drink from [src]."))
-		if(istype(src, /turf/open/water/sewer))
-			to_chat(user, span_userdanger("Have I gone mad!? Why am I drinking sewage?"))
 		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		drink_act(user, L)
 		return
@@ -429,6 +427,19 @@
 	icon_state = "paving"
 	water_color = pick("#705a43","#697043", "#6C6543")
 	.  = ..()
+
+/turf/open/water/sewer/onbite(mob/user)
+	// I think it's okay to have these checks copy-pasted for something you really, *really* aren't supposed to be doing anyways.
+	if(isliving(user))
+		var/mob/living/L = user
+		if(L.stat != CONSCIOUS)
+			return
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			if(C.is_mouth_covered())
+				return
+		to_chat(L, span_userdanger("Have I gone mad!? Why am I drinking sewage?"))
+	..()
 
 /turf/open/water/swamp
 	name = "murk"

--- a/code/modules/roguetown/roguejobs/mages/magestructures.dm
+++ b/code/modules/roguetown/roguejobs/mages/magestructures.dm
@@ -142,17 +142,23 @@
 			var/mob/living/carbon/C = user
 			if(C.is_mouth_covered())
 				return
-		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
 		user.visible_message(span_info("[user] starts to drink from [src]."))
-		if(do_after(L, 25, target = src))
-			var/list/waterl = list(/datum/reagent/medicine/manapot = 2)
-			var/datum/reagents/reagents = new()
-			reagents.add_reagent_list(waterl)
-			reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
-			playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
+		playsound(user, pick('sound/foley/waterwash (1).ogg','sound/foley/waterwash (2).ogg'), 100, FALSE)
+		drink_mana(user, L)
 		return
 	..()
-	
+
+/obj/structure/well/fountain/mana/proc/drink_mana(mob/user, mob/living/L)
+	if(L.stat != CONSCIOUS)
+		return
+	if(do_after(L, 2.5 SECONDS, target = src))
+		var/list/waterl = list(/datum/reagent/medicine/manapot = 2)
+		var/datum/reagents/reagents = new()
+		reagents.add_reagent_list(waterl)
+		reagents.trans_to(L, reagents.total_volume, transfered_by = user, method = INGEST)
+		playsound(user,pick('sound/items/drink_gen (1).ogg','sound/items/drink_gen (2).ogg','sound/items/drink_gen (3).ogg'), 100, TRUE)
+		drink_mana(user, L)
+	return
 
 /obj/machinery/light/rogue/forge/arcane
 	icon = 'icons/roguetown/misc/forge.dmi'


### PR DESCRIPTION
## About The Pull Request
- **Fountains can fill any liquid container, not just buckets.**
- **Drinking directly from fountains and bodies of water no longer plays the washing sound repeatedly.** It will play once, and only the swallowing sound will repeat.
- You can now autodrink from the mana fountain. 
  - It still yields water when you FILL a container from it.
- Filling a bucket from a body of water no longer has a stupid click cooldown.
  - Filling from wells doesn't give you one, why should this? It objectively feels much worse to fill containers *with this cooldown*.
- Wells give a small error if you try to draw water with anything that isn't a bucket.
  - <img width="141" height="34" alt="image" src="https://github.com/user-attachments/assets/29f10448-b671-477a-a820-6e4b844ff4ec" />
- The (existing) warning message from drinking sewage now plays before you actually drink it.
  - <img width="492" height="68" alt="image" src="https://github.com/user-attachments/assets/2c31c0d7-2a8b-4390-8322-842b7d174930" />
- The swamp-water fountain now gives you "gross" murk water when trying to fill from it, the same you get when drinking directly.
  - It still has an identical sprite and name to the "real" water fountain, so mappers probably will need to come up with something if they want to make the bog fountain work well. However, this does get the code properly in-place in case they *do* want to put this in the world.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
### SOUND ON.


https://github.com/user-attachments/assets/5b08d5ae-62d6-462c-a405-3be17e2d05a4


https://github.com/user-attachments/assets/e63ce826-328a-4fcf-90fd-f97417d65f7e


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Most of these things have been small pain points for me for a while. I want to fix them, and help reverse the "death by a thousand cuts" of overly-janky yet highly-used stuff in the game not feeling good.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: At water fountains, you can now fill any liquid container (mugs, bottles, etc.), not just buckets.
sound: You will no longer repeatedly hear the washing sound when someone is drinking from bodies of water, or from fountains.
fix: You can now autodrink from mana fountains, just like regular fountains.
qol: Removed the click cooldown for filling liquid containers from a body of water. This cuts down on unnecessary delay, & brings the filling speed on par with wells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
