### PR TITLE
Makes the wardens hood fireproof

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -296,6 +296,7 @@
 	dynamic_hair_suffix = ""
 	edelay_type = 1
 	adjustable = CAN_CADJUST
+	resistance_flags = FIRE_PROOF
 	toggle_icon_state = TRUE
 	max_integrity = 200
 


### PR DESCRIPTION
## About The Pull Request

Makes the wardens hood fireproof as it is able to burn, it shouldn't burn anymore.

## Testing Evidence

compiles

## Why It's Good For The Game

a unique hood that you cannot get once it destroys itself is kind of lame, this should fix that

## Changelog
:cl:
warden's hood is now fireproof
/:cl:
