### PR TITLE
Fixes Poleaxe Standard Flag Sprite Bug

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -765,6 +765,7 @@
 
 //This is awful and I apologise.
 /obj/item/rogueweapon/spear/keep_standard/attack_self(mob/living/user)
+	..()
 	if(secondary_tag)
 		if(wielded)
 			detail_tag = "_det1"
@@ -774,7 +775,6 @@
 			detail_tag = "_det"
 			update_icon()
 			user.update_inv_hands()
-	..()
 
 /obj/item/rogueweapon/spear/keep_standard/equipped(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The flag sprite on the poleaxe standard was completely off when wielding it. This fixes it.

## Testing Evidence
One line change.
<img width="351" height="226" alt="standardfix" src="https://github.com/user-attachments/assets/1a2a541c-2206-4c5b-a4c8-cb6fec9c2b51" />

## Why It's Good For The Game
Bug fixes good. I kept getting asked to do it.

## Changelog
:cl:
fix: Fixed the poleaxe standard flag sprite not adjusting itself visually in a proper way.
/:cl: