### PR TITLE
Adds the "Big Stick" option to Big Man thugs.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -139,7 +139,7 @@
 			H.adjust_skillrank_up_to(/datum/skill/labor/mining, SKILL_LEVEL_JOURNEYMAN, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/labor/lumberjacking, SKILL_LEVEL_JOURNEYMAN, TRUE)
 
-			var/options = list("Hands-On", "Big Axe")
+			var/options = list("Hands-On", "Big Axe", "Big Stick")
 			var/option_choice = input(H, "Choose your means.", "TAKE UP ARMS") as anything in options
 
 			switch(option_choice)


### PR DESCRIPTION
## About The Pull Request

Big Man towner thugs have an option in the code to use a mace as their preferred weapon. For some reason, this option was not being provided to players. This PR fixes that.

## Testing Evidence

Untested, one line change. I really don't see what it could break.

## Why It's Good For The Game

My new towner thug would look better with a mace than with an axe.

## Changelog

:cl:
add: Big Man towner thugs can now choose to spawn with a mace
/:cl:
