### PR TITLE
Forester Warden QoL & Loadout Changes

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/leather.dm
+++ b/code/modules/clothing/rogueclothes/armor/leather.dm
@@ -104,6 +104,22 @@
 	equip_delay_self = 4 SECONDS
 	smeltresult = /obj/item/ingot/iron
 
+/obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee
+	name = "forester's cuirass"
+	desc = "A hardened leather harness with a reinforced pauldron worn over a maille coat. Imbued with Dendor's essence, it is built sturdier for front-line fighting."
+	armor = ARMOR_CUIRASS
+	armor_class = ARMOR_CLASS_MEDIUM
+	max_integrity = ARMOR_INT_CHEST_MEDIUM_STEEL
+
+/obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee/upgraded
+	name = "forester's hauberk"
+	desc = "A forester's cuirass reinforced with plates and maille rings, the result of careful smithwork."
+	icon_state = "forestbrig"
+	armor = ARMOR_CUIRASS
+	max_integrity = ARMOR_INT_CHEST_PLATE_BRIGANDINE
+	equip_delay_self = 4 SECONDS
+	smeltresult = /obj/item/ingot/steel
+
 /obj/item/clothing/suit/roguetown/armor/leather/studded
 	name = "studded leather armor"
 	desc = "Studded leather is the most durable of all hides and leathers and about as light."

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -571,6 +571,11 @@
 /obj/item/clothing/head/roguetown/helmet/bascinet/antler/ComponentInitialize()
 	AddComponent(/datum/component/adjustable_clothing, (HEAD|EARS|HAIR), (HIDEEARS|HIDEHAIR), null, 'sound/items/visor.ogg', null, UPD_HEAD)	//Standard helmet
 
+/obj/item/clothing/head/roguetown/helmet/bascinet/antler/melee
+	name = "forester's antler helm"
+	desc = "A beastly snouted armet with the large horns of an elder saiga, reinforced with additional steel plating for front-line combat."
+	max_integrity = ARMOR_INT_HELMET_HEAVY_IRON + 50
+
 /obj/item/clothing/head/roguetown/helmet/sallet/warden
 	flags_inv = HIDEFACE|HIDESNOUT
 	body_parts_covered = FULL_HEAD
@@ -597,6 +602,21 @@
 	icon = 'icons/roguetown/clothing/special/warden.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/warden.dmi'
 	icon_state = "skullmet_bear"
+
+/obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf/melee
+	name = "forester's volfskull helm"
+	desc = "The large, intimidating skull of an elusive white volf, plated with extra steel reinforcement for front-line combat - paired together with a steel maille mask and worn with a linen shroud. Such trophies are associated with life-long hunters and their descendants."
+	max_integrity = ARMOR_INT_HELMET_HEAVY_IRON + 50
+
+/obj/item/clothing/head/roguetown/helmet/sallet/warden/goat/melee
+	name = "forester's ramskull helm"
+	desc = "The large, intimidating horned skull of an elusive vale great ram, plated with extra steel reinforcement for front-line combat - paired together with a steel maille mask and worn with a linen shroud. Such trophies are associated with life-long hunters and their descendants."
+	max_integrity = ARMOR_INT_HELMET_HEAVY_IRON + 50
+
+/obj/item/clothing/head/roguetown/helmet/sallet/warden/bear/melee
+	name = "forester's bearskull helm"
+	desc = "The large, intimidating skull of a common direbear, plated with extra steel reinforcement for front-line combat - paired together with a steel maille mask and worn with a linen shroud. Such trophies are associated with life-long hunters and their descendants."
+	max_integrity = ARMOR_INT_HELMET_HEAVY_IRON + 50
 
 /obj/item/clothing/head/roguetown/roguehood/warden
 	name = "warden's hood"

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -32,7 +32,6 @@
 	)
 
 /datum/outfit/job/roguetown/warden
-	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	cloak = /obj/item/clothing/cloak/wardencloak
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
 	belt = /obj/item/storage/belt/rogue/leather
@@ -76,6 +75,7 @@
 
 /datum/outfit/job/roguetown/warden/ranger/pre_equip(mob/living/carbon/human/H)
 	..()
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden
 	neck = /obj/item/clothing/neck/roguetown/coif
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy
@@ -179,12 +179,13 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
 			if("Sword & Shield")
 				backl = /obj/item/rogueweapon/shield/iron
-				beltl = /obj/item/rogueweapon/scabbard/sheath
+				beltl = /obj/item/rogueweapon/scabbard/sword
 				r_hand = /obj/item/rogueweapon/sword/short/messer
 				backpack_contents = list(
 					/obj/item/storage/keyring/guard = 1,
 					/obj/item/flashlight/flare/torch/lantern = 1,
-					/obj/item/rogueweapon/scabbard/sheath/aavnik = 1,
+					/obj/item/rogueweapon/scabbard/sheath = 1,
+					/obj/item/rogueweapon/huntingknife/idagger/warden_machete = 1,
 					/obj/item/signal_horn = 1
 					)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)

