### PR TITLE
add double press wall leaning and you can lean on windows

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
@@ -62,6 +62,8 @@
 #define COMSIG_MOVABLE_KEYBIND_FACE_DIR "keybind_face_dir"
 	///ignores the movement lock key, used for turning while strafing in a mech
 	#define COMSIG_IGNORE_MOVEMENT_LOCK (1<<0)
+///from base of client/key_down(): (dir). A single fresh press of a movement key while the movement lock is held, camera-corrected. Unlike COMSIG_MOVABLE_KEYBIND_FACE_DIR, fires once per press rather than every tick the key is held.
+#define COMSIG_MOB_MOVEMENT_LOCKED_KEY_PRESSED "mob_movement_locked_key_pressed"
 
 /// from /datum/component/singularity/proc/can_move(), as well as /obj/energy_ball/proc/can_move()
 /// if a callback returns `SINGULARITY_TRY_MOVE_BLOCK`, then the singularity will not move to that turf

--- a/code/datums/components/wallpress_doubletap.dm
+++ b/code/datums/components/wallpress_doubletap.dm
@@ -1,0 +1,35 @@
+#define WALLPRESS_DOUBLETAP_WINDOW (0.5 SECONDS)
+
+/**
+ * Double-tapping a direction away from an adjacent wall while the movement lock is held backs the mob
+ * against it, leaning with their back to the wall.
+ */
+/datum/component/wallpress_doubletap
+	var/last_tap_dir = NONE
+	COOLDOWN_DECLARE(doubletap_window)
+
+/datum/component/wallpress_doubletap/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/wallpress_doubletap/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOB_MOVEMENT_LOCKED_KEY_PRESSED, PROC_REF(on_movement_key_pressed))
+
+/datum/component/wallpress_doubletap/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_MOVEMENT_LOCKED_KEY_PRESSED)
+
+/datum/component/wallpress_doubletap/proc/on_movement_key_pressed(mob/living/source, direction)
+	SIGNAL_HANDLER
+	if(source.is_wallpressed() || !(direction in GLOB.cardinals))
+		return
+	if((last_tap_dir != direction) || COOLDOWN_FINISHED(src, doubletap_window))
+		last_tap_dir = direction
+		COOLDOWN_START(src, doubletap_window, WALLPRESS_DOUBLETAP_WINDOW)
+		return
+	last_tap_dir = NONE
+	COOLDOWN_RESET(src, doubletap_window)
+	var/turf/target = get_step(source, REVERSE_DIR(direction))
+	var/atom/leanable = target?.get_wallpress_atom()
+	leanable?.wallpress(source)
+
+#undef WALLPRESS_DOUBLETAP_WINDOW

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -111,6 +111,10 @@
 /obj/structure/MouseDrop_T(atom/movable/O, mob/user)
 	. = ..()
 	if(!climbable)
+		if(can_wallpress() && user == O && isliving(O))
+			var/mob/living/presser = O
+			if(presser.mobility_flags & MOBILITY_MOVE)
+				wallpress(presser)
 		return
 	if(user == O && isliving(O))
 		var/mob/living/L = O

--- a/code/game/objects/structures/roguewindow.dm
+++ b/code/game/objects/structures/roguewindow.dm
@@ -21,6 +21,7 @@
 	break_sound = "glassbreak"
 	destroy_sound = 'sound/combat/hits/onwood/destroywalldoor.ogg'
 	var/window_lock_strength
+	var/wallpress = TRUE
 	var/list/repair_costs = list(/obj/item/grown/log/tree/small, /obj/item/natural/glass)
 	var/repair_skill = /datum/skill/craft/carpentry
 	var/repair_started = FALSE
@@ -28,6 +29,9 @@
 /obj/structure/roguewindow/Initialize(mapload)
 	update_icon()
 	..()
+
+/obj/structure/roguewindow/can_wallpress()
+	return wallpress && !climbable && density
 
 /obj/structure/roguewindow/obj_destruction(damage_flag)
 	..()
@@ -192,7 +196,7 @@
 	icon_state = "harem3-solid"
 	base_state = "harem3-solid"
 	repair_costs = list(/obj/item/natural/glass, /obj/item/natural/glass)
-	
+
 /obj/structure/roguewindow/harem3/frosted
 	name = "frosted glass window"
 	desc = "A frosted glass window, it obscures the view but focuses the mind on just what could be hiding behind it."

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -22,7 +22,7 @@
 
 /turf/closed/MouseDrop_T(atom/movable/O, mob/user)
 	. = ..()
-	if(!wallpress)
+	if(!can_wallpress())
 		return
 	if(user == O && isliving(O))
 		var/mob/living/L = O
@@ -47,8 +47,24 @@
 	for(var/obj/structure/lever/hidden/lever in contents)
 		lever.feel_button(user)
 
-/turf/closed/proc/wallpress(mob/living/user, mob/living/pressing_mob = null)
-	if(user.wallpressed)
+/// Whether a mob can currently lean against us. Anything that returns TRUE must be dense and occupy an adjacent turf.
+/atom/proc/can_wallpress()
+	return FALSE
+
+/turf/closed/can_wallpress()
+	return wallpress
+
+/// The atom in this turf that can be leaned against, if any.
+/turf/proc/get_wallpress_atom()
+	if(can_wallpress())
+		return src
+	for(var/obj/checked_obj in src)
+		if(checked_obj.can_wallpress())
+			return checked_obj
+	return null
+
+/atom/proc/wallpress(mob/living/user, mob/living/pressing_mob = null)
+	if(user.is_wallpressed())
 		return
 	if(user.is_shifted)
 		return
@@ -61,8 +77,7 @@
 		dir2wall = get_dir(user,src)
 	if(!(dir2wall in GLOB.cardinals))
 		return
-	user.wallpressed = dir2wall
-	user.update_wallpress_slowdown()
+	user.set_wallpressed(dir2wall)
 	if(pressing_mob)
 		user.visible_message(span_info("[user] is pushed against [src] by [pressing_mob]."))
 	else if(user.m_intent == MOVE_INTENT_SNEAK)
@@ -103,15 +118,14 @@
 	return 255
 
 /turf/closed/proc/wallshove(mob/living/user)
-	if(user.wallpressed)
+	if(user.is_wallpressed())
 		return
 	if(!(user.mobility_flags & MOBILITY_STAND))
 		return
 	var/dir2wall = get_dir(user,src)
 	if(!(dir2wall in GLOB.cardinals))
 		return
-	user.wallpressed = dir2wall
-	user.update_wallpress_slowdown()
+	user.set_wallpressed(dir2wall)
 	switch(dir2wall)
 		if(NORTH)
 			user.setDir(NORTH)
@@ -125,6 +139,20 @@
 		if(WEST)
 			user.setDir(WEST)
 			user.set_mob_offsets("wall_press", _x = -12, _y = 0)
+
+/// Sets wallpressed to a cardinal dir or FALSE, doing any related effects
+/mob/living/proc/set_wallpressed(new_wallpressed = FALSE)
+	if(wallpressed == new_wallpressed)
+		return
+	wallpressed = new_wallpressed
+	if(!wallpressed)
+		reset_offsets("wall_press")
+	update_wallpress_slowdown()
+
+/// The cardinal dir of the wall we're pressed against, or FALSE.
+/mob/living/proc/is_wallpressed()
+	SHOULD_BE_PURE(TRUE)
+	return wallpressed
 
 /mob/living/proc/update_wallpress_slowdown()
 	if(!wallpressed)
@@ -281,7 +309,7 @@
 				user.movement_type &= ~FLYING
 				if(istype(user.loc, /turf/open/transparent/openspace)) // basically only apply this slop after we moved. if we are hovering on the openspace turf, then good, we are doing an 'active climb' instead of the usual vaulting action
 					var/climber2wall_dir = get_dir(climber, src)
-					climber.wallpressed = climber2wall_dir
+					climber.set_wallpressed(climber2wall_dir)
 					switch(climber2wall_dir)// we are pressed against the wall after all that shit and are facing it, also hugging it too bcoz sou
 						if(NORTH)
 							climber.setDir(NORTH)

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -150,7 +150,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 			user.forceMove(target)
 			user.movement_type &= ~FLYING
 			if(istype(user.loc, /turf/open/transparent/openspace)) // basically only apply this slop after we moved. if we are hovering on the openspace turf, then good, we are doing an 'active climb' instead of the usual vaulting action
-				climber.wallpressed = climber2wall_dir
+				climber.set_wallpressed(climber2wall_dir)
 				switch(climber2wall_dir)// we are pressed against the wall after all that shit and are facing it, also hugging it too bcoz sou
 					if(NORTH)
 						climber.setDir(NORTH)
@@ -180,10 +180,10 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 			if (!A.dextrous)
 				return
 		if(L.mobility_flags & MOBILITY_MOVE)
-			wallpress(L)
+			climb_from_openspace(L)
 			return
 
-/turf/open/transparent/openspace/proc/wallpress(mob/living/user) // only cardinals, correct chat
+/turf/open/transparent/openspace/proc/climb_from_openspace(mob/living/user) // only cardinals, correct chat
 	var/turf/climb_target = src
 	var/mob/living/carbon/human/climber = user // https://discord.com/channels/1389349752700928050/1389452066493169765/1413195734441922580
 	if(!(climber.stat != CONSCIOUS))
@@ -241,8 +241,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 						playsound(climber, 'sound/foley/climb.ogg', sfx_vol)
 					else
 						playsound(climber, pick(cloth_wipe_sfx), 100, TRUE)
-					climber.update_wallpress_slowdown()
-					climber.wallpressed = wall2wall_dir // we set our wallpressed flag to TRUE and regain blue bar somewhat, might wanna remove dat idk
+					climber.set_wallpressed(wall2wall_dir) // we set our wallpressed flag to TRUE and regain blue bar somewhat, might wanna remove dat idk
 					switch(wall2wall_dir)// we are pressed against the wall after all that shit and are facing it, also hugging it too bcoz sou
 						if(NORTH)
 							climber.setDir(NORTH)
@@ -282,7 +281,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 				to_chat(living_user, span_warning("There's nowhere to tie the rope here."))
 				return
 			var/obj/structure/rope_ladder/rope = new(target)
-			if(living_user.wallpressed)
+			if(living_user.is_wallpressed())
 				rope.dir = living_user.dir
 			else
 				rope.dir = get_dir(src, living_user)

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -24,8 +24,7 @@
 	if((movement_dir & EAST) && (movement_dir & WEST))
 		movement_dir &= ~(EAST|WEST)
 
-	if(user.dir != NORTH && movement_dir) //If we're not moving, don't compensate, as byond will auto-fill dir otherwise
-		movement_dir = turn(movement_dir, -dir2angle(user.dir)) //By doing this we ensure that our input direction is offset by the client (camera) direction
+	movement_dir = user.camera_relative_dir(movement_dir)
 
 	//Completely block movement. Useful so you can use keybinds that overlap with WASD
 	if(user.movement_blocked)
@@ -39,6 +38,13 @@
 		return !!movement_dir //true if there was actually any player input
 
 	return FALSE
+
+/// Offsets an input direction by the client (camera) direction. NONE is passed through, as byond would auto-fill dir otherwise.
+/client/proc/camera_relative_dir(direction)
+	SHOULD_BE_PURE(TRUE)
+	if(dir == NORTH || !direction)
+		return direction
+	return turn(direction, -dir2angle(dir))
 
 /client/proc/calculate_move_dir()
 	var/movement_dir = NONE

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -50,6 +50,8 @@
 		calculate_move_dir()
 		if(!movement_locked && !(next_move_dir_sub & movement))
 			next_move_dir_add |= movement
