### PR TITLE
actually fixes the ducal blacksteel staff this time

### DIFF
--- a/modular_azurepeak/code/game/objects/items/magic_staffs.dm
+++ b/modular_azurepeak/code/game/objects/items/magic_staffs.dm
@@ -23,6 +23,7 @@
 		/datum/crafting_recipe/gemstaff/diamond_staff,
 		/datum/crafting_recipe/gemstaff/riddle_of_steel_staff,
 		/datum/crafting_recipe/gemstaff/blacksteelstaffupgrade,
+		/datum/crafting_recipe/gemstaff/ducalblacksteelstaffupgrade,
 		)
 
 	AddElement(


### PR DESCRIPTION
## About The Pull Request

Single line PR that adds a datum to slapcrafting to actually fix the ducal blacksteel staff

## Testing Evidence

compiles + 1 line

## Why It's Good For The Game

Fixes are always good


## Changelog



:cl:
add: Executed the local venard who claimed their dorpels were top quality to put put on the heirs blacksteel staff, local garrison has discovered they were not "top quality".
/:cl:

