### PR TITLE
underlay lighting

### DIFF
--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -87,7 +87,7 @@ SUBSYSTEM_DEF(lighting)
 	queue = objects_queue
 	while(current_index < length(queue))
 		current_index += 1
-		var/atom/movable/lighting_object/lighting_object = queue[current_index]
+		var/datum/lighting_object/lighting_object = queue[current_index]
 		// these can't delete themselves in update() and so nothing in this should be qdeleted
 		ASSERT(!QDELETED(lighting_object))
 		lighting_object.update()

--- a/code/controllers/subsystem/particle_weather_outdoors.dm
+++ b/code/controllers/subsystem/particle_weather_outdoors.dm
@@ -238,7 +238,6 @@ SUBSYSTEM_DEF(outdoor_effects)
 
 // Updates overlays and vis_contents for outdoor effects
 /datum/controller/subsystem/outdoor_effects/proc/update_outdoor_effect_overlays(datum/outdoor_info/OE)
-	var/old_sunlight_overlay = OE.sunlight_overlay
 	var/mutable_appearance/MA
 	if (OE.state != SKY_BLOCKED)
 		MA = get_sunlight_overlay(1,1,1,1) /* fully lit */
@@ -260,15 +259,24 @@ SUBSYSTEM_DEF(outdoor_effects)
 
 		MA = get_sunlight_overlay(fr, fg, fb, fa)
 
-	OE.sunlight_overlay = MA
-	//Get weather overlay if not weatherproof
-	if(OE.weatherproof)
-		OE.source_turf.underlays -= shared_weather_overlay
-	else
-		OE.source_turf.underlays |= shared_weather_overlay
-	OE.source_turf.underlays -= old_sunlight_overlay
-	OE.source_turf.underlays += MA
-	OE.source_turf.luminosity = max(OE.source_turf.luminosity, MA.luminosity)
+	var/turf/source_turf = OE.source_turf
+	var/dirty = OE.underlays_dirty
+
+	var/want_weather = !OE.weatherproof
+	if(dirty || want_weather != OE.weather_applied)
+		if(want_weather)
+			source_turf.underlays |= shared_weather_overlay
+		else
+			source_turf.underlays -= shared_weather_overlay
+		OE.weather_applied = want_weather
+
+	if(dirty || MA != OE.sunlight_overlay)
+		source_turf.underlays -= OE.sunlight_overlay
+		source_turf.underlays |= MA
+		OE.sunlight_overlay = MA
+
+	OE.underlays_dirty = FALSE
+	source_turf.luminosity = max(source_turf.luminosity, MA.luminosity)
 
 //Retrieve an overlay from the list - create if necessary
 /datum/controller/subsystem/outdoor_effects/proc/get_sunlight_overlay(fr, fg, fb, fa)

--- a/code/datums/outdoor_datum.dm
+++ b/code/datums/outdoor_datum.dm
@@ -31,9 +31,14 @@ Sunlight System
 	/* misc vars */
 	var/state 					 = SKY_VISIBLE	// If we can see the see the sky, are blocked, or we have a blocked neighbour (SKY_BLOCKED/VISIBLE/VISIBLE_BORDER)
 	var/weatherproof			 = FALSE        // If we have a weather overlay
+	var/weather_applied			 = FALSE        // whether source_turf's underlays currently hold the weather overlay
+	var/underlays_dirty			 = TRUE         // source_turf's underlays may not match our cached state, so reapply unconditionally
 	var/turf/source_turf
 	var/mutable_appearance/sunlight_overlay
 	var/list/datum/lighting_corner/affecting_corners
+
+/datum/outdoor_info/proc/reset_applied_overlays()
+	underlays_dirty = TRUE
 
 /datum/outdoor_info/Destroy(force, ...)
 	if (!force)

--- a/code/datums/outdoor_datum.dm
+++ b/code/datums/outdoor_datum.dm
@@ -31,8 +31,8 @@ Sunlight System
 	/* misc vars */
 	var/state 					 = SKY_VISIBLE	// If we can see the see the sky, are blocked, or we have a blocked neighbour (SKY_BLOCKED/VISIBLE/VISIBLE_BORDER)
 	var/weatherproof			 = FALSE        // If we have a weather overlay
-	var/weather_applied			 = FALSE        // whether source_turf's underlays currently hold the weather overlay
-	var/underlays_dirty			 = TRUE         // source_turf's underlays may not match our cached state, so reapply unconditionally
+	var/weather_applied			 = FALSE
+	var/underlays_dirty			 = TRUE
 	var/turf/source_turf
 	var/mutable_appearance/sunlight_overlay
 	var/list/datum/lighting_corner/affecting_corners

--- a/code/game/machinery/trams_and_elevators/industrial_lift.dm
+++ b/code/game/machinery/trams_and_elevators/industrial_lift.dm
@@ -136,7 +136,7 @@ GLOBAL_LIST_INIT(all_radial_directions, list(
 
 /obj/structure/industrial_lift/proc/AddItemOnLift(datum/source, atom/movable/new_lift_contents)
 	SIGNAL_HANDLER
-	var/static/list/blacklisted_types = typecacheof(list(/obj/effect/decal/cleanable, /obj/structure/industrial_lift, /mob/camera, /obj/effect/overlay/water, /atom/movable/lighting_object))
+	var/static/list/blacklisted_types = typecacheof(list(/obj/effect/decal/cleanable, /obj/structure/industrial_lift, /mob/camera, /obj/effect/overlay/water))
 	if(is_type_in_typecache(new_lift_contents, blacklisted_types) || new_lift_contents.invisibility == INVISIBILITY_ABSTRACT) //prevents the tram from stealing things like landmarks
 		return FALSE
 	if(new_lift_contents in lift_load)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 /turf/proc/empty(turf_type=/turf/open/floor/rogue/naturalstone, baseturf_type, list/ignore_typecache, flags)
 	// Remove all atoms except observers, landmarks, docking ports
-	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark, /atom/movable/lighting_object))
+	var/static/list/ignored_atoms = typecacheof(list(/mob/dead, /obj/effect/landmark))
 	var/list/allowed_contents = typecache_filter_list_reverse(GetAllContentsIgnoring(ignore_typecache), ignored_atoms)
 	allowed_contents -= src
 	for(var/i in 1 to allowed_contents.len)
@@ -149,6 +149,10 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		recalc_atom_opacity()
 		lighting_object = old_lighting_object
 		corners = old_corners
+
+		if(lighting_object && !lighting_object.needs_update)
+			lighting_object.update()
+
 		if (old_opacity != opacity || dynamic_lighting != old_dynamic_lighting)
 			reconsider_lights()
 

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -143,6 +143,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(SSlighting.initialized)
 		if(SSoutdoor_effects.initialized)
 			outdoor_effect = old_outdoor_effect
+			outdoor_effect?.reset_applied_overlays()
 			get_sky_and_weather_states()
 
 		recalc_atom_opacity()

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -152,6 +152,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 		if(lighting_object && !lighting_object.needs_update)
 			lighting_object.update()
+		else if(!lighting_object && has_dynamic_lighting())
+			underlays += GLOB.lighting_underlay_dark
+			luminosity = 0
 
 		if (old_opacity != opacity || dynamic_lighting != old_dynamic_lighting)
 			reconsider_lights()

--- a/code/modules/lighting/lighting_area.dm
+++ b/code/modules/lighting/lighting_area.dm
@@ -17,8 +17,7 @@
 	else
 		add_overlay(/obj/effect/fullbright)
 		for (var/turf/T in src)
