### PR TITLE
Added a pair of brackets to damage calculation, or, how I learned why Gnolls and Werewolves die horribly

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2033,7 +2033,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE)
 	SEND_SIGNAL(H, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
 	var/hit_percent = 1
-	damage = max(damage-blocked+armor,0)
+	damage = max(damage-(blocked+armor),0)
 //	var/hit_percent =  (100-(blocked+armor))/100
 	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
 	var/atom/movable/screen/zone_sel/zone_sel


### PR DESCRIPTION
## About The Pull Request

So, presently, damage is calculated by `damage = max(damage - blocked + armor, 0` ; The `armor` here is the interesting thing, cause in the case of gnolls and werewolves, this value is `30`. Because of how the math crunches out, this means WWs and Gnolls are, in every single instance of damage taken, having an additional 30 added on to hits they take. This explains a few things, but most notably why people feel like Gnolls and WWs are made of glass. This adds a second set of brackets, making it `damage = max(damage - (blocked + armor), 0)`, properly accounting for the species armor present on things such as gnolls and werewolves in particular, who were feeling particularly frail under fire.

## Testing Evidence

<img width="323" height="88" alt="dreamseeker_DnqNZm4bJO" src="https://github.com/user-attachments/assets/5f8beaf3-c2dc-4979-885b-9476656cf3b3" />
<img width="132" height="77" alt="dreamseeker_ZopD3MTSUS" src="https://github.com/user-attachments/assets/8034b878-5402-4f9e-88e6-49f5b25ada36" />
<img width="322" height="274" alt="dreamseeker_0IGeAJBn2i" src="https://github.com/user-attachments/assets/f3ea85c5-7503-494e-818c-339618388366" />

First two pics: Swung at self with claw on CUT, 13 str. 49 brute each.
Last pic, after adding brackets: Swung at self with same setup, didn't break armor or do damage to self at all, had to break armor entirely to meaningfully hurt self. The gnoll no longer explodes.

## Why It's Good For The Game

This oddity of the armor computation most notably arose when hitting gnolls with a lot of small attacks that you think would not be nearly as effective, but for, whatever reason, were BLOWING GNOLLS THE FUCK UP, and werewolves by extension.

Fire in particular was quite good at this, as it would hit multiple zones at once with damage that was then being vastly increased by this order of operations.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: buff to ww and gnoll armor (it was broken)
code: added additional set of brackets to line of code in species.dm, Line 2036
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
