### PR TITLE
Fix for chair-buckle self throw

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -252,7 +252,7 @@
 
 	if(thrown_thing)
 		if(src in thrown_thing.buckled_mobs) //Buckling to a chair and then grab-throwing the chair
-			to_chat(src, "<span class='notice'>I am not tricky enough to throw [thrown_thing] while I am buckled to it.</span>")
+			to_chat(src, span_notice("I am not tricky enough to throw [thrown_thing] while I am buckled to it."))
 			return
 		// Admin alert for coin throws
 		if(istype(thrown_thing, /obj/item/roguecoin))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -251,6 +251,9 @@
 
 
 	if(thrown_thing)
+		if(src in thrown_thing.buckled_mobs) //Buckling to a chair and then grab-throwing the chair
+			to_chat(src, "<span class='notice'>I am not tricky enough to throw [thrown_thing] while I am buckled to it.</span>")
+			return
 		// Admin alert for coin throws
 		if(istype(thrown_thing, /obj/item/roguecoin))
 			var/obj/item/roguecoin/coin = thrown_thing


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

I saw a guy throwing himself around on his dinghy, he was able to throw the dinghy "up" and hop up Z-levels. Tested it, and it's the case for chairs, too. Every chair being a z-level hop is very interesting technology, but might be a little unrealistic

## Testing Evidence
Before

https://github.com/user-attachments/assets/51d84d10-b771-4e85-a516-08ac5322b366

After

https://github.com/user-attachments/assets/bad4f971-0a4a-49ef-b021-6ae321cb7daa


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
You can still throw the chair while someone else is buckled to it, which aligns with the current code of, people going prone and having a buddy throw them up a z-level.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Prevented buckling oneself to an object, and throwing the object and self around or up to a different Z level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
