### PR TITLE
Add moff features to wildkins

### DIFF
--- a/code/modules/client/customizer/customizers/organ/eyes.dm
+++ b/code/modules/client/customizer/customizers/organ/eyes.dm
@@ -70,7 +70,10 @@
 	var/second_color = "#111111"
 
 /datum/customizer/organ/eyes/humanoid
-	customizer_choices = list(/datum/customizer_choice/organ/eyes/humanoid)
+	customizer_choices = list(
+		/datum/customizer_choice/organ/eyes/humanoid,
+		/datum/customizer_choice/organ/eyes/moth,
+		)
 	default_choice = /datum/customizer_choice/organ/eyes/humanoid
 
 /datum/customizer_choice/organ/eyes/humanoid
@@ -80,4 +83,5 @@
 	default_choice = /datum/customizer_choice/organ/eyes/moth
 
 /datum/customizer_choice/organ/eyes/moth
+	name = "Fluvian Eyes"
 	organ_type = /obj/item/organ/eyes/moth

--- a/code/modules/client/customizer/customizers/organ/neck_feature.dm
+++ b/code/modules/client/customizer/customizers/organ/neck_feature.dm
@@ -45,6 +45,7 @@
 	default_disabled = TRUE
 	customizer_choices = list(
 		/datum/customizer_choice/organ/neck_feature/anthro_fluff,
+		/datum/customizer_choice/organ/neck_feature/moth_fluff,
 		)
 
 /datum/customizer_choice/organ/neck_feature/anthro_fluff

--- a/code/modules/client/customizer/customizers/organ/wings.dm
+++ b/code/modules/client/customizer/customizers/organ/wings.dm
@@ -145,7 +145,10 @@
 			reset_accessory_colors(prefs, entry)
 
 /datum/customizer/organ/wings/anthro
-	customizer_choices = list(/datum/customizer_choice/organ/wings/anthro)
+	customizer_choices = list(
+		/datum/customizer_choice/organ/wings/anthro,
+		/datum/customizer_choice/organ/wings/moth,
+		)
 	allows_disabling = TRUE
 	default_disabled = TRUE
 

--- a/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/anthromorph.dm
@@ -29,7 +29,7 @@
 	"Goat-Kin", "Rous-Kin", "Possum-Kin", "Pig-Kin", "Boar-Kin", "Rabbit-Kin", "Cabbit-Kin", "Hare-Kin", "Horse-Kin",
 	"Donkey-Kin", "Hyena-Kin", "Deer-Kin", "Bear-Kin", "Panda-Kin", "Coyote-Kin", "Moose-Kin",
 	"Jackal-Kin", "Panther-Kin", "Lynx-Kin", "Leopard-Kin", "Monkey-Kin", "Bird-Kin", "Seal-Kin", "Frog-Kin",
-	"Bat-Kin", "Otter-Kin", "Cow-Kin", "Bull-Kin", "Bee-Kin", "Lizard-Kin", "Drakian-Kin", "Dragon-Kin", "Insect-Kin", "Spider-Kin", "Monster-Kin", "Chimera"
+	"Bat-Kin", "Otter-Kin", "Cow-Kin", "Bull-Kin", "Bee-Kin", "Lizard-Kin", "Drakian-Kin", "Dragon-Kin", "Insect-Kin", "Spider-Kin", "Monster-Kin", "Chimera", "Moth-Kin"
 	)
 
 	default_color = "444"
@@ -125,6 +125,7 @@
 		/datum/customizer/organ/horns/anthro,
 		/datum/customizer/organ/frills/anthro,
 		/datum/customizer/organ/wings/anthro,
+		/datum/customizer/organ/antennas/moth,
 		/datum/customizer/organ/neck_feature/anthro,
 		/datum/customizer/organ/testicles/anthro,
 		/datum/customizer/organ/penis/anthro,


### PR DESCRIPTION
## About The Pull Request
Moff (check changelog)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
So simple i tested and forgor to take pictures
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Moff
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Wild-Kin can now pick Fluvian (moth-kin) styles for their eyes, wings, and neck fluff alongside the usual options, and can grow Fluvian antennas.
cadd: Added Moth-Kin as a Wild-Kin race title.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
