### PR TITLE
Knight-Squire Expected Responsibilities 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
@@ -11,7 +11,7 @@
 	tutorial = "Having proven yourself both loyal and capable, you have been knighted to serve the realm as the royal family's sentry. \
 	You listen to your Liege, the Marshal, and the Knight Captain, defending your Lord and realm - the last beacon of chivalry in these dark times. \
 	You're wholly dedicated to the standing Regent and their safety. Do not fail. \
-	You may pick your own Squire, but if you have none, you must take on any willing Squire and train them; teaching combat and duty is a core part of your role and is not optional. \
+	You may pick your own Squire, but if you have none, you must take on any willing Squire and involve them in your duties; whether you train them, interact with them, or have them tend your arms and armour, actually engaging with them is not optional. \
 	Consistently turning them away or neglecting one without good reason fails what is expected of you in this rigid hierarchy."
 	display_order = JDO_KNIGHT
 	whitelist_req = TRUE
@@ -55,8 +55,8 @@
 					H.mind.person_knows_me(MF)
 
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
-		INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon/human, squire_duty_acknowledgement), "Taking on and training a Squire is a core duty of your role and is not optional. You may pick your own first, \
-			but if you have none you must accept any willing Squire. Teach them combat and the duties of the role, and give them real chances to learn. \
+		INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon/human, squire_duty_acknowledgement), "Taking on a Squire and involving them in your duties is a core part of your role and is not optional. You may pick your own first, \
+			but if you have none you must accept any willing Squire. Engage with them however you like, be it training, roleplay, or having them tend your arms and armour, just do not neglect them. \
 			Consistently turning willing Squires away, or neglecting your own without good in-character reason, fails your role and may be ban-worthy.")
 
 /datum/outfit/job/roguetown/knight

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight.dm
@@ -10,7 +10,9 @@
 	allowed_ages = list(AGE_ADULT, AGE_MIDDLEAGED, AGE_OLD)
 	tutorial = "Having proven yourself both loyal and capable, you have been knighted to serve the realm as the royal family's sentry. \
 	You listen to your Liege, the Marshal, and the Knight Captain, defending your Lord and realm - the last beacon of chivalry in these dark times. \
-	You're wholly dedicated to the standing Regent and their safety. Do not fail."
+	You're wholly dedicated to the standing Regent and their safety. Do not fail. \
+	You may pick your own Squire, but if you have none, you must take on any willing Squire and train them; teaching combat and duty is a core part of your role and is not optional. \
+	Consistently turning them away or neglecting one without good reason fails what is expected of you in this rigid hierarchy."
 	display_order = JDO_KNIGHT
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/knight
@@ -53,6 +55,9 @@
 					H.mind.person_knows_me(MF)
 
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+		INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon/human, squire_duty_acknowledgement), "Taking on and training a Squire is a core duty of your role and is not optional. You may pick your own first, \
+			but if you have none you must accept any willing Squire. Teach them combat and the duties of the role, and give them real chances to learn. \
+			Consistently turning willing Squires away, or neglecting your own without good in-character reason, fails your role and may be ban-worthy.")
 
 /datum/outfit/job/roguetown/knight
 	neck = /obj/item/clothing/neck/roguetown/bevor
@@ -70,6 +75,19 @@
 /datum/outfit/job/roguetown/knight/pre_equip(mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/take_squire
+
+/*
+	The shared Knight & Squire system: the roundstart duty acknowledgement, the Take Squire verb,
+	and the proximity buffs / stress events that bind a knight and their squire together.
+	Also used by the Squire (garrison/squire.dm) and Knight Captain (nobility/captain.dm) jobs.
+*/
+
+/mob/living/carbon/human/proc/squire_duty_acknowledgement(message)
+	set waitfor = FALSE
+	UNTIL(!client || (!advsetup && advjob && cloak))
+	while(client)
+		if(alert(src, message, "Knight & Squire Duty", "I acknowledge.") == "I acknowledge.")
+			return
 
 /mob/living/carbon/human/proc/take_squire()
 	set name = "Take Squire"

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -14,8 +14,8 @@
 	tutorial = "Your folks said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics \
 		in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy \
 		bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday. \
-		A Knight may choose their own Squire first, but if you find yourself without a master, do not despair, as no willing Squire is meant to go \
-		untrained and a Knight is bound to take one on. Seek them out."
+		A Knight may choose their own Squire first, but if you find yourself without a master, do not despair, as no willing Squire is meant to be \
+		left idle and a Knight is bound to take one on. Seek them out."
 	outfit = /datum/outfit/job/roguetown/squire
 	display_order = JDO_SQUIRE
 	give_bank_account = TRUE

--- a/code/modules/jobs/job_types/roguetown/garrison/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/squire.dm
@@ -13,7 +13,9 @@
 
 	tutorial = "Your folks said you were going to be something, they had better aspirations for you than the life of a peasant. You practiced the basics \
 		in the field alongside your friends, swordfighting with sticks, chasing rabbits with grain flail, and helping around the house lifting heavy \
-		bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday."
+		bags of grain. The Knight took notice of your potential and brought you on as his personal ward. You're going to be something someday. \
+		A Knight may choose their own Squire first, but if you find yourself without a master, do not despair, as no willing Squire is meant to go \
+		untrained and a Knight is bound to take one on. Seek them out."
 	outfit = /datum/outfit/job/roguetown/squire
 	display_order = JDO_SQUIRE
 	give_bank_account = TRUE
@@ -44,6 +46,9 @@
 	. = ..()
 	if(ishuman(L))
 		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, cloak_and_title_setup)), 50)
+		// Knight & Squire system (Take Squire verb, proximity buffs, stress events, this acknowledgement) is defined in garrison/knight/knight.dm
+		INVOKE_ASYNC(L, TYPE_PROC_REF(/mob/living/carbon/human, squire_duty_acknowledgement), "A Knight may pick their own Squire first, but any Knight without one must take on a willing Squire. \
+		If you have no master, seek a Knight out and hold them to it.")
 
 /datum/advclass/squire/lancer
 	name = "Lancer Squire"

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -76,7 +76,7 @@
 
 		// Knight & Squire system (Take Squire verb, proximity buffs, stress events, this acknowledgement) is defined in garrison/knight/knight.dm
 		INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon/human, squire_duty_acknowledgement), "As Knight Captain, leading and organizing the realm's Knights is your first and foremost duty. \
-			You also oversee the training of Squires; should you have none, you may take on a willing Squire and teach them combat and their duties. \
+			You may also take on a willing Squire should you have none; involve them in your duties however you see fit, be it training, roleplay, or tending your arms and armour. \
 			Consistently turning willing Squires away, or neglecting your own without good in-character reason, is a failure of your role and may be ban-worthy.")
 
 /datum/advclass/captain/infantry

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -74,6 +74,11 @@
 					MF.known_people -= prev_real_name
 					H.mind.person_knows_me(MF)
 
+		// Knight & Squire system (Take Squire verb, proximity buffs, stress events, this acknowledgement) is defined in garrison/knight/knight.dm
+		INVOKE_ASYNC(H, TYPE_PROC_REF(/mob/living/carbon/human, squire_duty_acknowledgement), "As Knight Captain, leading and organizing the realm's Knights is your first and foremost duty. \
+			You also oversee the training of Squires; should you have none, you may take on a willing Squire and teach them combat and their duties. \
+			Consistently turning willing Squires away, or neglecting your own without good in-character reason, is a failure of your role and may be ban-worthy.")
+
 /datum/advclass/captain/infantry
 	name = "Knight Captain"
 	tutorial = "You've fought shoulder to shoulder with the realm's worthiest Knights while embedded directly within \


### PR DESCRIPTION
## About The Pull Request

Based on request from Staff, this clarifies and enforces the expectation that Knights (and Knight Captains) are required to take on a willing Squire.

In other words, they have responsibilities. How will Ratwood recover from this?

Two changes:

1. Round-Start Text highlights this for both Knights and Squires. Although, Knight-Captain Round-Start text has not been changed.

2. We have a required acknowledgement pop-up where they must acknowledge that they have a duty to take on squires if they are willing..

**Edit:**

Right, because people are misunderstanding the idea of this PR and are taking this literally, I'm taking out the emphasis on training the squire. That was originally in for flavor, but people are fixating on that and are fussing over the trees and ignoring the forest.

The point is that you are required to take a squire and you are required to interact with them. If that happens to involve training, great. If not, okay. The point is, you are a knight. You need a squire. You need to interact with them.

## Testing Evidence

<img width="638" height="254" alt="knightsquire" src="https://github.com/user-attachments/assets/a93908d7-ac7f-4c8e-ba22-bffe110f787b" />


## Why It's Good For The Game

Turning away Squires or benching them has been a recurring point of friction.

Squires are a training/mentorship role that only works if a Knight actually engages with them.

Making the expectation explicit in the role text, and forcing an acknowledgement, removes the "I didn't know it was required" excuse and sets a clear, enforceable standard without adding any hard mechanical restriction.

## Changelog

:cl:
add: Knights, Squires, and Knight Captains now receive a mandatory acknowledgement pop-up on spawn explaining that a Knight must take on and train a willing Squire if they have none. 
/:cl:
