### PR TITLE
AI Fix

### DIFF
--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -184,7 +184,7 @@
 	if(I)
 		if(I.associated_skill)
 			ourskill = user.get_skill_level(I.associated_skill)
-		if(L.mind)
+		if(L.skills)
 			I = L.get_active_held_item()
 			if(I?.associated_skill)
 				theirskill = L.get_skill_level(I.associated_skill)

--- a/code/game/objects/items/rogueweapons/rmb_intents.dm
+++ b/code/game/objects/items/rogueweapons/rmb_intents.dm
@@ -122,8 +122,6 @@
 		return
 	if(user.incapacitated())
 		return
-	if(!user.mind)
-		return
 	if(user.has_status_effect(/datum/status_effect/debuff/specialcd))
 		return
 
@@ -160,8 +158,6 @@
 	if(!user)
 		return
 	if(user.incapacitated())
-		return
-	if(!user.mind)
 		return
 	if(user.has_status_effect(/datum/status_effect/debuff/feintcd))
 		return

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -888,14 +888,14 @@
 				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
 
 			if(special_attacker && prob(50) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
-				if(length(weapon_special_intents) > 1)
+				if(length(weapon_special_intents) >= 1)
 					if(possible_rmb_intents & /datum/rmb_intent/strong)
 						swap_rmb_intent(/datum/rmb_intent/strong)
 						try_special_attack(target)
 						return TRUE //We used our special intent on the target as soon as we could.
 
 			if(smart_combatant && prob(50)) // Only if we use rmb intents...
-				if(length(possible_rmb_intents) > 1)
+				if(length(possible_rmb_intents) >= 1)
 					if(!has_status_effect(/datum/status_effect/debuff/feintcd))
 						if(possible_rmb_intents & /datum/rmb_intent/feint && rmb_intent != /datum/rmb_intent/feint && prob(50))
 							swap_rmb_intent(/datum/rmb_intent/feint)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -888,14 +888,14 @@
 				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
 
 			if(special_attacker && prob(50) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
-				if(length(weapon_special_intents) >= 1)
+				if(weapon_special_intents)
 					if(possible_rmb_intents & /datum/rmb_intent/strong)
 						swap_rmb_intent(/datum/rmb_intent/strong)
 						try_special_attack(target)
 						return TRUE //We used our special intent on the target as soon as we could.
 
 			if(smart_combatant && prob(50)) // Only if we use rmb intents...
-				if(length(possible_rmb_intents) >= 1)
+				if(possible_rmb_intents)
 					if(!has_status_effect(/datum/status_effect/debuff/feintcd))
 						if(possible_rmb_intents & /datum/rmb_intent/feint && rmb_intent != /datum/rmb_intent/feint && prob(50))
 							swap_rmb_intent(/datum/rmb_intent/feint)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -56,7 +56,13 @@
 	///our current cell grid
 	var/datum/cell_tracker/our_cells
 
-/mob/living/carbon/human/Initialize(mapload)
+	//If we utilize special attacks or not; All is handled within do_best_melee_attack() chain.
+	var/special_attacker = FALSE
+
+	//If we utilize our intents further outside of strong intent.
+	var/smart_combatant = FALSE
+
+/mob/living/carbon/human/Initialize()
 	. = ..()
 	our_cells = new(interesting_dist, interesting_dist, 1)
 	set_new_cells()
@@ -830,6 +836,15 @@
 	Weapon = get_active_held_item()
 	OffWeapon = get_inactive_held_item()
 
+	//Feint Riposte check before we do any further attacks to teach our enemy a lesson.
+	if(smart_combatant && istype(Weapon, /obj/item/rogueweapon)) //Make sure we have a proper weapon in hand. No feinting with a stick or some shit.
+		if(!has_status_effect(/datum/status_effect/debuff/feintcd) && target.has_status_effect(/datum/status_effect/buff/clash))
+			if(possible_rmb_intents & /datum/rmb_intent/feint)
+				swap_rmb_intent(/datum/rmb_intent/feint)
+				if(Adjacent(target))
+					try_special_attack(target)
+					return TRUE //Attempt to feint and ruin their clash...
+
 	// What is the chance we try to grab with our offhand?
 	var/make_grab_chance = Weapon ? 5 : 20 // If unarmed, 20% chance; otherwise 5%
 	var/use_grab_chance = 30 // 30% chance to use a grab if we already have one
@@ -859,7 +874,46 @@
 			// todo: decide to drop the offhand maybe?
 			if(!OffWeapon) // wield it!
 				Weapon.attack_self(src)
-		rog_intent_change(1)
+
+		//Lets spice things up.
+		var/did_we_change_intent = FALSE
+		if(istype(Weapon, /obj/item/rogueweapon))
+			var/obj/item/rogueweapon/actual_weapon = Weapon
+			var/weapon_intents = actual_weapon.possible_item_intents
+			var/weapon_special_intents = actual_weapon.special
+			
+			if(length(weapon_intents) > 1 && !has_status_effect(/datum/status_effect/debuff/swapped_intent_npc))
+				did_we_change_intent = TRUE
+				rog_intent_change(rand(1, length(weapon_intents))) 
+				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
+
+			if(special_attacker && prob(50) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
+				if(length(weapon_special_intents) > 1)
+					if(possible_rmb_intents & /datum/rmb_intent/strong)
+						swap_rmb_intent(/datum/rmb_intent/strong)
+						try_special_attack(target)
+						return TRUE //We used our special intent on the target as soon as we could.
+
+			if(smart_combatant && prob(50)) // Only if we use rmb intents...
+				if(length(possible_rmb_intents) > 1)
+					if(!has_status_effect(/datum/status_effect/debuff/feintcd))
+						if(possible_rmb_intents & /datum/rmb_intent/feint && rmb_intent != /datum/rmb_intent/feint && prob(50))
+							swap_rmb_intent(/datum/rmb_intent/feint)
+							try_special_attack(target)
+							return TRUE
+					else if(!has_status_effect(/datum/status_effect/debuff/clashcd))
+						if(possible_rmb_intents & /datum/rmb_intent/riposte && rmb_intent != /datum/rmb_intent/riposte && prob(50))
+							swap_rmb_intent(/datum/rmb_intent/riposte)
+							try_special_attack(target)
+							return TRUE
+					else if(!has_status_effect(/datum/status_effect/debuff/baitcd)) //May work sometimes; more than likely it wont however.
+						if(possible_rmb_intents & /datum/rmb_intent/aimed && rmb_intent != /datum/rmb_intent/aimed) //Default to aimed as the final choice to attempt baiting.
+							swap_rmb_intent(/datum/rmb_intent/aimed)
+							try_special_attack(target)
+							return TRUE
+
+		if(!did_we_change_intent) //Always default regardless.
+			rog_intent_change(1)
 		used_intent = a_intent
 		Weapon.melee_attack_chain(src, victim)
 		// attackby and attack_obj handles cooldowns already
@@ -910,6 +964,8 @@
 /mob/living/carbon/human/proc/monkey_attack(mob/living/L)
 	if(next_move > world.time)
 		return FALSE // no time to attack this turn!
+	if(has_status_effect(/datum/status_effect/buff/clash))
+		return FALSE //We're clashing right now! Don't fuck us up! Also give the player a chance to respond with a feint.
 
 	npc_choose_attack_zone(L)
 	NPC_THINK("Aiming for \the [zone_selected]!")
@@ -1042,3 +1098,15 @@
 	. = ..()
 	if(mode != NPC_AI_OFF)
 		update_grid()
+
+//NPC SPECIFIC DEBUFF FOR INTENT HANDLING, DO NOT USE ANYWHERE ELSE.
+/datum/status_effect/debuff/swapped_intent_npc
+	id = "swapped_intent_npc"
+	alert_type = /atom/movable/screen/alert/status_effect/debuff/swapped_intent_npc
+	duration = 10 SECONDS
+	status_type = STATUS_EFFECT_UNIQUE
+
+/atom/movable/screen/alert/status_effect/debuff/swapped_intent_npc
+	name = "Swapped Intent Cooldown (NPC)"
+	desc = "I swapped my weapon intent, I must wait before I can do it again."
+	icon_state = "strikecd"

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -62,7 +62,7 @@
 	//If we utilize our intents further outside of strong intent.
 	var/smart_combatant = FALSE
 
-/mob/living/carbon/human/Initialize()
+/mob/living/carbon/human/Initialize(mapload)
 	. = ..()
 	our_cells = new(interesting_dist, interesting_dist, 1)
 	set_new_cells()

--- a/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
+++ b/code/modules/mob/living/carbon/human/npc/deranged_knight.dm
@@ -30,6 +30,10 @@ GLOBAL_LIST_INIT(hedgeknight_aggro, world.file2list("strings/rt/hedgeknightaggro
 	var/forced_preset = "" // If set, force a specific preset instead of randomizing.
 	var/never_goon = FALSE // If TRUE, this DK will not spawn goons on creation.
 
+	//We are the biggest and baddest for boss fights... We're smart, and well trained.
+	smart_combatant = TRUE
+	special_attacker = TRUE
+
 /mob/living/carbon/human/species/human/northern/deranged_knight/retaliate(mob/living/L)
 	var/newtarg = target
 	.=..()

--- a/code/modules/mob/living/carbon/human/npc/drow.dm
+++ b/code/modules/mob/living/carbon/human/npc/drow.dm
@@ -11,6 +11,9 @@ GLOBAL_LIST_INIT(drowraider_aggro, world.file2list("strings/rt/drowaggrolines.tx
 	possible_rmb_intents = list()
 	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 
+	//Whilst smart, they prefer to not take risks and instead will utilize their weapons for special means of attack.
+	special_attacker = TRUE
+
 /mob/living/carbon/human/species/elf/dark/drowraider/ambush
 	aggressive = 1
 	mode = NPC_AI_IDLE

--- a/code/modules/mob/living/carbon/human/npc/lizardmen_dungeon.dm
+++ b/code/modules/mob/living/carbon/human/npc/lizardmen_dungeon.dm
@@ -5,6 +5,8 @@
 	aggressive=1
 	rude = TRUE
 	mode = NPC_AI_IDLE
+	smart_combatant = TRUE
+	special_attacker = TRUE
 	faction = list("psy_vault_guard")
 	ambushable = FALSE
 	cmode = 1

--- a/code/modules/mob/living/carbon/human/npc/orc/orc.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/orc.dm
@@ -26,6 +26,7 @@
 	mode = NPC_AI_IDLE
 	wander = FALSE
 	cmode_music = FALSE
+	special_attacker = TRUE
 
 /mob/living/carbon/human/species/orc/npc/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/npc/searaider.dm
+++ b/code/modules/mob/living/carbon/human/npc/searaider.dm
@@ -11,6 +11,9 @@ GLOBAL_LIST_INIT(searaider_aggro, world.file2list("strings/rt/searaideraggroline
 	possible_rmb_intents = list()
 	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 
+	//Trained, but like Drow, only utilize special attacks. They're VIKING! POWER IS THEIR STRONGSUIT!
+	special_attacker = TRUE
+
 
 /mob/living/carbon/human/species/human/northern/searaider/ambush
 	aggressive=1

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_lich.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_lich.dm
@@ -2,6 +2,10 @@
 	skel_fragile = FALSE
 	skel_outfit = /datum/outfit/job/roguetown/npc/skeleton/dungeon/lich
 
+	//We're a BOSS. We are SMART and SPECIAL.
+	smart_combatant = TRUE
+	special_attacker = TRUE
+
 /datum/outfit/job/roguetown/npc/skeleton/dungeon/lich/pre_equip(mob/living/carbon/human/H)
 	..()
 	wrists = /obj/item/clothing/wrists/roguetown/bracers

--- a/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits_skills_only.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/skeleton_outfits_skills_only.dm
@@ -22,6 +22,9 @@
 	H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
 
+	//Medium Skills, smart.
+	H.smart_combatant = TRUE
+
 /mob/living/carbon/human/species/skeleton/npc/hard/noequip
 	skel_outfit = /datum/outfit/job/roguetown/skeleton/npc/hard_skills_only
 
@@ -42,3 +45,7 @@
 	H.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/swimming, 3, TRUE)
 	H.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+
+	//Hard skills. Capable of a LOT.
+	H.smart_combatant = TRUE
+	H.special_attacker = TRUE

--- a/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/bog_deserters.dm
@@ -91,6 +91,9 @@
 	aggressive=1
 	rude = TRUE
 	mode = NPC_AI_IDLE
+	//Well trained soldiers.
+	smart_combatant = TRUE
+	special_attacker = TRUE
 	faction = list("viking", "station")
 	ambushable = FALSE
 	cmode = 1

--- a/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/highwayman.dm
@@ -12,6 +12,9 @@ GLOBAL_LIST_INIT(highwayman_aggro, world.file2list("strings/rt/highwaymanaggroli
 	possible_rmb_intents = list()
 	var/is_silent = FALSE /// Determines whether or not we will scream our funny lines at people.
 
+	//We're slightly smarter bandits than the peasant militia. 
+	smart_combatant = TRUE
+
 
 /mob/living/carbon/human/species/human/northern/highwayman/ambush
 	aggressive = 1

--- a/code/modules/mob/living/carbon/human/npc/soldiers/militia.dm
+++ b/code/modules/mob/living/carbon/human/npc/soldiers/militia.dm
@@ -11,6 +11,9 @@
 	possible_rmb_intents = list()
 	var/is_silent = TRUE /// Determines whether or not we will scream our funny lines at people.
 
+	//They'll try and use special attacks but more than likely fail in using them. These are peasants, after all. Unlike Highwaymen, which are more organized and can at least try smart attacks.
+	special_attacker = TRUE
+
 /* /mob/living/carbon/human/species/human/northern/militia/retaliate(mob/living/L)
 	var/newtarg = target
 	.=..()

--- a/code/modules/mob/living/carbon/human/npc/thief.dm
+++ b/code/modules/mob/living/carbon/human/npc/thief.dm
@@ -10,6 +10,9 @@
 	aggressive= TRUE
 	wander = TRUE
 
+	//Thieves, often smart and slippery.
+	smart_combatant = TRUE
+
 /mob/living/carbon/human/species/human/northern/thief/retaliate(mob/living/L)
 	.=..()
 	if(m_intent == MOVE_INTENT_SNEAK)


### PR DESCRIPTION
## About The Pull Request

This is a combination of pulls done by Posshum.

It adds two new booleans to some mobs making them utilize special attacks or rmb attacks.
These two
```dm
	//If we utilize special attacks or not; All is handled within do_best_melee_attack() chain.
	var/special_attacker = FALSE
	//If we utilize our intents further outside of strong intent.
	var/smart_combatant = FALSE
``` 

I have some concerns if RW has additional mobs which CC doesn't. Those might break.
Though this should prevent that
```dm
		if(!did_we_change_intent) //Always default regardless.
			rog_intent_change(1)
``` 
If they do break spreading vars on them too should fix the issue.

I also have some concerns about this.
```dm
/mob/living/carbon/human/Initialize()
``` 
In RW it is usually written as Initialize(mapload). It might break mobs with new vars.

## Testing Evidence

I've taken a couple of vids just poking deranged knights in the face. They supposed to be smart and special.
No idea if it counts as evidence. I don't play the game.

https://github.com/user-attachments/assets/eb0b5624-1c64-4f0e-ab50-c9bccd62c343

https://github.com/user-attachments/assets/30c15f6d-9a57-41e0-a28b-31d558844269

## Why It's Good For The Game

People asked for it or so I heard. Smarter enemies are generally good. It makes combat with NPCs (hopefully) less trivial.

## Changelog

:cl:
add: Added 2 new booleans to manage AI behaviour
add: NPCs recieve a set of new actions they could take based on their designated behaviour.
balance: The following NPCs are now considered smart combatants: skeleton liches, skeleton soldiers, skeleton dreadnoughts, bog deserters, highwaymen, deranged knights, dungeon lizardmen, thieves.
balance: The following NPCs are now considered special attackers: militia, bog deserters, skeleton dreadnoughts, skeleton liches, orcs, sea raiders, dungeon lizardmen, drow, deranged knights.
:cl:
