### PR TITLE
Fixes hear_barks pref behavior

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -741,7 +741,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["bark_speed"] >> bark_speed
 	S["bark_pitch"] >> bark_pitch
 	S["bark_variance"] >> bark_variance
-	hear_barks = TRUE
+	S["hear_barks"] >> hear_barks
 
 	if(!(bark_id in GLOB.bark_list))
 		bark_id = pick(GLOB.bark_random_list)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -587,7 +587,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		for(var/i in 1 to barks)
 			if(total_delay > BARK_MAX_TIME)
 				break
-			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, bark), listening, message_range, (vocal_volume * (is_yell ? 1.5 : 1)), BARK_DO_VARY(vocal_pitch, vocal_pitch_range), vocal_current_bark), total_delay)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, bark), hears_barks, message_range, (vocal_volume * (is_yell ? 1.5 : 1)), BARK_DO_VARY(vocal_pitch, vocal_pitch_range), vocal_current_bark), total_delay)
 			total_delay += rand(DS2TICKS(vocal_speed / BARK_SPEED_BASELINE), DS2TICKS(vocal_speed / BARK_SPEED_BASELINE) + DS2TICKS((vocal_speed / BARK_SPEED_BASELINE) * (is_yell ? 0.5 : 1))) TICKS
 
 /mob/proc/binarycheck()


### PR DESCRIPTION
## About The Pull Request

1) ``addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, bark), blahblah)`` was passing the list with all mobs who heard the message, not all mobs with clients who have hear_barks = TRUE
2) ``_load_barks()`` was setting hear_barks to TRUE instead of reading the pref's value from a given savefile

## Testing Evidence

For a long while, I was thinking myself insane for hearing vocal barks with the setting set to false.

Github isn't allowing me to embed the video for reasons unknown, so here's gyazo link for you all.
https://i.gyazo.com/8bbb218af95ecaaf415d6c55c0a7b6dd.mp4

## Why It's Good For The Game

Bugs bad fixes good

## Changelog

:cl:
fix: Fixes Hear Vocal Bark save/load logic, removes the lack of inability to actually turn voice barks off
/:cl:

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
