### PR TITLE
Remove shatter chance

### DIFF
--- a/code/modules/roguetown/roguejobs/ceramicist/clay.dm
+++ b/code/modules/roguetown/roguejobs/ceramicist/clay.dm
@@ -20,7 +20,7 @@
 	var/burning = 0				// This variable measures the progress of the burning act
 	var/burntime = 5 MINUTES	// How long must it be left unattended to burn and be ruined?
 	var/burned_color = "#302d2d"
-	var/shatter_chance = 0
+
 	var/ash_kneads = 0
 	var/sand_added = FALSE
 	var/is_wet = FALSE
@@ -253,12 +253,6 @@
 /obj/item/natural/clay/heating_act(atom/A)
 	var/obj/item/result
 	if(istype(A,/obj/machinery/light/rogue/oven))
-		if(prob(shatter_chance))
-			if(A)
-				A.visible_message(span_warning("[src] cracks apart in the heat!"))
-			playsound(src, 'sound/foley/glassbreak.ogg', 75, TRUE)
-			qdel(src)
-			return null
 		if(cooked_type)
 			result = new cooked_type(A)
 			apply_pottery_quality(result, pottery_quality, creator_skill)

--- a/code/modules/roguetown/roguejobs/ceramicist/clay.dm
+++ b/code/modules/roguetown/roguejobs/ceramicist/clay.dm
@@ -20,7 +20,7 @@
 	var/burning = 0				// This variable measures the progress of the burning act
 	var/burntime = 5 MINUTES	// How long must it be left unattended to burn and be ruined?
 	var/burned_color = "#302d2d"
-	var/shatter_chance = 20
+	var/shatter_chance = 0
 	var/ash_kneads = 0
 	var/sand_added = FALSE
 	var/is_wet = FALSE


### PR DESCRIPTION
20% chance to say fuck you, after all that nonsense with the kneading.

## About The Pull Request

line edit to reduce frustration

## Testing Evidence

There is no way this will not work
## Why It's Good For The Game
incredibly frustrating, pottery is. 

## Changelog


:cl:
qol: Pottery no longer has a chance to explode in oven
/:cl:
My inspiration
Crude fancy clay bottle
<img width="960" height="1280" alt="Pottery_Jug_Depicting_Egyptian_God_Bes,_5th_Century_BC_(cropped)" src="https://github.com/user-attachments/assets/2d7216a6-bac6-4121-afc4-b8de3cdf2cfc" />

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
