### PR TITLE
Chestjak

### DIFF
--- a/code/game/objects/structures/crates_lockers/roguetown.dm
+++ b/code/game/objects/structures/crates_lockers/roguetown.dm
@@ -12,7 +12,7 @@
 	sellprice = 1
 	max_integrity = 200
 	blade_dulling = DULLING_BASHCHOP
-	mob_storage_capacity = 1
+	mob_storage_capacity = 2
 	allow_dense = FALSE
 
 /obj/structure/closet/crate/chest/gold


### PR DESCRIPTION
## About The Pull Request
- Does the most incredibly OP chest buff in history and increases its mob container amount to 2.

## Testing Evidence
Literally a single number change.
<img width="195" height="251" alt="chest" src="https://github.com/user-attachments/assets/7b9bc174-451a-4cc5-b4ef-f900b235fcf4" />

## Why It's Good For The Game
Closets could already do this. I feel like this just fixes an oversight. Please tell me how this could possibly be a negative to gameplay.

Anyway, I wanted to ERP in a chest the other day and couldn't even close the lid. This bumps it to 2 so someone can actually do such a thing if one wanted to. Chests already inherited rough sexcon rocking mechanics like beds and closets do too so it's just sovlfvl to allow them to make use of it with a higher body count.

## Changelog
:cl:
qol: Allows sex in chests by bumping their mob storage to 2 instead of 1.
/:cl: