### PR TITLE
Rebalances direct attacks on dropped weapons and armors.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -442,7 +442,10 @@
 
 /obj/attacked_by(obj/item/I, mob/living/user)
 	user.changeNext_move(CLICK_CD_INTENTCAP)
-	var/newforce = (get_complex_damage(I, user, blade_dulling) * I.demolition_mod)
+	var/newforce = get_complex_damage(I, user, blade_dulling)
+	if(isclothing(src) || istype(src, /obj/item/rogueweapon))
+		newforce = min(newforce, 5)
+	newforce *= I.demolition_mod
 	if(!newforce)
 		testing("dam33")
 		return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1780,7 +1780,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		obj_destroyed = TRUE
 		burn()
 		return TRUE
-	if (ismob(loc) && !always_destroy)
+	if (!always_destroy && (ismob(loc) || isclothing(src) || istype(src, /obj/item/rogueweapon)))
 		return FALSE
 
 	obj_destroyed = TRUE


### PR DESCRIPTION
## About The Pull Request

- Caps base damage from a direct attack on a weapon or clothing piece (i.e. a dropped longsword) to **5 x the demolition mod.**
- Prevents direct attacks on clothing and weapons from deleting them past the broken 0 integrity state. (fire, acid, lava, smelting, and always delete still break them).

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/daf87771-0576-4b07-bc56-2c7b59a470be


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

As funny as disarming someone and insta breaking their special sword with dual-wielded axes, it's unbalanced and has been deemed by maints and staff as such (i am making this after getting a ticket opened regarding me abusing this very mechanic, mb chat).


<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Capped direct attacks on dropped rougeweapons and rogueclothes at 5 x demolition mod. Layman's terms, you can't instantly drop a concheck-dropped silver weapon to 0 integrity. 
balance: Weapons and clothing/armor can NOT be deleted/destroyed by direct attacks when in a broken state (i.e. 0 integrity). Lava, fire, acid, and always_delete still work to break things. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
