### PR TITLE
Heretic seer QOL

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -96,6 +96,10 @@
 		. += span_info("This is <EM>[name]</EM>.")
 	else if(obscure_name)
 		. += span_info("This is an unknown <EM>[name]</EM>.")
+		if(HAS_TRAIT(user, TRAIT_HERETIC_SEER))
+			var/heretic_text = get_heretic_text(user)
+			if(heretic_text)
+				. += span_notice(heretic_text)
 	else
 		on_examine_face(user)
 		var/used_name = name


### PR DESCRIPTION
## About The Pull Request
Heretic seer (the trait that only anti pope has) can now see inhume patrons even if someone face is obscured
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="639" height="93" alt="Zrzut ekranu 2026-07-28 044207" src="https://github.com/user-attachments/assets/1fd3cf2e-f808-419a-8607-6d985254a343" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I played the Heresiath recently and i realized how hard it is to be a proper priest for all heretics when 90% of them walk around in facemasks with stop your "see all heretics" trait from working. Now you can pick out other ascendant worshipers from crowd instead of hoping that you see one of the very few without masks

I don't really see how it would be abusable as the only role that has that trait is the one with is spiritual leader for all ascendants and as such shouldn't be trying to screw them over.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Antipope sight is no longer stopped by mere mortal masks (he can see other heretics even if their faces are covered)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
