### PR TITLE
Adds cursed collar prefs and confirmation prompt

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -118,6 +118,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/chastity_hardmode = CHASTITY_HARDMODE_DISABLED
 	var/extreme_erp = FALSE
 	var/edging = FALSE
+	/// If a cursed collar can be equipped to them at all
+	var/cursed_collarable = FALSE
 	var/compliance_notifs = TRUE
 	var/skillcap_notifs = TRUE
 	var/restricted_species_pref = null

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -136,6 +136,7 @@
 		list("id" = "permanent_binding", "label" = "Enable Permanent Binding", "enabled" = (owner.prefs.chastity_hardmode == CHASTITY_HARDMODE_ENABLED), "desc" = "Enable irreversible key-only chastity lock behavior."),
 		list("id" = "extreme_erp", "label" = "Enable Extreme ERP Content", "enabled" = !!owner.prefs.extreme_erp, "desc" = "Allow extreme ERP content categories."),
 		list("id" = "edging", "label" = "Enable Edging Content", "enabled" = !!owner.prefs.edging, "desc" = "Allow edging-related ERP content."),
+		list("id" = "cursed_collars", "label" = "Enable Cursed Collars", "enabled" = !!owner.prefs.cursed_collarable, "desc" = "Allow others to equip a cursed collar on you."),
 	)
 
 	data["categories"] = list(
@@ -229,6 +230,8 @@
 				owner.toggle_extreme_ERP()
 			if("edging")
 				owner.toggle_edging()
+			if("cursed_collars")
+				owner.toggle_cursed_collars()
 		SStgui.update_uis(src)
 		return TRUE
 
@@ -450,6 +453,26 @@
 			to_chat(src, "You ENDVRE through orgasms.")
 		else
 			to_chat(src, "You will no longer ENDVRE through orgasms.")
+
+/client/verb/toggle_cursed_collars() // Toggles cursed collars. Will drop existing collars if toggled off while wearing one
+	set category = "Options"
+	set name = "Toggle Cursed Collars"
+	set hidden = 1
+	if(!prefs)
+		return
+	prefs.cursed_collarable = !prefs.cursed_collarable
+	prefs.save_preferences()
+	if(prefs.cursed_collarable)
+		to_chat(src, "You can now be collared.")
+		return
+	to_chat(src, "You are no longer able to be collared")
+	if(!ishuman(usr))
+		return
+	var/mob/living/carbon/human/human_user = usr
+	var/obj/item/clothing/neck/roguetown/cursed_collar/collar = human_user.wear_neck
+	if(!istype(collar))
+		return
+	collar.dropped(human_user)
 
 /client/verb/toggle_compliance_notifs() // The messages need to be on-by-default while this is in its early stages.
 	set category = "Options"

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -415,13 +415,6 @@
 /obj/item/clothing/neck/roguetown/gorget/cursed_collar/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_SELF_UNEQUIP, CURSED_ITEM_TRAIT)
-/*
-/obj/item/clothing/neck/roguetown/gorget/cursed_collar/dropped(mob/living/carbon/human/user)
-	. = ..()
-	if(QDELETED(src))
-		return
-	qdel(src)
-*/
 
 /obj/item/clothing/neck/roguetown/psicross
 	name = "psycross"

--- a/modular/code/modules/slave_collar/cursed_collar.dm
+++ b/modular/code/modules/slave_collar/cursed_collar.dm
@@ -47,17 +47,21 @@
 /obj/item/clothing/neck/roguetown/cursed_collar/proc/reset_received_cum_count()
 	received_cum_count = 0
 
-/obj/item/clothing/neck/roguetown/cursed_collar/attack(mob/living/carbon/human/C, mob/living/user)
-	if(!istype(C))
+/obj/item/clothing/neck/roguetown/cursed_collar/attack(mob/living/carbon/human/target, mob/living/user)
+	if(!istype(target))
 		return ..()
 
-	if(C.get_item_by_slot(SLOT_NECK))
-		to_chat(user, span_warning("[C] is already wearing something around their neck!"))
+	if(!target.client?.prefs?.cursed_collarable)
+		to_chat(user, span_warning("[target] has cursed collars disabled in their prefs!"))
 		return
 
-	var/obj/item/chastity/existing_chastity = C.chastity_device
+	if(target.get_item_by_slot(SLOT_NECK))
+		to_chat(user, span_warning("[target] is already wearing something around their neck!"))
+		return
+
+	var/obj/item/chastity/existing_chastity = target.chastity_device
 	if(istype(existing_chastity) && existing_chastity.chastity_cursed)
-		to_chat(user, span_warning("[C] is already bound by cursed chastity."))
+		to_chat(user, span_warning("[target] is already bound by cursed chastity."))
 		return
 
 	var/datum/mind/master_mind = collar_master
@@ -72,34 +76,43 @@
 		return
 
 	var/surrender_mod = 1
-	if(C.surrendering || C.compliance)
+	if(target.surrendering || target.compliance)
 		surrender_mod = 0.5
 
 	applying = TRUE
-	if(do_mob(user, C, 50 * surrender_mod))
-		playsound(loc, 'sound/foley/equip/equip_armor_plate.ogg', 30, TRUE, -2)
+	if(!do_mob(user, target, 50 * surrender_mod))
+		applying = FALSE
+		return
 
-		// Get or create collar master datum first
-		var/datum/component/collar_master/CM = master_mind.GetComponent(/datum/component/collar_master)
-		if(!CM)
-			CM = master_mind.AddComponent(/datum/component/collar_master)
+	if(tgui_alert(target, "Submit to the collar's control?", "Cursed Collar", list("Yes!", "No")) != "Yes!")
+		user.visible_message(span_warning("[target] resists the collar's control."))
+		to_chat(target, span_warning("Your defiant will prevents the collar from binding to you!"))
+		applying = FALSE
+		return
 
-		// Try to equip
-		if(!C.equip_to_slot_if_possible(src, SLOT_NECK, TRUE, TRUE))
-			to_chat(user, span_warning("You fail to lock the collar around [C]'s neck!"))
-			applying = FALSE
-			return
+	playsound(loc, 'sound/foley/equip/equip_armor_plate.ogg', 30, TRUE, -2)
 
-		// Add pet to the master's list before sending collar signals
-		if(!CM.add_pet(C))
-			to_chat(user, span_warning("The collar fails to bind [C]."))
-			C.dropItemToGround(src, force = TRUE)
-			applying = FALSE
-			return
+	// Get or create collar master datum first
+	var/datum/component/collar_master/CM = master_mind.GetComponent(/datum/component/collar_master)
+	if(!CM)
+		CM = master_mind.AddComponent(/datum/component/collar_master)
 
-		SEND_SIGNAL(C, COMSIG_CARBON_COLLAR_BOUND, collar_master, src)
-		ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
-		log_combat(user, C, "tried to collar", addition="with [src]")
+	// Try to equip
+	if(!target.equip_to_slot_if_possible(src, SLOT_NECK, TRUE, TRUE))
+		to_chat(user, span_warning("You fail to lock the collar around [target]'s neck!"))
+		applying = FALSE
+		return
+
+	// Add pet to the master's list before sending collar signals
+	if(!CM.add_pet(target))
+		to_chat(user, span_warning("The collar fails to bind [target]."))
+		target.dropItemToGround(src, force = TRUE)
+		applying = FALSE
+		return
+
+	SEND_SIGNAL(target, COMSIG_CARBON_COLLAR_BOUND, collar_master, src)
+	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
+	log_combat(user, target, "tried to collar", addition="with [src]")
 	applying = FALSE
 
 /obj/item/clothing/neck/roguetown/cursed_collar/attack_self(mob/user)


### PR DESCRIPTION
## About The Pull Request
Adds cursed collar prefs and confirmation prompt
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/87b4c92b-8f00-4378-a7b0-a8cf3a5f1d3c" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I'm sick of an ERP tool being abused in combat. 
Well no longer.
It is now fully opt-in and has a confirmation prompt. At any time you can opt out by turning off the prefs.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a toggle in prefs to enable/disable cursed collars
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
