### PR TITLE
Renames the "Gronnic" gear to be nation-agnostic, fixes up some descriptions

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_exotic.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_exotic.dm
@@ -8,8 +8,8 @@
 	crate_type = /obj/structure/closet/crate/chest/merchant
 	no_name_quantity = TRUE
 
-/datum/supply_pack/rogue/armor_exotic/gronn_pack_light
-	name = "Gronnic Ravager Leather Set (Light)"
+/datum/supply_pack/rogue/armor_exotic/hammerhold_pack_light
+	name = "Ravager Leather Set (Light)"
 	cost = 125
 	contains = list(
 		/obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn,
@@ -18,8 +18,8 @@
 		/obj/item/clothing/gloves/roguetown/angle/gronn
 		)
 
-/datum/supply_pack/rogue/armor_exotic/gronn_pack_medium
-	name = "Gronnic Byrine Chain Set (Medium)"
+/datum/supply_pack/rogue/armor_exotic/hammerhold_pack_medium
+	name = "Byrine Chain Set (Medium)"
 	cost = 225
 	contains = list(
 		/obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn/ownel,
@@ -28,8 +28,8 @@
 		/obj/item/clothing/under/roguetown/splintlegs/iron/gronn
 		)
 
-/datum/supply_pack/rogue/armor_exotic/gronn_pack_heavy
-	name = "Gronnic Norsii Plate Set (Heavy)"
+/datum/supply_pack/rogue/armor_exotic/hammerhold_pack_heavy
+	name = "Norsii Plate Set (Heavy)"
 	cost = 400
 	contains = list(
 		/obj/item/clothing/head/roguetown/helmet/heavy/bucket/gronn,

--- a/code/modules/clothing/rogueclothes/armor/gronn.dm
+++ b/code/modules/clothing/rogueclothes/armor/gronn.dm
@@ -1,9 +1,9 @@
 // LIGHT ARMORS
 
 /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn
-	name = "gronnic ravager helm"
-	desc = "A helmet of hardened leather with a carved animal skull to appear similar to a human, A unique design of The Empty North. \
-			The visage is said in Iskarn to scare the spirits of those defeated in the battle field \
+	name = "ravager helm"
+	desc = "A helmet of hardened leather with a carved animal skull to appear similar to a human, A unique design of a distant freezing land \
+			The visage is said to scare the spirits of those defeated in the battle field \
 			and prevent Necra or The Moose from allowing them to haunt."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
@@ -17,9 +17,9 @@
 	min_cold_protection_temperature = 50
 
 /obj/item/clothing/suit/roguetown/armor/leather/heavy/gronn
-	name = "gronnic ravager mantle"
+	name = "ravager mantle"
 	desc = "A carefully created mantle of bone and hardened leather. It offers superior protection against the threats of the wild while remaining light, \
-			A popular design in Iskarn is to adorn a shoulder with a wolf pelt and skull. So that a great beast is always with you."
+			A popular design is to adorn a shoulder with a wolf pelt and skull. So that a great beast is always with you."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
 	icon_state = "gronnleatherarmor"
@@ -29,7 +29,7 @@
 	min_cold_protection_temperature = 50
 
 /obj/item/clothing/under/roguetown/trou/leather/gronn
-	name = "gronnic fur pants"
+	name = "fur pants"
 	desc = "A pair of hardened leather pants with bone reinforcements along the legs, \
 			A wild design that offers superior protection against blunt and slashing. The attack of beasts."
 	icon_state = "gronnleatherpants"
@@ -44,7 +44,7 @@
 	min_cold_protection_temperature = 50
 
 /obj/item/clothing/gloves/roguetown/angle/gronn
-	name = "gronnic fur-lined leather gloves"
+	name = "fur-lined leather gloves"
 	desc = "Thick, padded gloves made for the harshest of climates, and wildest of beasts encountered in the untamed lands."
 	icon_state = "gronnleathergloves"
 	item_state = "gronnleathergloves"
@@ -55,7 +55,7 @@
 	min_cold_protection_temperature = 50
 
 /obj/item/clothing/gloves/roguetown/angle/gronnfur
-	name = "gronnic fur-lined bone gloves"
+	name = "fur-lined bone gloves"
 	desc = "A pair of hardened leather gloves with a bone reinforcement across the wrist\
 			and the back of the hand offering superior protection against\
 			the claws of beasts and the claw of nature and plant common for gatherers."
@@ -203,15 +203,15 @@
 // MEDIUM ARMOR -- Iron reskins
 
 /obj/item/clothing/head/roguetown/helmet/bascinet/atgervi/gronn/ownel
-	name = "gronnic ownel helmet"
+	name = "ownel helmet"
 	desc = "A full helmet that protects the eyes and head well, \
-			The slits decorated with a harsh gold dye are said to in Gronn to give those the ability to see keenly like a bird."
+			The slits decorated with a harsh gold dye are said to give those the ability to see keenly like a bird."
 	icon_state = "gronnhelm"
 	item_state = "gronnhelm"
 
 /obj/item/clothing/suit/roguetown/armor/brigandine/gronn
-	name = "gronn byrine hauberk"
-	desc = "A chain shirt of Gronnic design with a leather coat layered over \
+	name = "byrine hauberk"
+	desc = "A chain shirt of a foreign design with a leather coat layered over \
 			offering additional protection and superior movement. Often used by sea raiders."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
@@ -220,7 +220,7 @@
 	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/gloves/roguetown/chain/gronn
-	name = "gronn byrine gloves"
+	name = "byrine gloves"
 	desc = "A pair of leather gloves with chain to protects the wrists and back of the hand."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
@@ -228,7 +228,7 @@
 	item_state = "gronnchaingloves"
 
 /obj/item/clothing/under/roguetown/splintlegs/iron/gronn
-	name = "gronn byrine chausses"
+	name = "byrine chausses"
 	desc = "A pair of chain pants with a leather subligar for both protection and comfort."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
@@ -239,10 +239,9 @@
 // HEAVY ARMOR -- ditto
 
 /obj/item/clothing/head/roguetown/helmet/heavy/bucket/gronn
-	name = "gronn norsii horned helmet"
-	desc = "A horned Iron helmet, A clear design of Gronn. \
-		Styled after the appearance of invading knights of legend from the northern empty, \
-		A time before their was snow. Brutal and plain."
+	name = "norsii horned helmet"
+	desc = "A horned iron helmet, An exotic foreign design. \
+		Styled after the appearance of invading knights of legends from a distant land. Brutal and plain."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/onmob/64x64/gronn.dmi'
 	bloody_icon = 'icons/effects/blood64.dmi'
@@ -257,10 +256,8 @@
 	worn_y_dimension = 64
 
 /obj/item/clothing/suit/roguetown/armor/plate/iron/gronn
-	name = "gronn norsii iron plate"
-	desc = "Iron chestplate adorned with tassets and roundels, \
-			Those of Gronn oft never used plate but when the northmen come in plate, \
-			It is said to be a sight to shake armies."
+	name = "norsii iron plate"
+	desc = "A strange iron chestplate adorned with tassets and roundels. It is said to be a sight to shake armies."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
 	icon_state = "gronnplate"
@@ -271,25 +268,25 @@
 	smeltresult = /obj/item/ingot/iron
 
 /obj/item/clothing/gloves/roguetown/plate/iron/gronn
-	name = "gronn norsii iron gauntlets"
-	desc = "Iron gauntlets, Simple and protective in design.. A single punch leaves a nasty mark."
+	name = "norsii iron gauntlets"
+	desc = "Iron gauntlets, Simple and protective in design. A single punch leaves a nasty mark."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
 	icon_state = "gronnplategloves"
 	item_state = "gronnplategloves"
 
 /obj/item/clothing/under/roguetown/platelegs/iron/gronn
-	name = "gronn norsii iron chausses"
-	desc = "Iron Chausses with an added set of leather for comfort and padding, The knees are adorned with a skull like shape and that of the moon."
+	name = "norsii iron chausses"
+	desc = "Iron chausses with an added set of leather for comfort and padding, The knees are adorned with a skull like shape and that of the moon."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'
 	icon_state = "gronnplatepants"
 	item_state = "gronnplatepants"
 
 /obj/item/clothing/shoes/roguetown/boots/armor/iron/gronn
-	name = "gronn norsii iron boots"
-	desc = "Iron boots, Tied with leather strapping. \
-			Protective, A Gronnic legend tells of a great warrior who fought for aeons until a \
+	name = "norsii iron boots"
+	desc = "Iron boots, tied with leather strapping. \
+			Protective, an ancient legend tells of a great warrior who fought for aeons until a \
 			hero speared him in the foot. Many follow this example by protecting their feet heavily."
 	icon = 'icons/roguetown/clothing/special/gronn.dmi'
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/gronn.dmi'

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 /datum/loadout_item/tri_grenzelhoft_hat_capless
 	name = "Capless Grenzelhoft Hat"
 	path = /obj/item/clothing/head/roguetown/caplessgrenzelhofthat
-	
+
 //CLOAKS
 /datum/loadout_item/tabard
 	name = "Tabard"
@@ -1694,27 +1694,27 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	triumph_cost = 3
 
 /datum/loadout_item/tri_gronn_byrine_chausses
-	name = "Gronn Byrine Chausses"
+	name = "Byrine Chausses"
 	path = /obj/item/clothing/under/roguetown/splintlegs/iron/gronn
 	triumph_cost = 3
 
 /datum/loadout_item/tri_gronn_byrine_gloves
-	name = "Gronn Byrine Gloves"
+	name = "Byrine Gloves"
 	path = /obj/item/clothing/gloves/roguetown/chain/gronn
 	triumph_cost = 3
 
 /datum/loadout_item/tri_gronn_byrine_hauberk
-	name = "Gronn Byrine"
+	name = "Byrine"
 	path = /obj/item/clothing/suit/roguetown/armor/brigandine/gronn
 	triumph_cost = 3
 
 /datum/loadout_item/tri_gronn_fur_pants
-	name = "Gronn Fur Pants"
+	name = "Fur Pants"
 	path = /obj/item/clothing/under/roguetown/trou/leather/gronn
 	triumph_cost = 3
 
 /datum/loadout_item/tri_gronn_bone_gloves
-	name = "Gronn Bone Gloves"
+	name = "Bone Gloves"
 	path = /obj/item/clothing/gloves/roguetown/angle/gronnfur
 	triumph_cost = 3
 
@@ -1724,7 +1724,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	triumph_cost = 3
 
 /datum/loadout_item/tri_gronn_ravager_mantle
-	name = "Gronn Ravager Mantle"
+	name = "Ravager Mantle"
 	path = /obj/item/clothing/suit/roguetown/armor/leather/heavy/gronn
 	triumph_cost = 3
 


### PR DESCRIPTION
## About The Pull Request
Step 1 of de-viking-ising Gronns, which are actually supposed to be Mongols in RW's lore. Most of their viking gear (except for Atgervi Shaman-exclusive stuff) is renamed to sound nation-agnostic rather than full-on Hammerholdian to avoid messing with existing characters for NOW. I also avoided touching classes' actual (technical) names for now.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="448" height="81" alt="image" src="https://github.com/user-attachments/assets/d0663ce3-98f2-429c-aeb9-34587d4ee9f5" />

String changes. Abyssor damn me if something breaks.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
De-viking-ising Gronns, so that the game finally matches the lore.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: some "Gronnic" stuff is now actually called nation-agnostic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