-			if (T.lighting_object)
-				T.lighting_clear_overlay()
+			T.lighting_clear_overlay()
 
 	return TRUE
 

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -112,10 +112,14 @@ GLOBAL_LIST_INIT(LIGHTING_CORNER_DIAGONAL, list(NORTHEAST, SOUTHEAST, SOUTHWEST,
 
 	for (var/TT in masters)
 		var/turf/T = TT
-		if (T.lighting_object)
-			if (!T.lighting_object.needs_update)
-				T.lighting_object.needs_update = TRUE
-				SSlighting.objects_queue += T.lighting_object
+		var/datum/lighting_object/lighting_object = T.lighting_object
+		if (!lighting_object)
+			if (SSlighting.initialized && T.has_dynamic_lighting())
+				new /datum/lighting_object(T)
+			continue
+		if (!lighting_object.needs_update)
+			lighting_object.needs_update = TRUE
+			SSlighting.objects_queue += lighting_object
 
 /datum/lighting_corner/proc/vis_update()
 	for (var/datum/light_source/light_source as anything in affecting)

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -1,14 +1,18 @@
+GLOBAL_DATUM_INIT(lighting_underlay_dark, /mutable_appearance, create_lighting_underlay("dark"))
+GLOBAL_DATUM_INIT(lighting_underlay_transparent, /mutable_appearance, create_lighting_underlay("transparent"))
+
 /datum/lighting_object
 	var/mutable_appearance/current_underlay
+	var/mutable_appearance/private_underlay
 
 	var/needs_update = FALSE
 
 	var/turf/affected_turf
 
-/proc/create_lighting_underlay()
+/proc/create_lighting_underlay(icon_state = "transparent")
 	var/mutable_appearance/underlay = new()
 	underlay.icon = LIGHTING_ICON
-	underlay.icon_state = "transparent"
+	underlay.icon_state = icon_state
 	underlay.plane = LIGHTING_PLANE
 	underlay.layer = LIGHTING_LAYER
 	underlay.invisibility = INVISIBILITY_LIGHTING
@@ -23,7 +27,7 @@
 
 	. = ..()
 
-	current_underlay = create_lighting_underlay()
+	current_underlay = GLOB.lighting_underlay_dark
 
 	affected_turf = source
 	if(affected_turf.lighting_object)
@@ -103,25 +107,28 @@
 	if(affected_turf.outdoor_effect?.sunlight_overlay?.luminosity)
 		set_luminosity = max(set_luminosity, affected_turf.outdoor_effect.sunlight_overlay.luminosity)
 
-	var/mutable_appearance/current_underlay = src.current_underlay
+	// remove the currently applied underlay before any mutation so removal matches by value
 	affected_turf.underlays -= current_underlay
 
+	var/mutable_appearance/new_underlay
 	if((rr & gr & br & ar) && (rg + gg + bg + ag + rb + gb + bb + ab == 8))
 	//anything that passes the first case is very likely to pass the second, and addition is a little faster in this case
-		current_underlay.icon_state = "transparent"
-		current_underlay.color = null
+		new_underlay = GLOB.lighting_underlay_transparent
 	else if(!set_luminosity)
-		current_underlay.icon_state = "dark"
-		current_underlay.color = null
+		new_underlay = GLOB.lighting_underlay_dark
 	else
-		current_underlay.icon_state = null
-		current_underlay.color = list(
+		if(!private_underlay)
+			private_underlay = create_lighting_underlay()
+		private_underlay.icon_state = null
+		private_underlay.color = list(
 			rr, rg, rb, 00,
 			gr, gg, gb, 00,
 			br, bg, bb, 00,
 			ar, ag, ab, 00,
 			00, 00, 00, 01
 		)
+		new_underlay = private_underlay
 
-	affected_turf.underlays += current_underlay
+	affected_turf.underlays += new_underlay
+	current_underlay = new_underlay
 	affected_turf.luminosity = set_luminosity

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -1,62 +1,55 @@
-/atom/movable/lighting_object
-	name          = ""
-
-	anchored      = TRUE
-
-	icon             = LIGHTING_ICON
-	icon_state       = "transparent"
-	color            = null //we manually set color in init instead
-	plane            = LIGHTING_PLANE
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	layer            = LIGHTING_LAYER
-	invisibility     = INVISIBILITY_LIGHTING
+/datum/lighting_object
+	var/mutable_appearance/current_underlay
 
 	var/needs_update = FALSE
-	var/turf/myturf
 
-/atom/movable/lighting_object/Initialize(mapload)
+	var/turf/affected_turf
+
+/proc/create_lighting_underlay()
+	var/mutable_appearance/underlay = new()
+	underlay.icon = LIGHTING_ICON
+	underlay.icon_state = "transparent"
+	underlay.plane = LIGHTING_PLANE
+	underlay.layer = LIGHTING_LAYER
+	underlay.invisibility = INVISIBILITY_LIGHTING
+	underlay.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
+	return underlay
+
+/datum/lighting_object/New(turf/source)
+	if(!isturf(source))
+		qdel(src, force = TRUE)
+		stack_trace("a lighting object was assigned to [source], a non turf!")
+		return
+
 	. = ..()
-	verbs.Cut()
-	//We avoid setting this in the base as if we do then the parent atom handling will add_atom_color it and that
-	//is totally unsuitable for this object, as we are always changing it's colour manually
-	color = LIGHTING_BASE_MATRIX
 
-	myturf = loc
-	if(myturf.lighting_object)
-		qdel(myturf.lighting_object, force = TRUE)
-	myturf.lighting_object = src
-	myturf.luminosity = 0
+	current_underlay = create_lighting_underlay()
+
+	affected_turf = source
+	if(affected_turf.lighting_object)
+		qdel(affected_turf.lighting_object, force = TRUE)
+		stack_trace("a lighting object was assigned to a turf that already had a lighting object!")
+
+	affected_turf.lighting_object = src
+	affected_turf.luminosity = 1
 
 	needs_update = TRUE
 	SSlighting.objects_queue += src
 
-/atom/movable/lighting_object/Destroy(force)
-	if (force)
-		SSlighting.objects_queue -= src
-		if (loc != myturf)
-			var/turf/oldturf = get_turf(myturf)
-			var/turf/newturf = get_turf(loc)
-			stack_trace("A lighting object was qdeleted with a different loc then it is suppose to have ([COORD(oldturf)] -> [COORD(newturf)])")
-		if (isturf(myturf))
-			myturf.lighting_object = null
-			myturf.luminosity = 1
-		myturf = null
-
-		return ..()
-
-	else
+/datum/lighting_object/Destroy(force)
+	if(!force)
 		return QDEL_HINT_LETMELIVE
 
-/atom/movable/lighting_object/proc/update()
-	if (loc != myturf)
-		if (loc)
-			var/turf/oldturf = get_turf(myturf)
-			var/turf/newturf = get_turf(loc)
-			warning("A lighting object realised it's loc had changed in update() ([myturf]\[[myturf ? myturf.type : "null"]]([COORD(oldturf)]) -> [loc]\[[ loc ? loc.type : "null"]]([COORD(newturf)]))!")
+	SSlighting.objects_queue -= src
+	if(isturf(affected_turf))
+		affected_turf.lighting_object = null
+		affected_turf.luminosity = 1
+		affected_turf.underlays -= current_underlay
+	affected_turf = null
 
-		qdel(src, TRUE)
-		return
+	return ..()
 
+/datum/lighting_object/proc/update()
 	// To the future coder who sees this and thinks
 	// "Why didn't he just use a loop?"
 	// Well my man, it's because the loop performed like shit.
@@ -68,7 +61,9 @@
 	// See LIGHTING_CORNER_DIAGONAL in lighting_corner.dm for why these values are what they are.
 	var/static/datum/lighting_corner/dummy/dummy_lighting_corner = new
 
-	var/list/corners = myturf.corners
+	var/turf/affected_turf = src.affected_turf
+
+	var/list/corners = affected_turf.corners
 	var/datum/lighting_corner/cr = dummy_lighting_corner
 	var/datum/lighting_corner/cg = dummy_lighting_corner
 	var/datum/lighting_corner/cb = dummy_lighting_corner
@@ -105,46 +100,28 @@
 	var/set_luminosity = max > 1e-6
 	#endif
 
-	if(myturf.outdoor_effect?.sunlight_overlay?.luminosity)
-		set_luminosity = max(set_luminosity, myturf.outdoor_effect.sunlight_overlay.luminosity)
+	if(affected_turf.outdoor_effect?.sunlight_overlay?.luminosity)
+		set_luminosity = max(set_luminosity, affected_turf.outdoor_effect.sunlight_overlay.luminosity)
+
+	var/mutable_appearance/current_underlay = src.current_underlay
+	affected_turf.underlays -= current_underlay
 
 	if((rr & gr & br & ar) && (rg + gg + bg + ag + rb + gb + bb + ab == 8))
 	//anything that passes the first case is very likely to pass the second, and addition is a little faster in this case
-		icon_state = "transparent"
-		color = null
+		current_underlay.icon_state = "transparent"
+		current_underlay.color = null
 	else if(!set_luminosity)
-		icon_state = "dark"
-		color = null
+		current_underlay.icon_state = "dark"
+		current_underlay.color = null
 	else
-		icon_state = null
-		color = list(
+		current_underlay.icon_state = null
+		current_underlay.color = list(
 			rr, rg, rb, 00,
 			gr, gg, gb, 00,
 			br, bg, bb, 00,
 			ar, ag, ab, 00,
 			00, 00, 00, 01
 		)
-/*		if(color)
-			animate(src, color = list(rr, rg, rb,00,gr, gg, gb, 00,br, bg, bb, 00,ar, ag, ab, 00,00, 00, 00, 01), time = 5)
-		else
-			color = list(
-				rr, rg, rb, 00,
-				gr, gg, gb, 00,
-				br, bg, bb, 00,
-				ar, ag, ab, 00,
-				00, 00, 00, 01
-			)*/
-	luminosity = set_luminosity
 
-// Variety of overrides so the overlays don't get affected by weird things.
-
-/atom/movable/lighting_object/ex_act(severity)
-	return 0
-
-/atom/movable/lighting_object/onTransitZ()
-	return
-
-// Override here to prevent things accidentally moving around overlays.
-/atom/movable/lighting_object/forceMove(atom/destination, no_tp=FALSE, harderforce = FALSE)
-	if(harderforce)
-		. = ..()
+	affected_turf.underlays += current_underlay
+	affected_turf.luminosity = set_luminosity

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -8,6 +8,7 @@
 			if(!IS_DYNAMIC_LIGHTING(T))
 				continue
 
-			new /datum/lighting_object(T)
+			T.underlays += GLOB.lighting_underlay_dark
+			T.luminosity = 0
 			CHECK_TICK
 		CHECK_TICK

--- a/code/modules/lighting/lighting_setup.dm
+++ b/code/modules/lighting/lighting_setup.dm
@@ -8,6 +8,6 @@
 			if(!IS_DYNAMIC_LIGHTING(T))
 				continue
 
-			new/atom/movable/lighting_object(T)
+			new /datum/lighting_object(T)
 			CHECK_TICK
 		CHECK_TICK

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -13,9 +13,18 @@
 	for(var/datum/lighting_corner/corner as anything in get_corners())
 		corner.vis_update()
 
+/turf/proc/has_dynamic_lighting()
+	if(lighting_object)
+		return TRUE
+	var/area/A = loc
+	return IS_DYNAMIC_LIGHTING(src) && IS_DYNAMIC_LIGHTING(A)
+
 /turf/proc/lighting_clear_overlay()
 	if (lighting_object)
 		qdel(lighting_object, TRUE)
+	else
+		underlays -= GLOB.lighting_underlay_dark
+		luminosity = 1
 
 // Builds a lighting object for us, but only if our area is dynamic.
 /turf/proc/lighting_build_overlay()
@@ -26,7 +35,7 @@
 
 // Used to get a scaled lumcount.
 /turf/proc/get_lumcount(minlum = 0, maxlum = 1)
-	if (!lighting_object)
+	if (!has_dynamic_lighting())
 		return 1
 
 	var/totallums = 0
@@ -57,7 +66,7 @@
 // itself as too dark to allow sight and see_in_dark becomes useful.
 // So basically if this returns true the tile is unlit black.
 /turf/proc/is_softly_lit()
-	if (!lighting_object)
+	if (!has_dynamic_lighting())
 		return FALSE
 
 	return !luminosity

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -4,7 +4,7 @@
 
 	var/tmp/lighting_corners_initialised = FALSE
 
-	var/tmp/atom/movable/lighting_object/lighting_object // Our lighting object.
+	var/tmp/datum/lighting_object/lighting_object // Our lighting object.
 	var/tmp/list/datum/lighting_corner/corners
 	var/tmp/opaque_atom_count = 0 // Not to be confused with opacity, this is the number of opaque atoms on the tile.
 
@@ -22,7 +22,7 @@
 	if(lighting_object)
 		qdel(lighting_object,force=TRUE) //Shitty fix for lighting objects persisting after death
 
-	new/atom/movable/lighting_object(src)
+	new /datum/lighting_object(src)
 
 // Used to get a scaled lumcount.
 /turf/proc/get_lumcount(minlum = 0, maxlum = 1)
@@ -60,7 +60,7 @@
 	if (!lighting_object)
 		return FALSE
 
-	return !lighting_object.luminosity
+	return !luminosity
 
 // Can't think of a good name, this proc will recalculate the opaque_atom_count variable.
 /turf/proc/recalc_atom_opacity()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -264,7 +264,7 @@
 
 // Please do not add one-off mob AIs here, but override this function for your mob
 /mob/living/simple_animal/hostile/CanAttack(atom/the_target)//Can we actually attack a possible target?
-	if(isturf(the_target) || !the_target || the_target.type == /atom/movable/lighting_object) // bail out on invalids
+	if(isturf(the_target) || !the_target) // bail out on invalids
 		return FALSE
 
 	if(binded)


### PR DESCRIPTION
## About The Pull Request
moves us to TG's underlay lighting system, costs more CPU but better maptick
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
from testing there seems to be a 9~% increase in maptick cpu from the MC tab, need to test in tracy
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
good maptick very important
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: use tg underlay lighting instead of atom movable lighting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
