### PR TITLE
Removes the duplicate examine text of Inquisition papers

### DIFF
--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -352,8 +352,6 @@
 		else
 			to_chat(user, span_notice("This writ has not yet been signed."))
 
-/obj/item/paper/inqslip/examine(mob/user)
-	. = ..()
 
 /obj/item/paper/inqslip/proc/attemptsign(mob/user, mob/living/carbon/human/M)
 	if(sliptype == 2)

--- a/code/modules/paperwork/rogue.dm
+++ b/code/modules/paperwork/rogue.dm
@@ -354,7 +354,6 @@
 
 /obj/item/paper/inqslip/examine(mob/user)
 	. = ..()
-	. += span_notice(desc)
 
 /obj/item/paper/inqslip/proc/attemptsign(mob/user, mob/living/carbon/human/M)
 	if(sliptype == 2)


### PR DESCRIPTION
## About The Pull Request
<img width="787" height="287" alt="image" src="https://github.com/user-attachments/assets/2d74ce05-6d3b-47b5-9c3a-c48b002d78f7" />

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
No
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fucking *raw!*
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Removed the duplicate examine text from Inquisition-specific papers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
