### PR TITLE
fix signal message on drug inhaling.

### DIFF
--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -106,8 +106,10 @@
 				to_chat(user, span_warning("[C.p_theyre(TRUE)] missing something."))
 			if(!C.can_smell())
 				to_chat(user, span_warning("[C.p_theyre(TRUE)] has no nose!"))
-			user.visible_message(span_danger("[user] attempts to force [C] to inhale [src]."), \
-								span_danger("[user] attempts to force me to inhale [src]!"))
+			if(C != user)
+				user.visible_message(span_danger("[user] attempts to force [C] to inhale [src]."), \
+								span_danger("I attempt to force [C] to inhale [src]!"))
+		
 			if(C.cmode)
 				if(!CH.grabbedby)
 					to_chat(user, span_info("[C.p_they(TRUE)] steals [C.p_their()] face from it."))

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -106,8 +106,8 @@
 				to_chat(user, span_warning("[C.p_theyre(TRUE)] missing something."))
 			if(!C.can_smell())
 				to_chat(user, span_warning("[C.p_theyre(TRUE)] has no nose!"))
-			if(C != user)
-				user.visible_message(span_danger("[user] attempts to force [C] to inhale [src]."), \
+			
+			user.visible_message(span_danger("[user] attempts to force [C] to inhale [src]."), \
 								span_danger("I attempt to force [C] to inhale [src]!"))
 		
 			if(C.cmode)


### PR DESCRIPTION

## About The Pull Request

this irked me,
so I fixed it.

from "terry attempts to force me to inhale x", when forcing someone else to sniff stuff to -> "terry attempts to force berry to inhale x"

## Testing Evidence

<img width="504" height="54" alt="image" src="https://github.com/user-attachments/assets/5362d58e-3406-492b-96a3-410579f7166f" />


## Why It's Good For The Game

this makes people not confused about forcing people to sniff drugs.

## Changelog

:cl:
fix: message on forced drug sniffing
/:cl:


