### PR TITLE
Fixes Kargrund Maul silver functionality.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -659,7 +659,6 @@
 	Unwieldy to those weak of arm or faith, its mighty blows have the strength to shatter both stone and skull alike."
 	icon_state = "malumhammer"
 	is_silver = TRUE
-	wdefense_wbonus = 5 // 7
 	minstr = 8//Handled by the unique interaction below. Inverted to start, since they spawn with it, and funny stuff can happen.
 
 /obj/item/rogueweapon/mace/maul/grand/malum/pickup(mob/living/user)
@@ -670,7 +669,7 @@
 	..()
 
 //This thing is warded. For fluff. And because it's COOL, we give them silver blessings.
-//Being silver is already a huge boon. Component did give 1 extra wdef but that's been shifted to the wdefense_wbonus.
+//Being silver is already a huge boon. No need for additional boons on this guy.
 /obj/item/rogueweapon/mace/maul/grand/malum/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -658,6 +658,8 @@
 	desc = "Forged from the legacy of dwarven rock-hammers, this maul’s holy steel and divine runes grant it immense power. \
 	Unwieldy to those weak of arm or faith, its mighty blows have the strength to shatter both stone and skull alike."
 	icon_state = "malumhammer"
+	is_silver = TRUE
+	wdefense_wbonus = 5 // 7
 	minstr = 8//Handled by the unique interaction below. Inverted to start, since they spawn with it, and funny stuff can happen.
 
 /obj/item/rogueweapon/mace/maul/grand/malum/pickup(mob/living/user)
@@ -668,7 +670,7 @@
 	..()
 
 //This thing is warded. For fluff. And because it's COOL, we give them silver blessings.
-//+1 DEF from it, too. For a total of 7 defence when wielded.
+//Being silver is already a huge boon. Component did give 1 extra wdef but that's been shifted to the wdefense_wbonus.
 /obj/item/rogueweapon/mace/maul/grand/malum/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\
@@ -677,7 +679,7 @@
 		added_force = 0,\
 		added_blade_int = 0,\
 		added_int = 0,\
-		added_def = 1,\
+		added_def = 0,\
 	)
 
 //Dwarvish mauls. Unobtanium outside of Grudgebearer. Do not change that.


### PR DESCRIPTION
## About The Pull Request
The Kargrund maul (Malum templar) weapon is now tagged as silver, which should allow the silverblessing functionality to well, function.

Removes the 1 wdef increase in anticipation of https://github.com/Rotwood-Vale/Ratwood-2.0/pull/2241
(10 wdef on a giant maul is a bit silly, blessed or otherwise)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="668" height="174" alt="image" src="https://github.com/user-attachments/assets/1c669b3c-f6ad-46ac-8cf8-35f86adb54e2" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The maul is already an item with the silver-blessing component, I'm fairly sure its an oversight that it doesn't function as a silverblessed weapon. The precedent for silverblessed roundstart templar weapons already exists (look at the necran flail, etc), and arguably some other templar weapons should count as silver (the see weapons), but for now this'll do.

This PR previously fixed wdef value not increasing with the silver component as well but seeing as PR #2241 exists, I'll just let it inherit the wdef of a grand maul and call it a day. The weapon is sufficently superior to its regular counterpart by virtue of not requiring incredible strength investment & being silver.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kargrund maul now properly functions as a silver-blessed weapon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
