### PR TITLE
Adds Sword Options to Knave Shop

### DIFF
--- a/code/modules/cargo/packsrogue/bandit/classes/Knave.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Knave.dm
@@ -148,6 +148,31 @@
 	cost = 40
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish)
 
+/datum/supply_pack/rogue/Knave/rapier
+	name = "Rapier"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/sword/rapier)
+
+/datum/supply_pack/rogue/Knave/sabre
+	name = "Sabre"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/sword/sabre)
+
+/datum/supply_pack/rogue/Knave/messer
+	name = "Messer"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/sword/short/messer)
+
+/datum/supply_pack/rogue/Knave/falchion
+	name = "Falchion"
+	cost = 20
+	contains = list(/obj/item/rogueweapon/sword/short/falchion)
+
+/datum/supply_pack/rogue/Knave/estoc
+	name = "Estoc"
+	cost = 40
+	contains = list(/obj/item/rogueweapon/estoc)
+
 //////////////////////
 // WEAPONS - RANGED //
 //////////////////////


### PR DESCRIPTION
## About The Pull Request

knaves get rapiers, sabres, messers, falchions and estocs in their shop, now.

## Testing Evidence

<img width="208" height="210" alt="image" src="https://github.com/user-attachments/assets/0aac5fae-5e7c-4d82-80cf-77f8ab784189" />


## Why It's Good For The Game

knaves get expert swords and a sword loadout option but unable to buy any swords. this fixes that

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Knaves get rapiers, sabres, messers, falchions and estocs in their shop tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
