### PR TITLE
Makes Sexcon Menu Open With Ctrl+Shift+Click

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -122,6 +122,9 @@
 					changeNext_move(mmb_intent.clickcd)
 					stop_attack()
 					return
+	if(modifiers["shift"] && modifiers["ctrl"] && modifiers["left"])
+		A.MiddleMouseDrop_T(src, src)
+		return
 	if(modifiers["left"] && atkswinging == "left")
 		if(active_hand_index == 1)
 			used_hand = 1


### PR DESCRIPTION
## About The Pull Request

the sexcon menu will now also open with ctrl+shift+click. it works on yourself. it works on other people.

## Testing Evidence

look dude it works. do you want me to take a video of me ctrl+shift+clicking an npc

## Why It's Good For The Game

mmb drag is annoying as FUCK especially with the 7 person same-tile orgies i get up to

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The sex menu will now open using ctrl+shift+click in addition to MMB drag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
