### PR TITLE
Monk > MAA wrestling unarmed

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -14,8 +14,8 @@
 		STATKEY_CON = 2,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -82,8 +82,8 @@
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Discipline - Unarmed")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist//Just this and disciple, effectively.
 			if("Katar")
 				beltl = /obj/item/rogueweapon/katar/bronze


### PR DESCRIPTION
## About The Pull Request

This PR is adjusting monk's wrestling/unarmed Skill to a baseline of Expert putting regular monk on par with the common combat classes across the rest of the code base. This will ensure the class can retain its purpose as an unarmed martial artist that is supposed to be a cut above the normal in martial prowess and wrestling

## Testing Evidence

<img width="310" height="26" alt="image" src="https://github.com/user-attachments/assets/f78e84f3-99b2-4634-ad1b-c4ca7b851551" />


## Why It's Good For The Game

Readjusts monks back to a decent state before other combat classes were power creeped into higher wrestling skills leaving monk irrelevant

## Changelog


:cl:
balance: adjusted monks to combat class unarmed/wrestling level
/:cl: