### PR TITLE
Prevents maps from being played consecutively! Or No, You Can't Play Rockhill Twice.

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -248,6 +248,8 @@ SUBSYSTEM_DEF(vote)
 				var/datum/map_config/VM = config.maplist[map]
 				if(!VM.votable)
 					continue
+				if(VM.map_name == SSmapping.config.map_name)
+					continue
 				var/player_count = GLOB.clients.len
 				if(VM.config_max_users > 0 && player_count >= VM.config_max_users)
 					continue


### PR DESCRIPTION
## About The Pull Request

I like Dun World. I like Desert Town. I don't like 30 Rockhill rounds in a row.

## Testing Evidence

Two line change...? I'm not actually sure how to test this in local without waiting 3 hours anyhow. I'm dumb.
(This means TM it before fullmerging in case I fucked up!!!)

## Why It's Good For The Game

If people played the other two maps, they'd probably like them more. If not, this exposes the flaws and issues that'll help us fix them. Why have three map if we're not going to use them?

## Changelog

:cl:
config: You can no longer vote for the map that was just played.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
