### PR TITLE
Absolver revive change

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -227,6 +227,15 @@
 	name = "Lux Ripped"
 	desc = "The very essence of my lyfe was roughly torn from me."
 
+/datum/status_effect/debuff/absolver
+	id = "absolve_weakness"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/absolver
+	effectedstats = list(STATKEY_STR = -3, STATKEY_CON = -5, STATKEY_WIL = -3)	//Absolver punishing.
+
+/atom/movable/screen/alert/status_effect/debuff/absolver
+	name = "Absolving Weakness"
+	desc = "I strained my lux bringing back another's. My body is weakened and will not survive another such strain anytime soon."
+
 /datum/status_effect/debuff/vamp_dreams
 	id = "sleepytime"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/vamp_dreams

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -352,9 +352,17 @@
 			return FALSE
 		// Create visual effects
 		H.apply_status_effect(/datum/status_effect/buff/psyvived)
-		// Kill the caster
-		user.say("MY LYFE FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
-		user.death()
+		if(user.has_status_effect(/datum/status_effect/debuff/devitalised))
+			// Kill the caster
+			user.say("MY LYFE FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
+			user.death()
+		else
+			// Once per 15 minutes you get to not die for it
+			user.say("MY LUX FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
+			user.apply_status_effect(/datum/status_effect/debuff/devitalised)
+			to_chat(user, span_warning("You reach out and restore [H]'s Lux, at the cost of your own! If you dont let it recover, you will not live though next attempt."))
+			user.Knockdown(5 SECONDS)
+			user.Stun(5 SECONDS)
 		// Revive the target
 		H.revive(full_heal = TRUE, admin_revive = FALSE)
 		H.adjustOxyLoss(-H.getOxyLoss())

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -361,6 +361,7 @@
 			user.say("MY LUX FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
 			user.apply_status_effect(/datum/status_effect/debuff/devitalised)
 			H.apply_status_effect(/datum/status_effect/debuff/revived)
+			H.apply_status_effect(/datum/status_effect/debuff/devitalised)
 			to_chat(user, span_warning("You reach out and restore [H]'s Lux at the cost of your own! If you don't first let it recover, you will not lyve though another."))
 			user.Knockdown(5 SECONDS)
 			user.Stun(5 SECONDS)

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -360,6 +360,7 @@
 			// Once per 15 minutes you get to not die for it
 			user.say("MY LUX FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
 			user.apply_status_effect(/datum/status_effect/debuff/devitalised)
+			H.apply_status_effect(/datum/status_effect/debuff/revived)
 			to_chat(user, span_warning("You reach out and restore [H]'s Lux at the cost of your own! If you don't first let it recover, you will not lyve though another."))
 			user.Knockdown(5 SECONDS)
 			user.Stun(5 SECONDS)

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -360,7 +360,7 @@
 			// Once per 15 minutes you get to not die for it
 			user.say("MY LUX FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
 			user.apply_status_effect(/datum/status_effect/debuff/devitalised)
-			to_chat(user, span_warning("You reach out and restore [H]'s Lux, at the cost of your own! If you dont let it recover, you will not live though next attempt."))
+			to_chat(user, span_warning("You reach out and restore [H]'s Lux at the cost of your own! If you don't first let it recover, you will not lyve though another."))
 			user.Knockdown(5 SECONDS)
 			user.Stun(5 SECONDS)
 		// Revive the target

--- a/code/modules/spells/roguetown/oldgod.dm
+++ b/code/modules/spells/roguetown/oldgod.dm
@@ -352,16 +352,15 @@
 			return FALSE
 		// Create visual effects
 		H.apply_status_effect(/datum/status_effect/buff/psyvived)
-		if(user.has_status_effect(/datum/status_effect/debuff/devitalised))
+		if(user.has_status_effect(/datum/status_effect/debuff/absolver))
 			// Kill the caster
 			user.say("MY LYFE FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
 			user.death()
 		else
 			// Once per 15 minutes you get to not die for it
 			user.say("MY LUX FOR YOURS! LYVE, AS DOES HE!", forced = TRUE)
-			user.apply_status_effect(/datum/status_effect/debuff/devitalised)
+			user.apply_status_effect(/datum/status_effect/debuff/absolver)
 			H.apply_status_effect(/datum/status_effect/debuff/revived)
-			H.apply_status_effect(/datum/status_effect/debuff/devitalised)
 			to_chat(user, span_warning("You reach out and restore [H]'s Lux at the cost of your own! If you don't first let it recover, you will not lyve though another."))
 			user.Knockdown(5 SECONDS)
 			user.Stun(5 SECONDS)


### PR DESCRIPTION
## About The Pull Request
Absolver reviving someone now gives him devitalised debuff (the same as lux extraction, lasts 15 minutes)
Reviving someone when debuffed that way will kill absolver
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested on a own server, very very anoying to test do to needing 2 creatures with mind (old dreamaker -> guest join trick)

<img width="789" height="353" alt="Zrzut ekranu 2026-07-09 014901" src="https://github.com/user-attachments/assets/030b641f-c1ff-480a-8b84-a31d5f323e06" />

<img width="785" height="488" alt="Zrzut ekranu 2026-07-09 014914" src="https://github.com/user-attachments/assets/b3c78058-6c32-4e7e-aadf-1862cd35ea18" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Absolver being able to revive someone is something that existed as a option for a long time, but was extremely rare as there is next to no situation where its worth trading in the inquisitions only healer for anyone on frontline. From the conversations with other absolver players they don't use it for the same reason.

Now absolver gets to once per fairly long time (15 minutes) bring someone back to life without dying, and still has a option of sacrificing himself to perform a second resurrection.

This also means that finally absolver and stigmata distinction is meaningful, as before the only meaningful thing they lacked compared to absolver is his slightly better self healing. Now his ability to resurrect with they lack will be used.

Apparently this is idea already implemented on AP, but since this is second hand information i cant guarantee that's true.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Absolver now can absolve death at a cost of getting the lux drain debuff instead of dying, doing so while drained will kill him like before.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
