### PR TITLE
Old age stat/job restoration and parry buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/cavalry.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/cavalry.dm
@@ -42,7 +42,7 @@
 	..()
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
-
+	beltl = /obj/item/rogueweapon/mace/cudgel
 	H.adjust_blindness(-3)
 	if(H.mind)
 		var/weapons = list("Bardiche","Sword & Shield")

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/gormless.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/gormless.dm
@@ -37,7 +37,7 @@
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
 	wrists = /obj/item/clothing/wrists/roguetown/splintarms/iron
 	pants = /obj/item/clothing/under/roguetown/splintlegs/iron
-
+	beltl = /obj/item/rogueweapon/mace/cudgel
 	H.adjust_blindness(-3)
 	if(H.mind)
 		var/weapons = list("Stunmace & Shield","Maul - 14STR Minimum")

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/manorguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/manorguard.dm
@@ -8,7 +8,7 @@
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	job_traits = list(TRAIT_GUARDSMAN, TRAIT_STEELHEARTED)
 	tutorial = "Having proven yourself loyal and capable, you are entrusted to defend the town and enforce its laws. \
 				Trained regularly in combat and siege warfare, you deal with threats - both within and without. \
@@ -30,6 +30,7 @@
 		/datum/advclass/manorguard/skirmisher,
 		/datum/advclass/manorguard/cavalry,
 		/datum/advclass/manorguard/gormless,
+		/datum/advclass/manorguard/retainer,
 		/datum/advclass/manorguard/standard_bearer
 	)
 
@@ -43,7 +44,6 @@
 
 /datum/outfit/job/roguetown/manorguard
 	shoes = /obj/item/clothing/shoes/roguetown/boots/leather/reinforced
-	beltl = /obj/item/rogueweapon/mace/cudgel
 	belt = /obj/item/storage/belt/rogue/leather
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/scomstone/bad/garrison

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/retainer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/retainer.dm
@@ -1,15 +1,16 @@
-// Melee goon. STR and martial setup.
-/datum/advclass/manorguard/footsman
-	name = "Footman"
-	tutorial = "You are a professional soldier of the realm, specializing in melee warfare. Stalwart and hardy, your body can both withstand and dish out powerful strikes.."
-	outfit = /datum/outfit/job/roguetown/manorguard/footsman
-
+// special old class ported from RW1
+/datum/advclass/manorguard/retainer
+	name = "Retainer"
+	tutorial = "You are an aging man-at-arms who has spent decades in faithful service. Though the vigor of youth has faded, discipline and experience remain."
+	outfit = /datum/outfit/job/roguetown/manorguard/retainer
+	allowed_ages = list(AGE_OLD)
 	category_tags = list(CTAG_MENATARMS)
 	traits_applied = list(TRAIT_MEDIUMARMOR)
 	subclass_stats = list(
-		STATKEY_STR = 2,// seems kinda lame but remember guardsman bonus!!
+		STATKEY_STR = 1,// seems kinda lame but remember guardsman bonus!!
 		STATKEY_INT = 1,
-		STATKEY_CON = 1,
+		STATKEY_PER = 1,
+		STATKEY_CON = 2,
 		STATKEY_WIL = 1
 	)
 	subclass_skills = list(
@@ -33,13 +34,12 @@
 		/datum/skill/misc/tracking = SKILL_LEVEL_NOVICE,
 	)
 
-/datum/outfit/job/roguetown/manorguard/footsman/pre_equip(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/manorguard/retainer/pre_equip(mob/living/carbon/human/H)
 	..()
-
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
 	neck = /obj/item/clothing/neck/roguetown/gorget
 	gloves = /obj/item/clothing/gloves/roguetown/plate/iron
-	beltl = /obj/item/rogueweapon/mace/cudgel
+	beltl = /obj/item/rogueweapon/sword/decorated
 	H.adjust_blindness(-3)
 	if(H.mind)
 		var/weapons = list("Warhammer & Shield","Axe & Shield","Halberd","Greataxe")

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/skirmisher.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/skirmisher.dm
@@ -39,7 +39,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/splintarms
 	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light/retinue
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-
+	beltl = /obj/item/rogueweapon/mace/cudgel
 	H.adjust_blindness(-3)
 	if(H.mind)
 		var/weapons = list("Crossbow","Bow","Sling")

--- a/code/modules/jobs/job_types/roguetown/garrison/manorguard/standard_bearer.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/manorguard/standard_bearer.dm
@@ -37,6 +37,7 @@
 	wrists = /obj/item/clothing/wrists/roguetown/splintarms
 	pants = /obj/item/clothing/under/roguetown/splintlegs
 	backl = /obj/item/rogueweapon/scabbard/gwstrap
+	beltl = /obj/item/rogueweapon/mace/cudgel
 	backpack_contents = list(
 		/obj/item/rogueweapon/huntingknife/idagger/steel/special = 1,
 		/obj/item/rope/chain = 1,

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -8,7 +8,7 @@
 	selection_color = JCOLOR_SOLDIER
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = ACCEPTED_RACES
-	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED)
+	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	job_traits = list(TRAIT_GUARDSMAN, TRAIT_STEELHEARTED)
 	tutorial = "Responsible for the safety of the city and the enforcement of the law, \
 	you patrol the city streets, on the look out for crime and disorder. \

--- a/code/modules/mob/living/combat/parry.dm
+++ b/code/modules/mob/living/combat/parry.dm
@@ -118,6 +118,11 @@
 	if(HAS_TRAIT(user, TRAIT_CURSE_RAVOX))
 		prob2defend -= 40
 
+	if(ishuman(H))
+		var/mob/living/carbon/human/oldie = H
+		if(oldie.age == AGE_OLD && !HAS_TRAIT(oldie, TRAIT_MAGEARMOR))//Old martial characters get a bonus to parry. Mages do not, they get unique bonuses already for being old.
+			prob2defend += 20
+
 	// parrying while knocked down sucks ass
 	if(!(mobility_flags & MOBILITY_STAND))
 		prob2defend *= 0.65

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -71,7 +71,7 @@
 				change_stat(STATKEY_SPD, -2)
 				change_stat(STATKEY_PER, -1)
 				change_stat(STATKEY_CON, -2)
-				change_stat(STATKEY_INT, 2)
+				change_stat(STATKEY_INT, 3)
 				change_stat(STATKEY_LCK, 1)
 		if(key)
 			if(check_blacklist(ckey(key)))
@@ -166,7 +166,7 @@
 				BUFPER++
 			STAPER = newamt
 			see_override = initial(src.see_invisible) + (STAPER/3.25) //PER is far easier to get in Rogueslop 2.0
-			update_sight() //This also fixes a few new bugs that have come and gone. 
+			update_sight() //This also fixes a few new bugs that have come and gone.
 			update_fov_angles()
 
 		if(STATKEY_INT)
@@ -272,7 +272,7 @@
 
 /// Calculates a luck value in the range [1, 400] (calculated as STALUC^2), then maps the result linearly to the given range
 /// min must be >= 0, max must be <= 100, and min must be <= max
-/// For giving 
+/// For giving
 /mob/living/proc/get_scaled_sq_luck(min, max)
 	if (min < 0)
 		min = 0

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -1943,6 +1943,7 @@
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard\footman.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard\gormless.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard\manorguard.dm"
+#include "code\modules\jobs\job_types\roguetown\garrison\manorguard\retainer.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard\skirmisher.dm"
 #include "code\modules\jobs\job_types\roguetown\garrison\manorguard\standard_bearer.dm"
 #include "code\modules\jobs\job_types\roguetown\Inquisition\absolutionist.dm"


### PR DESCRIPTION
## About The Pull Request
This PR re-enables old age for a few guardsmen roles that had old age available back in RW1.
It also ports the 'veteran' men at arms class rebranded as Retainer. The Retainer has a broader stat spread, though it still adds up to a weighted 7 stat points, like the other classes. 
We have also restored the Int bonus from being old from 2, back to three. AP originally reduced the int bonus to 2, back when feints were king and left people able to be hit for an extended period of time, but never adjusted it back after the parry changes we presently have.
Finally, For the past few days I have been grappling with the fact that if you play any martial role that wasn't a mage, being old was shooting yourself in the foot. Non martial roles got benefits by virtue of having their skill level increased in their specific jobs- but doing this naturally to martial roles presented a significant balance challenge, as well as making it difficult to handle roles that already have high martial skill that can't be increased without causing problems.
Thusly, in an effort to make Old martial characters a bit less suffering, Non-mage old characters get a bonus when it comes to parrying, simply for being old, something I think thematically makes sense. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="518" height="227" alt="image" src="https://github.com/user-attachments/assets/dbc98386-e87c-48bf-917e-f1d8b1b85700" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Previously, Playing old martial characters who aren't living legends like the Veteran was functionally kneecapping yourself. You lost 1 strength, 2 speed, 2 con, 1 perception for two intelligence and one fortune. When applying the standard stat weight, that Speed and strength at worth '2', that ends up being a net six stat loss- something that is exceptionally painful. In the past, that was fairly mitigateable due to how busted feints were, leaving people open for repeated strikes for an extended period. However, with the changes to how feints work, int based characters, which old characters predominantly exclusively are, suffered.

I looked back to RW1 to see how best to improve the situation, and noticed the discrepancy between stat blocks. That alone is an easy fix to restore old folks getting 3 int again, as well as restoring the option for being old in some guard roles as rather soulful, But it still leaves us with the problem that with feinting no where near as good as it used to be (And it should probably never return to how oppressive it was), old martial roles are fairly shafted.
The introduction of the parry buff to old characters is a fairly reasoned change that I think helps reflect an old character having lived as long as they have, while preventing a balance nightmare of actually giving them an extra skill level- something that affects training other roles and affects bypassing the opponents parry.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Old age buff to parrying
add: Retainer Subclass to men at arms for old age MAA.
add: MAA & Town Guards are once more able to be old
balance: old age once more grants 3 int instead of 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
