### PR TITLE
Pickpocketing rework

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -53,18 +53,19 @@
 		sate_addiction(/datum/charflaw/addiction/kleptomaniac)
 	grant_pickpocket_xp(victim, exp_to_gain)
 
-/datum/component/storage/proc/pickpocket_show(mob/living/carbon/human/thief, is_belt = FALSE)
+/// A steal-odds label floated over one grid item. Client-local, so only the thief sees it, never the mark.
+/atom/movable/screen/pickpocket_odds
+	plane = ABOVE_HUD_PLANE
+	layer = ABOVE_HUD_LAYER + 1
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT // clicks fall through to the item beneath
+	maptext_x = 0
+	maptext_y = 20
+	maptext_width = 32
+	maptext_height = 12
+
+/datum/component/storage/proc/pickpocket_show(mob/living/carbon/human/thief)
 	if(isnull(thief.client) || !show_to(thief))
 		return FALSE
-	var/atom/real_location = real_location()
-	if(!istype(real_location))
-		return FALSE
-	for(var/obj/item/I in real_location.contents)
-		I.maptext = "<span style='text-align:center;color:#ffe670'>[thief.pickpocket_extract_chance(I, is_belt)]%</span>"
-		I.maptext_x = 0
-		I.maptext_y = 20
-		I.maptext_width = 32
-		I.maptext_height = 12
 	return TRUE
 
 /datum/pickpocket_session
@@ -75,6 +76,7 @@
 	var/margin = 0
 	var/exp_to_gain = 0
 	var/resolving = FALSE
+	var/list/odds_labels
 
 /datum/pickpocket_session/New(mob/living/carbon/human/thief, mob/living/carbon/human/victim, obj/item/storage/container, margin, exp_to_gain)
 	. = ..()
@@ -84,18 +86,16 @@
 	src.margin = margin
 	src.exp_to_gain = exp_to_gain
 	STR = container.GetComponent(/datum/component/storage)
-	if(!STR || !STR.pickpocket_show(thief, istype(container, /obj/item/storage/belt)))
+	if(!STR || !STR.pickpocket_show(thief))
 		qdel(src)
 		return
+	build_odds_labels()
 	RegisterSignal(thief, COMSIG_MOB_CLICKON, PROC_REF(on_click))
 	RegisterSignal(thief, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(on_disturbed))
 	RegisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(on_disturbed))
 
 /datum/pickpocket_session/Destroy()
