### PR TITLE
Removes (most) polearm sweetspots

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -10,10 +10,8 @@
 	clickcd = CLICK_CD_CHARGED
 	warnie = "mobwarning"
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	penfactor = 50
+	penfactor = 45
 	item_d_type = "stab"
-	effective_range = 2
-	effective_range_type = EFF_RANGE_EXACT
 
 /datum/intent/spear/thrust/oneh
 	name = "one-handed thrust"


### PR DESCRIPTION
## About The Pull Request

Removes the sweetspot requirement from the spear thrust. As compensation, lowers the penetration of the 
intent to 45.

## Testing Evidence

Worked for years without these lines in the file.

## Why It's Good For The Game

De-Azureification.

Spears and thrusting polearms have been miserable and less than viable with the sweetspot requirement. Maintaining a consistent 2-tile range to use a slow intent with modest AP is not something workable. There are far superior options that do not occupy two hands like warhammers and knuckles - let's bring greatweapons back up to snuff.

## Changelog

:cl:
balance: Spear thrusts no longer require a sweetspot to penetrate, and penetrate for less.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