+		else if(movement_locked && mob)
+			SEND_SIGNAL(mob, COMSIG_MOB_MOVEMENT_LOCKED_KEY_PRESSED, camera_relative_dir(movement))
 
 	// Client-level keybindings are ones anyone should be able to do at any time
 	// Things like taking screenshots, hitting tab, and adminhelps.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -8,6 +8,7 @@
 	. = ..()
 	update_a_intents()
 	swap_rmb_intent(num=1)
+	AddComponent(/datum/component/wallpress_doubletap)
 	if(unique_name)
 		name = "[name] ([rand(1, 1000)])"
 		real_name = name
@@ -962,19 +963,16 @@
 		reset_offsets("wall_press")
 		return FALSE
 	if(buckled || lying)
-		wallpressed = FALSE
+		set_wallpressed(FALSE)
 		reset_offsets("wall_press")
 		return FALSE
 	var/turf/newwall = get_step(newloc, wallpressed)
 	if(!T.Adjacent(newwall))
 		return reset_offsets("wall_press")
-	if(isclosedturf(newwall) && fixedeye)
-		var/turf/closed/C = newwall
-		if(C.wallpress)
-			return TRUE
-	wallpressed = FALSE
+	if(fixedeye && newwall?.get_wallpress_atom())
+		return TRUE
+	set_wallpressed(FALSE)
 	reset_offsets("wall_press")
-	update_wallpress_slowdown()
 
 /mob/living/Move(atom/newloc, direct, glide_size_override)
 
@@ -1954,6 +1952,10 @@
 
 /mob/living/vv_edit_var(var_name, var_value)
 	switch(var_name)
+		if (NAMEOF(src, wallpressed))
+			set_wallpressed(var_value)
+			datum_flags |= DF_VAR_EDITED
+			return TRUE
 		if ("maxHealth")
 			if (!isnum(var_value) || var_value <= 0)
 				return FALSE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -3,9 +3,9 @@
 	sight = 0
 	see_in_dark = 8
 	hud_possible = list(ANTAG_HUD)
-	
+
 	typing_indicator_enabled = TRUE
-	
+
 	var/resize = 1 //Badminnery resize
 	var/lastattacker = null
 	var/lastattackerckey = null
@@ -27,7 +27,8 @@
 	var/mobility_flags = MOBILITY_FLAGS_DEFAULT
 
 	var/resting = FALSE
-	var/wallpressed = FALSE
+	/// Cardinal dir of the wall we're pressed against, or FALSE. Use set_wallpressed()/is_wallpressed().
+	VAR_PROTECTED/wallpressed = FALSE
 	var/climbing = FALSE
 
 	var/pixelshift_layer = 0
@@ -63,7 +64,7 @@
 
 	var/tod = null // Time of death
 
-	/// The boolean "Are we on fire?" var. 
+	/// The boolean "Are we on fire?" var.
 	var/on_fire = FALSE
 	/// Helper vars for quick access to firestacks, these should be updated every time firestacks are adjusted
 	var/fire_stacks = 0

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -684,6 +684,7 @@
 #include "code\datums\components\tether.dm"
 #include "code\datums\components\vampire_disguise.dm"
 #include "code\datums\components\waddling.dm"
+#include "code\datums\components\wallpress_doubletap.dm"
 #include "code\datums\components\wearertargeting.dm"
 #include "code\datums\components\wet_floor.dm"
 #include "code\datums\components\connect\connect_containers.dm"


### PR DESCRIPTION
## About The Pull Request
refactors wallpress a bunch and fixes issues where the slowdown was sticking to players
also adds a new feature where you can wallpress via double pressing the movement key for a wall behind you to lean into it, if you are holding CTRL click
also you can lean into windows now because it's odd you couldn't before
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
tested by wall leaning, buckling into a bed, unbuckling, which i could confirm caused the issue, now no longer does, also tested the double input leaning now
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
qol is really nice, clickdragging is worse but we keep it for muscle memory, and annoying pesky bugs being fixes is lovely
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: if you hold ctrl and your back is facing a wall, you can double input a movement key to that wall to lean into it
add: you can now wall-lean on windows now
fix: fix issues where wall leaning could persist slowdown on the mob
code: refactored how wall leaning works and turned it into a setter/getter syntax
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