-	if(!QDELETED(container))
-		for(var/obj/item/I in container.contents)
-			if(I.maptext)
-				I.maptext = ""
+	clear_odds_labels()
 	if(thief)
 		UnregisterSignal(thief, list(COMSIG_MOB_CLICKON, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
 		if(STR && thief.active_storage == STR)
@@ -107,6 +107,25 @@
 	container = null
 	STR = null
 	return ..()
+
+/// Float a private steal-odds label over each grid item, seen only by the thief.
+/datum/pickpocket_session/proc/build_odds_labels()
+	odds_labels = list()
+	if(isnull(thief.client))
+		return
+	var/is_belt = istype(container, /obj/item/storage/belt)
+	for(var/obj/item/I in container.contents)
+		var/atom/movable/screen/pickpocket_odds/label = new
+		label.screen_loc = I.screen_loc
+		label.maptext = "<span style='text-align:center;color:#ffe670'>[thief.pickpocket_extract_chance(I, is_belt)]%</span>"
+		thief.client.screen += label
+		odds_labels += label
+
+/datum/pickpocket_session/proc/clear_odds_labels()
+	if(thief?.client)
+		for(var/atom/movable/screen/pickpocket_odds/label in odds_labels)
+			thief.client.screen -= label
+	QDEL_LIST(odds_labels)
 
 /datum/pickpocket_session/proc/on_disturbed(datum/source)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -228,8 +228,8 @@
 		thief.changeNext_move(clickcd)
 		return
 
-	// The contested detection check: thieving + speed vs perception + speed, scaled by the mark's awareness.
-	var/thief_score = roll("[thiefskill + 1]d6") + round((thief.STASPD - 10) / 3)
+	// The contested detection check: thieving + fortune vs perception + speed, scaled by the mark's awareness.
+	var/thief_score = roll("[thiefskill + 1]d6") + round((thief.STALUC - 10) / 3)
 	var/victim_score
 	if(victim_unaware)
 		victim_score = round(effective_targetperception * 0.35)

--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -1,3 +1,149 @@
+#define PICKPOCKET_FUMBLE_FLOOR    -6
+#define PICKPOCKET_NEARFAIL_CEIL    5
+#define PICKPOCKET_MIDDLING_CEIL   10
+#define PICKPOCKET_SHAKE_CEIL      17
+
+/mob/living/carbon/human/proc/get_pickpocket_skill()
+	return get_skill_level(/datum/skill/misc/stealing) + (has_world_trait(/datum/world_trait/matthios_fingers) ? 1 : 0)
+
+/obj/item/proc/get_pickpocket_difficulty(is_belt = FALSE)
+	return max(0, (w_class - WEIGHT_CLASS_NORMAL)) * 8
+
+/obj/item/roguekey/get_pickpocket_difficulty(is_belt = FALSE)
+	. = ..()
+	. += 25
+	if(is_belt)
+		. += 20
+
+/obj/item/storage/keyring/get_pickpocket_difficulty(is_belt = FALSE)
+	. = ..()
+	. += 25
+	if(is_belt)
+		. += 20
+
+/mob/living/carbon/human/proc/pickpocket_extract_chance(obj/item/I, is_belt = FALSE)
+	return clamp(45 + (get_pickpocket_skill() * 9) - I.get_pickpocket_difficulty(is_belt), 5, 100)
+
+/mob/living/carbon/human/proc/pickpocket_feedback(mob/living/carbon/human/victim, margin, atom/movable/jostled)
+	if(margin < PICKPOCKET_SHAKE_CEIL && jostled)
+		var/matrix/old_matrix = jostled.transform
+		animate(jostled, time = 1.5, loop = 0, transform = jostled.transform.Scale(1.07, 0.9))
+		animate(time = 2, transform = old_matrix)
+	if(margin < PICKPOCKET_NEARFAIL_CEIL)
+		playsound(victim, "rustle", 60, TRUE, -4)
+		victim.balloon_alert(victim, "someone's in my things!")
+	else if(margin < PICKPOCKET_MIDDLING_CEIL)
+		to_chat(victim, span_warning("I feel a faint tug at my belongings..."))
+
+/mob/living/carbon/human/proc/grant_pickpocket_xp(mob/living/carbon/human/victim, amount)
+	if(src != victim && victim.stat == CONSCIOUS && mind)
+		mind.add_sleep_experience(/datum/skill/misc/stealing, amount, FALSE)
+
+/mob/living/carbon/human/proc/finalize_pickpocket_steal(mob/living/carbon/human/victim, obj/item/picked, exp_to_gain)
+	put_in_active_hand(picked)
+	to_chat(src, span_green("I stole [picked]!"))
+	victim.log_message("has had \the [picked] stolen by [key_name(src)]", LOG_ATTACK, color="white")
+	log_message("has stolen \the [picked] from [key_name(victim)]", LOG_ATTACK, color="white")
+	if(victim.client && victim.stat != DEAD)
+		SEND_SIGNAL(src, COMSIG_ITEM_STOLEN, victim)
+		record_featured_stat(FEATURED_STATS_THIEVES, src)
+		record_featured_stat(FEATURED_STATS_CRIMINALS, src)
+		GLOB.azure_round_stats[STATS_ITEMS_PICKPOCKETED]++
+	if(has_flaw(/datum/charflaw/addiction/kleptomaniac))
+		sate_addiction(/datum/charflaw/addiction/kleptomaniac)
+	grant_pickpocket_xp(victim, exp_to_gain)
+
+/datum/component/storage/proc/pickpocket_show(mob/living/carbon/human/thief, is_belt = FALSE)
+	if(isnull(thief.client) || !show_to(thief))
+		return FALSE
+	var/atom/real_location = real_location()
+	if(!istype(real_location))
+		return FALSE
+	for(var/obj/item/I in real_location.contents)
+		I.maptext = "<span style='text-align:center;color:#ffe670'>[thief.pickpocket_extract_chance(I, is_belt)]%</span>"
+		I.maptext_x = 0
+		I.maptext_y = 20
+		I.maptext_width = 32
+		I.maptext_height = 12
+	return TRUE
+
+/datum/pickpocket_session
+	var/mob/living/carbon/human/thief
+	var/mob/living/carbon/human/victim
+	var/obj/item/storage/container
+	var/datum/component/storage/STR
+	var/margin = 0
+	var/exp_to_gain = 0
+	var/resolving = FALSE
+
+/datum/pickpocket_session/New(mob/living/carbon/human/thief, mob/living/carbon/human/victim, obj/item/storage/container, margin, exp_to_gain)
+	. = ..()
+	src.thief = thief
+	src.victim = victim
+	src.container = container
+	src.margin = margin
+	src.exp_to_gain = exp_to_gain
+	STR = container.GetComponent(/datum/component/storage)
+	if(!STR || !STR.pickpocket_show(thief, istype(container, /obj/item/storage/belt)))
+		qdel(src)
+		return
+	RegisterSignal(thief, COMSIG_MOB_CLICKON, PROC_REF(on_click))
+	RegisterSignal(thief, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(on_disturbed))
+	RegisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(on_disturbed))
+
+/datum/pickpocket_session/Destroy()
+	if(!QDELETED(container))
+		for(var/obj/item/I in container.contents)
+			if(I.maptext)
+				I.maptext = ""
+	if(thief)
+		UnregisterSignal(thief, list(COMSIG_MOB_CLICKON, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+		if(STR && thief.active_storage == STR)
+			STR.hide_from(thief)
+	if(victim)
+		UnregisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+	thief = null
+	victim = null
+	container = null
+	STR = null
+	return ..()
+
+/datum/pickpocket_session/proc/on_disturbed(datum/source)
+	SIGNAL_HANDLER
+	qdel(src)
+
+/datum/pickpocket_session/proc/on_click(mob/source, atom/target, params)
+	SIGNAL_HANDLER
+	if(resolving)
+		return COMSIG_MOB_CANCEL_CLICKON
+	if(QDELETED(container) || QDELETED(victim) || QDELETED(thief) || !STR)
+		qdel(src)
+		return COMSIG_MOB_CANCEL_CLICKON
+	if(target == STR.closer)
+		qdel(src)
+		return COMSIG_MOB_CANCEL_CLICKON
+	if(isitem(target) && (target in container.contents))
+		resolving = TRUE
+		INVOKE_ASYNC(src, PROC_REF(attempt_lift), target)
+		return COMSIG_MOB_CANCEL_CLICKON
+	qdel(src)
+	return
+
+/datum/pickpocket_session/proc/attempt_lift(obj/item/wanted)
+	if(thief.get_active_held_item())
+		to_chat(thief, span_warning("My hand is full."))
+		qdel(src)
+		return
+	var/success = prob(thief.pickpocket_extract_chance(wanted, istype(container, /obj/item/storage/belt)))
+	if(success)
+		STR.remove_from_storage(wanted, get_turf(victim))
+	else
+		to_chat(thief, span_warning("My fingers slip off [wanted]."))
+	thief.pickpocket_feedback(victim, margin, container)
+	if(success)
+		thief.finalize_pickpocket_steal(victim, wanted, exp_to_gain)
+	qdel(src)
+
 /datum/intent/steal
 	name = "steal"
 	candodge = FALSE
@@ -30,19 +176,15 @@
 		to_chat(thief, span_warning("What am I going to steal from there?"))
 		return
 
-	var/thiefskill = thief.get_skill_level(/datum/skill/misc/stealing) + (has_world_trait(/datum/world_trait/matthios_fingers) ? 1 : 0)
-	var/stealroll = roll("[thiefskill]d6")
-	var/targetperception = (victim.STAPER)
+	var/thiefskill = thief.get_pickpocket_skill()
 	var/chance_add = stealmods["chance_add"]
 	if(!isnum(chance_add))
 		chance_add = 0
-	var/effective_targetperception = targetperception
+	var/effective_targetperception = victim.STAPER
 	if(chance_add > 0)
-		effective_targetperception = max(0, round(targetperception * (100 - chance_add) / 100))
-	var/list/stealpos = list()
-	var/list/mobsbehind = list()
+		effective_targetperception = max(0, round(victim.STAPER * (100 - chance_add) / 100))
 	var/exp_to_gain = thief.STAINT
-	to_chat(thief, span_notice("I try to steal from [victim]..."))	
+	to_chat(thief, span_notice("I try to steal from [victim]..."))
 	if(!do_after(thief, 1 SECONDS, target = victim, progress = 0))
 		return
 	// Pickpocketting checks after the channel in case something changed
@@ -58,68 +200,91 @@
 	if(!(thief.zone_selected in stealablezones))
 		to_chat(thief, span_warning("What am I going to steal from there?"))
 		return
-	if(stealroll > effective_targetperception)
-		mobsbehind |= cone(victim, list(turn(victim.dir, 180)), list(thief))
-		if(mobsbehind.Find(thief) || victim.IsUnconscious() || victim.eyesclosed || victim.eye_blind || victim.eye_blurry || !(victim.mobility_flags & MOBILITY_STAND))
-			switch(thief.zone_selected)
-				if("chest")
-					if (victim.get_item_by_slot(SLOT_BACK_L))
-						stealpos.Add(victim.get_item_by_slot(SLOT_BACK_L))
-					if (victim.get_item_by_slot(SLOT_BACK_R))
-						stealpos.Add(victim.get_item_by_slot(SLOT_BACK_R))
-				if("neck")
-					if (victim.get_item_by_slot(SLOT_NECK))
-						stealpos.Add(victim.get_item_by_slot(SLOT_NECK))
-				if("groin")
-					if (victim.get_item_by_slot(SLOT_BELT))
-						stealpos.Add(victim.get_item_by_slot(SLOT_BELT))
-				if("l_leg")
-					if (victim.get_item_by_slot(SLOT_BELT_L))
-						stealpos.Add(victim.get_item_by_slot(SLOT_BELT_L))
-				if("r_leg")
-					if (victim.get_item_by_slot(SLOT_BELT_R))
-						stealpos.Add(victim.get_item_by_slot(SLOT_BELT_R))
-				if("r_hand", "l_hand")
-					if (victim.get_item_by_slot(SLOT_RING))
-						stealpos.Add(victim.get_item_by_slot(SLOT_RING))
-			if(length(stealpos) > 0)
-				var/obj/item/picked = pick(stealpos)
-				if(istype(picked,/obj/item/storage))
-					var/obj/item/storage/container = picked
-					var/datum/component/storage/STR = container.GetComponent(/datum/component/storage)
-					var/list/stuff = STR.contents()
-					if(stuff.len > 0)
-						picked = pick(stuff)
-						STR.remove_from_storage(picked, get_turf(victim))
-				victim.dropItemToGround(picked)
-				thief.put_in_active_hand(picked)
-				to_chat(thief, span_green("I stole [picked]!"))
-				victim.log_message("has had \the [picked] stolen by [key_name(thief)]", LOG_ATTACK, color="white")
-				thief.log_message("has stolen \the [picked] from [key_name(victim)]", LOG_ATTACK, color="white")
-				if(victim.client && victim.stat != DEAD)
-					SEND_SIGNAL(thief, COMSIG_ITEM_STOLEN, victim)
-					record_featured_stat(FEATURED_STATS_THIEVES, thief)
-					record_featured_stat(FEATURED_STATS_CRIMINALS, thief)
-					GLOB.azure_round_stats[STATS_ITEMS_PICKPOCKETED]++
-				if(thief.has_flaw(/datum/charflaw/addiction/kleptomaniac))
-					thief.sate_addiction(/datum/charflaw/addiction/kleptomaniac)
-			else
-				exp_to_gain /= 2 // these can be removed or changed on reviewer's discretion
-				to_chat(thief, span_warning("I didn't find anything there. Perhaps I should look elsewhere."))
+
+	// The contested detection check: thieving + speed vs perception + speed, scaled by the mark's awareness.
+	var/thief_score = roll("[thiefskill + 1]d6") + round((thief.STASPD - 10) / 3)
+	var/victim_unaware = victim.IsUnconscious() || victim.eyesclosed || victim.eye_blind || victim.eye_blurry || !(victim.mobility_flags & MOBILITY_STAND)
+	var/list/mobsbehind = cone(victim, list(turn(victim.dir, 180)), list(thief))
+	var/thief_behind = mobsbehind.Find(thief)
+	var/victim_score
+	if(victim_unaware)
+		victim_score = round(effective_targetperception * 0.35)
+	else if(thief_behind)
+		victim_score = effective_targetperception + round((victim.STASPD - 10) / 3)
+	else
+		victim_score = round(effective_targetperception * 1.75) + round((victim.STASPD - 10) / 3) // watching you the whole time
+	var/margin = thief_score - victim_score
+
+	if(margin < 0)
+		victim.log_message("has had an attempted pickpocket by [key_name(thief)]", LOG_ATTACK, color="white")
+		thief.log_message("has attempted to pickpocket [key_name(victim)]", LOG_ATTACK, color="white")
+		if(margin < PICKPOCKET_FUMBLE_FLOOR)
+			thief.visible_message(span_danger("[thief] is caught rummaging through [victim]'s belongings!"))
+			victim.balloon_alert(victim, "thief!")
+			to_chat(victim, span_danger("[thief] tried to rob me!"))
 		else
-			to_chat(thief, "<span class='warning'>They can see me!")
-	if(stealroll <= 5)
-		victim.log_message("has had an attempted pickpocket by [key_name(thief)]", LOG_ATTACK, color="white")
-		thief.log_message("has attempted to pickpocket [key_name(victim)]", LOG_ATTACK, color="white")
-		thief.visible_message(span_danger("[thief] failed to pickpocket [victim]!"))
-		to_chat(victim, span_danger("[thief] tried pickpocketing me!"))
-	if(stealroll < effective_targetperception)
-		victim.log_message("has had an attempted pickpocket by [key_name(thief)]", LOG_ATTACK, color="white")
-		thief.log_message("has attempted to pickpocket [key_name(victim)]", LOG_ATTACK, color="white")
-		to_chat(thief, span_danger("I failed to pick the pocket!"))
-		to_chat(victim, span_danger("Someone tried pickpocketing me!"))
-		exp_to_gain /= 5 // these can be removed or changed on reviewer's discretion
-	// If we're pickpocketing someone else, and that person is conscious, grant XP
-	if(thief != victim && victim.stat == CONSCIOUS)
-		thief.mind.add_sleep_experience(/datum/skill/misc/stealing, exp_to_gain, FALSE)
+			to_chat(thief, span_warning("I can't get at it without being noticed. Best stop here."))
+			victim.balloon_alert(victim, "...?")
+			to_chat(victim, span_danger("Someone's fumbling at my belongings!"))
+		thief.changeNext_move(clickcd)
+		return
+
+	var/list/stealpos = list()
+	switch(thief.zone_selected)
+		if("chest")
+			if(victim.get_item_by_slot(SLOT_BACK_L))
+				stealpos.Add(victim.get_item_by_slot(SLOT_BACK_L))
+			if(victim.get_item_by_slot(SLOT_BACK_R))
+				stealpos.Add(victim.get_item_by_slot(SLOT_BACK_R))
+		if("neck")
+			if(victim.get_item_by_slot(SLOT_NECK))
+				stealpos.Add(victim.get_item_by_slot(SLOT_NECK))
+		if("groin")
+			if(victim.get_item_by_slot(SLOT_BELT))
+				stealpos.Add(victim.get_item_by_slot(SLOT_BELT))
+		if("l_leg")
+			if(victim.get_item_by_slot(SLOT_BELT_L))
+				stealpos.Add(victim.get_item_by_slot(SLOT_BELT_L))
+		if("r_leg")
+			if(victim.get_item_by_slot(SLOT_BELT_R))
+				stealpos.Add(victim.get_item_by_slot(SLOT_BELT_R))
+		if("r_hand", "l_hand")
+			if(victim.get_item_by_slot(SLOT_RING))
+				stealpos.Add(victim.get_item_by_slot(SLOT_RING))
+
+	if(!length(stealpos))
+		to_chat(thief, span_warning("I didn't find anything there. Perhaps I should look elsewhere."))
+		thief.changeNext_move(clickcd)
+		return
+
+	var/obj/item/target = pick(stealpos)
+
+	if(thief.zone_selected == "r_hand" || thief.zone_selected == "l_hand")
+		var/ring_chance = clamp(8 + (thiefskill * 7), 3, 90)
+		to_chat(thief, span_info("[target]: [ring_chance]% to slip free."))
+		var/success = prob(ring_chance)
+		if(success)
+			victim.dropItemToGround(target)
+		else
+			to_chat(thief, span_warning("I can't work [target] loose without them noticing."))
+		thief.pickpocket_feedback(victim, margin, target)
+		if(success)
+			thief.finalize_pickpocket_steal(victim, target, exp_to_gain)
+		thief.changeNext_move(clickcd)
+		return
+
+	if(istype(target, /obj/item/storage))
+		var/obj/item/storage/container = target
+		var/datum/component/storage/storage = container.GetComponent(/datum/component/storage)
+		if(!storage || !length(storage.contents()))
+			to_chat(thief, span_warning("There's nothing in [container] worth taking."))
+			thief.changeNext_move(clickcd)
+			return
+		thief.changeNext_move(clickcd)
+		new /datum/pickpocket_session(thief, victim, container, margin, exp_to_gain)
+		return
+
+	victim.dropItemToGround(target)
+	thief.pickpocket_feedback(victim, margin, target)
+	thief.finalize_pickpocket_steal(victim, target, exp_to_gain)
 	thief.changeNext_move(clickcd)

--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -220,18 +220,21 @@
 		to_chat(thief, span_warning("What am I going to steal from there?"))
 		return
 
-	// The contested detection check: thieving + speed vs perception + speed, scaled by the mark's awareness.
-	var/thief_score = roll("[thiefskill + 1]d6") + round((thief.STASPD - 10) / 3)
+	// No lifting from the front - it has to be from behind, or off someone who can't see at all.
 	var/victim_unaware = victim.IsUnconscious() || victim.eyesclosed || victim.eye_blind || victim.eye_blurry || !(victim.mobility_flags & MOBILITY_STAND)
 	var/list/mobsbehind = cone(victim, list(turn(victim.dir, 180)), list(thief))
-	var/thief_behind = mobsbehind.Find(thief)
+	if(!victim_unaware && !mobsbehind.Find(thief))
+		to_chat(thief, span_warning("They can see me!"))
+		thief.changeNext_move(clickcd)
+		return
+
+	// The contested detection check: thieving + speed vs perception + speed, scaled by the mark's awareness.
+	var/thief_score = roll("[thiefskill + 1]d6") + round((thief.STASPD - 10) / 3)
 	var/victim_score
 	if(victim_unaware)
 		victim_score = round(effective_targetperception * 0.35)
-	else if(thief_behind)
-		victim_score = effective_targetperception + round((victim.STASPD - 10) / 3)
 	else
-		victim_score = round(effective_targetperception * 1.75) + round((victim.STASPD - 10) / 3) // watching you the whole time
+		victim_score = effective_targetperception + round((victim.STASPD - 10) / 3)
 	var/margin = thief_score - victim_score
 
 	if(margin < 0)


### PR DESCRIPTION
## About The Pull Request
reworks pickpocketing to let you see what items you pickpocket, % chances on a per-item basis if you're opening inventories & make belts and keys harder to pickpocket out of
also makes pickpocketing now scale with pickpocketer's luck stat to compensate, as you need higher ceiling to avoid being caught whatsoever
also also, the contest calculation factors in victim's stat speed and not just perception
the new pickpocketing UI does require both to stay still, but should show up fast enough to not be too big a issue
see https://arturlang.github.io/pages/pickpocket-rng.html for a RNG chart

closes https://github.com/Rotwood-Vale/Ratwood-2.0/pull/2152
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/ff6321f7-9a48-4583-bef3-b23d7b626e7e

https://github.com/user-attachments/assets/37311a5e-be64-4ff7-a99f-38dbc5009dc0



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
more interaction both ways, probably.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: stealing from belts and stealing keys themselves both separately make it 25% harder to be stolen, which can stack
balance: a lot more semi-failure states for pickpocketing that show the victim that something was stolen
balance: pickpocketing scales now with the speed stat as well for it's success chances, but the victim now also contests their speed in addition to their perception
add: new UI for stealing from containers that shows your chances
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
