### PR TITLE
Stone 2 clay

### DIFF
--- a/code/modules/roguetown/roguecrafting/alchemy.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy.dm
@@ -205,6 +205,14 @@
 	craftdiff = 2
 	verbage_simple = "transmute"
 
+/datum/crafting_recipe/roguetown/alchemy/s2cto
+	name = "stone to clay"
+	category = "Transmutation"
+	result = list(/obj/item/natural/clay = 2)
+	reqs = list(/obj/item/natural/stone = 1)
+	craftdiff = 2
+	verbage_simple = "transmute"
+
 /datum/crafting_recipe/roguetown/alchemy/s2coa
 	name = "stone to coal"
 	category = "Transmutation"


### PR DESCRIPTION
Inverse of another recipe

You can transform clay to stone. Why not the inverse. I think this will be useful.
:cl:
Alchemy can make clay from stone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