--- a/code/modules/jobs/job_types/roguetown/garrison/warden.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/warden.dm
@@ -127,9 +127,10 @@
 		STATKEY_PER = 1
 	)
 	subclass_skills = list(
-		/datum/skill/combat/axes = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/axes = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/shields = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/slings = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/bows = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/crossbows = SKILL_LEVEL_APPRENTICE,
@@ -152,6 +153,7 @@
 
 /datum/outfit/job/roguetown/warden/forester/pre_equip(mob/living/carbon/human/H)
 	..()
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee
 	neck = /obj/item/clothing/neck/roguetown/chaincoif/iron
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
 	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail/iron
@@ -170,11 +172,28 @@
 	H.set_blindness(0)
 
 	if(H.mind)
+		var/weapons = list("Axe", "Sword & Shield")
+		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
+		switch(weapon_choice)
+			if("Axe")
+				H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_EXPERT, TRUE)
+			if("Sword & Shield")
+				backl = /obj/item/rogueweapon/shield/iron
+				beltl = /obj/item/rogueweapon/scabbard/sheath
+				r_hand = /obj/item/rogueweapon/sword/short/messer
+				backpack_contents = list(
+					/obj/item/storage/keyring/guard = 1,
+					/obj/item/flashlight/flare/torch/lantern = 1,
+					/obj/item/rogueweapon/scabbard/sheath/aavnik = 1,
+					/obj/item/signal_horn = 1
+					)
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_EXPERT, TRUE)
+
 		var/helmets = list(
-			"Antlers of the Antelope" 	= /obj/item/clothing/head/roguetown/helmet/bascinet/antler,
-			"Skull of the Volf"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf,
-			"Skull of the Ram"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat,
-			"Skull of the Bear"		= /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear,
+			"Antlers of the Antelope"   = /obj/item/clothing/head/roguetown/helmet/bascinet/antler/melee,
+			"Skull of the Volf"         = /obj/item/clothing/head/roguetown/helmet/sallet/warden/wolf/melee,
+			"Skull of the Ram"          = /obj/item/clothing/head/roguetown/helmet/sallet/warden/goat/melee,
+			"Skull of the Bear"         = /obj/item/clothing/head/roguetown/helmet/sallet/warden/bear/melee,
 			"None"
 		)
 		var/helmchoice = input(H, "Choose your Path.", "HELMET SELECTION") as anything in helmets

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -293,6 +293,12 @@
 	created_item = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/upgraded
 	i_type = "Armor"
 
+/datum/anvil_recipe/armor/steel/wardenmeleehauberk
+	name = "Forester's Hauberk (+1 Forester's Cuirass, +1 Essence of Wilderness)"
+	additional_items = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee, /obj/item/natural/cured/essence, /obj/item/ingot/steel)
+	created_item = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee/upgraded
+	i_type = "Armor"
+
 /datum/anvil_recipe/armor/iron/halfplate
 	name = "Half-Plate, Iron (+1 Iron Breastplate, +2 Cured Leather)"
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/plate/half/iron, /obj/item/natural/hide/cured, /obj/item/natural/hide/cured)

--- a/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/anvil_recipes/armor.dm
@@ -294,7 +294,7 @@
 	i_type = "Armor"
 
 /datum/anvil_recipe/armor/steel/wardenmeleehauberk
-	name = "Forester's Hauberk (+1 Forester's Cuirass, +1 Essence of Wilderness)"
+	name = "Forester's Hauberk (+1 Forester's Cuirass, +1 Essence of Wilderness, +1 Steel)"
 	additional_items = list(/obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee, /obj/item/natural/cured/essence, /obj/item/ingot/steel)
 	created_item = /obj/item/clothing/suit/roguetown/armor/leather/studded/warden/melee/upgraded
 	i_type = "Armor"


### PR DESCRIPTION
## About The Pull Request
- Gives ranger warden a sheath for their seax. No more unprotected seax on my watch.
- Forester gets a warden seax instead of a hunting knife.
- Foresters now get unique armor that is based off the ranger one. It has slightly more durability and plate stats. Can be upgraded to be like a cuirass.
- Foresters can choose between an axe or sword now. They get a cool steel messer as their primary weapon with an iron shield if they pick swords. Expert in swords or expert in axes. Your choice.
- Bumped shield skill up from apprentice to journeyman.

## Testing Evidence
<img width="715" height="890" alt="ward1" src="https://github.com/user-attachments/assets/8f5e2ce1-ae8f-4a8c-8ed0-7c530a95af6b" />
<img width="1241" height="1432" alt="ward2" src="https://github.com/user-attachments/assets/6a933711-cc18-4d72-b21b-eea81a1be0ba" />

## Why It's Good For The Game
See: https://discord.com/channels/1240735983276654733/1524224369117626408

It was a commission and also foresters kinda needed slightly better armor. Giving them a choice to choose between sword and shield or using the axe as their primary weapon helps a bit too. They barely even get to use the wooden ones because their shield skill sucked and it is not really worth using in combat anyway. Now they can feel more like front line fighters.

## Changelog
:cl:
qol: Gives ranger warden a sheath for their seax. No more unprotected seax on my watch.
qol: Forester gets a warden seax instead of a hunting knife.
add: Foresters now get unique armor that is based off the ranger one. It has slightly more durability and plate stats. Can be upgraded to be like a cuirass.
add: Foresters can choose between an axe or sword now. They get a cool steel messer as their primary weapon with an iron shield if they pick swords. Expert in swords or expert in axes. Your choice.
balance: Bumped shield skill up from apprentice to journeyman.
/:cl: