### PR TITLE
Lower gravity spell strength resist threshold to 15. 

### DIFF
--- a/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
+++ b/code/modules/spells/spell_types/wizard/invoked_single_target/gravity.dm
@@ -50,7 +50,7 @@
 				playsound(get_turf(L), 'sound/magic/magic_nulled.ogg', 100)
 				return TRUE
 
-			if(L.STASTR <= 15)
+			if(L.STASTR <= 14)
 				L.adjustBruteLoss(60)
 				L.Knockdown(5)
 				to_chat(L, "<span class='userdanger'>You're magically weighed down, losing your footing!</span>")


### PR DESCRIPTION
## About The Pull Request

- Lowers the threshold for resisting gravity knockdown from 16 (strength statpack on horc, drakian, lamia, arachnid + 3 strength job stats) to 15

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
1 number change ( L.STASTR <= 14)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
15 is the threshold for chain snap, 16 is far harder to get unless you build alongside species stats. Free knockdown for everyone but 4 specific races on the dedicated unga strength class with a strength statpack is a bit much. In its current state, resisting the spell still puts you in a position to be kicked down.

Also, I died to it once. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Lowered the strength knockdown resist check for the gravity spell from 16 to 15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
