### PR TITLE
Helmet Choice for Astratan Paladins

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -266,7 +266,16 @@
 						head = /obj/item/clothing/head/roguetown/helmet/heavy/psybucket
 		if(/datum/patron/divine/astrata)
 			cloak = /obj/item/clothing/cloak/templar/astrata
-			head = /obj/item/clothing/head/roguetown/helmet/heavy/astratan
+			if(H.mind)
+				var/helmets = list("Barbute", "Visored Barbute","Buckethelm")
+				var/helmet_choice = input(H, "Choose your HELMET.", "WALK IN HER LIGHT.") as anything in helmets
+				switch(helmet_choice)
+					if("Barbute")
+						head = /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm
+					if("Visored Barbute")
+						head = /obj/item/clothing/head/roguetown/helmet/heavy/astratahelm/visor
+					if("Buckethelm")
+						head = /obj/item/clothing/head/roguetown/helmet/heavy/astratan
 			armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk
 		if(/datum/patron/divine/noc)
 			cloak = /obj/item/clothing/cloak/templar/noc


### PR DESCRIPTION
## About The Pull Request

Astratan warriors have a few helmets to choose from in the game currently. They all have exactly the same stats- this PR makes it so that, like Astratan Templars, Astratan Adventurer-Paladins are able to choose which helmet they get.

## Testing Evidence

<img width="489" height="304" alt="dreamseeker_2026-07-08_07-13-44" src="https://github.com/user-attachments/assets/09f5dda0-9568-40d0-8eb1-c6d1f2986fa3" />
<img width="331" height="163" alt="dreamseeker_2026-07-08_07-15-49" src="https://github.com/user-attachments/assets/bd2beb1c-47cf-4e89-89be-2caa489e4c6c" />


## Why It's Good For The Game

Psydonite paladins get a helmet switch for all the various different Psydon-helmets, so this feels fair. And many of the other patrons get their own deity-specific templar-helmets, Astratans just have multiple to choose from. I like being able to pick the better-looking options that are more to my preference. Hopefully others will too! Not entirely sure if the description of helms as 'barbute' helmets is entirely accurate-- if someone knows better, feel free to correct me.

## Changelog

:cl:
add: Astratan Paladins can now choose which style of helmet they prefer.
/:cl
