### PR TITLE
Adds a loadout papakha thats allowed in helmets.

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -84,6 +84,17 @@
 	cold_protection = HEAD
 	min_cold_protection_temperature = 50
 
+/obj/item/clothing/head/roguetown/loadoutpapakha
+	name = "Soft-sided papakha"
+	icon_state = "papakha"
+	item_state = "papakha"
+	resistance_flags = FIRE_PROOF //doesnt spawn, only a cosmetic loadout item. Keep the swag.
+	nudist_approved = TRUE
+	salvage_result = /obj/item/natural/fur
+	salvage_amount = 1
+	cold_protection = HEAD
+	min_cold_protection_temperature = 50
+
 /obj/item/clothing/head/roguetown/hatblu
 	name = "fur hat"
 	desc = "A blue hat lined with fur."
@@ -611,4 +622,5 @@
 	color = "#262927"
 	detail_color = "#FFFFFF"
 	altdetail_color = "#9c2525"
-	
+
+

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -343,6 +343,10 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	name = "Capless Grenzelhoft Hat"
 	path = /obj/item/clothing/head/roguetown/caplessgrenzelhofthat
 
+/datum/loadout_item/loadoutpapakha
+	name = "Soft-sided papakha"
+	path = /obj/item/clothing/head/roguetown/loadoutpapakha
+
 //CLOAKS
 /datum/loadout_item/tabard
 	name = "Tabard"


### PR DESCRIPTION

## About The Pull Request

See Title.

Just essentially a loadout only for layering papakha

## Testing Evidence

<img width="1917" height="916" alt="image" src="https://github.com/user-attachments/assets/0b9ec4dc-cf24-44b2-acd8-fd73b99c2f5a" />

## Why It's Good For The Game

Adds a papakha thats in the loadout similar to the capless Grenz hat

## Changelog

:cl:
add: Adds loadout helmet layerable Papakha
/:cl:
