### PR TITLE
Changes necra lore sins

### DIFF
--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -1,7 +1,7 @@
 /datum/patron/divine/necra
 	name = "Necra"
 	domain = "Death, The Afterlife, Rebirth"
-	desc = "The Undermaiden is the custodian of the Afterlife, where all souls must eventually go. She tasks the lost with the Trials of the Forgotten, where they must ruminate on their lyfe to be reborn. Her followers find resurrection to be abhorrent, choosing to isolate themselves to their graveyards."
+	desc = "The Undermaiden is the custodian of the Afterlife, where all souls must eventually go. She tasks the lost with the Trials of the Forgotten, where they must ruminate on their lyfe to be reborn. Necra's followers are known for choosing to isolate themselves to their graveyards."
 	worshippers = "Gravediggers, Morticians, Disgraced Physicians, Loners"
 	virtues = "Respecting the Dead, Sloth, Fatalism"
 	sins = "Undeath & Humor. Enabling an untimely death."

--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -4,7 +4,7 @@
 	desc = "The Undermaiden is the custodian of the Afterlife, where all souls must eventually go. She tasks the lost with the Trials of the Forgotten, where they must ruminate on their lyfe to be reborn. Her followers find resurrection to be abhorrent, choosing to isolate themselves to their graveyards."
 	worshippers = "Gravediggers, Morticians, Disgraced Physicians, Loners"
 	virtues = "Respecting the Dead, Sloth, Fatalism"
-	sins = "Undeath, Humor, Revival"
+	sins = "Undeath & Humor. Enabling an untimely death."
 	mob_traits = list(TRAIT_SOUL_EXAMINE, TRAIT_NOSTINK)	//No stink is generic but they deal with dead bodies so.. makes sense, I suppose?
 	miracles = list(/obj/effect/proc_holder/spell/targeted/touch/orison				= CLERIC_ORI,
 					/obj/effect/proc_holder/spell/invoked/necras_sight				= CLERIC_T0,


### PR DESCRIPTION
## About The Pull Request

This was kinda stupid, the mechanics push it otherwise.

## Testing Evidence

yeah

## Why It's Good For The Game

ditto

## Changelog

:cl:
remove: Removes a sin from Necra and clarifies it as Necrans wanting to prevent an "early" death.
/:cl:
