### PR TITLE
Lizard Accent back to Brazillian Portuguese

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -14,8 +14,8 @@
 		STATKEY_CON = 2,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -82,8 +82,8 @@
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Discipline - Unarmed")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist//Just this and disciple, effectively.
 			if("Katar")
 				beltl = /obj/item/rogueweapon/katar/bronze

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -14,8 +14,8 @@
 		STATKEY_CON = 2,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/wrestling = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/combat/polearms = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/swimming = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
@@ -82,8 +82,8 @@
 		var/weapon_choice = input(H, "Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 		switch(weapon_choice)
 			if("Discipline - Unarmed")
-				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 5, TRUE)
-				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 5, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 4, TRUE)
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 4, TRUE)
 				gloves = /obj/item/clothing/gloves/roguetown/bandages/pugilist//Just this and disciple, effectively.
 			if("Katar")
 				beltl = /obj/item/rogueweapon/katar/bronze

--- a/strings/brazillian_replacement.json
+++ b/strings/brazillian_replacement.json
@@ -1,21 +1,85 @@
 {
-	"full": {
-		"hiss": "hhissssssssssssss"
-	},
-	"start": {
-
-	},
-	"end": {
-		"ish": "ishh"
-	},
-	"multiword": {
-
-	},
-	"syllable": {
-		"th": "thh",
-		"sh": "shh",
-		"h": "hh",
-		"s": "sss",
-		"y": "yhh"
+    "full": {
+		"hello": "olá",
+		"hi": "oi",
+		"hey": "ei",
+		"goodbye": [
+			"adeus",
+			"fique bem",
+			"fique com deus"
+		],
+		"bye": [
+			"tchau",
+			"até mais"
+		],
+		"I am": "Eu sou",
+		"I'm": "Eu sou",
+		"I": "Eu",
+		"please": "por favor",
+		"thankful": "grato",
+		"thanks": "obrigado",
+		"thank": "obrigado",
+		"love": "amor",
+		"beautiful": "bonito",
+		"god": "deus",
+		"bad": "ruim",
+		"good": "bom",
+		"great": "ótimo",
+		"cool": "legal",
+		"morning": "manhã",
+		"afternoon": "tarde",
+		"evening": "tarde",
+		"night": "noite",
+		"nite": "noite",
+		"day": "dia",
+		"dae": "dia",
+		"friend": "amigo",
+		"shit": "bosta",
+		"black": "negro",
+		"stupid": "estúpido",
+		"idiot": "idiota",
+		"ghetto": "favela",
+		"what": "que",
+        "what's": "qual é",
+        "who's": "quem é",
+		"haha": "huehue",
+		"awesome": "incrível",
+		"happy": "feliz",
+		"sad": "triste ",
+		"small": "pequeno",
+		"little": "pequeno",
+		"large": "grande",
+		"big": "grande",
+		"powerful": "poderoso",
+		"power": "poder",
+		"holy": "divino",
+		"beggar": "mendigo",
+		"cunt": "buceta",
+		"pussy": "buceta",
+		"retard": "retardado",
+		"nimrod": "retardado",
+		"asshole": "cuzão",
+		"young": "jovem",
+		"old": "velho",
+		"mother": "mãe",
+		"father": "pai",
+		"house": "casa",
+		"dick": "caralho",
+		"boss": "chefe",
+		"yes": "sim",
+		"no": "não",
+		"my ": "meu",
+		"you're": "você é",
+		"your": "seu",
+		"you": "você",
+		"is": "é",
+		"of": "de",
+		"and": "e",
+		"in": "em",
+		"the": "o",
+		"shi": "chee",
+		"thi": "thee",
+		"sh": "ch",
+		"ish": "eesh"
 	}
 }

--- a/strings/brazillian_replacement.json
+++ b/strings/brazillian_replacement.json
@@ -77,12 +77,14 @@
 		"and": "e",
 		"in": "em",
 		"the": "o",
-		"shi": "chee",
-		"thi": "thee",
-		"sh": "ch",
-		"ish": "eesh"
 	},
 	"multiword": {
 		"who are you": "quem é você"
-	}
+	},
+	"syllable": {
+        "shi": "chee",
+		"thi": "thee",
+		"sh": "ch",
+		"ish": "eesh"
+    }
 }

--- a/strings/brazillian_replacement.json
+++ b/strings/brazillian_replacement.json
@@ -76,7 +76,7 @@
 		"of": "de",
 		"and": "e",
 		"in": "em",
-		"the": "o",
+		"the": "o"
 	},
 	"multiword": {
 		"who are you": "quem é você"

--- a/strings/brazillian_replacement.json
+++ b/strings/brazillian_replacement.json
@@ -80,7 +80,9 @@
 		"shi": "chee",
 		"thi": "thee",
 		"sh": "ch",
-		"ish": "eesh",
+		"ish": "eesh"
+	},
+	"multiword": {
 		"who are you": "quem é você"
 	}
 }

--- a/strings/brazillian_replacement.json
+++ b/strings/brazillian_replacement.json
@@ -68,7 +68,7 @@
 		"boss": "chefe",
 		"yes": "sim",
 		"no": "não",
-		"my ": "meu",
+		"my": "meu",
 		"you're": "você é",
 		"your": "seu",
 		"you": "você",
@@ -80,6 +80,7 @@
 		"shi": "chee",
 		"thi": "thee",
 		"sh": "ch",
-		"ish": "eesh"
+		"ish": "eesh",
+		"who are you": "quem é você"
 	}
 }


### PR DESCRIPTION
## About The Pull Request

Brings lizard accent back to portuguese

## Testing Evidence

<img width="672" height="333" alt="image" src="https://github.com/user-attachments/assets/02736a37-915f-4db0-bfd2-35388eacf6ea" />

<img width="214" height="217" alt="image" src="https://github.com/user-attachments/assets/dca1ff2e-3da8-4209-bd90-7be8c2cec927" />


## Why It's Good For The Game

Having more unique accents are better than having two of the same accent slightly different
Theres a hissy accent to add more ssss' to when people sssssssay a word with an sssss
As it previously was lizard accent was the same has hissssssssy accent but with like 1 less s.

## Changelog

:cl:
qol: Reverts lizard accent back to RW 1.0 lizard accent
/:cl: