### PR TITLE
fix: rebel win-time message

### DIFF
--- a/code/controllers/subsystem/storyteller.dm
+++ b/code/controllers/subsystem/storyteller.dm
@@ -615,7 +615,7 @@ SUBSYSTEM_DEF(gamemode)
 				to_chat(world, span_boldwarning("The round will end in 15 minutes."))
 			else
 				reb_end_time = INITIAL_ROUND_TIMER
-				to_chat(world, span_boldwarning("The round will end at the 2:30 hour mark."))
+				to_chat(world, span_boldwarning("The round will end at the 2:45 hour mark."))
 		if(ttime >= reb_end_time)
 			return TRUE
 


### PR DESCRIPTION
## About The Pull Request

this simple adjusment fixes the message print out for the rebel-win con, as it was printed out as 2:30, even though it is based at 2:45

## Testing Evidence

its a string adjusemnt, 

## Why It's Good For The Game

it makes it clear on what happens.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed rebel win-time mesage from 2:30 -> 2:45

/:cl:
