### PR TITLE
fix werewolf name jank

### DIFF
--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -36,10 +36,6 @@
 
 
 	// Werewolf reverts to human form during the day
-	else if(transformed)
-		H.real_name = wolfname
-		H.name = wolfname
-
 		if(GLOB.tod != "night")
 			if(!untransforming)
 				untransforming = world.time // Start untransformation phase
@@ -82,6 +78,12 @@
 		ww_path = /mob/living/carbon/human/species/werewolf/female
 
 	var/mob/living/carbon/human/species/werewolf/W = new ww_path(loc)
+
+	//Set the werewolf's name from the antagonist datum
+	var/datum/antagonist/werewolf/Were = mind.has_antag_datum(/datum/antagonist/werewolf/)
+	if(Were)
+		W.real_name = Were.wolfname
+		W.name = Were.wolfname
 
 	W.set_patron(src.patron)
 	W.gender = gender

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf_transformation.dm
@@ -79,16 +79,17 @@
 
 	var/mob/living/carbon/human/species/werewolf/W = new ww_path(loc)
 
-	//Set the werewolf's name from the antagonist datum
-	var/datum/antagonist/werewolf/Were = mind.has_antag_datum(/datum/antagonist/werewolf/)
-	if(Were)
-		W.real_name = Were.wolfname
-		W.name = Were.wolfname
 
 	W.set_patron(src.patron)
 	W.gender = gender
 	W.regenerate_icons()
 	W.stored_mob = src
+
+	//Set the werewolf's name from the antagonist datum
+	var/datum/antagonist/werewolf/Were = mind.has_antag_datum(/datum/antagonist/werewolf/)
+	if(Were)
+		W.real_name = Were.wolfname
+		W.name = Were.wolfname
 	W.limb_destroyer = TRUE
 	W.ambushable = FALSE
 	W.cmode_music = 'sound/music/cmode/antag/combat_darkstar.ogg'


### PR DESCRIPTION
## About The Pull Request

Copies a six-line change from [Azure Peak](https://github.com/Azure-Peak/Azure-Peak/pull/4755) to fix werewolves getting stuck with their wolf name after being revived.
fixes https://github.com/Rotwood-Vale/Ratwood-2.0/issues/2101

## Testing Evidence
There is a video through the link to AP's github testing the change, and I copied those four lines plus their comment exactly.

I lack video recording software, but here are some screenshots, doing exactly what was done in the recording for AP.
<img width="539" height="352" alt="image" src="https://github.com/user-attachments/assets/f8ca1112-0308-4cb6-85df-416dfeeddd27" />

<img width="544" height="129" alt="image" src="https://github.com/user-attachments/assets/a5cb906b-16e4-4539-b311-f61e46d46162" />

<img width="527" height="76" alt="image" src="https://github.com/user-attachments/assets/2941eeed-68d2-4e31-8484-8e4e29922320" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Getting stuck with a werewolf name after being killed and revived sucks.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: you no longer need facial reconstruction surgery if killed as a werewolf and then revived
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
