### PR TITLE
Janissary Jezail fixes + zybantine/janissary boot armor buff

### DIFF
--- a/modular_deserttown/desertclothing.dm
+++ b/modular_deserttown/desertclothing.dm
@@ -742,7 +742,7 @@
 	color = "#d4c7bf"
 	armor = ARMOR_LEATHER_GOOD
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT, BCLASS_TWIST)	//Same as gloves
-	max_integrity = 100			//Half that of iron boots
+	max_integrity = ARMOR_INT_SIDE_HARDLEATHER
 
 	
 /obj/item/clothing/shoes/roguetown/boots/armor/shalal

--- a/modular_deserttown/jobs/garrison/janissary/jezail.dm
+++ b/modular_deserttown/jobs/garrison/janissary/jezail.dm
@@ -14,7 +14,7 @@
 		STATKEY_WIL = 2,
 		STATKEY_INT = 1,
 	)
-	traits_applied = list(TRAIT_DODGEEXPERT)
+	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_FUSILIER)
 
 	subclass_skills = list(
 		/datum/skill/combat/firearms = 5,//Your entire point is GUN.
@@ -41,7 +41,7 @@
 	pants = /obj/item/clothing/under/roguetown/splintlegs
 	wrists = /obj/item/clothing/wrists/roguetown/splintarms
 	gloves = /obj/item/clothing/gloves/roguetown/fingerless_leather
-	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/janissary
+	armor = /obj/item/clothing/suit/roguetown/armor/leather/heavy/coat/zyb
 	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/zyb
 	head = /obj/item/clothing/head/roguetown/helmet/janissaryhelm
 	beltr = /obj/item/quiver/bullet/lead//nice to have variety but blunderbus might not fit the vibe


### PR DESCRIPTION
## About The Pull Request
-> Gives the Janissary Jezail sub-class the fusilier trait, seeing as they're a gun-wielding class with master in firearms. Shouldn't affect much but it's good to keep the standard intact (since classes like the Warden master/azeb agha get it for their respective gun)
-> Gives Janissary Jezail the same light armor that their skirmisher equivilient gets, seeing as they have dodge expert. If they wanna swap out they can get some of the spare medium armor in the armory.
-> Buffs the funny babouche boots that the janissarys get to match heavy leather boots. 
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
https://i.gyazo.com/6ff2ba07c34a5bd378f0f33dc9f657b6.png
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
These seem like oversights. They're a gun guy they should get the gun trait. As for the armor, they're dodge experts. Why give them the trait only to start them with medium armor? Eh.

As for the boots, this just brings them up to the new standard for heavy leather boots and their equivilients. Which this boot is.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Janissary Jezail sub-class now has the fusilier trait.
balance: Janissary Jezail sub-class now starts with light armor instead of janissary medium maille.
balance: Fine babouche now matches the integrity value of heavy leather boots.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
