### PR TITLE
probably fix cyclical grab loops crashing the server

### DIFF
--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -190,25 +190,29 @@
 			if(C.canZMove(UP, turf_above))
 				var/athletics_skill = max(C.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 				var/stamina_cost_final = round((10 - athletics_skill), 1)
-				var/mob/living/carbon/human/pulling = C.pulling
+				var/atom/movable/pulling = C.pulling
 				var/time_taken = 1.5 SECONDS
 				if(ismob(pulling))
 					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
 					time_taken *= 2
 				if(do_after(C, time_taken))
-					if(ismob(C.pulling))
-						ADD_TRAIT(C.pulling, TRAIT_PREVENT_Z_FALL, "z_transition") // This is given to prevent them falling before we can regrab
-						C.pulling.forceMove(turf_above)
+					if(QDELETED(pulling) || C.pulling != pulling) // our grab could have been broken or the grabbed deleted while taking off
+						pulling = null
+					if(ismob(pulling))
+						ADD_TRAIT(pulling, TRAIT_PREVENT_Z_FALL, "z_transition") // This is given to prevent them falling before we can regrab
+						pulling.forceMove(turf_above)
 					C.forceMove(turf_above)
 					for(var/mob/buckled_living as anything in C.buckled_mobs)
 						buckled_living.forceMove(turf_above)
-					C.start_pulling(pulling, state = 1, supress_message = TRUE)
-					if(C.pulling)
-						C.buckle_mob(pulling, TRUE, TRUE, FALSE, 0, 0)
-						var/obj/item/grabbing/I = C.get_inactive_held_item()
-						if(istype(I, /obj/item/grabbing/))
-							I.icon_state = null
-						REMOVE_TRAIT(C.pulling, TRAIT_PREVENT_Z_FALL, "z_transition")
+					if(pulling)
+						C.start_pulling(pulling, state = 1, supress_message = TRUE)
+						if(C.pulling == pulling)
+							C.buckle_mob(pulling, TRUE, TRUE, FALSE, 0, 0)
+							var/obj/item/grabbing/I = C.get_inactive_held_item()
+							if(istype(I, /obj/item/grabbing/))
+								I.icon_state = null
+						if(ismob(pulling))
+							REMOVE_TRAIT(pulling, TRAIT_PREVENT_Z_FALL, "z_transition")
 					C.stamina_add(stamina_cost_final)
 					to_chat(C, span_notice("I fly upwards."))
 			else
@@ -245,25 +249,29 @@
 			if(C.canZMove(DOWN, turf_below))
 				var/athletics_skill = max(C.get_skill_level(/datum/skill/misc/athletics), SKILL_LEVEL_NOVICE)
 				var/stamina_cost_final = round((10 - athletics_skill), 1)
-				var/mob/living/carbon/human/pulling = C.pulling
+				var/atom/movable/pulling = C.pulling
 				var/time_taken = 1.5 SECONDS
 				if(ismob(pulling))
 					stamina_cost_final *= 2 //double our stamina cost if we're pulling someone with us
 					time_taken *= 2
 				if(do_after(C, time_taken))
-					if(ismob(C.pulling))
-						ADD_TRAIT(C.pulling, TRAIT_PREVENT_Z_FALL, "z_transition") // This is given to prevent them falling before we can regrab
-						C.pulling.forceMove(turf_below)
+					if(QDELETED(pulling) || C.pulling != pulling) // our grab could have been broken or the grabbed deleted while taking off
+						pulling = null
+					if(ismob(pulling))
+						ADD_TRAIT(pulling, TRAIT_PREVENT_Z_FALL, "z_transition") // This is given to prevent them falling before we can regrab
+						pulling.forceMove(turf_below)
 					C.forceMove(turf_below)
 					for(var/mob/buckled_living as anything in C.buckled_mobs)
 						buckled_living.forceMove(turf_below)
-					C.start_pulling(pulling, state = 1, supress_message = TRUE)
-					if(C.pulling)
-						C.buckle_mob(pulling, TRUE, TRUE, FALSE, 0, 0)
-						var/obj/item/grabbing/I = C.get_inactive_held_item()
-						if(istype(I, /obj/item/grabbing/))
-							I.icon_state = null
-						REMOVE_TRAIT(C.pulling, TRAIT_PREVENT_Z_FALL, "z_transition")
+					if(pulling)
+						C.start_pulling(pulling, state = 1, supress_message = TRUE)
+						if(C.pulling == pulling)
+							C.buckle_mob(pulling, TRUE, TRUE, FALSE, 0, 0)
+							var/obj/item/grabbing/I = C.get_inactive_held_item()
+							if(istype(I, /obj/item/grabbing/))
+								I.icon_state = null
+						if(ismob(pulling))
+							REMOVE_TRAIT(pulling, TRAIT_PREVENT_Z_FALL, "z_transition")
 					C.stamina_add(stamina_cost_final)
 					to_chat(C, span_notice("I fly downwards."))
 			else

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -142,6 +142,8 @@
 		L.stamina_add(stamina_cost)
 	L.forceMove(newtarg)
 	if(pulling)
+		/// Grab chains can loop back on themselves (A grabs B while B grabs A), ensure we only grab along olong each mob only once
+		var/list/atom/movable/already_dragged = list(L, pulling)
 		L.stop_pulling()
 		pulling.forceMove(newtarg)
 		L.start_pulling(pulling, supress_message = TRUE)
@@ -149,18 +151,16 @@
 			L.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)
 		if(isliving(pulling))
 			var/mob/living/P = pulling
-			while(P.pulling && isliving(P.pulling))
-				was_pulled_buckled = FALSE
-				pulling = P.pulling
-				if(pulling in P.buckled_mobs)
-					was_pulled_buckled = TRUE
+			while(isliving(P.pulling) && !(P.pulling in already_dragged))
+				var/mob/living/next_pulled = P.pulling
+				was_pulled_buckled = (next_pulled in P.buckled_mobs)
+				already_dragged += next_pulled
 				P.stop_pulling()
-				pulling.forceMove(newtarg)
-				P.start_pulling(pulling, supress_message = TRUE)
+				next_pulled.forceMove(newtarg)
+				P.start_pulling(next_pulled, supress_message = TRUE)
 				if(was_pulled_buckled) // Assume this was a fireman carry since piggybacking is not a thing
-					P.buckle_mob(pulling, TRUE, TRUE, 90, 0, 0)
-				if(isliving(pulling))
-					P = pulling
+					P.buckle_mob(next_pulled, TRUE, TRUE, 90, 0, 0)
+				P = next_pulled
 
 /obj/structure/stairs/dark
 	icon_state = "desc"//visual change for dark basements and tight quarters
@@ -180,7 +180,7 @@
 	name = "curved stairs"
 	icon = 'icons/obj/stairscurve.dmi'
 	icon_state = "woodCCW"
-	
+
 /obj/structure/stairs/ccwdown
 	icon = 'icons/obj/stairscurve.dmi'
 	icon_state = "woodCCWdown"

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -142,7 +142,7 @@
 		L.stamina_add(stamina_cost)
 	L.forceMove(newtarg)
 	if(pulling)
-		/// Grab chains can loop back on themselves (A grabs B while B grabs A), ensure we only grab along olong each mob only once
+		/// Grab chains can loop back on themselves (A grabs B while B grabs A), ensure we only grab each mob along only once
 		var/list/atom/movable/already_dragged = list(L, pulling)
 		L.stop_pulling()
 		pulling.forceMove(newtarg)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -976,6 +976,8 @@ GLOBAL_VAR_INIT(mobids, 1)
 /mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)
 	if(M.buckled)
 		return 0
+	if(buckled == M) // mutual buckling makes every Move() recurse between the two of us until the server dies
+		return 0
 	var/turf/T = get_turf(src)
 	if(M.loc != T)
 		var/old_density = density


### PR DESCRIPTION
## About The Pull Request
fix cyclical grab loops crashing the server, check for buckling, potential fix for z fall trait staying forever
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
kinda hard to test this.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
crash bad
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: probably fix cyclical grab loops crashing the server
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
