### PR TITLE
Resurrect oxyloss removal before the revive check

### DIFF
--- a/code/modules/surgery/surgeries_hearth/revival.dm
+++ b/code/modules/surgery/surgeries_hearth/revival.dm
@@ -65,6 +65,7 @@
 				"[user] tries to infuse [target] with lux, but it refuses to take.")
 			target.visible_message(span_danger("[target]'s body convulses violently, rejecting the light!"), span_warning("Something is terribly wrong..."))
 			return FALSE
+	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	if(!target.revive(full_heal = FALSE))
 		display_results(user, target, span_notice("The lux refuses to meld with [target]'s heart. Their damage must be too severe still."),
 			"[user] works the lux into [target]'s innards, but nothing happens.",
@@ -82,7 +83,6 @@
 			"[user] works the lux into [target]'s innards, but nothing happens.",
 			"[user] works the lux into [target]'s innards, but nothing happens.")
 		return FALSE
-	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	display_results(user, target, span_notice("You succeed in restarting [target]'s heart with the infusion of lux."),
 		"[user] works the lux into [target]'s innards.",
 		"[user] works the lux into [target]'s innards.")

--- a/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
+++ b/code/modules/surgery/surgeries_hearth/revival_big_fat_tick.dm
@@ -57,6 +57,7 @@
 	if(!target.mind.active)
 		to_chat(user, "Necra is not done with [target], yet.")
 		return
+	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	if(!target.revive(full_heal = FALSE))
 		display_results(user, target, span_notice("The leechtick refuses to meld with [target]'s heart. Their damage must be too severe still."),
 			"[user] works the leechtick into [target]'s innards, but nothing happens.",
@@ -65,7 +66,6 @@
 	display_results(user, target, span_notice("You succeed in restarting [target]'s heart with the infusion of the leechtick's viscera."),
 		"[user] works the leechtick into [target]'s innards.",
 		"[user] works the leechtick into [target]'s innards.")
-	target.adjustOxyLoss(-target.getOxyLoss())
 	target.emote("breathgasp")
 	target.Jitter(100)
 	record_round_statistic(STATS_LUX_REVIVALS)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

#497 moved the "	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR" line after the "if(!target.revive(full_heal = FALSE))" check for both lux surgery and leechtick surgery: which leads to an edge case where a corpse may too suffocated to actually be resurrected by these means. This PR puts the Oxyloss heal before the revive check, which aligns with the way the other forms of resurrect handle it: namely the revive chair and the Anastasis resurrects.

Here's a picture of me running into the issue in a round.
<img width="903" height="1057" alt="image" src="https://github.com/user-attachments/assets/61d85627-2f26-4892-bb45-7d64cdb7e9a4" />

## Testing Evidence
Before, recreated the bug.
[old_oxyloss720.webm](https://github.com/user-attachments/assets/bb3419bf-5f7d-40ee-b7d7-d1fcd2094ea3)



After.
[oxyloss.webm](https://github.com/user-attachments/assets/3f0639c0-98a0-4e25-a8a6-75322afe7dd1)


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Barber surgeons 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed edge case of a corpse being too suffocated to be resurrected by lux surgery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
