### PR TITLE
Unapologetic maul buff

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -658,6 +658,7 @@
 	desc = "Forged from the legacy of dwarven rock-hammers, this maul’s holy steel and divine runes grant it immense power. \
 	Unwieldy to those weak of arm or faith, its mighty blows have the strength to shatter both stone and skull alike."
 	icon_state = "malumhammer"
+	is_silver = TRUE
 	minstr = 8//Handled by the unique interaction below. Inverted to start, since they spawn with it, and funny stuff can happen.
 
 /obj/item/rogueweapon/mace/maul/grand/malum/pickup(mob/living/user)
@@ -668,7 +669,7 @@
 	..()
 
 //This thing is warded. For fluff. And because it's COOL, we give them silver blessings.
-//+1 DEF from it, too. For a total of 7 defence when wielded.
+//+1 DEF from it, too. For a total of 10 defence when wielded.
 /obj/item/rogueweapon/mace/maul/grand/malum/ComponentInitialize()
 	AddComponent(\
 		/datum/component/silverbless,\

--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -618,8 +618,8 @@
 	slot_flags = null//No.
 	smelt_bar_num = 2
 	minstr = 14
-	wdefense = 2
-	wdefense_wbonus = 1//3
+	wdefense = 4
+	wdefense_wbonus = 2//6
 	demolition_mod = 1.25//Oh, yes...
 	pixel_y = -16
 	pixel_x = -16
@@ -645,10 +645,10 @@
 	desc = "You could probably crack a man's spine just by tapping them with this. \
 	Only a lunatic would carry something so heavy, however."
 	icon_state = "cross"
-	force_wielded = 34//-1 compared to grand mace.
+	force_wielded = 36//+1 compared to grand mace.
 	smeltresult = /obj/item/ingot/steel
 	minstr = 15
-	wdefense_wbonus = 4//6
+	wdefense_wbonus = 5
 	smelt_bar_num = 3
 	max_integrity = 350
 
@@ -688,7 +688,7 @@
 	icon_state = "dwarfhammer"
 	smeltresult = /obj/item/ingot/steel
 	minstr = 11//+2STR from Grudgebearer Soldier. Should cover this.
-	wdefense_wbonus = 3//5
+	wdefense_wbonus = 3//7
 	smelt_bar_num = 3//You'll break my heart.
 	max_integrity = 340
 
@@ -698,7 +698,7 @@
 	This one has been well balanced, allowing for a weaker wielder to make use of it."
 	icon_state = "spiky"
 	gripped_intents = list(/datum/intent/maul/spiked, /datum/intent/maul/crush, /datum/intent/effect/daze, /datum/intent/effect/hobble)
-	wdefense_wbonus = 2//4
+	wdefense_wbonus = 3//7
 	minstr = 10//+1STR from Grudgebearer Smith. It should be fine.
 	smelt_bar_num = 3//Please don't...
 	max_integrity = 320


### PR DESCRIPTION
## About The Pull Request

- Standard Maul weapon defense increased from 3 when wielded (dogshit) to 6
- Grand Maul weapon defense increased from 6 to 9 when wielded
- Grand Maul force raised to 36, one above the grand mace. You are a stupid -int idiot who invested their statpack towards 15 strength; you shouldn't have your big dumb hammer end up being lesser than a boring mace, flail, etc. 
- Dwarven Maul and Spiked Maul weapon defense increased to 7 when wielded
- Fix Malum templar Maul by giving it the is_silver var

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Simple number changes only.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
At expert maces, the standard maul against an expert weapon skill opponent had around a 40% parry chance. That's abysmal; you were better off running with dodge expert maul drakian than actually parrying with your big funny hammer. The maul also suffered from lower force and lacking range compared to the grand mace or general power potential of something like the steel flail. 
This aims to give mauls both the defense power and stopping power to be viable in the current combat landscape. Shouldn't become too too strong given heavy balance gets utterly stomped by anyone running dodge. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Standard Maul weapon defense increased from 3 when wielded to 6.
balance: Grand Maul weapon defense increased from 6 to 9 when wielded. Grand Maul force raised from 34 to 36. 
balance: Dwarven Maul and Spiked Maul weapon defense increased to 7 when wielded.
fix: Malum templar maul now functions like a silver weapon as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
