### PR TITLE
Removes Loadout Examine Link

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -32,18 +32,10 @@
 		lines += ext_lines
 	return lines
 
-/mob/living/carbon/human/proc/get_examine_item_name_with_custom_link(mob/user, obj/item/I)
-	if(!I)
-		return ""
-	var/display_name = I.get_examine_string(user)
-	if(!I.has_customized_identity() && !I.always_show_examine_link)
-		return display_name
-	return "<a href='?src=[REF(src)];task=show_custom_item_info;item_ref=[REF(I)]'>[display_name]</a>"
-
 /mob/living/carbon/human/proc/get_examine_item_name_with_hover(mob/user, obj/item/I)
 	if(!I)
 		return ""
-	var/display_name = get_examine_item_name_with_custom_link(user, I)
+	var/display_name = I.get_examine_string(user)
 	if(!I.show_examine_hover_tooltip())
 		return display_name
 	var/self_examine = (src == user)
@@ -51,7 +43,7 @@
 	if(!tooltip_html)
 		return display_name
 	var/label = display_name
-	if(!I.has_customized_identity() && !I.always_show_examine_link)
+	if(!I.always_show_examine_link)
 		label = "<u><font color='#add8e6'>[display_name]</font></u>"
 	return "<span data-component=\"TooltipHTML\" data-position=\"bottom-start\" data-html=\"[html_encode(tooltip_html)]\">[label]</span>"
 

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -23,34 +23,6 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		mob_examine_panel.ui_interact(usr)
 		return
 
-	if(href_list["task"] == "show_custom_item_info")
-		if(!observer_privilege && !usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
-			return
-		var/obj/item/target_item = locate(href_list["item_ref"])
-		if(!istype(target_item))
-			return
-		if(!(target_item in held_items) && !(target_item in get_equipped_items(TRUE)) && \
-			target_item != chastity_device && \
-			!(chastity_device && target_item == chastity_device.attached_toy))
-			return
-		var/is_chastity_item = (target_item == chastity_device)
-		var/is_chastity_attached_toy = (chastity_device && target_item == chastity_device.attached_toy)
-		if(!observer_privilege && (is_chastity_item || is_chastity_attached_toy))
-			if(!get_location_accessible(src, BODY_ZONE_PRECISE_GROIN))
-				return
-			var/perception_level = 15
-			if(isliving(usr))
-				var/mob/living/L = usr
-				perception_level = L.STAPER
-			if(perception_level < 8)
-				return
-		if(!target_item.has_customized_identity() && !target_item.always_show_examine_link)
-			return
-		var/list/item_examine = target_item.examine(usr)
-		if(length(item_examine))
-			to_chat(usr, usr.client?.prefs?.no_examine_blocks ? item_examine.Join("\n") : examine_block(item_examine.Join("\n")))
-		return
-
 	if(href_list["inspect_limb"] && (observer_privilege || usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY)))
 		var/list/msg = list()
 		var/mob/user = usr


### PR DESCRIPTION
## About The Pull Request

Removes the clickable link from loadout items on examine.

## Testing Evidence

<img width="620" height="438" alt="image" src="https://github.com/user-attachments/assets/1f756133-745d-4e80-80f8-327ec9ef2411" />

## Why It's Good For The Game

This feature is made irrelevant by hover pop-ups.

## Changelog
:cl:
del: Redundant link when loadout items are examined on a player.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
