### PR TITLE
Giving Dwarfs two more skin tones.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/dwarf/dwarfm.dm
@@ -95,7 +95,9 @@
 		"Obsidian" = SKIN_COLOR_OBSIDIAN,
 		"Brimstone" = SKIN_COLOR_BRIMSTONE,
 		"Jade" = SKIN_COLOR_JADE,
-		"Ceragyrite" = SKIN_COLOR_CERAGYRITE
+		"Ceragyrite" = SKIN_COLOR_CERAGYRITE,
+		"Tuscan Red" = SKIN_COLOR_TUSCAN,
+		"Smoky Quartz" = SKIN_COLOR_SMOKY_QUARTZ
 	)
 
 /datum/species/dwarf/mountain/get_hairc_list()


### PR DESCRIPTION
Giving the dwarfs two more skin tones 
TUSCAN "7e4e4a"
SMOKY QUARTZ "452516"

## About The Pull Request

Adding two more skin tones to the Dwarf, I believed they needed more skin tones between the lighter skin color and the darker. The contrast from the darkest white to the lightest dark is immense. I added one single skin tone and a light red one. 

## Testing Evidence
I did not test it locally, it's only four lines of code. 

## Why It's Good For The Game

Gives you more skin tones to customize your dwarf with. 

## Changelog
:cl:
code: 	Changed: "Ceragyrite" = SKIN_COLOR_CERAGYRITE    TO ->  "Ceragyrite" = SKIN_COLOR_CERAGYRITE, 

		Added: "Tuscan Red" = SKIN_COLOR_TUSCAN,
		Added: "Smoky Quartz" = SKIN_COLOR_SMOKY_QUARTZ
/:cl: