### PR TITLE
Forced pop-up of the Voting-UI & a null-refrence hang on update_temperature_hud

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -234,7 +234,7 @@ SUBSYSTEM_DEF(vote)
 	to_chat(world, span_infoplain(vote_font("\n[span_bold(to_display)]\n\
 		Type <b>vote</b> or click <a href='byond://winset?command=vote'>here</a> to place your votes.\n\
 		You have [DisplayTimeText(duration)] to vote.")))
-
+	
 	// And now that it's going, give everyone a voter action
 	for(var/client/new_voter as anything in GLOB.clients)
 		var/datum/action/vote/voting_action = new()
@@ -243,10 +243,13 @@ SUBSYSTEM_DEF(vote)
 
 		new_voter.player_details.player_actions += voting_action
 		generated_actions += voting_action
-
+		
 		if(current_vote.vote_sound)
 			SEND_SOUND(new_voter, sound(current_vote.vote_sound))
 
+		if(SSvote.initialized)
+			SSvote.ui_interact(new_voter.mob)
+			
 	return TRUE
 
 /**

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -247,9 +247,8 @@ SUBSYSTEM_DEF(vote)
 		if(current_vote.vote_sound)
 			SEND_SOUND(new_voter, sound(current_vote.vote_sound))
 
-		if(SSvote.initialized)
-			if(new_voter.prefs.voting_popup)
-				SSvote.ui_interact(new_voter.mob)
+		if(SSvote.initialized && new_voter.prefs.voting_popup)
+			SSvote.ui_interact(new_voter.mob)
 			
 	return TRUE
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -248,7 +248,8 @@ SUBSYSTEM_DEF(vote)
 			SEND_SOUND(new_voter, sound(current_vote.vote_sound))
 
 		if(SSvote.initialized)
-			SSvote.ui_interact(new_voter.mob)
+			if(new_voter.prefs.voting_popup)
+				SSvote.ui_interact(new_voter.mob)
 			
 	return TRUE
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -119,8 +119,8 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/extreme_erp = FALSE
 	var/edging = FALSE
 	/// If a cursed collar can be equipped to them at all
-	var/voting_popup = TRUE
 	var/cursed_collarable = FALSE
+	var/voting_popup = TRUE
 	var/compliance_notifs = TRUE
 	var/skillcap_notifs = TRUE
 	var/restricted_species_pref = null

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_EMPTY(chosen_names)
 	var/extreme_erp = FALSE
 	var/edging = FALSE
 	/// If a cursed collar can be equipped to them at all
+	var/voting_popup = TRUE
 	var/cursed_collarable = FALSE
 	var/compliance_notifs = TRUE
 	var/skillcap_notifs = TRUE

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -469,10 +469,8 @@
 	prefs.save_preferences()
 	if(prefs.voting_popup)
 		to_chat(src, "You will see a popup of the voting ui as a vote is called.")
-		return
 	else
 		to_chat(src, "You will no longer see a popup of the voting ui as a vote is called.")
-		return
 
 	
 /client/verb/toggle_cursed_collars() // Toggles cursed collars. Will drop existing collars if toggled off while wearing one

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -122,6 +122,8 @@
 		list("id" = "deadchat", "label" = "Show Deadchat", "enabled" = !!(owner.prefs.chat_toggles & CHAT_DSAY), "desc" = "Receive deadchat messages."),
 		list("id" = "legacy_craft", "label" = "Enable Legacy Craft", "enabled" = !!owner.legacycraft, "desc" = "Use legacy crafting UI/behavior."),
 		list("id" = "roleplay_ads", "label" = "Receive Roleplay Ads", "enabled" = !!(owner.prefs.toggles & ROLEPLAY_ADS), "desc" = "Receive notifications for new roleplay ads."),
+		list("id" = "voting_popup", "label" = "Enable Voting UI Popup", "enabled" = !!owner.prefs.voting_popup, "desc" = "Allow a popup of the voting-ui."),
+	
 	)
 
 	var/list/audio_entries = list(
@@ -232,6 +234,8 @@
 				owner.toggle_edging()
 			if("cursed_collars")
 				owner.toggle_cursed_collars()
+			if("voting_popup")
+				owner.toggle_voting_popup()
 		SStgui.update_uis(src)
 		return TRUE
 
@@ -454,6 +458,23 @@
 		else
 			to_chat(src, "You will no longer ENDVRE through orgasms.")
 
+/client/verb/toggle_voting_popup()
+	set category = "Options"
+	set name = "Toggle Voting Popup"
+	set hidden = 1
+	if(!prefs)
+		return
+
+	prefs.voting_popup = !prefs.voting_popup
+	prefs.save_preferences()
+	if(prefs.voting_popup)
+		to_chat(src, "You will see a popup of the voting ui as a vote is called.")
+		return
+	else
+		to_chat(src, "You will no longer see a popup of the voting ui as a vote is called.")
+		return
+
+	
 /client/verb/toggle_cursed_collars() // Toggles cursed collars. Will drop existing collars if toggled off while wearing one
 	set category = "Options"
 	set name = "Toggle Cursed Collars"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -629,6 +629,8 @@
 
 
 /mob/living/carbon/human/proc/update_temperature_hud()
+	if(isnull(hud_used))
+		return FALSE
 	if(isnull(hud_used.temperature) || stat == DEAD)
 		return FALSE
 	if(bodytemperature >= BODYTEMP_NORMAL_MIN && bodytemperature <= BODYTEMP_NORMAL_MAX)


### PR DESCRIPTION
## About The Pull Request

What is this? Well- it is quite simple. This new voting system for whatever reason only had a message and forced the users to be proactive. Surprise, surprise. People are busy once the round ends or is about to start leading to only about maybe, at tops 30% of the people voting. 

So. 
This forces the voting-menu to open as a vote is called, and it also fixes a silly null-ref hangup that can happen from forcing a start of the game.

## Testing Evidence

<img width="1153" height="245" alt="image" src="https://github.com/user-attachments/assets/6f4c6088-71ae-4a8f-a619-430f3d4d6744" />

## Why It's Good For The Game

People lack the concentration (me included), to spot out the 'vote now' button as it gets buried underneath 200 ooc-messages leading to VERY, VERY low voting %. It should be without a doubt something **really** simple to fix with this one feature of adding a simple FORCED interaction. 

## Changelog

:cl:
fix: null-ref hangup on update_temperature_hud.
add: added a forced pop-up of the voting ui whenever a vote is called.

/:cl:

