### PR TITLE
Spellbook Overloading AKA NOC BREAK MY CHAINS!!

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -116,6 +116,9 @@ GLOBAL_VAR_INIT(dayspassed, FALSE)
 		if(HAS_TRAIT(mind.current, TRAIT_NOSLEEP)) // new hackslop to allow anything that cannot sleep to do their daily stuff
 			if(mind.has_changed_spell)
 				mind.has_changed_spell = FALSE
+				mind.free_spell_unbinds = 0
+				mind.strained_spell_unbinds = 0
+				mind.has_fed_spellbook_lux = FALSE
 				to_chat(mind.current, span_smallnotice("I feel like I can change my spells again."))
 			if(mind.has_rituos)
 				mind.has_rituos = FALSE

--- a/code/datums/sleep_adv/sleep_adv.dm
+++ b/code/datums/sleep_adv/sleep_adv.dm
@@ -405,6 +405,9 @@ GLOBAL_LIST_INIT(cross_training_map, list(
 		return
 	if(mind.has_changed_spell)
 		mind.has_changed_spell = FALSE
+		mind.free_spell_unbinds = 0
+		mind.strained_spell_unbinds = 0
+		mind.has_fed_spellbook_lux = FALSE
 		to_chat(mind.current, span_smallnotice("I feel like I can change my spells again."))
 	if(mind.has_rituos)
 		mind.has_rituos = FALSE

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -403,6 +403,28 @@
 	desc = "You felt lyfe itself course through you, restoring your lux and your essance. You.. live - but your body aches. It still needs time to recover.."
 	icon_state = "revived"
 
+/datum/status_effect/debuff/mana_burden
+	id = "mana_burden"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/mana_burden
+	effectedstats = list(STATKEY_STR = -1, STATKEY_PER = -1, STATKEY_INT = -1, STATKEY_WIL = -1, STATKEY_CON = -1, STATKEY_SPD = -1, STATKEY_LCK = -1)
+	duration = 15 MINUTES
+
+/atom/movable/screen/alert/status_effect/debuff/mana_burden
+	name = "Mana Burden"
+	desc = "My thoughts are clouded, my body feels sluggish and heavy. I need some time to recover."
+	icon_state = "revived"
+
+/datum/status_effect/debuff/mana_toxicity
+	id = "mana_toxicity"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/mana_toxicity
+	effectedstats = list(STATKEY_STR = -1, STATKEY_PER = -1, STATKEY_INT = -1, STATKEY_WIL = -1, STATKEY_CON = -1, STATKEY_SPD = -1, STATKEY_LCK = -1)
+	duration = 15 MINUTES
+
+/atom/movable/screen/alert/status_effect/debuff/mana_toxicity
+	name = "Mana Toxicity"
+	desc = "My body is rejecting excess knowledge. What have I done?"
+	icon_state = "revived"
+
 //For de-rot - your body ROTTED. Harsher penalty for longer, can be fully off-set with a cure-rot potion.
 /datum/status_effect/debuff/rotted
 	id = "rotted_body"

--- a/code/modules/spells/spell_types/wizard/spell_list.dm
+++ b/code/modules/spells/spell_types/wizard/spell_list.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_INIT(learnable_spells, (list(/obj/effect/proc_holder/spell/invoked/p
 		/obj/effect/proc_holder/spell/invoked/create_campfire,
 		/obj/effect/proc_holder/spell/invoked/mending,
 		/obj/effect/proc_holder/spell/self/light,
+		/obj/effect/proc_holder/spell/self/magos_book_bind,
 		/obj/effect/proc_holder/spell/invoked/conjure_weapon,
 		/obj/effect/proc_holder/spell/self/conjure_armor,
 		/obj/effect/proc_holder/spell/self/conjure_armor/dragonhide,

--- a/code/modules/spells/spell_types/wizard/utility/magos_book_bind.dm
+++ b/code/modules/spells/spell_types/wizard/utility/magos_book_bind.dm
@@ -1,7 +1,6 @@
 /obj/effect/proc_holder/spell/self/magos_book_bind
 	name = "Magos' Book Bind"
 	desc = "Bind a spellbook by middle-clicking it, allowing the tome to be recalled to your hand."
-	chargetime = 2 SECONDS
 	recharge_time = 30 SECONDS
 	chargedloop = /datum/looping_sound/invokegen
 	associated_skill = /datum/skill/magic/arcane

--- a/code/modules/spells/spell_types/wizard/utility/magos_book_bind.dm
+++ b/code/modules/spells/spell_types/wizard/utility/magos_book_bind.dm
@@ -10,7 +10,7 @@
 	invocation_type = "whisper"
 	action_icon_state = "summons"
 
-	var/obj/item/book/spellbook/bound_spellbook
+	var/obj/item/bound_spellbook
 
 /obj/effect/proc_holder/spell/self/magos_book_bind/cast(list/targets, mob/living/user = usr)
 	if(!bound_spellbook)

--- a/code/modules/spells/spell_types/wizard/utility/magos_book_bind.dm
+++ b/code/modules/spells/spell_types/wizard/utility/magos_book_bind.dm
@@ -1,0 +1,44 @@
+/obj/effect/proc_holder/spell/self/magos_book_bind
+	name = "Magos' Book Bind"
+	desc = "Bind a spellbook by middle-clicking it, allowing the tome to be recalled to your hand."
+	chargetime = 2 SECONDS
+	recharge_time = 30 SECONDS
+	chargedloop = /datum/looping_sound/invokegen
+	associated_skill = /datum/skill/magic/arcane
+	cost = 1
+	spell_tier = 1
+	invocations = list("Redi ad manum.")//return to hand, i think
+	invocation_type = "whisper"
+	action_icon_state = "summons"
+
+	var/obj/item/book/spellbook/bound_spellbook
+
+/obj/effect/proc_holder/spell/self/magos_book_bind/cast(list/targets, mob/living/user = usr)
+	if(!bound_spellbook)
+		to_chat(user, span_warning("I have no spellbook bound. I must middle-click one first."))
+		revert_cast()
+		return FALSE
+	if(QDELETED(bound_spellbook))
+		to_chat(user, span_warning("I can no longer sense my bound spellbook."))
+		bound_spellbook = null
+		revert_cast()
+		return FALSE
+	if(bound_spellbook.loc == user)
+		to_chat(user, span_notice("My bound spellbook is already in my possession."))
+		revert_cast()
+		return FALSE
+	if(user.get_active_held_item() && user.get_inactive_held_item())
+		to_chat(user, span_warning("I need a free hand to recall my bound spellbook."))
+		revert_cast()
+		return FALSE
+	if(ismob(bound_spellbook.loc))
+		var/mob/holder = bound_spellbook.loc
+		holder.dropItemToGround(bound_spellbook)
+	bound_spellbook.visible_message(span_warning("[bound_spellbook] vanishes in a swirl of arcyne energy!"))
+	if(!user.put_in_hands(bound_spellbook))
+		to_chat(user, span_warning("My bound spellbook resists the summons."))
+		revert_cast()
+		return FALSE
+	user.visible_message(span_warning("[bound_spellbook] appears in [user]'s hand in a swirl of arcyne energy!"), span_notice("I recall [bound_spellbook] to my hand."))
+	playsound(user, 'sound/magic/unmagnet.ogg', 60, TRUE)
+	return TRUE

--- a/modular_azurepeak/code/datums/mind.dm
+++ b/modular_azurepeak/code/datums/mind.dm
@@ -1,5 +1,8 @@
 /datum/mind
 	var/has_changed_spell = FALSE // If the person has changed their spells for theday
+	var/free_spell_unbinds = 0 // Free spellbook unbinds used today (3 for t3 arcane+)
+	var/strained_spell_unbinds = 0 // Costly spellbook unbinds used today (2 for real, "3" though the third one kills you)
+	var/has_fed_spellbook_lux = FALSE // Lux-fed spellbook unbind used today
 	/// If you have a spell granted by Rituos, resets when you sleep
 	var/has_rituos = FALSE
 	var/obj/effect/proc_holder/spell/rituos_spell

--- a/modular_azurepeak/code/game/objects/items/spellbooks.dm
+++ b/modular_azurepeak/code/game/objects/items/spellbooks.dm
@@ -2,7 +2,7 @@
 #define GEM_CHARGE_REDUCTION 0.25
 
 /* Spellbook
-Intended to be a reward or a goal for pure mage, allowing them to reset and swap out 2 spells per day, and
+Intended to be a reward or a goal for pure mage, allowing them to reset and swap out 2 spells per day (3 with T3+ arcyne), and
 decreases charge time if held opened in hand, for pure mage build + aesthetics.
 */
 
@@ -23,6 +23,26 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 	desc = "A crackling, glowing book, filled with runes and symbols that hurt the mind to stare at. Can be used to unbind spells, or to assist the caster in arcing some of their projectiles."
 	var/picked // if the book has had it's style picked or not
 	var/born_of_rock = FALSE // was a magical stone used to make it instead of a gem
+
+/obj/item/book/spellbook/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/storage/concrete)
+	var/datum/component/storage/storage = GetComponent(/datum/component/storage)
+	storage.max_items = 1
+	storage.max_w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/book/spellbook/MiddleClick(mob/living/user, params)
+	if(!user.mind)
+		return ..()
+	if(!user.Adjacent(src) && loc != user)
+		to_chat(user, span_warning("I need to be closer to bind this tome."))
+		return TRUE
+	for(var/obj/effect/proc_holder/spell/self/magos_book_bind/bind_spell in user.mind.spell_list)
+		bind_spell.bound_spellbook = src
+		to_chat(user, span_notice("I bind [src] to my arcyne grasp. I can now recall it with Magos' Book Bind."))
+		playsound(src, 'sound/magic/charged.ogg', 50, TRUE)
+		return TRUE
+	return ..()
 
 /obj/item/book/spellbook/getonmobprop(tag)
 	. = ..()
@@ -82,7 +102,8 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 
 /obj/item/book/spellbook/examine(mob/user)
 	. = ..()
-	. += span_notice("Reading it once per day allows you to unbind two spells and refund its spell point.")
+	var/unbind_limit = (HAS_TRAIT(user, TRAIT_ARCYNE_T3) || HAS_TRAIT(user, TRAIT_ARCYNE_T4)) ? 3 : 2
+	. += span_notice("Reading it once per day allows you to unbind up to [unbind_limit] spells and refund their spell points.")
 	if(born_of_rock)
 		. += span_notice("This tome was made from a magical stone instead of a proper gem. Holding it in your hand with it open reduces spell charge time by [ROCK_CHARGE_REDUCTION * 100]%")
 	else
@@ -104,10 +125,11 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 	change_spells()
 	return FALSE
 
-/obj/item/book/spellbook/proc/change_spells(mob/user = usr)
+/obj/item/book/spellbook/proc/change_spells(mob/living/user = usr)
 	var/datum/mind/user_mind = user.mind
 	if(!user_mind) return // How??
-	if(user_mind.has_changed_spell)
+	var/unbind_limit = (HAS_TRAIT(user, TRAIT_ARCYNE_T3) || HAS_TRAIT(user, TRAIT_ARCYNE_T4)) ? 3 : 2
+	if(user_mind.has_changed_spell && user_mind.free_spell_unbinds < unbind_limit)
 		to_chat(user, span_warning("I have already unbinded my spells today!"))
 		return
 	var/list/resettable_spells = list()
@@ -117,25 +139,99 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 		if(spell.refundable == TRUE)
 			if(spell.cost > 0)
 				resettable_spells["[spell.name]: [spell.cost]"] = spell_list[i]
-	if(!resettable_spells.len)
+	if(!resettable_spells.len && user_mind.strained_spell_unbinds < 2)
 		to_chat(user, span_warning("I have no spells to unbind!"))
 		return
-	user_mind.has_changed_spell = TRUE //To pre-empt a halting duplication in the for loop here
-	var/unlearn_success = FALSE
-	for(var/i = 1, i <= 2, i++)
-		var/choice = input(user, "Choose up to two spells to unbind. Cancel both to not use up your daily unbinding.") as null|anything in resettable_spells
-		var/obj/effect/proc_holder/spell/item = resettable_spells[choice]
-		if(!item)
-			break
-		if(!resettable_spells.len)
+	if(!user_mind.has_changed_spell)
+		user_mind.has_changed_spell = TRUE //To pre-empt a halting duplication in the for loop here
+		for(var/i = 1, i <= unbind_limit, i++)
+			var/choice = input(user, "Choose up to [unbind_limit] spells to unbind. Cancel all to not use up your daily unbinding.") as null|anything in resettable_spells
+			var/obj/effect/proc_holder/spell/item = resettable_spells[choice]
+			if(!item)
+				break
+			if(user_mind.RemoveSpell(item))
+				user_mind.used_spell_points -= item.cost
+				user_mind.free_spell_unbinds++
+				resettable_spells.Remove(choice)
+				user_mind.check_learnspell()
+			if(!resettable_spells.len)
+				break
+		if(!user_mind.free_spell_unbinds)
+			user_mind.has_changed_spell = FALSE
 			return
-		if(user_mind.RemoveSpell(item))
-			user_mind.used_spell_points -= item.cost
-			unlearn_success = TRUE
+	if(user_mind.free_spell_unbinds < unbind_limit || (!resettable_spells.len && user_mind.strained_spell_unbinds < 2))
+		return
+	var/obj/item/held_lux = user.get_inactive_held_item()
+	if(!user_mind.has_fed_spellbook_lux && (istype(held_lux, /obj/item/reagent_containers/lux) || istype(held_lux, /obj/item/reagent_containers/lux_impure)))
+		var/lux_prompt = "THE SYMBOLS ON THE PAGE GLOW AND VIBRATE, AS IF THEY'RE LEECHED TOWARDS YOUR OTHER HAND..\n\nFEED THE BOOK WITH LUX?"
+		if(alert(user, lux_prompt, "THE TOME HUNGERS", "FEED THE BOOK", "NAY") == "FEED THE BOOK")
+			if(!do_after(user, 5 SECONDS, target = src))
+				return
+			if(user.get_inactive_held_item() != held_lux)
+				to_chat(user, span_warning("The tome's symbols dim as the lux leaves my hand."))
+				return
+			playsound(user, 'sound/magic/charged.ogg', 75, TRUE)
+			user_mind.has_fed_spellbook_lux = TRUE
+			qdel(held_lux)
+			var/lux_choice = input(user, "Choose a spell to unbind.") as null|anything in resettable_spells
+			var/obj/effect/proc_holder/spell/lux_item = resettable_spells[lux_choice]
+			if(!lux_item)
+				return
+			if(user_mind.RemoveSpell(lux_item))
+				user_mind.used_spell_points -= lux_item.cost
+				resettable_spells.Remove(lux_choice)
+				user_mind.check_learnspell()
+			return
+	if(user_mind.strained_spell_unbinds >= 3)
+		to_chat(user, span_warning("The tome's symbols lie still. I can force nothing more from them today."))
+		return
+	var/strain = user_mind.strained_spell_unbinds + 1
+	var/prompt
+	switch(strain)
+		if(1)
+			prompt = "THE SYMBOLS ON THE PAGE PULSATE INQUISITIVELY. YOU MAY BE ABLE TO UNBIND ANOTHER SPELL, BUT IT WILL LEAVE A COST ON YOUR MIND."
+		if(2)
+			prompt = "THE SYMBOLS ON THE PAGE PULSATE HUNGRILY. YOU MAY BE ABLE TO UNBIND ANOTHER SPELL, BUT IT WILL LEAVE A WITHERING, EXSANGUINATED COST ON YOUR SPIRIT. \n\n (WARNING: THIS WILL LYFE END YOU WITHOUT PREPARATION!!)"
+		if(3)
+			prompt = "THE SYMBOLS ON THE PAGE PULSATE GREEDILY. YOU MAY BE ABLE TO UNBIND ANOTHER SPELL, BUT IT WILL LEAVE A DIRE, FATAL COST ON YOUR BODY.\n\n(WARNING: THIS WILL LYFE END YOU!!)"
+	if(alert(user, prompt, "THE TOME BECKONS", "PUSH FORWARD", "NAY") != "PUSH FORWARD")
+		return
+	if(!do_after(user, 5 SECONDS, target = src))
+		return
+	user_mind.strained_spell_unbinds++
+	if(strain == 3)
+		var/turf/death_turf = get_turf(user)
+		user.emote("scream", forced = TRUE)
+		to_chat(user, span_bigbold(span_userdanger("MY BODY TWISTS AND CONTORTS.. THIS WAS A MISTAKE!!")))
+		playsound(user, 'sound/magic/fleshtostone.ogg', 100, TRUE)
+		if(ishuman(user))
+			var/mob/living/carbon/human/twisted_user = user
+			for(var/obj/item/bodypart/bodypart in twisted_user.bodyparts)
+				bodypart.add_wound(/datum/wound/fracture)
+		user.adjustBruteLoss(5000)
+		if(user.stat != DEAD)
+			user.death()
+		new /obj/item/reagent_containers/lux_impure(death_turf)
+		if(istype(death_turf, /turf/open/floor/rogue/dirt))
+			new /obj/structure/flora/roguegrass/herb/manabloom(death_turf) // remember us.. remember that we once lived..
+		return
+	playsound(user, 'sound/magic/charged.ogg', 75, TRUE)
+	switch(strain)
+		if(1)
+			user.apply_status_effect(/datum/status_effect/debuff/mana_burden)
+		if(2)
+			user.apply_status_effect(/datum/status_effect/debuff/mana_toxicity)
+			if(iscarbon(user))
+				var/mob/living/carbon/bloodless_user = user
+				bloodless_user.blood_volume = 0 // everything has a price.
+	var/choice = input(user, "Choose a spell to unbind.") as null|anything in resettable_spells
+	var/obj/effect/proc_holder/spell/item = resettable_spells[choice]
+	if(!item)
+		return
+	if(user_mind.RemoveSpell(item))
+		user_mind.used_spell_points -= item.cost
 		resettable_spells.Remove(choice)
 		user_mind.check_learnspell()
-	if(!unlearn_success)
-		user_mind.has_changed_spell = FALSE //If we didn't unlearn anything, reset
 
 /obj/item/book/spellbook/proc/get_cdr()
 	if(born_of_rock)

--- a/modular_azurepeak/code/game/objects/items/spellbooks.dm
+++ b/modular_azurepeak/code/game/objects/items/spellbooks.dm
@@ -129,9 +129,6 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 	var/datum/mind/user_mind = user.mind
 	if(!user_mind) return // How??
 	var/unbind_limit = (HAS_TRAIT(user, TRAIT_ARCYNE_T3) || HAS_TRAIT(user, TRAIT_ARCYNE_T4)) ? 3 : 2
-	if(user_mind.has_changed_spell && user_mind.free_spell_unbinds < unbind_limit)
-		to_chat(user, span_warning("I have already unbinded my spells today!"))
-		return
 	var/list/resettable_spells = list()
 	var/list/spell_list = user_mind.spell_list
 	for(var/i = 1, i <= spell_list.len, i++)
@@ -142,16 +139,18 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 	if(!resettable_spells.len && user_mind.strained_spell_unbinds < 2)
 		to_chat(user, span_warning("I have no spells to unbind!"))
 		return
-	if(!user_mind.has_changed_spell)
+	if(user_mind.free_spell_unbinds < unbind_limit)
 		user_mind.has_changed_spell = TRUE //To pre-empt a halting duplication in the for loop here
-		for(var/i = 1, i <= unbind_limit, i++)
-			var/choice = input(user, "Choose up to [unbind_limit] spells to unbind. Cancel all to not use up your daily unbinding.") as null|anything in resettable_spells
+		for(var/i = user_mind.free_spell_unbinds + 1, i <= unbind_limit, i++)
+			var/remaining_unbinds = unbind_limit - user_mind.free_spell_unbinds
+			var/choice = input(user, "Choose a spell to unbind. I have [remaining_unbinds] unbind[remaining_unbinds == 1 ? "" : "s"] remaining today.") as null|anything in resettable_spells
 			var/obj/effect/proc_holder/spell/item = resettable_spells[choice]
 			if(!item)
 				break
+			var/spell_cost = item.cost
 			if(user_mind.RemoveSpell(item))
-				user_mind.used_spell_points -= item.cost
 				user_mind.free_spell_unbinds++
+				user_mind.used_spell_points -= spell_cost
 				resettable_spells.Remove(choice)
 				user_mind.check_learnspell()
 			if(!resettable_spells.len)
@@ -161,13 +160,19 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 			return
 	if(user_mind.free_spell_unbinds < unbind_limit || (!resettable_spells.len && user_mind.strained_spell_unbinds < 2))
 		return
-	var/obj/item/held_lux = user.get_inactive_held_item()
+	var/obj/item/active_item = user.get_active_held_item()
+	var/obj/item/inactive_item = user.get_inactive_held_item()
+	var/obj/item/held_lux
+	if(active_item != src && (istype(active_item, /obj/item/reagent_containers/lux) || istype(active_item, /obj/item/reagent_containers/lux_impure)))
+		held_lux = active_item
+	else if(inactive_item != src && (istype(inactive_item, /obj/item/reagent_containers/lux) || istype(inactive_item, /obj/item/reagent_containers/lux_impure)))
+		held_lux = inactive_item
 	if(!user_mind.has_fed_spellbook_lux && (istype(held_lux, /obj/item/reagent_containers/lux) || istype(held_lux, /obj/item/reagent_containers/lux_impure)))
 		var/lux_prompt = "THE SYMBOLS ON THE PAGE GLOW AND VIBRATE, AS IF THEY'RE LEECHED TOWARDS YOUR OTHER HAND..\n\nFEED THE BOOK WITH LUX?"
 		if(alert(user, lux_prompt, "THE TOME HUNGERS", "FEED THE BOOK", "NAY") == "FEED THE BOOK")
 			if(!do_after(user, 5 SECONDS, target = src))
 				return
-			if(user.get_inactive_held_item() != held_lux)
+			if(user.get_active_held_item() != held_lux && user.get_inactive_held_item() != held_lux)
 				to_chat(user, span_warning("The tome's symbols dim as the lux leaves my hand."))
 				return
 			playsound(user, 'sound/magic/charged.ogg', 75, TRUE)
@@ -177,12 +182,13 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 			var/obj/effect/proc_holder/spell/lux_item = resettable_spells[lux_choice]
 			if(!lux_item)
 				return
+			var/lux_spell_cost = lux_item.cost
 			if(user_mind.RemoveSpell(lux_item))
-				user_mind.used_spell_points -= lux_item.cost
+				user_mind.used_spell_points -= lux_spell_cost
 				resettable_spells.Remove(lux_choice)
 				user_mind.check_learnspell()
 			return
-	if(user_mind.strained_spell_unbinds >= 3)
+	if(user_mind.strained_spell_unbinds >= 3) // shouldn't actually happen because of the previous limit check, but just to be safe.
 		to_chat(user, span_warning("The tome's symbols lie still. I can force nothing more from them today."))
 		return
 	var/strain = user_mind.strained_spell_unbinds + 1
@@ -228,8 +234,9 @@ decreases charge time if held opened in hand, for pure mage build + aesthetics.
 	var/obj/effect/proc_holder/spell/item = resettable_spells[choice]
 	if(!item)
 		return
+	var/spell_cost = item.cost
 	if(user_mind.RemoveSpell(item))
-		user_mind.used_spell_points -= item.cost
+		user_mind.used_spell_points -= spell_cost
 		resettable_spells.Remove(choice)
 		user_mind.check_learnspell()
 

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2746,6 +2746,7 @@
 #include "code\modules\spells\spell_types\undead\self\calcic_outburst.dm"
 #include "code\modules\spells\spell_types\undead\summon\raise_undead.dm"
 #include "code\modules\spells\spell_types\wizard\learnspell.dm"
+#include "code\modules\spells\spell_types\wizard\utility\magos_book_bind.dm"
 #include "code\modules\spells\spell_types\wizard\spell_list.dm"
 #include "code\modules\spells\spell_types\wizard\spells_status_effects.dm"
 #include "code\modules\spells\spell_types\wizard\buffs_debuffs\darkvision.dm"


### PR DESCRIPTION
## About The Pull Request
changes spellbooks + spell unbinding in a few ways:

## QOL

first of all, cancelling unbinding no longer locks you out of unbinding for the day, granted you have remaining charges to unbind spells.

previously: 2 charges. i go to unbind, unbind one spell, cancel, i can't use my 1 remaining charge.
now: 2 charges. i go to unbind, unbind one spell, cancel, i can unbind one more time.

mages of t3 or higher can rebind **three** spells a day.

spellbooks are now a hollow book, being able to hold one item of WEIGHT_CLASS_SMALL or lower.

## magos' book bind
a new 1 cost spell that allows you to mark a spellbook with middle mouse, then recall it to your hand. 30 second cooldown.

## spellbook overloading

after you've used up your daily unbinds (reminder 2 normally, 3 for real mages), you can get up to 3* more.

careful though, as all greed has a cost.

trying to get an extra unbind will give you a prompt, warning about the cost to your mind. continuing anyway will grant you the unbind, in exchange for a -1 omni-debuff that will last for 15 minutes.

trying for a second will again warn you, this time about the cost to your spirit. continuing anyway will grant you another stacked -1 omni-debuff, as well as take away **all** your blood. prepare carefully, or this will kill you.

trying for a third will warn you about the fatal cost to your body. continuing anyway (this prompt explicitly tells you that you will die) will kill you through brute damage, fracture your bones, pop out your impure lux and plant a grown manabloom beneath you. (if you're on dirt!)

<img width="174" height="151" alt="ptY1MqzKhE" src="https://github.com/user-attachments/assets/8282efaf-8bac-4e64-899f-765436629a44" />

environmental storytelling

this **doesn't** actually grant you an unbind. womp womp. sometimes magic fails.

### feeding lux

once per day, you can get **one** extra unbind, separate from the stuff above and how many you typically get, by feeding lux (pure or impure, doesn't matter) to your spellbook. holding lux in your offhand while having the spellbook active will give you a prompt explaining this when you click.
 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
compiles fine
<img width="395" height="383" alt="dreamseeker_usESgIi3rA" src="https://github.com/user-attachments/assets/5a246080-86cd-4a35-9656-b90ff0efb9fe" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

spellbook unbinds are kinda clunky with how they worked before, i also feel like this will encourage build variety by allowing mages to pick things that aren't necessarily meta but more situational, as they'll have more freedom to take away these choices and swap to something more useful to them in their given moment.

it's also funny. 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: mushy
add: Added the ability to exhume lux into an extra spell unbind.
add: Added the ability to get extra unbinds, at a grave cost.
qol: You are now longer locked out from remaining spell unbinds for the day if you cancel.
balance: Mages of T3 and higher now get 3 spell unbinds per day.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
