### PR TITLE
Fix for eye UI element getting stuck, a port from ye olde RW1

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -205,9 +205,11 @@
 	if(mob.curplaying)
 		mob.curplaying.on_mouse_up()
 
-	if(!mob.fixedeye)
+	if(mob.tempfixeye)
 		mob.tempfixeye = FALSE
-		mob.nodirchange = FALSE
+
+		if(!mob.fixedeye)
+			mob.nodirchange = FALSE
 
 	if(mob.hud_used)
 		for(var/atom/movable/screen/eye_intent/eyet in mob.hud_used.static_inventory)


### PR DESCRIPTION
## About The Pull Request

There's a bug that AP never ported nor fixed on their own and Im re-porting from RW1 that made fixing the EYE (strafe function) feature.
This was fixed years ago.
Fucking LOL!!!

edit: Oh yeah here's the PR link, https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2038

## Testing Evidence

I compiled the fix, ran it, and spammed the hotkey a hundred times. The bug didn't occur. But it happens randomly. Pretty confident.

## Why It's Good For The Game

Fixes a bug.

## Changelog

:cl:
fix: fixed fixeye sticky bug
/:cl:
