### PR TITLE
Adds cup-hilt rapier to knaves

### DIFF
--- a/code/modules/cargo/packsrogue/bandit/classes/Knave.dm
+++ b/code/modules/cargo/packsrogue/bandit/classes/Knave.dm
@@ -153,6 +153,11 @@
 	cost = 20
 	contains = list(/obj/item/rogueweapon/sword/rapier)
 
+/datum/supply_pack/rogue/Knave/cuprapier
+	name = "Etruscan Rapier"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/sword/rapier/vaquero)
+
 /datum/supply_pack/rogue/Knave/sabre
 	name = "Sabre"
 	cost = 20


### PR DESCRIPTION
## About The Pull Request

Adds onto the recent PR by the lovely SigmaPredator to include the cup-hilt rapier, matching the already-available sail dagger which knaves can acquire.

## Testing Evidence
<img width="225" height="56" alt="Screenshot 2026-07-13 181733" src="https://github.com/user-attachments/assets/95f56ba8-7f5a-42fd-a912-0549e50a135d" />
<img width="318" height="243" alt="Screenshot 2026-07-13 181812" src="https://github.com/user-attachments/assets/47c4dc12-9465-4911-bd95-f7a6dba9c6fb" />



## Why It's Good For The Game

For the same reasons as the recently merged addition of swords to knave. The class gets the skill to use them, but previously had no access to swords. Additionally, knaves could acquire the 'sail dagger' but not the matching rapier which is paired with it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: ability to purchase cup-hilt rapier for knaves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
