### PR TITLE
Restores old failed apprentice.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/failed_apprentice.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/vagabond/failed_apprentice.dm
@@ -4,14 +4,13 @@
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/vagabond/mage
-	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT)
+	traits_applied = list(TRAIT_MAGEARMOR, TRAIT_ARCYNE_T2, TRAIT_ALCHEMY_EXPERT)
 	category_tags = list(CTAG_VAGABOND)
 	subclass_social_rank = SOCIAL_RANK_PEASANT
 	subclass_stats = list(
 		STATKEY_INT = 2,
-		STATKEY_CON = -2,
-		STATKEY_WIL = -2,
-		STATKEY_SPD = -1
+		STATKEY_CON = -1,
+		STATKEY_WIL = -1
 	)
 	subclass_spellpoints = 9
 	subclass_skills = list(


### PR DESCRIPTION
## About The Pull Request

A long time ago, someone updated the failed apprentice vagabond class to have worse stats and T3 magic. It was done without explanation during the transition to advclass. I have undone this, reverting them to T2 magic and slightly better (albeit still shitty) stats.

## Testing Evidence

Compiles.
<img width="590" height="100" alt="image" src="https://github.com/user-attachments/assets/21c15d74-b8bd-48eb-bff8-469651f8d72d" />

## Why It's Good For The Game

It doesn't make sense design-wise or thematically for the beggar mage to have T3 magic, especially when some of the mage associate subclasses don't even have that. + the massive stat debuff, worse than other vagabond subclasses, sucked.

## Changelog

:cl:
balance: Restored old vagabond mage.
/:cl:
