### PR TITLE
Fixes Hookahs' targeting and adds the ability to make you able to force others to puff the Hookah. vol2

### DIFF
--- a/code/game/objects/structures/hookah.dm
+++ b/code/game/objects/structures/hookah.dm
@@ -160,14 +160,23 @@
 			return
 
 		if(!(shisha.reagents?.total_volume))
-			return
+			return	
 
 		var/smoke_amount = shisha.reagents.maximum_volume / shisha.reagents.total_volume
-		shisha.reagents.reaction(user, INGEST, min(REAGENTS_METABOLISM / smoke_amount, 1))
-		if(!shisha.reagents.trans_to(user, smoke_amount))
+
+		var/mob/living/carbon/human/smoker = M
+
+		if(smoker != user)
+			user.visible_message(span_danger("[user] attempts to force [smoker] to take a puff from \the [src]."), \
+								span_danger("I attempt to force [smoker] to puff \the [src]."))
+		else
+			to_chat(smoker, span_notice("You take a pleasant puff from \the [src]."))	
+
+		shisha.reagents.reaction(smoker, INGEST, min(REAGENTS_METABOLISM / smoke_amount, 1))
+		if(!shisha.reagents.trans_to(smoker, smoke_amount))
 			shisha.reagents.remove_any(smoke_amount)
 
-		var/turf/my_turf = get_turf(user)
+		var/turf/my_turf = get_turf(smoker)
 		my_turf.pollute_turf(/datum/pollutant/smoke, 5)
 		return FALSE
 
@@ -273,7 +282,7 @@
 		var/smoke_amount = reagents.maximum_volume / reagents.total_volume
 
 		if(smoker != user)
-			user.visible_message(span_danger("[user] attempt to force [smoker] to take a puff from \the [src]."), \
+			user.visible_message(span_danger("[user] attempts to force [smoker] to take a puff from \the [src]."), \
 								span_danger("I attempt to force [smoker] to puff \the [src]."))
 		else
 			to_chat(smoker, span_notice("You take a pleasant puff from \the [src]."))		

--- a/code/game/objects/structures/hookah.dm
+++ b/code/game/objects/structures/hookah.dm
@@ -263,24 +263,33 @@
 		playsound(get_turf(src), 'sound/foley/shisha_gurgle.ogg', rand(50, 70), FALSE, -1)
 		
 		if(!do_after(user, 2 SECONDS, target = user) || QDELETED(src) || !lit)
+
 			return
 
 		if(!reagents?.total_volume)
 			return
 
+		var/mob/living/carbon/human/smoker = M 
 		var/smoke_amount = reagents.maximum_volume / reagents.total_volume
+
+		if(smoker != user)
+			user.visible_message(span_danger("[user] attempt to force [smoker] to take a puff from \the [src]."), \
+								span_danger("I attempt to force [smoker] to puff \the [src]."))
+		else
+			to_chat(smoker, span_notice("You take a pleasant puff from \the [src]."))		
+
 		reagents.reaction(user, INGEST, min(REAGENTS_METABOLISM / smoke_amount, 1))
-		if(!reagents.trans_to(user, smoke_amount))
+		if(!reagents.trans_to(smoker, smoke_amount))
 			reagents.remove_any(smoke_amount)
 
-		var/turf/my_turf = get_turf(user)
-		if(my_turf)
+		var/turf/my_turf = get_turf(smoker)
+		if(my_turf)	
 			my_turf.pollute_turf(/datum/pollutant/smoke, 3)
 
-		to_chat(user, span_notice("You take a pleasant puff from \the [src]."))
+
 
 		if(!reagents.total_volume)
-			to_chat(user, span_warning("\The [src] goes out as the smoking mix burns out."))
+			to_chat(smoker, span_warning("\The [src] goes out as the smoking mix burns out."))
 			extinguish()
 
 	else


### PR DESCRIPTION
## About The Pull Request

So. I felt this in game. I clicked someone, and thought: "hey, I want to share this smoke without dropping the Hookah: so I clicked X' and then noticed, I got the smoke effect. I crawled through the code noticed that target is not referenced at all, it is only the user. So this pull-requests fixes that and makes it so that you can infact make others smoke the hookah with you.

## Testing Evidence

<img width="539" height="181" alt="image" src="https://github.com/user-attachments/assets/d39e502b-9a5b-4e7b-94de-0a048f169fa7" />
<img width="633" height="75" alt="image" src="https://github.com/user-attachments/assets/8fff5a26-c739-449c-bf79-7ad55bda30c1" />
<img width="646" height="143" alt="image" src="https://github.com/user-attachments/assets/cbf64e22-bf2b-47fb-8ed7-dc2dc5a2ca1d" />

## Why It's Good For The Game

Why is this great? well-- now it is a bit more realistic, you can smoke with others: sharing the hookah from your hand, without having to always drop it down on the ground. Now you can just-- target someone with the smoke intent and click them so that they get the drug-effects.

## Changelog

🆑
add: Added the ability to make others smoke the Hookah's (Portable and Stationary)
Fix: Fixed targeting of Hookahs. (you could click someone else and it would make you smoke the Hookah)
/:cl:
