### PR TITLE
[BOUNTY] add: readdition of the 'unsettling-beauty' vice - vol 2

### DIFF
--- a/code/__DEFINES/charflaws.dm
+++ b/code/__DEFINES/charflaws.dm
@@ -12,6 +12,7 @@
 		/datum/charflaw/leprosy,\
 		/datum/charflaw/scarred,\
 		/datum/charflaw/disfigured,\
+		/datum/charflaw/unsettling_beauty,\
 		/datum/charflaw/limbloss/arm_l,\
 		/datum/charflaw/limbloss/arm_r,\
 		/datum/charflaw/nudist,\

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -196,6 +196,7 @@
 #define TRAIT_BAD_MOOD "Bad Mood"
 #define TRAIT_NIGHT_OWL "Night Owl"
 #define TRAIT_BEAUTIFUL "Beautiful"
+#define TRAIT_UNSETTLING_BEAUTY "Unsettling Beauty"
 #define TRAIT_SCARRED "Scarred"
 #define TRAIT_SIMPLE_WOUNDS "simple_wounds"
 #define TRAIT_VAMP_DREAMS "vamp_dreams"

--- a/code/datums/character_flaw/_character_flaw.dm
+++ b/code/datums/character_flaw/_character_flaw.dm
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	"Wood Arm (L) (+1 TRI)"=/datum/charflaw/limbloss/arm_l,
 	"Wood Arm (R) (+1 TRI)"=/datum/charflaw/limbloss/arm_r,
 	"Hemophage (+1 TRI)"=/datum/charflaw/hemophage,
+	"Unsettling Beauty (-2 TRI)"=/datum/charflaw/unsettling_beauty,
 	"Feeble-bodied"=/datum/charflaw/weak,
 	"Frail"=/datum/charflaw/frail,
 	"Doddering"=/datum/charflaw/slow,
@@ -898,6 +899,24 @@ GLOBAL_LIST_INIT(character_flaws, list(
 	REMOVE_TRAIT(user, TRAIT_HEMOPHAGE, TRAIT_GENERIC)
 	REMOVE_TRAIT(user, TRAIT_VAMPBITE, TRAIT_GENERIC)
 
+
+
+/datum/charflaw/unsettling_beauty
+	name = "Unsettling Beauty"
+	desc = "My appearance is deeply unsettling to most. There's something profoundly wrong about my features that disturbs those who look upon me. Incompatible with Socialite virtue."
+
+/datum/charflaw/unsettling_beauty/on_mob_creation(mob/user)
+	..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		ADD_TRAIT(H, TRAIT_UNSETTLING_BEAUTY, TRAIT_GENERIC)
+		user.adjust_triumphs(-2)
+
+/datum/charflaw/unsettling_beauty/on_removal(mob/user)
+	..()
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		REMOVE_TRAIT(H, TRAIT_UNSETTLING_BEAUTY, TRAIT_GENERIC)
 
 /datum/charflaw/weak
 	name = "Feeble-bodied"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -15,6 +15,13 @@
 		if(HAS_TRAIT(user, TRAIT_XYLIX) && !user.has_status_effect(/datum/status_effect/buff/xylix_joy))
 			user.apply_status_effect(/datum/status_effect/buff/xylix_joy)
 			to_chat(user, span_info("Their beauty brings a smile to my face, and fortune to my steps!"))
+	if(HAS_TRAIT(src, TRAIT_UNSETTLING_BEAUTY) && user != src)
+		// 70% chance to give debuff, 30% chance to give buff
+		if(prob(70) && !user.has_stress_event(/datum/stressevent/uncanny))
+			user.add_stress(/datum/stressevent/uncanny)
+		else
+			if(!user.has_stress_event(/datum/stressevent/beautiful))
+				user.add_stress(/datum/stressevent/beautiful)
 	if(HAS_TRAIT(src, TRAIT_UNSEEMLY) && user != src)
 		if(!HAS_TRAIT(user, TRAIT_UNSEEMLY))
 			user.add_stress(/datum/stressevent/unseemly)
@@ -375,6 +382,24 @@
 					. += span_beautiful_fem("[capitalize(m2)] face is grotesquely disfigured, making [m2] unrecognizable.")
 				if (THEY_THEM, THEY_THEM_F, IT_ITS)
 					. += span_beautiful_nb("[capitalize(m2)] face is grotesquely disfigured, making [m2] unrecognizable.")
+
+		if (HAS_TRAIT(src, TRAIT_UNSETTLING_BEAUTY))
+			switch (pronouns)
+				if (HE_HIM, SHE_HER_M)
+					if(user.has_stress_event(/datum/stressevent/uncanny))
+						. += span_beautiful_masc("[m1] unsettlingly handsome... something is deeply wrong.")
+					else
+						. += span_beautiful_masc("[m1] hauntingly handsome.")
+				if (SHE_HER, HE_HIM_F)
+					if(user.has_stress_event(/datum/stressevent/uncanny))
+						. += span_beautiful_fem("[m1] unsettlingly beautiful... something is deeply wrong.")
+					else
+						. += span_beautiful_fem("[m1] hauntingly beautiful.")
+				if (THEY_THEM, THEY_THEM_F, IT_ITS)
+					if(user.has_stress_event(/datum/stressevent/uncanny))
+						. += span_beautiful_nb("[m1] unsettlingly attractive... something is deeply wrong.")
+					else
+						. += span_beautiful_nb("[m1] hauntingly attractive.")
 
 		// Shouldn't be able to tell they are unrevivable through a mask as a Necran
 		if(HAS_TRAIT(src, TRAIT_DNR) && src != user)


### PR DESCRIPTION
## About The Pull Request

This pull-request re-adds that 'unsettling beauty' vice at at -2 triumph cost. (-3) is for no flaws at all, and it feels like a super cool 're-addition' to the roster of vices that are already quite about here and there. Colorblind is the coolest of them all, but being beautiful in an unsettling way? sign me right back in coach and approve this PR!

> I had some conflict resolve, and github said -- "you'll merge the whole main to this....", and I fell for it-- and my ability to undo commits is too small, sooo. Here's a new PR for this. Sorry!


## Testing Evidence

<img width="396" height="118" alt="image" src="https://github.com/user-attachments/assets/c77ed777-7ea3-49cb-aa66-ad3e707f7913" />
<img width="316" height="156" alt="image" src="https://github.com/user-attachments/assets/2e2da045-f7f5-47e0-b3a2-575049a7bcdf" />

## Why It's Good For The Game

Why? Additional customization is never bad. -2 triumph cost makes it not 'free' like clingy, or then annoying face or even sadist if we go there. This would be further customization for the people who want to mechanically represent their characters beauty as not just out right classic beauty but something monster like and so on.

It gives mechanical representation to those "could kill you-- and will kill you"-beauties a vice to roll with. It has a 30% chance to give a anti-stress boon and a 70% chance to give negative stres . Hey? It isn't just another 'beautiful'!!.

## Changelog

🆑
add: re-adds the 'unsettling beauty' vice at a 2 triumph cost.
/:cl:
