### PR TITLE
Fix an exploit allowing you to phase through windows

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -159,9 +159,14 @@
 
 /turf/open/floor/MouseDrop_T(atom/movable/O, mob/user)
 	. = ..()
-	if(isliving(user))
-		var/mob/living/L = user
-		if(L.has_status_effect(/datum/status_effect/debuff/climbing_lfwb))
-			if(do_after(L, 10, target = src))
-				L.forceMove(src)
-				return
+	if(!isliving(user))
+		return
+	var/mob/living/living_user = user
+	if(!living_user.has_status_effect(/datum/status_effect/debuff/climbing_lfwb))
+		return
+	if(is_blocked_turf())
+		to_chat(living_user, span_notice("can't move here!"))
+		return
+	if(!do_after(living_user, 1 SECONDS, target = src))
+		return
+	living_user.forceMove(src)


### PR DESCRIPTION
## About The Pull Request
Fix an exploit where you can phase through a window by clinging to a wall then dragging yourself to the turf
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Tested on local, can no longer do the exploit
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugfix/Exploit fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed an exploit that allowed you to phase through windows.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
