### PR TITLE
Fix broken and natural armor crit protection

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -78,14 +78,14 @@
 	if(isbodypart(def_zone))
 		var/obj/item/bodypart/CBP = def_zone
 		def_zone = CBP.body_zone
-	var/list/body_parts = list(head, wear_mask, wear_wrists, wear_shirt, wear_neck, cloak, wear_armor, wear_pants, backr, backl, gloves, shoes, belt, s_store, glasses, ears, wear_ring) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
+	var/list/body_parts = list(skin_armor, head, wear_mask, wear_wrists, wear_shirt, wear_neck, cloak, wear_armor, wear_pants, backr, backl, gloves, shoes, belt, s_store, glasses, ears, wear_ring) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
 	for(var/bp in body_parts)
 		if(!bp)
 			continue
 		if(bp && istype(bp , /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(zone2covered(def_zone, C.body_parts_covered_dynamic))
-				if(C.obj_integrity > 1)
+				if(C.obj_integrity > 1 && !C.obj_broken)
 					if(d_type in C.prevent_crits)
 						return TRUE
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -86,6 +86,7 @@
 
 // BEGIN_INCLUDE
 #include "anchored_mobs.dm"
+#include "broken_helmet_crits.dm"
 #include "colorblind_hud_palette.dm"
 #include "component_tests.dm"
 #include "create_and_destroy.dm"

--- a/code/modules/unit_tests/broken_helmet_crits.dm
+++ b/code/modules/unit_tests/broken_helmet_crits.dm
@@ -1,0 +1,27 @@
+/datum/unit_test/broken_helmet_crits/Run()
+	var/mob/living/carbon/human/consistent/human = allocate(/mob/living/carbon/human/consistent)
+	var/obj/item/clothing/head/roguetown/helmet/heavy/helmet = allocate(/obj/item/clothing/head/roguetown/helmet/heavy, human)
+	human.equip_to_slot(helmet, SLOT_HEAD)
+	helmet.obj_integrity = 50
+
+	TEST_ASSERT(human.checkcritarmor(BODY_ZONE_HEAD, BCLASS_PICK), "An intact heavy helmet should prevent pick crits.")
+
+	human.run_armor_check(
+		BODY_ZONE_HEAD,
+		"stab",
+		armor_penetration = 80,
+		damage = 26,
+		blade_dulling = BCLASS_PICK,
+	)
+
+	TEST_ASSERT(helmet.obj_broken, "The controlled hit should break the helmet.")
+	TEST_ASSERT_EQUAL(helmet.obj_integrity, 24, "The breaking hit should leave the helmet above zero integrity.")
+	TEST_ASSERT(!human.checkcritarmor(BODY_ZONE_HEAD, BCLASS_PICK), "A broken helmet should not prevent pick crits.")
+
+/datum/unit_test/skin_armor_crits/Run()
+	var/mob/living/carbon/human/consistent/human = allocate(/mob/living/carbon/human/consistent)
+	var/obj/item/clothing/suit/roguetown/armor/skin_armor/bear_skin/skin = allocate(/obj/item/clothing/suit/roguetown/armor/skin_armor/bear_skin, human)
+	human.skin_armor = skin
+
+	TEST_ASSERT_EQUAL(human.get_best_worn_armor(BODY_ZONE_HEAD, "slash"), skin, "Natural armor should be used for normal armor checks.")
+	TEST_ASSERT(human.checkcritarmor(BODY_ZONE_HEAD, BCLASS_CUT), "Natural armor should also prevent its listed crit classes.")


### PR DESCRIPTION
## About the PR

Broken armor could continue preventing critical hits after it had lost all armor rating, while natural `skin_armor` was skipped by critical-hit protection entirely.

This PR makes `checkcritarmor()`:

- ignore armor as soon as `obj_break()` marks it broken;
- include `skin_armor`, matching the armor used by normal damage checks.

## Root cause

`checkcritarmor()` used `obj_integrity > 1` as its validity check. Clothing normally breaks at roughly 10% integrity, so a broken item could retain its listed `prevent_crits` classes while no longer providing an armor rating.

The same proc also maintained its own armor-slot list, but that list omitted `skin_armor`. As a result, natural armor such as bear or werewolf skin mitigated normal damage through `get_best_worn_armor()`, but never prevented its listed critical-hit classes.

## Reproduction and proof

The helmet regression test is deterministic:

1. Equip a heavy helmet and set its integrity to `50`.
2. Apply one simulated iron warhammer pick hit for `26` integrity damage.
3. Confirm that the helmet breaks at `24` integrity rather than being destroyed.
4. Check whether it still prevents `BCLASS_PICK` critical hits.

A second test assigns bear skin to `skin_armor` and verifies that normal armor selection and critical-hit protection recognize the same item.

| Test | Before | After |
| --- | --- | --- |
| Broken helmet no longer prevents pick crits | FAIL | PASS |
| Natural armor prevents its listed crit classes | FAIL | PASS |

![Armor crit protection regression proof](https://raw.githubusercontent.com/Animusin/Ratwood-2.0/pr-assets/armor-crit-proof/.github/pr-assets/armor-crit-proof.png)

## Validation

- `PASS: /datum/unit_test/broken_helmet_crits`
- `PASS: /datum/unit_test/skin_armor_crits`
- BYOND 516.1684 compile: `0 errors, 0 warnings`
