### PR TITLE
Adds Councillor Ministry system: improves councillor skills with town leader cooperation

### DIFF
--- a/_maps/map_files/deserttown/deserttown.dmm
+++ b/_maps/map_files/deserttown/deserttown.dmm
@@ -46488,7 +46488,6 @@
 /turf/open/floor/rogue/citybrick/citybrick1,
 /area/rogue/under/dungeon/desert_pyramid)
 "nyg" = (
-/obj/item/bodypart/l_arm/devil,
 /obj/item/bodypart/r_arm/goblin,
 /obj/item/bodypart/r_arm,
 /obj/item/reagent_containers/food/snacks/zizo_bane,
@@ -65136,6 +65135,10 @@
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/basement)
+"sTz" = (
+/obj/structure/roguemachine/scomm/r,
+/turf/open/floor/rogue/tile/harem1,
+/area/rogue/indoors/town/manor/desert)
 "sTD" = (
 /obj/structure/fluff/walldeco/stone/bronze,
 /turf/closed/wall/mineral/rogue/sandstone,
@@ -74002,9 +74005,7 @@
 /turf/open/floor/rogue/darkpath,
 /area/rogue/outdoors/town/desert)
 "vvu" = (
-/obj/structure/roguemachine/scomm/l{
-	scom_tag = "Qasr - Sheikh Office"
-	},
+/obj/structure/roguemachine/ministry_bureau,
 /turf/open/floor/rogue/deserttile{
 	icon_state = "tilewhitebluespecial";
 	color = "#b8ae9e"
@@ -534382,7 +534383,7 @@ oTJ
 hZy
 wBj
 vVO
-jgz
+sTz
 klw
 klw
 klw

--- a/_maps/map_files/deserttown/deserttown.dmm
+++ b/_maps/map_files/deserttown/deserttown.dmm
@@ -25650,6 +25650,12 @@
 	},
 /turf/open/water/bath,
 /area/rogue/indoors/town/manor/desert)
+"hss" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = Qasr - Sheikh Office
+	},
+/turf/open/floor/rogue/tile/harem1,
+/area/rogue/indoors/town/manor/desert)
 "hsD" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/rock,
 /turf/open/floor/rogue/citybrick/citybrick1,
@@ -65135,10 +65141,6 @@
 /obj/machinery/light/rogue/candle/blue/l,
 /turf/open/floor/rogue/blocks/stonered,
 /area/rogue/indoors/town/church/basement)
-"sTz" = (
-/obj/structure/roguemachine/scomm/r,
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/manor/desert)
 "sTD" = (
 /obj/structure/fluff/walldeco/stone/bronze,
 /turf/closed/wall/mineral/rogue/sandstone,
@@ -534383,7 +534385,7 @@ oTJ
 hZy
 wBj
 vVO
-sTz
+hss
 klw
 klw
 klw

--- a/_maps/map_files/deserttown/deserttown.dmm
+++ b/_maps/map_files/deserttown/deserttown.dmm
@@ -25650,12 +25650,6 @@
 	},
 /turf/open/water/bath,
 /area/rogue/indoors/town/manor/desert)
-"hss" = (
-/obj/structure/roguemachine/scomm/r{
-	scom_tag = Qasr - Sheikh Office
-	},
-/turf/open/floor/rogue/tile/harem1,
-/area/rogue/indoors/town/manor/desert)
 "hsD" = (
 /mob/living/simple_animal/hostile/retaliate/rogue/spider/rock,
 /turf/open/floor/rogue/citybrick/citybrick1,
@@ -72325,6 +72319,12 @@
 	icon = 'modular_deserttown/icons/alt/roguefloor.dmi'
 	},
 /area/rogue/under/town/basement/desert)
+"uTK" = (
+/obj/structure/roguemachine/scomm/r{
+	scom_tag = "Qasr - Sheikh Office"
+	},
+/turf/open/floor/rogue/tile/harem1,
+/area/rogue/indoors/town/manor/desert)
 "uTL" = (
 /obj/structure/fluff/railing/border{
 	dir = 6
@@ -534385,7 +534385,7 @@ oTJ
 hZy
 wBj
 vVO
-hss
+uTK
 klw
 klw
 klw

--- a/_maps/map_files/dun_world/dun_world.dmm
+++ b/_maps/map_files/dun_world/dun_world.dmm
@@ -89983,6 +89983,10 @@
 	},
 /turf/open/floor/rogue/dirt,
 /area/rogue/under/cavewet/bogcaves/west)
+"sJf" = (
+/obj/structure/roguemachine/ministry_bureau,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor)
 "sJi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/rogue/churchbrick,
@@ -323833,7 +323837,7 @@ xHQ
 rrD
 fAA
 iJY
-xHQ
+sJf
 xHQ
 qIt
 qIt

--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -7655,6 +7655,10 @@
 	},
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors/rtfield/rockhill)
+"bJC" = (
+/obj/structure/roguemachine/ministry_bureau,
+/turf/open/floor/carpet/royalblack,
+/area/rogue/indoors/town/manor/rockhill)
 "bJK" = (
 /obj/structure/table/wood/poor,
 /obj/item/paper,
@@ -615070,7 +615074,7 @@ cQd
 pTR
 tpQ
 ged
-ged
+bJC
 ged
 wtF
 jZx

--- a/_maps/map_files/roguetest/roguetest.dmm
+++ b/_maps/map_files/roguetest/roguetest.dmm
@@ -66,11 +66,12 @@
 /obj/item/candle/candlestick/gold/lit{
 	pixel_y = 15
 	},
-/turf/open/floor/rogue/grass,
-/area)
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors)
 "cd" = (
-/turf/closed/mineral/rogue/bedrock,
-/area)
+/obj/item/roguemachine/mastermail,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors)
 "ce" = (
 /obj/effect/decal/mossy{
 	dir = 1
@@ -189,8 +190,9 @@
 /turf/open/floor/rogue/dirt/road,
 /area/rogue/outdoors/bog/north)
 "fE" = (
-/turf/closed/wall/mineral/rogue/decowood/vert,
-/area)
+/obj/machinery/light/rogue/candle/r,
+/turf/open/floor/rogue/tile/harem,
+/area/rogue/indoors)
 "gP" = (
 /obj/structure/table/cooling,
 /obj/item/storage/roguebag,
@@ -343,7 +345,7 @@
 /obj/item/rogueweapon/surgery/scalpel,
 /obj/item/needle,
 /turf/open/floor/rogue/dirt/road,
-/area)
+/area/rogue/indoors)
 "mq" = (
 /obj/machinery/light/rogue/firebowl/stump,
 /turf/open/floor/rogue/grass,
@@ -1100,8 +1102,9 @@
 /turf/open/floor/rogue/tile/harem,
 /area/rogue/indoors)
 "DO" = (
+/obj/structure/roguemachine/ministry_bureau,
 /turf/open/floor/rogue/tile/harem,
-/area)
+/area/rogue/indoors)
 "Ef" = (
 /obj/effect/decal/mossy{
 	dir = 8
@@ -1212,10 +1215,6 @@
 /obj/item/rogueweapon/thresher,
 /turf/open/floor/rogue/grass,
 /area/rogue/outdoors)
-"Jc" = (
-/obj/machinery/light/rogue/candle/l,
-/turf/open/floor/rogue/tile/harem,
-/area)
 "JD" = (
 /obj/item/rogueweapon/pick/blacksteel,
 /turf/open/floor/rogue/ruinedwood,
@@ -1781,15 +1780,15 @@ AO
 AO
 AO
 AO
-cd
-cd
-cd
-cd
-dB
-dB
-dB
-dB
-dB
+AO
+AO
+AO
+AO
+AO
+AO
+AO
+AO
+AO
 dB
 dB
 dB
@@ -1836,12 +1835,12 @@ zo
 zo
 zo
 zo
-fE
-fE
-fE
-dB
-dB
-dB
+zo
+zo
+zo
+zo
+zo
+AO
 dB
 dB
 dB
@@ -1888,12 +1887,12 @@ Ey
 tc
 Ey
 Ey
-Jc
-DO
-fE
-dB
-dB
-dB
+tc
+Ey
+tc
+Ey
+zo
+AO
 dB
 dB
 dB
@@ -1941,11 +1940,11 @@ zo
 Br
 Ey
 mm
-DO
-fE
-dB
-dB
-dB
+Ey
+Ey
+Ey
+zo
+AO
 dB
 dB
 dB
@@ -1993,11 +1992,11 @@ zo
 BX
 Ey
 ca
-DO
-fE
-dB
-dB
-dB
+Ey
+Ey
+Ey
+zo
+AO
 dB
 dB
 dB
@@ -2040,15 +2039,15 @@ zo
 DG
 zo
 zo
-Ey
+cd
 zo
 KJ
 Ey
 bm
 Ey
+fE
+DO
 zo
-AO
-AO
 AO
 AO
 AO

--- a/code/controllers/subsystem/rogue/roguemachine.dm
+++ b/code/controllers/subsystem/rogue/roguemachine.dm
@@ -15,6 +15,7 @@ PROCESSING_SUBSYSTEM_DEF(roguemachine)
 	var/last_death_report
 	var/obj/item/clothing/head/roguetown/crown/serpcrown/crown
 	var/obj/item/key
+	var/obj/structure/roguemachine/ministry_bureau/ministry_bureau
 
 /datum/controller/subsystem/processing/roguemachine/fire(resumed = 0)
 	. = ..()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1941,3 +1941,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return TRUE
 	return FALSE
 
+// The mob carrying this, through any depth of containers.
+/obj/item/proc/find_items_mob_carrier()
+	if(ismob(loc))
+		return loc
+	for(var/atom/location as anything in get_nested_locs(src))
+		if(ismob(location))
+			return location
+	return null

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -73,3 +73,526 @@
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/councillor
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		cloak = null
+	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/petition_ministry, H)
+
+// ===== MINISTRIES =====
+// A councillor petitions a faction head to serve as their voice in the keep.
+// The head keeps a writ and a seal; the councillor takes their charter to the
+// bureau to be sworn in, gaining that faction's keys, skills and secrets.
+
+GLOBAL_LIST_INIT(ministry_charters, list(
+	"Guildmaster" = /datum/ministry/guild,
+	"Bishop" = /datum/ministry/church,
+	"Bathmaster" = /datum/ministry/night,
+	"Inquisitor" = /datum/ministry/inquisition,
+	"Court Magician" = /datum/ministry/mage,
+	"Head Physician" = /datum/ministry/physician,
+	"Innkeeper" = /datum/ministry/innkeeper,
+	"Merchant" = /datum/ministry/merchant
+))
+
+/mob/living/carbon/human
+	var/datum/ministry/ministry_active
+	var/datum/ministry/ministry_partner
+	// Agreed-but-unsworn ministry. Held by the councillor until the bureau seats them.
+	var/datum/ministry/ministry_pending
+
+/datum/ministry
+	var/name = "Ministry"
+	var/display_title = "Minister"
+	var/income_bonus = 20
+	var/list/ministry_keys = list()
+	var/list/archive_traits = list()
+	var/list/archive_skills = list()
+	var/ring_type
+	var/seal_type
+	var/mob/living/carbon/human/councillor
+	var/mob/living/carbon/human/partner
+	var/obj/item/clothing/ring/minister/ring
+	var/obj/item/seal_of_ministry/seal
+	var/active = FALSE
+
+/datum/ministry/Destroy()
+	councillor = null
+	partner = null
+	ring = null
+	seal = null
+	return ..()
+
+// Extra perks beyond keys, traits and skills. Runs after those are applied.
+/datum/ministry/proc/archive_bonus(mob/living/carbon/human/H)
+	return
+
+// Reports every charter and its standing, so a councillor knows who is worth
+// walking to before they go looking.
+/proc/ministry_roster()
+	var/obj/structure/roguemachine/ministry_bureau/bureau = SSroguemachine.ministry_bureau
+	bureau?.prune_ministries()
+	var/list/lines = list()
+	for(var/job_title in GLOB.ministry_charters)
+		var/charter = GLOB.ministry_charters[job_title]
+		var/datum/ministry/M = bureau?.active_ministries?[charter]
+		if(M)
+			lines += "[job_title] — served by [M.councillor?.real_name || "a minister"]."
+			continue
+		var/mob/living/carbon/human/holder
+		for(var/mob/living/carbon/human/H in GLOB.human_list)
+			if(H.mind?.assigned_role == job_title && H.stat != DEAD)
+				holder = H
+				break
+		if(!holder)
+			lines += "[job_title] — no one holds the post."
+		else if(holder.ministry_partner)
+			lines += "[job_title] — already spoken for."
+		else
+			lines += "[job_title] — open to petition."
+	return lines
+
+/datum/ministry/guild
+	name = "Guild Ministry"
+	display_title = "Minister of Crafts"
+	ministry_keys = list(/obj/item/roguekey/crafterguild)
+	archive_traits = list(TRAIT_SEEPRICES, TRAIT_SMITHING_EXPERT)
+	archive_skills = list(
+		/datum/skill/craft/blacksmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/armorsmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/weaponsmithing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/engineering = SKILL_LEVEL_NOVICE
+	)
+	ring_type = /obj/item/clothing/ring/minister/guild
+	seal_type = /obj/item/seal_of_ministry/guild
+
+/datum/ministry/church
+	name = "Church Ministry"
+	display_title = "Minister of the Faith"
+	ministry_keys = list(/obj/item/roguekey/church, /obj/item/roguekey/graveyard)
+	archive_traits = list(TRAIT_RITUALIST, TRAIT_VOTARY)
+	archive_skills = list(/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE)
+	ring_type = /obj/item/clothing/ring/minister/church
+	seal_type = /obj/item/seal_of_ministry/church
+
+/datum/ministry/church/archive_bonus(mob/living/carbon/human/H)
+	H.put_in_hands(new /obj/item/ritechalk(get_turf(H)))
+	if(!H.patron || istype(H.patron, /datum/patron/godless))
+		to_chat(H, span_warning("You hold no faith. Odd."))
+		return
+	if(H.devotion)
+		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
+		to_chat(H, span_notice("The archive deepens your existing devotion to [H.patron.name]."))
+		return
+	var/datum/devotion/C = new /datum/devotion(H, H.patron)
+	C.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
+	to_chat(H, span_notice("The archive stirs your faith. You feel the first whispers of [H.patron.name]'s gifts."))
+
+/datum/ministry/night
+	name = "Night Ministry"
+	display_title = "Minister of Vice"
+	ministry_keys = list(/obj/item/roguekey/nightmaiden)
+	archive_traits = list(TRAIT_CICERONE, TRAIT_GOODLOVER)
+	archive_skills = list(
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE
+	)
+	ring_type = /obj/item/clothing/ring/minister/night
+	seal_type = /obj/item/seal_of_ministry/night
+
+/datum/ministry/inquisition
+	name = "Inquisition Ministry"
+	display_title = "Minister of Orthodoxy"
+	ministry_keys = list(/obj/item/roguekey/inquisition)
+	archive_traits = list(TRAIT_STEELHEARTED)
+	archive_skills = list(
+		/datum/skill/combat/swords = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/holy = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT
+	)
+	ring_type = /obj/item/clothing/ring/minister/inquisition
+	seal_type = /obj/item/seal_of_ministry/inquisition
+
+/datum/ministry/inquisition/archive_bonus(mob/living/carbon/human/H)
+	if(H.devotion)
+		if(!istype(H.patron, /datum/patron/old_god))
+			to_chat(H, span_warning("You are already bound to a credo more alive than PSYDON's. The Old God will not share."))
+			return
+		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
+		to_chat(H, span_notice("The archive reaffirms your covenant. ENDVRE."))
+		return
+	H.set_patron(/datum/patron/old_god)
+	var/datum/devotion/C = new /datum/devotion(H, GLOB.patronlist[/datum/patron/old_god])
+	C.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
+	to_chat(H, span_notice("The dusty notes in the back of the archive remind you of the Old God's covenant. Surely, PSYDON yet lives!"))
+
+/datum/ministry/mage
+	name = "Arcane Ministry"
+	display_title = "Minister of Magic"
+	ministry_keys = list(/obj/item/roguekey/tower)
+	archive_traits = list(TRAIT_ALCHEMY_EXPERT)
+	archive_skills = list(
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
+	)
+	ring_type = /obj/item/clothing/ring/minister/mage
+	seal_type = /obj/item/seal_of_ministry/mage
+
+/datum/ministry/mage/archive_bonus(mob/living/carbon/human/H)
+	if(!H.mind)
+		return
+	if(!H.mind.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, H)
+	H.mind.adjust_spellpoints(9)
+	to_chat(H, span_notice("The archive imparts the arcyne secrets of the previous Minister. You feel a thrum of latent power."))
+
+/datum/ministry/physician
+	name = "Physician Ministry"
+	display_title = "Minister of Health"
+	ministry_keys = list(/obj/item/roguekey/physician, /obj/item/roguekey/courtphysician)
+	archive_traits = list(TRAIT_EMPATH, TRAIT_MEDICINE_EXPERT)
+	archive_skills = list(/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT)
+	ring_type = /obj/item/clothing/ring/minister/physician
+	seal_type = /obj/item/seal_of_ministry/physician
+
+/datum/ministry/physician/archive_bonus(mob/living/carbon/human/H)
+	H.put_in_hands(new /obj/item/storage/belt/rogue/surgery_bag/full/physician(get_turf(H)))
+	to_chat(H, span_notice("The previous Minister's surgeon kit is collecting dust in the back of the archive. Following their notes, you might make use of it."))
+
+/datum/ministry/innkeeper
+	name = "Tavern Ministry"
+	display_title = "Minister of Commons"
+	ministry_keys = list(/obj/item/roguekey/tavern)
+	archive_traits = list(TRAIT_CICERONE, TRAIT_EMPATH, TRAIT_TAVERN_FIGHTER)
+	archive_skills = list(/datum/skill/craft/cooking = SKILL_LEVEL_JOURNEYMAN)
+	ring_type = /obj/item/clothing/ring/minister/innkeeper
+	seal_type = /obj/item/seal_of_ministry/innkeeper
+
+/datum/ministry/merchant
+	name = "Trade Ministry"
+	display_title = "Minister of Trade"
+	ministry_keys = list(/obj/item/roguekey/shop)
+	archive_traits = list(TRAIT_SEEPRICES, TRAIT_CICERONE)
+	archive_skills = list(/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN)
+	ring_type = /obj/item/clothing/ring/minister/merchant
+	seal_type = /obj/item/seal_of_ministry/merchant
+
+// ===== PETITION SPELL =====
+// Sits on the councillor's HUD until they've struck a deal and been sworn in.
+
+/obj/effect/proc_holder/spell/self/petition_ministry
+	name = "Petition Ministry"
+	desc = "Offer yourself to a faction head as their voice within the keep. Cast with none in reach to survey which posts stand open."
+	overlay_state = "recruit_titlegrant"
+	antimagic_allowed = TRUE
+	recharge_time = 100
+	var/petition_range = 3
+
+/obj/effect/proc_holder/spell/self/petition_ministry/cast(list/targets, mob/user = usr)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/councillor = user
+	if(councillor.ministry_active)
+		to_chat(councillor, span_warning("I already hold an office."))
+		return
+	if(councillor.ministry_pending)
+		to_chat(councillor, span_notice("My charter is agreed. The bureau in the council chamber awaits my swearing-in."))
+		return
+
+	SSroguemachine.ministry_bureau?.prune_ministries()
+	var/list/prospects = list()
+	for(var/mob/living/carbon/human/head in (get_hearers_in_view(petition_range, councillor) - councillor))
+		var/charter = GLOB.ministry_charters[head.mind?.assigned_role]
+		if(!charter || head.stat == DEAD)
+			continue
+		if(head.ministry_partner)
+			continue
+		if(SSroguemachine.ministry_bureau?.active_ministries?[charter])
+			continue
+		prospects[head.name] = head
+	if(!length(prospects))
+		to_chat(councillor, span_warning("There is nobody here whose patronage I might seek."))
+		for(var/line in ministry_roster())
+			to_chat(councillor, span_notice(line))
+		return
+
+	var/picked = input(councillor, "Whose patronage do you seek?", "[name]") as null|anything in prospects
+	if(!picked)
+		return
+	var/mob/living/carbon/human/head = prospects[picked]
+	if(QDELETED(head) || !(head in get_hearers_in_view(petition_range, councillor)))
+		to_chat(councillor, span_warning("They have gone."))
+		return
+	INVOKE_ASYNC(src, PROC_REF(propose), councillor, head)
+
+/obj/effect/proc_holder/spell/self/petition_ministry/proc/propose(mob/living/carbon/human/councillor, mob/living/carbon/human/head)
+	var/charter = GLOB.ministry_charters[head.mind?.assigned_role]
+	if(!charter)
+		return
+	var/datum/ministry/charter_ref = charter
+	councillor.say("[head.real_name], let me be your voice within the keep.")
+	var/answer = alert(head, "[councillor.real_name] petitions to serve as your [initial(charter_ref.display_title)]. They will be granted a measure of your trade's knowledge, and you a seal to speak with them.", "Ministry", "Accept", "Refuse")
+	if(answer != "Accept")
+		to_chat(councillor, span_warning("[head.real_name] declines my petition."))
+		to_chat(head, span_notice("You decline the petition."))
+		return
+	// Everything could have changed while the prompt sat open.
+	if(QDELETED(councillor) || QDELETED(head) || councillor.stat == DEAD || head.stat == DEAD)
+		return
+	if(!(head in get_hearers_in_view(petition_range, councillor)))
+		to_chat(councillor, span_warning("I'm much too far away now!"))
+		to_chat(head, span_warning("They have wandered off before the matter was settled."))
+		return
+	if(councillor.ministry_active || councillor.ministry_pending || head.ministry_partner)
+		to_chat(head, span_warning("The arrangement has already been overtaken by events."))
+		return
+	if(SSroguemachine.ministry_bureau?.active_ministries?[charter])
+		to_chat(head, span_warning("A minister of this house has already been seated."))
+		return
+
+	var/datum/ministry/proto = new charter()
+	councillor.ministry_pending = proto
+	head.ministry_partner = proto
+	proto.councillor = councillor
+	proto.partner = head
+
+	var/obj/item/paper/scroll/ministry_writ/writ = new(get_turf(head))
+	writ.finalize(councillor, head, proto)
+	head.put_in_hands(writ)
+	head.visible_message(span_notice("[head.real_name] takes [councillor.real_name] into their confidence."))
+	to_chat(head, span_notice("You accept the petition. Keep this writ as your record of it."))
+	to_chat(councillor, span_notice("[head.real_name] accepts. Go to the bureau in the council chamber to be sworn in."))
+
+// ===== WRIT OF MINISTRY =====
+// The partner's copy. Arrives finalized, stays with them. Nothing to sign.
+
+/obj/item/paper/scroll/ministry_writ
+	name = "writ of ministry"
+	desc = "A charter of appointment, sealed and witnessed."
+	icon_state = "contractsigned"
+	open = TRUE
+	textper = 150
+	var/ministry_type
+
+/obj/item/paper/scroll/ministry_writ/proc/finalize(mob/living/carbon/human/minister, mob/living/carbon/human/partner, datum/ministry/M)
+	ministry_type = M.type
+	name = "writ of the [M.name]"
+	desc = "A charter appointing [minister.real_name] to the office of [M.display_title]."
+	info = "<font face=\"[FOUNTAIN_PEN_FONT]\" color=#14103f>"
+	info += "<center><b>Writ of Ministry</b></center><hr/>"
+	info += "Let it be known that on this day, [partner.real_name], [partner.mind?.assigned_role || "of the town"], \
+			does receive into their confidence [minister.real_name], Councillor of the keep, \
+			granting unto them the office and privileges of <b>[M.display_title]</b>.<br/><br/>"
+	info += "The Minister shall speak for this house within the council chamber. The seal accompanying this writ \
+			shall carry their voice, and bear yours in return.<br/><br/>"
+	info += "SIGNED,<br/>"
+	info += "[minister.real_name], [M.display_title] of [SSmapping.map_adjustment.realm_name]"
+	info += "</font>"
+	update_icon_state()
+
+/obj/item/paper/scroll/ministry_writ/update_icon_state()
+	if(!open)
+		icon_state = "scroll_closed"
+		name = "scroll"
+		return
+	icon_state = "contractsigned"
+
+// ===== MINISTER'S SIGNET =====
+// Paired with a seal held by the partner. Speak into one, the other hears.
+
+/obj/item/clothing/ring/minister
+	name = "minister's signet"
+	desc = "A signet ring bearing the mark of a ministerial office. Press it to your lips to speak with your patron."
+	icon_state = "signet"
+	sellprice = 100
+	slot_flags = ITEM_SLOT_RING
+	var/obj/item/seal_of_ministry/paired_seal
+	var/ministry_cooldown = 0
+	var/ministry_cooldown_time = 1 MINUTES
+
+/obj/item/clothing/ring/minister/Destroy()
+	if(paired_seal)
+		paired_seal.paired_ring = null
+		paired_seal = null
+	return ..()
+
+// Works worn or in hand.
+/obj/item/clothing/ring/minister/attack_self(mob/user)
+	. = ..()
+	attack_right(user)
+
+/obj/item/clothing/ring/minister/attack_right(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(!H.ministry_active || H.ministry_active.councillor != H)
+		to_chat(H, span_warning("The ring is cold and dead in my hand. It was not made for me."))
+		return
+	if(H.restrained() || H.incapacitated())
+		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
+	if(world.time < ministry_cooldown)
+		to_chat(H, span_warning("The ring's metal is still heated from its last use."))
+		return
+	if(QDELETED(paired_seal))
+		to_chat(H, span_warning("The ring has no paired seal. The bond is broken."))
+		return
+	if(!ismob(paired_seal.loc))
+		to_chat(H, span_warning("The seal is not being carried. My words find no one."))
+		return
+	H.changeNext_move(CLICK_CD_INTENTCAP)
+	visible_message(span_notice("[H] presses their ring against their mouth."))
+	var/msg = input(H, "Speak into the ring.", "Ministry Channel") as null|text
+	if(!msg || QDELETED(paired_seal))
+		return
+	ministry_cooldown = world.time + ministry_cooldown_time
+	H.whisper(msg)
+	paired_seal.relay_ministry_message(msg, H.real_name, "Minister")
+
+/obj/item/clothing/ring/minister/proc/relay_ministry_message(msg, speaker_name, speaker_role)
+	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
+	say("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>")
+
+/obj/item/clothing/ring/minister/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	if(!message)
+		return
+	if(!language)
+		language = get_default_language()
+	if(isitem(loc))
+		var/obj/item/I = loc
+		I.send_speech(message, 1, I, , spans, message_language = language)
+		return
+	send_speech(message, 1, src, , spans, message_language = language)
+
+/obj/item/clothing/ring/minister/guild
+	name = "guild minister's signet"
+	desc = "A well-worn signet ring, yet smoke-stained from the fires of the Guild."
+
+/obj/item/clothing/ring/minister/church
+	name = "church minister's signet"
+	desc = "A holy ring befitting a priest of the Divine Pantheon, now besmirched by court politick."
+	icon_state = "signet_silver"
+
+/obj/item/clothing/ring/minister/night
+	name = "night minister's signet"
+	desc = "An unassuming, sleek ring. Careful that it does not sink to the bottom of the baths."
+
+/obj/item/clothing/ring/minister/inquisition
+	name = "inquisition minister's signet"
+	desc = "A signet ring bearing the Inquisition's mark. An ENDVRING fashion choice, if outdated."
+	icon_state = "signet_silver"
+
+/obj/item/clothing/ring/minister/mage
+	name = "arcane minister's signet"
+	desc = "A ring faintly warm to the touch, marked with an arcyne glyph."
+
+/obj/item/clothing/ring/minister/physician
+	name = "physician minister's signet"
+	desc = "A ring bearing the Pestran tendrils of the court physician's office."
+
+/obj/item/clothing/ring/minister/innkeeper
+	name = "tavern minister's signet"
+	desc = "A ring bearing the inn's tap-mark. Its sheen is scratched by knife and cutting board."
+
+/obj/item/clothing/ring/minister/merchant
+	name = "trade minister's signet"
+	desc = "A ring bearing the mammon-hoarding marque of the Merchant's Guild."
+
+// ===== SEAL OF MINISTRY =====
+// The partner's half of the pair.
+
+/obj/item/seal_of_ministry
+	name = "seal of ministry"
+	desc = "A sealed dispatch bearing a ministerial mark. The wax is soft and dark."
+	icon = 'icons/roguetown/items/misc.dmi'
+	icon_state = "scroll_closed"
+	w_class = WEIGHT_CLASS_TINY
+	dropshrink = 0.6
+	var/obj/item/clothing/ring/minister/paired_ring
+	var/ministry_cooldown = 0
+	var/ministry_cooldown_time = 1 MINUTES
+
+/obj/item/seal_of_ministry/Destroy()
+	if(paired_ring)
+		paired_ring.paired_seal = null
+		paired_ring = null
+	return ..()
+
+/obj/item/seal_of_ministry/attack_self(mob/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	if(!H.ministry_partner || H.ministry_partner.partner != H)
+		to_chat(H, span_warning("The wax is inert. This seal answers to another hand."))
+		return
+	if(H.restrained() || H.incapacitated())
+		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
+	if(world.time < ministry_cooldown)
+		to_chat(H, span_warning("The seal is still reforming from its last break."))
+		return
+	if(QDELETED(paired_ring))
+		to_chat(H, span_warning("The seal has no paired ring. The bond is broken."))
+		return
+	if(!ismob(paired_ring.loc))
+		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
+		return
+	H.changeNext_move(CLICK_CD_INTENTCAP)
+	visible_message(span_notice("[H] murmurs into the wax of the seal."))
+	var/msg = input(H, "Send word to your minister.", "Ministry Channel") as null|text
+	if(!msg || QDELETED(paired_ring))
+		return
+	ministry_cooldown = world.time + ministry_cooldown_time
+	H.whisper(msg)
+	paired_ring.relay_ministry_message(msg, H.real_name, "Patron")
+
+/obj/item/seal_of_ministry/proc/relay_ministry_message(msg, speaker_name, speaker_role)
+	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
+	say("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>")
+
+/obj/item/seal_of_ministry/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	if(!message)
+		return
+	if(!language)
+		language = get_default_language()
+	if(isitem(loc))
+		var/obj/item/I = loc
+		I.send_speech(message, 1, I, , spans, message_language = language)
+		return
+	send_speech(message, 1, src, , spans, message_language = language)
+
+/obj/item/seal_of_ministry/guild
+	name = "guild seal of ministry"
+	desc = "A rolled dispatch sealed with the crossed-hammer mark of the Guildmaster. The wax feels warm when held."
+
+/obj/item/seal_of_ministry/church
+	name = "church seal of ministry"
+	desc = "A scroll bound shut with the Pantheon cross in pale wax. It carries the faint smell of flower petals."
+
+/obj/item/seal_of_ministry/night
+	name = "night seal of ministry"
+	desc = "A plain roll of parchment, sealed with unmarked black wax. Nothing about it invites curiosity."
+
+/obj/item/seal_of_ministry/inquisition
+	name = "inquisition seal of ministry"
+	desc = "A tightly rolled writ sealed with a silver stamp. The edges are sharp and precise."
+
+/obj/item/seal_of_ministry/mage
+	name = "arcane seal of ministry"
+	desc = "A scroll whose wax seal faintly glows with a glyph that shifts when you aren't looking directly at it."
+
+/obj/item/seal_of_ministry/physician
+	name = "physician seal of ministry"
+	desc = "A clinical roll of parchment sealed in dark red wax. Smells faintly of camphor."
+
+/obj/item/seal_of_ministry/innkeeper
+	name = "tavern seal of ministry"
+	desc = "A short scroll sealed with the inn's tap-mark pressed into amber wax. It smells vaguely of ale."
+
+/obj/item/seal_of_ministry/merchant
+	name = "trade seal of ministry"
+	desc = "A folded dispatch sealed with the merchant's mark in green wax, the edges worn from handling."

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -94,8 +94,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /mob/living/carbon/human
 	var/datum/ministry/ministry_active
 	var/datum/ministry/ministry_partner
-	// Agreed-but-unsworn ministry. Held by the councillor until the bureau seats them.
-	var/datum/ministry/ministry_pending
+	var/datum/ministry/ministry_pending // held until finalized by clicking on the bureau
 
 /datum/ministry
 	var/name = "Ministry"
@@ -217,7 +216,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /datum/ministry/inquisition/archive_bonus(mob/living/carbon/human/H)
 	if(H.devotion)
 		if(!istype(H.patron, /datum/patron/old_god))
-			to_chat(H, span_warning("You are already bound to a credo more alive than PSYDON's. The Old God will not share."))
+			to_chat(H, span_warning("You are already bound to a credo more alive than PSYDON's. Your boots are conspicuously empty."))
 			return
 		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
 		to_chat(H, span_notice("The archive reaffirms your covenant. ENDVRE."))
@@ -251,8 +250,11 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	name = "Physician Ministry"
 	display_title = "Minister of Health"
 	ministry_keys = list(/obj/item/roguekey/physician, /obj/item/roguekey/courtphysician)
-	archive_traits = list(TRAIT_EMPATH, TRAIT_MEDICINE_EXPERT)
-	archive_skills = list(/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT)
+	archive_traits = list(TRAIT_EMPATH, TRAIT_MEDICINE_EXPERT, TRAIT_ALCHEMY_EXPERT)
+	archive_skills = list(
+		/datum/skill/misc/medicine = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN
+	)
 	ring_type = /obj/item/clothing/ring/minister/physician
 	seal_type = /obj/item/seal_of_ministry/physician
 
@@ -380,10 +382,12 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	ministry_type = M.type
 	name = "writ of the [M.name]"
 	desc = "A charter appointing [minister.real_name] to the office of [M.display_title]."
+	var/datum/job/ruler = SSjob.GetJobType(/datum/job/roguetown/lord)
+	var/ruler_title = ruler?.display_title || ruler?.title || "Grand Duke"
 	info = "<font face=\"[FOUNTAIN_PEN_FONT]\" color=#14103f>"
 	info += "<center><b>Writ of Ministry</b></center><hr/>"
-	info += "Let it be known that on this day, [partner.real_name], [partner.mind?.assigned_role || "of the town"], \
-			does receive into their confidence [minister.real_name], Councillor of the keep, \
+	info += "Let it be known that, [partner.real_name], [partner.mind?.assigned_role || "of the town"], \
+			does receive into their confidence [minister.real_name], Councillor to the [ruler_title], \
 			granting unto them the office and privileges of <b>[M.display_title]</b>.<br/><br/>"
 	info += "The Minister shall speak for this house within the council chamber. The seal accompanying this writ \
 			shall carry their voice, and bear yours in return.<br/><br/>"
@@ -409,8 +413,8 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	sellprice = 100
 	slot_flags = ITEM_SLOT_RING
 	var/obj/item/seal_of_ministry/paired_seal
-	var/ministry_cooldown = 0
-	var/ministry_cooldown_time = 1 MINUTES
+	var/speech_cooldown = 0
+	var/speech_cooldown_time = 1 MINUTES
 
 /obj/item/clothing/ring/minister/Destroy()
 	if(paired_seal)
@@ -434,13 +438,13 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(H.restrained() || H.incapacitated())
 		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
 		return
-	if(world.time < ministry_cooldown)
+	if(world.time < speech_cooldown)
 		to_chat(H, span_warning("The ring's metal is still heated from its last use."))
 		return
 	if(QDELETED(paired_seal))
 		to_chat(H, span_warning("The ring has no paired seal. The bond is broken."))
 		return
-	if(!ismob(paired_seal.loc))
+	if(!ismob(get_atom_on_turf(paired_seal, /mob)))
 		to_chat(H, span_warning("The seal is not being carried. My words find no one."))
 		return
 	H.changeNext_move(CLICK_CD_INTENTCAP)
@@ -448,7 +452,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	var/msg = input(H, "Speak into the ring.", "Ministry Channel") as null|text
 	if(!msg || QDELETED(paired_seal))
 		return
-	ministry_cooldown = world.time + ministry_cooldown_time
+	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
 	paired_seal.relay_ministry_message(msg, H.real_name, "Minister")
 
@@ -461,11 +465,11 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	if(!language)
 		language = get_default_language()
-	if(isitem(loc))
-		var/obj/item/I = loc
-		I.send_speech(message, 1, I, , spans, message_language = language)
-		return
-	send_speech(message, 1, src, , spans, message_language = language)
+	// Speak from whatever is sitting on the turf, so a bagged ring still carries.
+	var/atom/movable/source = get_atom_on_turf(src, /mob)
+	if(!source)
+		source = src
+	source.send_speech(message, 1, source, , spans, message_language = language)
 
 /obj/item/clothing/ring/minister/guild
 	name = "guild minister's signet"
@@ -512,8 +516,8 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	w_class = WEIGHT_CLASS_TINY
 	dropshrink = 0.6
 	var/obj/item/clothing/ring/minister/paired_ring
-	var/ministry_cooldown = 0
-	var/ministry_cooldown_time = 1 MINUTES
+	var/speech_cooldown = 0
+	var/speech_cooldown_time = 1 MINUTES
 
 /obj/item/seal_of_ministry/Destroy()
 	if(paired_ring)
@@ -532,13 +536,13 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(H.restrained() || H.incapacitated())
 		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
 		return
-	if(world.time < ministry_cooldown)
+	if(world.time < speech_cooldown)
 		to_chat(H, span_warning("The seal is still reforming from its last break."))
 		return
 	if(QDELETED(paired_ring))
 		to_chat(H, span_warning("The seal has no paired ring. The bond is broken."))
 		return
-	if(!ismob(paired_ring.loc))
+	if(!ismob(get_atom_on_turf(paired_ring, /mob)))
 		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
 		return
 	H.changeNext_move(CLICK_CD_INTENTCAP)
@@ -546,7 +550,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	var/msg = input(H, "Send word to your minister.", "Ministry Channel") as null|text
 	if(!msg || QDELETED(paired_ring))
 		return
-	ministry_cooldown = world.time + ministry_cooldown_time
+	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
 	paired_ring.relay_ministry_message(msg, H.real_name, "Patron")
 
@@ -559,11 +563,11 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	if(!language)
 		language = get_default_language()
-	if(isitem(loc))
-		var/obj/item/I = loc
-		I.send_speech(message, 1, I, , spans, message_language = language)
-		return
-	send_speech(message, 1, src, , spans, message_language = language)
+	// Speak from whatever is sitting on the turf, so a bagged seal still carries.
+	var/atom/movable/source = get_atom_on_turf(src, /mob)
+	if(!source)
+		source = src
+	source.send_speech(message, 1, source, , spans, message_language = language)
 
 /obj/item/seal_of_ministry/guild
 	name = "guild seal of ministry"

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -73,12 +73,10 @@
 		shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/councillor
 		shoes = /obj/item/clothing/shoes/roguetown/shalal
 		cloak = null
-	H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/petition_ministry, H)
+	if(SSroguemachine.ministry_bureau) // No bureau mapped in, no ministries to be had.
+		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/petition_ministry, H)
 
 // ===== MINISTRIES =====
-// A councillor petitions a faction head to serve as their voice in the keep.
-// The head keeps a writ and a seal; the councillor takes their charter to the
-// bureau to be sworn in, gaining that faction's keys, skills and secrets.
 
 GLOBAL_LIST_INIT(ministry_charters, list(
 	"Guildmaster" = /datum/ministry/guild,
@@ -94,7 +92,8 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /mob/living/carbon/human
 	var/datum/ministry/ministry_active
 	var/datum/ministry/ministry_partner
-	var/datum/ministry/ministry_pending // held until finalized by clicking on the bureau
+	var/datum/ministry/ministry_pending // Finalized by clicking on the bureau.
+	var/ministry_spent // We already trained the skills. Lock to reforming this one only.
 
 /datum/ministry
 	var/name = "Ministry"
@@ -118,31 +117,52 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	seal = null
 	return ..()
 
-// Extra perks beyond keys, traits and skills. Runs after those are applied.
+// Extra perks. Runs after keys, traits and skills.
 /datum/ministry/proc/archive_bonus(mob/living/carbon/human/H)
 	return
 
-// Reports every charter and its standing, so a councillor knows who is worth
-// walking to before they go looking.
+// Duplicating some HERMES logic here for mailing the writ and seal.
+/proc/post_to_ministry(obj/item/parcel, sender, mob/living/carbon/human/recipient, notice, turf/fallback)
+	if(!parcel || QDELETED(recipient))
+		return
+	parcel.mailer = sender
+	parcel.mailedto = recipient.real_name
+	var/obj/item/roguemachine/mastermail/master = SSroguemachine.hermailermaster
+	if(!master)
+		parcel.forceMove(fallback || get_turf(recipient))
+		return
+	parcel.forceMove(master.loc)
+	var/datum/component/storage/STR = master.GetComponent(/datum/component/storage)
+	STR?.handle_item_insertion(parcel, prevent_warning = TRUE)
+	master.new_mail = TRUE
+	master.update_icon()
+	recipient.apply_status_effect(/datum/status_effect/ugotmail)
+	recipient.playsound_local(recipient, 'sound/misc/mail.ogg', 100, FALSE, -1)
+	if(notice)
+		to_chat(recipient, span_notice(notice))
+
+// Every charter and its current standing.
 /proc/ministry_roster()
 	var/obj/structure/roguemachine/ministry_bureau/bureau = SSroguemachine.ministry_bureau
-	bureau?.prune_ministries()
+	bureau.prune_ministries()
 	var/list/lines = list()
 	for(var/job_title in GLOB.ministry_charters)
 		var/charter = GLOB.ministry_charters[job_title]
-		var/datum/ministry/M = bureau?.active_ministries?[charter]
+		var/datum/ministry/M = bureau.active_ministries[charter]
 		if(M)
 			lines += "[job_title] — served by [M.councillor?.real_name || "a minister"]."
 			continue
 		var/mob/living/carbon/human/holder
 		for(var/mob/living/carbon/human/H in GLOB.human_list)
-			if(H.mind?.assigned_role == job_title && H.stat != DEAD)
+			if(H.mind?.assigned_role == job_title && !QDELETED(H))
 				holder = H
 				break
 		if(!holder)
 			lines += "[job_title] — no one holds the post."
 		else if(holder.ministry_partner)
 			lines += "[job_title] — already spoken for."
+		else if(holder.stat == DEAD)
+			lines += "[job_title] — dead, but not yet gone."
 		else
 			lines += "[job_title] — open to petition."
 	return lines
@@ -282,7 +302,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	seal_type = /obj/item/seal_of_ministry/merchant
 
 // ===== PETITION SPELL =====
-// Sits on the councillor's HUD until they've struck a deal and been sworn in.
 
 /obj/effect/proc_holder/spell/self/petition_ministry
 	name = "Petition Ministry"
@@ -304,19 +323,26 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		to_chat(councillor, span_notice("My charter is agreed. The bureau in the council chamber awaits my swearing-in."))
 		return
 
-	SSroguemachine.ministry_bureau?.prune_ministries()
+	var/obj/structure/roguemachine/ministry_bureau/bureau = SSroguemachine.ministry_bureau
+	bureau.prune_ministries()
 	var/list/prospects = list()
 	for(var/mob/living/carbon/human/head in (get_hearers_in_view(petition_range, councillor) - councillor))
 		var/charter = GLOB.ministry_charters[head.mind?.assigned_role]
 		if(!charter || head.stat == DEAD)
 			continue
+		if(councillor.ministry_spent && councillor.ministry_spent != charter)
+			continue
 		if(head.ministry_partner)
 			continue
-		if(SSroguemachine.ministry_bureau?.active_ministries?[charter])
+		if(bureau.active_ministries[charter])
 			continue
 		prospects[head.name] = head
 	if(!length(prospects))
-		to_chat(councillor, span_warning("There is nobody here whose patronage I might seek."))
+		if(councillor.ministry_spent)
+			var/datum/ministry/spent = councillor.ministry_spent
+			to_chat(councillor, span_warning("I am schooled in one trade alone. Only a new [initial(spent.display_title)]'s sponsor will have me."))
+		else
+			to_chat(councillor, span_warning("There is nobody here whose patronage I might seek."))
 		for(var/line in ministry_roster())
 			to_chat(councillor, span_notice(line))
 		return
@@ -341,7 +367,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		to_chat(councillor, span_warning("[head.real_name] declines my petition."))
 		to_chat(head, span_notice("You decline the petition."))
 		return
-	// Everything could have changed while the prompt sat open.
+	// Revalidate after the prompt.
 	if(QDELETED(councillor) || QDELETED(head) || councillor.stat == DEAD || head.stat == DEAD)
 		return
 	if(!(head in get_hearers_in_view(petition_range, councillor)))
@@ -351,7 +377,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(councillor.ministry_active || councillor.ministry_pending || head.ministry_partner)
 		to_chat(head, span_warning("The arrangement has already been overtaken by events."))
 		return
-	if(SSroguemachine.ministry_bureau?.active_ministries?[charter])
+	if(SSroguemachine.ministry_bureau.active_ministries[charter])
 		to_chat(head, span_warning("A minister of this house has already been seated."))
 		return
 
@@ -363,13 +389,13 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 
 	var/obj/item/paper/scroll/ministry_writ/writ = new(get_turf(head))
 	writ.finalize(councillor, head, proto)
-	head.put_in_hands(writ)
+	post_to_ministry(writ, "[councillor.real_name], Councillor", head, "Your writ of ministry has been posted. Collect it from any HERMES.", get_turf(head))
 	head.visible_message(span_notice("[head.real_name] takes [councillor.real_name] into their confidence."))
-	to_chat(head, span_notice("You accept the petition. Keep this writ as your record of it."))
+	to_chat(head, span_notice("You accept the petition. The writ recording it will reach you by post."))
 	to_chat(councillor, span_notice("[head.real_name] accepts. Go to the bureau in the council chamber to be sworn in."))
 
 // ===== WRIT OF MINISTRY =====
-// The partner's copy. Arrives finalized, stays with them. Nothing to sign.
+// The partner's record. Arrives finalized, nothing to sign.
 
 /obj/item/paper/scroll/ministry_writ
 	name = "writ of ministry"
@@ -404,9 +430,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	icon_state = "contractsigned"
 
-// ===== MINISTER'S SIGNET =====
-// Paired with a seal held by the partner. Speak into one, the other hears.
-
+// Minister's Signet, works paired with the partner's seal like a two-way SCOM.
 /obj/item/clothing/ring/minister
 	name = "minister's signet"
 	desc = "A signet ring bearing the mark of a ministerial office. Press it to your lips to speak with your patron."
@@ -423,7 +447,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		paired_seal = null
 	return ..()
 
-// Works worn or in hand.
 /obj/item/clothing/ring/minister/attack_self(mob/user)
 	. = ..()
 	attack_right(user)
@@ -450,7 +473,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	H.changeNext_move(CLICK_CD_INTENTCAP)
 	visible_message(span_notice("[H] presses their ring against their mouth."))
-	var/msg = input(H, "Speak into the ring.", "Ministry Channel") as null|text
+	var/msg = input(H, "Speak into the ring.", "Ministerial Murmurs...") as null|text
 	if(!msg || QDELETED(paired_seal))
 		return
 	speech_cooldown = world.time + speech_cooldown_time
@@ -466,7 +489,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	if(!language)
 		language = get_default_language()
-	// Speak from whatever is sitting on the turf, so a bagged ring still carries.
 	var/atom/movable/source = get_atom_on_turf(src, /mob)
 	if(!source)
 		source = src
@@ -507,8 +529,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	desc = "A ring bearing the mammon-hoarding marque of the Merchant's Guild."
 
 // ===== SEAL OF MINISTRY =====
-// The partner's half of the pair.
-
 /obj/item/seal_of_ministry
 	name = "seal of ministry"
 	desc = "A sealed dispatch bearing a ministerial mark. The wax is soft and dark."
@@ -564,7 +584,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	if(!language)
 		language = get_default_language()
-	// Speak from whatever is sitting on the turf, so a bagged seal still carries.
 	var/atom/movable/source = get_atom_on_turf(src, /mob)
 	if(!source)
 		source = src

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -458,7 +458,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
-	paired_ring.relay_ministry_message(msg, H.real_name, "Patron")
+	paired_ring.relay_ministry_message(msg)
 
 /obj/item/paper/scroll/ministry_writ/proc/can_speak_ministry(mob/living/carbon/human/H)
 	if(H.restrained() || H.incapacitated())
@@ -470,17 +470,17 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(QDELETED(paired_ring))
 		to_chat(H, span_warning("The writ has no paired ring. The bond is broken."))
 		return FALSE
-	if(!ismob(get_atom_on_turf(paired_ring, /mob)))
+	if(!paired_ring.find_items_mob_carrier())
 		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
 		return FALSE
-	if(get_atom_on_turf(src, /mob) != H)
+	if(find_items_mob_carrier() != H)
 		to_chat(H, span_warning("The writ has left my hands."))
 		return FALSE
 	return TRUE
 
-/obj/item/paper/scroll/ministry_writ/proc/relay_ministry_message(msg, speaker_name, speaker_role)
+/obj/item/paper/scroll/ministry_writ/proc/relay_ministry_message(msg)
 	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
-	say("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>")
+	say("<font color='#C8A84B'>[msg]</font>")
 
 /obj/item/paper/scroll/ministry_writ/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)
@@ -536,7 +536,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
-	paired_writ.relay_ministry_message(msg, H.real_name, "Minister")
+	paired_writ.relay_ministry_message(msg)
 
 /obj/item/clothing/ring/minister/proc/can_speak_ministry(mob/living/carbon/human/H)
 	if(H.restrained() || H.incapacitated())
@@ -548,17 +548,17 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(QDELETED(paired_writ))
 		to_chat(H, span_warning("The ring has no paired writ. The bond is broken."))
 		return FALSE
-	if(!ismob(get_atom_on_turf(paired_writ, /mob)))
+	if(!paired_writ.find_items_mob_carrier())
 		to_chat(H, span_warning("The writ is not being carried. My words find no one."))
 		return FALSE
-	if(get_atom_on_turf(src, /mob) != H)
+	if(find_items_mob_carrier() != H)
 		to_chat(H, span_warning("The ring has left my hands."))
 		return FALSE
 	return TRUE
 
-/obj/item/clothing/ring/minister/proc/relay_ministry_message(msg, speaker_name, speaker_role)
+/obj/item/clothing/ring/minister/proc/relay_ministry_message(msg)
 	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
-	say("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>")
+	say("<font color='#C8A84B'>[msg]</font>")
 
 /obj/item/clothing/ring/minister/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	if(!message)

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -274,6 +274,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /datum/ministry/merchant
 	name = "Trade Ministry"
 	display_title = "Minister of Trade"
+	income_bonus = 70 // Trade Ministry is the weakest so more income helps cope
 	ministry_keys = list(/obj/item/roguekey/shop)
 	archive_traits = list(TRAIT_SEEPRICES, TRAIT_CICERONE)
 	archive_skills = list(/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN)

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -116,7 +116,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	writ = null
 	return ..()
 
-// Extra perks. Runs after keys, traits and skills.
 /datum/ministry/proc/archive_bonus(mob/living/carbon/human/H)
 	return
 
@@ -126,6 +125,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	parcel.mailer = sender
 	parcel.mailedto = recipient.real_name
+	parcel.update_icon()
 	var/obj/item/roguemachine/mastermail/master = SSroguemachine.hermailermaster
 	if(!master)
 		parcel.forceMove(fallback || get_turf(recipient))
@@ -140,7 +140,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(notice)
 		to_chat(recipient, span_notice(notice))
 
-// Every charter and its current standing.
 /proc/ministry_roster()
 	var/obj/structure/roguemachine/ministry_bureau/bureau = SSroguemachine.ministry_bureau
 	bureau.prune_ministries()
@@ -191,15 +190,15 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /datum/ministry/church/archive_bonus(mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/ritechalk(get_turf(H)))
 	if(!H.patron || istype(H.patron, /datum/patron/godless))
-		to_chat(H, span_warning("You hold no faith. Odd."))
+		to_chat(H, span_warning("I hold no faith. Odd."))
 		return
 	if(H.devotion)
 		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
-		to_chat(H, span_notice("The archive deepens your existing devotion to [H.patron.name]."))
+		to_chat(H, span_notice("The archive deepens my existing devotion to [H.patron.name]."))
 		return
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
 	C.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_2)
-	to_chat(H, span_notice("The archive stirs your faith. You feel the first whispers of [H.patron.name]'s gifts."))
+	to_chat(H, span_notice("The archive stirs my faith. I feel the first whispers of [H.patron.name]'s gifts."))
 
 /datum/ministry/night
 	name = "Night Ministry"
@@ -231,15 +230,15 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /datum/ministry/inquisition/archive_bonus(mob/living/carbon/human/H)
 	if(H.devotion)
 		if(!istype(H.patron, /datum/patron/old_god))
-			to_chat(H, span_warning("You are already bound to a credo more alive than PSYDON's. Your boots are conspicuously empty."))
+			to_chat(H, span_warning("I am already bound to a credo more alive than PSYDON's. My boots are conspicuously empty."))
 			return
 		H.devotion.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
-		to_chat(H, span_notice("The archive reaffirms your covenant. ENDVRE."))
+		to_chat(H, span_notice("The archive reaffirms my covenant. ENDVRE."))
 		return
 	H.set_patron(/datum/patron/old_god)
 	var/datum/devotion/C = new /datum/devotion(H, GLOB.patronlist[/datum/patron/old_god])
 	C.grant_miracles(H, cleric_tier = CLERIC_T0, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)
-	to_chat(H, span_notice("The dusty notes in the back of the archive remind you of the Old God's covenant. Surely, PSYDON yet lives!"))
+	to_chat(H, span_notice("The dusty notes in the back of the archive remind me of the Old God's covenant. Surely, PSYDON yet lives!"))
 
 /datum/ministry/mage
 	name = "Arcane Ministry"
@@ -258,7 +257,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(!H.mind.has_spell(/obj/effect/proc_holder/spell/targeted/touch/prestidigitation))
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/touch/prestidigitation, H)
 	H.mind.adjust_spellpoints(9)
-	to_chat(H, span_notice("The archive imparts the arcyne secrets of the previous Minister. You feel a thrum of latent power."))
+	to_chat(H, span_notice("The archive imparts the arcyne secrets of the previous Minister. I feel a thrum of latent power."))
 
 /datum/ministry/physician
 	name = "Physician Ministry"
@@ -273,7 +272,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 
 /datum/ministry/physician/archive_bonus(mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/storage/belt/rogue/surgery_bag/full/physician(get_turf(H)))
-	to_chat(H, span_notice("The previous Minister's surgeon kit is collecting dust in the back of the archive. Following their notes, you might make use of it."))
+	to_chat(H, span_notice("The previous Minister's surgeon kit is collecting dust in the back of the archive. Following their notes, I might make use of it."))
 
 /datum/ministry/innkeeper
 	name = "Tavern Ministry"
@@ -338,7 +337,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 			to_chat(councillor, span_notice(line))
 		return
 
-	var/picked = input(councillor, "Whose patronage do you seek?", "[name]") as null|anything in prospects
+	var/picked = input(councillor, "Whose patronage do I seek?", "[name]") as null|anything in prospects
 	if(!picked)
 		return
 	var/mob/living/carbon/human/head = prospects[picked]
@@ -353,12 +352,11 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	var/datum/ministry/charter_ref = charter
 	councillor.say("[head.real_name], let me be your voice within the keep.")
-	var/answer = alert(head, "[councillor.real_name] petitions to serve as your [initial(charter_ref.display_title)]. They will be granted a measure of your trade's knowledge, and you a seal to speak with them.", "Ministry", "Accept", "Refuse")
+	var/answer = alert(head, "[councillor.real_name] petitions to serve as my [initial(charter_ref.display_title)]. They will be granted a measure of my trade's knowledge, and some keys to my place of responsibility. In return I shall receive a writ to speak with them.", "Ministry", "Accept", "Refuse")
 	if(answer != "Accept")
 		to_chat(councillor, span_warning("[head.real_name] declines my petition."))
-		to_chat(head, span_notice("You decline the petition."))
+		to_chat(head, span_notice("I decline the petition."))
 		return
-	// Revalidate after the prompt.
 	if(QDELETED(councillor) || QDELETED(head) || councillor.stat == DEAD || head.stat == DEAD)
 		return
 	if(!(head in get_hearers_in_view(petition_range, councillor)))
@@ -382,11 +380,10 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	proto.partner = head
 
 	head.visible_message(span_notice("[head.real_name] takes [councillor.real_name] into their confidence."))
-	to_chat(head, span_notice("You accept the petition. The writ will reach you by post once they are sworn in."))
+	to_chat(head, span_notice("I accept the petition. The writ will reach me by post once they are sworn in."))
 	to_chat(councillor, span_notice("[head.real_name] accepts. Go to the bureau in the council chamber to be sworn in."))
 
 // ===== WRIT OF MINISTRY =====
-// The partner's half. Records the oath and carries their voice to the minister's ring.
 
 /obj/item/paper/scroll/ministry_writ
 	name = "writ of ministry"
@@ -440,7 +437,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	icon_state = "contractsigned"
 	name = open_name || initial(name)
 
-// Rolled up it folds like any scroll. Unrolled it carries the partner's voice.
 /obj/item/paper/scroll/ministry_writ/attack_self(mob/user)
 	// Let the parent clear the mail wrapper first, otherwise read() stays blocked.
 	if(mailer || !open || !paired_ring || !ishuman(user))
@@ -448,26 +444,39 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	var/mob/living/carbon/human/H = user
 	if(!H.ministry_partner || H.ministry_partner.partner != H)
 		return ..()
-	if(H.restrained() || H.incapacitated())
-		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
-		return
-	if(world.time < speech_cooldown)
-		to_chat(H, span_warning("The ink is still settling from its last use."))
-		return
-	if(QDELETED(paired_ring))
-		to_chat(H, span_warning("The writ has no paired ring. The bond is broken."))
-		return
-	if(!ismob(get_atom_on_turf(paired_ring, /mob)))
-		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
+	if(!can_speak_ministry(H))
 		return
 	H.changeNext_move(CLICK_CD_INTENTCAP)
 	visible_message(span_notice("[H] murmurs over the writ."))
-	var/msg = input(H, "Send word to your minister.", "Ministry Channel") as null|text
-	if(!msg || QDELETED(paired_ring))
+	var/msg = input(H, "Send word to my minister.", "Ministerial Murmurs...") as null|text
+	if(!msg)
+		return
+	if(!can_speak_ministry(H))
+		return
+	if(H.ministry_partner?.partner != H || !open || mailer)
+		to_chat(H, span_warning("The writ is no longer mine to speak upon."))
 		return
 	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
 	paired_ring.relay_ministry_message(msg, H.real_name, "Patron")
+
+/obj/item/paper/scroll/ministry_writ/proc/can_speak_ministry(mob/living/carbon/human/H)
+	if(H.restrained() || H.incapacitated())
+		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
+		return FALSE
+	if(world.time < speech_cooldown)
+		to_chat(H, span_warning("The ink is still settling from its last use."))
+		return FALSE
+	if(QDELETED(paired_ring))
+		to_chat(H, span_warning("The writ has no paired ring. The bond is broken."))
+		return FALSE
+	if(!ismob(get_atom_on_turf(paired_ring, /mob)))
+		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
+		return FALSE
+	if(get_atom_on_turf(src, /mob) != H)
+		to_chat(H, span_warning("The writ has left my hands."))
+		return FALSE
+	return TRUE
 
 /obj/item/paper/scroll/ministry_writ/proc/relay_ministry_message(msg, speaker_name, speaker_role)
 	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
@@ -484,7 +493,7 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	send_speech(message, 1, src, , spans, message_language = language)
 
-// Minister's Signet, works paired with the partner's seal like a two-way SCOM.
+// Minister's signet, paired to the partner's writ like a two-way SCOM.
 /obj/item/clothing/ring/minister
 	name = "minister's signet"
 	desc = "A signet ring bearing the mark of a ministerial office. Press it to your lips to speak with your patron."
@@ -513,26 +522,39 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(!H.ministry_active || H.ministry_active.councillor != H)
 		to_chat(H, span_warning("The ring is cold and dead in my hand. It was not made for me."))
 		return
-	if(H.restrained() || H.incapacitated())
-		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
-		return
-	if(world.time < speech_cooldown)
-		to_chat(H, span_warning("The ring's metal is still heated from its last use."))
-		return
-	if(QDELETED(paired_writ))
-		to_chat(H, span_warning("The ring has no paired seal. The bond is broken."))
-		return
-	if(!ismob(get_atom_on_turf(paired_writ, /mob)))
-		to_chat(H, span_warning("The seal is not being carried. My words find no one."))
+	if(!can_speak_ministry(H))
 		return
 	H.changeNext_move(CLICK_CD_INTENTCAP)
 	visible_message(span_notice("[H] presses their ring against their mouth."))
 	var/msg = input(H, "Speak into the ring.", "Ministerial Murmurs...") as null|text
-	if(!msg || QDELETED(paired_writ))
+	if(!msg)
+		return
+	if(!can_speak_ministry(H))
+		return
+	if(H.ministry_active?.councillor != H)
+		to_chat(H, span_warning("The ring has gone cold. My office is no longer mine."))
 		return
 	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
 	paired_writ.relay_ministry_message(msg, H.real_name, "Minister")
+
+/obj/item/clothing/ring/minister/proc/can_speak_ministry(mob/living/carbon/human/H)
+	if(H.restrained() || H.incapacitated())
+		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
+		return FALSE
+	if(world.time < speech_cooldown)
+		to_chat(H, span_warning("The ring's metal is still heated from its last use."))
+		return FALSE
+	if(QDELETED(paired_writ))
+		to_chat(H, span_warning("The ring has no paired writ. The bond is broken."))
+		return FALSE
+	if(!ismob(get_atom_on_turf(paired_writ, /mob)))
+		to_chat(H, span_warning("The writ is not being carried. My words find no one."))
+		return FALSE
+	if(get_atom_on_turf(src, /mob) != H)
+		to_chat(H, span_warning("The ring has left my hands."))
+		return FALSE
+	return TRUE
 
 /obj/item/clothing/ring/minister/proc/relay_ministry_message(msg, speaker_name, speaker_role)
 	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -103,25 +103,24 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	var/list/archive_traits = list()
 	var/list/archive_skills = list()
 	var/ring_type
-	var/seal_type
 	var/mob/living/carbon/human/councillor
 	var/mob/living/carbon/human/partner
 	var/obj/item/clothing/ring/minister/ring
-	var/obj/item/seal_of_ministry/seal
+	var/obj/item/paper/scroll/ministry_writ/writ
 	var/active = FALSE
 
 /datum/ministry/Destroy()
 	councillor = null
 	partner = null
 	ring = null
-	seal = null
+	writ = null
 	return ..()
 
 // Extra perks. Runs after keys, traits and skills.
 /datum/ministry/proc/archive_bonus(mob/living/carbon/human/H)
 	return
 
-// Duplicating some HERMES logic here for mailing the writ and seal.
+// Duplicating some HERMES logic here for mailing the writ.
 /proc/post_to_ministry(obj/item/parcel, sender, mob/living/carbon/human/recipient, notice, turf/fallback)
 	if(!parcel || QDELETED(recipient))
 		return
@@ -180,7 +179,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		/datum/skill/craft/engineering = SKILL_LEVEL_NOVICE
 	)
 	ring_type = /obj/item/clothing/ring/minister/guild
-	seal_type = /obj/item/seal_of_ministry/guild
 
 /datum/ministry/church
 	name = "Church Ministry"
@@ -189,7 +187,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	archive_traits = list(TRAIT_RITUALIST, TRAIT_VOTARY)
 	archive_skills = list(/datum/skill/magic/holy = SKILL_LEVEL_APPRENTICE)
 	ring_type = /obj/item/clothing/ring/minister/church
-	seal_type = /obj/item/seal_of_ministry/church
 
 /datum/ministry/church/archive_bonus(mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/ritechalk(get_turf(H)))
@@ -215,7 +212,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE
 	)
 	ring_type = /obj/item/clothing/ring/minister/night
-	seal_type = /obj/item/seal_of_ministry/night
 
 /datum/ministry/inquisition
 	name = "Inquisition Ministry"
@@ -231,7 +227,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT
 	)
 	ring_type = /obj/item/clothing/ring/minister/inquisition
-	seal_type = /obj/item/seal_of_ministry/inquisition
 
 /datum/ministry/inquisition/archive_bonus(mob/living/carbon/human/H)
 	if(H.devotion)
@@ -256,7 +251,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		/datum/skill/magic/arcane = SKILL_LEVEL_APPRENTICE
 	)
 	ring_type = /obj/item/clothing/ring/minister/mage
-	seal_type = /obj/item/seal_of_ministry/mage
 
 /datum/ministry/mage/archive_bonus(mob/living/carbon/human/H)
 	if(!H.mind)
@@ -276,7 +270,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN
 	)
 	ring_type = /obj/item/clothing/ring/minister/physician
-	seal_type = /obj/item/seal_of_ministry/physician
 
 /datum/ministry/physician/archive_bonus(mob/living/carbon/human/H)
 	H.put_in_hands(new /obj/item/storage/belt/rogue/surgery_bag/full/physician(get_turf(H)))
@@ -289,7 +282,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	archive_traits = list(TRAIT_CICERONE, TRAIT_EMPATH, TRAIT_TAVERN_FIGHTER)
 	archive_skills = list(/datum/skill/craft/cooking = SKILL_LEVEL_JOURNEYMAN)
 	ring_type = /obj/item/clothing/ring/minister/innkeeper
-	seal_type = /obj/item/seal_of_ministry/innkeeper
 
 /datum/ministry/merchant
 	name = "Trade Ministry"
@@ -299,7 +291,6 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	archive_traits = list(TRAIT_SEEPRICES, TRAIT_CICERONE)
 	archive_skills = list(/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN)
 	ring_type = /obj/item/clothing/ring/minister/merchant
-	seal_type = /obj/item/seal_of_ministry/merchant
 
 // ===== PETITION SPELL =====
 
@@ -377,6 +368,9 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(councillor.ministry_active || councillor.ministry_pending || head.ministry_partner)
 		to_chat(head, span_warning("The arrangement has already been overtaken by events."))
 		return
+	if(councillor.ministry_spent && councillor.ministry_spent != charter)
+		to_chat(head, span_warning("This one is schooled in another trade entirely."))
+		return
 	if(SSroguemachine.ministry_bureau.active_ministries[charter])
 		to_chat(head, span_warning("A minister of this house has already been seated."))
 		return
@@ -387,15 +381,12 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	proto.councillor = councillor
 	proto.partner = head
 
-	var/obj/item/paper/scroll/ministry_writ/writ = new(get_turf(head))
-	writ.finalize(councillor, head, proto)
-	post_to_ministry(writ, "[councillor.real_name], Councillor", head, "Your writ of ministry has been posted. Collect it from any HERMES.", get_turf(head))
 	head.visible_message(span_notice("[head.real_name] takes [councillor.real_name] into their confidence."))
-	to_chat(head, span_notice("You accept the petition. The writ recording it will reach you by post."))
+	to_chat(head, span_notice("You accept the petition. The writ will reach you by post once they are sworn in."))
 	to_chat(councillor, span_notice("[head.real_name] accepts. Go to the bureau in the council chamber to be sworn in."))
 
 // ===== WRIT OF MINISTRY =====
-// The partner's record. Arrives finalized, nothing to sign.
+// The partner's half. Records the oath and carries their voice to the minister's ring.
 
 /obj/item/paper/scroll/ministry_writ
 	name = "writ of ministry"
@@ -404,10 +395,21 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	open = TRUE
 	textper = 150
 	var/ministry_type
+	var/open_name
+	var/obj/item/clothing/ring/minister/paired_ring
+	var/speech_cooldown = 0
+	var/speech_cooldown_time = 10 SECONDS
+
+/obj/item/paper/scroll/ministry_writ/Destroy()
+	if(paired_ring)
+		paired_ring.paired_writ = null
+		paired_ring = null
+	return ..()
 
 /obj/item/paper/scroll/ministry_writ/proc/finalize(mob/living/carbon/human/minister, mob/living/carbon/human/partner, datum/ministry/M)
 	ministry_type = M.type
-	name = "writ of the [M.name]"
+	open_name = "writ of the [M.name]"
+	name = open_name
 	desc = "A charter appointing [minister.real_name] to the office of [M.display_title]."
 	var/datum/job/ruler = SSjob.GetJobType(/datum/job/roguetown/lord)
 	var/ruler_title = ruler?.display_title || ruler?.title || "Grand Duke"
@@ -416,19 +418,71 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	info += "Let it be known that, [partner.real_name], [partner.mind?.assigned_role || "of the town"], \
 			does receive into their confidence [minister.real_name], Councillor to the [ruler_title], \
 			granting unto them the office and privileges of <b>[M.display_title]</b>.<br/><br/>"
-	info += "The Minister shall speak for this house within the council chamber. The seal accompanying this writ \
-			shall carry their voice, and bear yours in return.<br/><br/>"
+	info += "The Minister shall speak for this house within the council chamber. Unroll this writ and speak \
+			upon it to reach them, wherever they stand.<br/><br/>"
 	info += "SIGNED,<br/>"
 	info += "[minister.real_name], [M.display_title] of [SSmapping.map_adjustment.realm_name]"
 	info += "</font>"
 	update_icon_state()
 
+/obj/item/paper/scroll/ministry_writ/examine(mob/user)
+	. = ..()
+	if(paired_ring && open)
+		. += span_notice("Speak upon it to reach the minister.")
+
 /obj/item/paper/scroll/ministry_writ/update_icon_state()
+	if(mailer)
+		return ..()
 	if(!open)
 		icon_state = "scroll_closed"
 		name = "scroll"
 		return
 	icon_state = "contractsigned"
+	name = open_name || initial(name)
+
+// Rolled up it folds like any scroll. Unrolled it carries the partner's voice.
+/obj/item/paper/scroll/ministry_writ/attack_self(mob/user)
+	// Let the parent clear the mail wrapper first, otherwise read() stays blocked.
+	if(mailer || !open || !paired_ring || !ishuman(user))
+		return ..()
+	var/mob/living/carbon/human/H = user
+	if(!H.ministry_partner || H.ministry_partner.partner != H)
+		return ..()
+	if(H.restrained() || H.incapacitated())
+		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
+		return
+	if(world.time < speech_cooldown)
+		to_chat(H, span_warning("The ink is still settling from its last use."))
+		return
+	if(QDELETED(paired_ring))
+		to_chat(H, span_warning("The writ has no paired ring. The bond is broken."))
+		return
+	if(!ismob(get_atom_on_turf(paired_ring, /mob)))
+		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
+		return
+	H.changeNext_move(CLICK_CD_INTENTCAP)
+	visible_message(span_notice("[H] murmurs over the writ."))
+	var/msg = input(H, "Send word to your minister.", "Ministry Channel") as null|text
+	if(!msg || QDELETED(paired_ring))
+		return
+	speech_cooldown = world.time + speech_cooldown_time
+	H.whisper(msg)
+	paired_ring.relay_ministry_message(msg, H.real_name, "Patron")
+
+/obj/item/paper/scroll/ministry_writ/proc/relay_ministry_message(msg, speaker_name, speaker_role)
+	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
+	say("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>")
+
+/obj/item/paper/scroll/ministry_writ/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	if(!message)
+		return
+	if(!language)
+		language = get_default_language()
+	if(isitem(loc))
+		var/obj/item/I = loc
+		I.send_speech(message, 1, I, , spans, message_language = language)
+		return
+	send_speech(message, 1, src, , spans, message_language = language)
 
 // Minister's Signet, works paired with the partner's seal like a two-way SCOM.
 /obj/item/clothing/ring/minister
@@ -437,14 +491,14 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	icon_state = "signet"
 	sellprice = 100
 	slot_flags = ITEM_SLOT_RING
-	var/obj/item/seal_of_ministry/paired_seal
+	var/obj/item/paper/scroll/ministry_writ/paired_writ
 	var/speech_cooldown = 0
-	var/speech_cooldown_time = 1 MINUTES
+	var/speech_cooldown_time = 10 SECONDS
 
 /obj/item/clothing/ring/minister/Destroy()
-	if(paired_seal)
-		paired_seal.paired_ring = null
-		paired_seal = null
+	if(paired_writ)
+		paired_writ.paired_ring = null
+		paired_writ = null
 	return ..()
 
 /obj/item/clothing/ring/minister/attack_self(mob/user)
@@ -465,20 +519,20 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 	if(world.time < speech_cooldown)
 		to_chat(H, span_warning("The ring's metal is still heated from its last use."))
 		return
-	if(QDELETED(paired_seal))
+	if(QDELETED(paired_writ))
 		to_chat(H, span_warning("The ring has no paired seal. The bond is broken."))
 		return
-	if(!ismob(get_atom_on_turf(paired_seal, /mob)))
+	if(!ismob(get_atom_on_turf(paired_writ, /mob)))
 		to_chat(H, span_warning("The seal is not being carried. My words find no one."))
 		return
 	H.changeNext_move(CLICK_CD_INTENTCAP)
 	visible_message(span_notice("[H] presses their ring against their mouth."))
 	var/msg = input(H, "Speak into the ring.", "Ministerial Murmurs...") as null|text
-	if(!msg || QDELETED(paired_seal))
+	if(!msg || QDELETED(paired_writ))
 		return
 	speech_cooldown = world.time + speech_cooldown_time
 	H.whisper(msg)
-	paired_seal.relay_ministry_message(msg, H.real_name, "Minister")
+	paired_writ.relay_ministry_message(msg, H.real_name, "Minister")
 
 /obj/item/clothing/ring/minister/proc/relay_ministry_message(msg, speaker_name, speaker_role)
 	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
@@ -528,97 +582,3 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 /obj/item/clothing/ring/minister/merchant
 	name = "trade minister's signet"
 	desc = "A ring bearing the mammon-hoarding marque of the Merchant's Guild."
-
-// ===== SEAL OF MINISTRY =====
-/obj/item/seal_of_ministry
-	name = "seal of ministry"
-	desc = "A sealed dispatch bearing a ministerial mark. The wax is soft and dark."
-	icon = 'icons/roguetown/items/misc.dmi'
-	icon_state = "scroll_closed"
-	w_class = WEIGHT_CLASS_TINY
-	dropshrink = 0.6
-	var/obj/item/clothing/ring/minister/paired_ring
-	var/speech_cooldown = 0
-	var/speech_cooldown_time = 1 MINUTES
-
-/obj/item/seal_of_ministry/Destroy()
-	if(paired_ring)
-		paired_ring.paired_seal = null
-		paired_ring = null
-	return ..()
-
-/obj/item/seal_of_ministry/attack_self(mob/user)
-	. = ..()
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(!H.ministry_partner || H.ministry_partner.partner != H)
-		to_chat(H, span_warning("The wax is inert. This seal answers to another hand."))
-		return
-	if(H.restrained() || H.incapacitated())
-		to_chat(H, span_warning("I cannot use this while restrained or incapacitated!"))
-		return
-	if(world.time < speech_cooldown)
-		to_chat(H, span_warning("The seal is still reforming from its last break."))
-		return
-	if(QDELETED(paired_ring))
-		to_chat(H, span_warning("The seal has no paired ring. The bond is broken."))
-		return
-	if(!ismob(get_atom_on_turf(paired_ring, /mob)))
-		to_chat(H, span_warning("My minister is not carrying their ring. My words find no one."))
-		return
-	H.changeNext_move(CLICK_CD_INTENTCAP)
-	visible_message(span_notice("[H] murmurs into the wax of the seal."))
-	var/msg = input(H, "Send word to your minister.", "Ministry Channel") as null|text
-	if(!msg || QDELETED(paired_ring))
-		return
-	speech_cooldown = world.time + speech_cooldown_time
-	H.whisper(msg)
-	paired_ring.relay_ministry_message(msg, H.real_name, "Patron")
-
-/obj/item/seal_of_ministry/proc/relay_ministry_message(msg, speaker_name, speaker_role)
-	playsound(src, 'sound/misc/scom.ogg', 80, FALSE, -1)
-	say("<font color='#C8A84B'><b>[speaker_name] ([speaker_role]):</b> [msg]</font>")
-
-/obj/item/seal_of_ministry/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	if(!message)
-		return
-	if(!language)
-		language = get_default_language()
-	if(isitem(loc))
-		var/obj/item/I = loc
-		I.send_speech(message, 1, I, , spans, message_language = language)
-		return
-	send_speech(message, 1, src, , spans, message_language = language)
-
-/obj/item/seal_of_ministry/guild
-	name = "guild seal of ministry"
-	desc = "A rolled dispatch sealed with the crossed-hammer mark of the Guildmaster. The wax feels warm when held."
-
-/obj/item/seal_of_ministry/church
-	name = "church seal of ministry"
-	desc = "A scroll bound shut with the Pantheon cross in pale wax. It carries the faint smell of flower petals."
-
-/obj/item/seal_of_ministry/night
-	name = "night seal of ministry"
-	desc = "A plain roll of parchment, sealed with unmarked black wax. Nothing about it invites curiosity."
-
-/obj/item/seal_of_ministry/inquisition
-	name = "inquisition seal of ministry"
-	desc = "A tightly rolled writ sealed with a silver stamp. The edges are sharp and precise."
-
-/obj/item/seal_of_ministry/mage
-	name = "arcane seal of ministry"
-	desc = "A scroll whose wax seal faintly glows with a glyph that shifts when you aren't looking directly at it."
-
-/obj/item/seal_of_ministry/physician
-	name = "physician seal of ministry"
-	desc = "A clinical roll of parchment sealed in dark red wax. Smells faintly of camphor."
-
-/obj/item/seal_of_ministry/innkeeper
-	name = "tavern seal of ministry"
-	desc = "A short scroll sealed with the inn's tap-mark pressed into amber wax. It smells vaguely of ale."
-
-/obj/item/seal_of_ministry/merchant
-	name = "trade seal of ministry"
-	desc = "A folded dispatch sealed with the merchant's mark in green wax, the edges worn from handling."

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -489,10 +489,11 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	if(!language)
 		language = get_default_language()
-	var/atom/movable/source = get_atom_on_turf(src, /mob)
-	if(!source)
-		source = src
-	source.send_speech(message, 1, source, , spans, message_language = language)
+	if(isitem(loc))
+		var/obj/item/I = loc
+		I.send_speech(message, 1, I, , spans, message_language = language)
+		return
+	send_speech(message, 1, src, , spans, message_language = language)
 
 /obj/item/clothing/ring/minister/guild
 	name = "guild minister's signet"
@@ -584,10 +585,11 @@ GLOBAL_LIST_INIT(ministry_charters, list(
 		return
 	if(!language)
 		language = get_default_language()
-	var/atom/movable/source = get_atom_on_turf(src, /mob)
-	if(!source)
-		source = src
-	source.send_speech(message, 1, source, , spans, message_language = language)
+	if(isitem(loc))
+		var/obj/item/I = loc
+		I.send_speech(message, 1, I, , spans, message_language = language)
+		return
+	send_speech(message, 1, src, , spans, message_language = language)
 
 /obj/item/seal_of_ministry/guild
 	name = "guild seal of ministry"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -177,6 +177,9 @@
 				. += span_notice("A fellow noble.")
 			else
 				. += span_notice("A noble!")
+
+		if(ministry_active?.active)
+			. += span_notice("[m3] the office of [ministry_active.display_title].")
 		// Leashed pet status effect message
 		if(has_status_effect(/datum/status_effect/leash_pet))
 			. += span_warning("A leash is hooked to their collar. They are being led like a pet.")

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -1,0 +1,217 @@
+// This machine enables and keeps track of the Councillor "minister" datums, allowing
+// Councillor jobs to secure approval of certain power roles for skills + access.
+
+#define MINISTRY_REISSUE_COST 10
+
+/obj/structure/roguemachine/ministry_bureau
+	name = "ministerial bureau"
+	desc = "A cabinet of sealed correspondence and official records, sorted by house. A councillor bearing an agreed charter may be sworn in here."
+	icon = 'icons/roguetown/misc/structure.dmi'
+	icon_state = "closetlord"
+	density = TRUE
+	layer = BELOW_OBJ_LAYER
+	attacked_sound = "woodimpact"
+	var/list/active_ministries = list()
+
+/obj/structure/roguemachine/ministry_bureau/Initialize(mapload)
+	. = ..()
+	if(!SSroguemachine.ministry_bureau)
+		SSroguemachine.ministry_bureau = src
+
+/obj/structure/roguemachine/ministry_bureau/Destroy()
+	if(SSroguemachine.ministry_bureau == src)
+		SSroguemachine.ministry_bureau = null
+	QDEL_LIST_ASSOC_VAL(active_ministries)
+	return ..()
+
+/obj/structure/roguemachine/ministry_bureau/examine(mob/user)
+	. = ..()
+	if(!length(active_ministries))
+		. += span_notice("No ministries are in session.")
+		return
+	. += span_notice("Ministries in session:")
+	for(var/charter in active_ministries)
+		var/datum/ministry/M = active_ministries[charter]
+		. += span_notice("[M.display_title] — [M.councillor?.real_name || "vacant"], seated by [M.partner?.real_name || "unknown"].")
+
+// Tears down ministries whose councillor or partner is gone.
+// Walks backwards so cutting entries doesn't skip the next one.
+/obj/structure/roguemachine/ministry_bureau/proc/prune_ministries()
+	for(var/i = length(active_ministries), i >= 1, i--)
+		var/charter = active_ministries[i]
+		var/datum/ministry/M = active_ministries[charter]
+		if(!M)
+			active_ministries.Cut(i, i + 1)
+			continue
+		var/mob/living/carbon/human/minister = M.councillor
+		var/mob/living/carbon/human/partner = M.partner
+		if(minister && !QDELETED(minister) && minister.stat != DEAD && partner && !QDELETED(partner) && partner.stat != DEAD)
+			continue
+		if(minister && !QDELETED(minister))
+			minister.ministry_active = null
+			if(SStreasury.noble_incomes[minister])
+				SStreasury.noble_incomes[minister] = max(0, SStreasury.noble_incomes[minister] - M.income_bonus)
+		if(partner && !QDELETED(partner))
+			partner.ministry_partner = null
+		active_ministries.Cut(i, i + 1)
+		qdel(M)
+
+/obj/structure/roguemachine/ministry_bureau/attackby(obj/item/P, mob/living/carbon/human/user, params)
+	if(!istype(user) || !istype(P, /obj/item/roguecoin/gold))
+		return ..()
+	if(user.mind?.assigned_role != "Councillor" || !user.ministry_active)
+		return ..()
+	reissue_regalia(user, P)
+
+/obj/structure/roguemachine/ministry_bureau/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(.)
+		return
+	if(!istype(user))
+		return
+	if(user.mind?.assigned_role != "Councillor")
+		to_chat(user, span_warning("These records are the council chamber's own."))
+		return
+	if(user.ministry_active)
+		to_chat(user, span_warning("I already hold an office."))
+		return
+	if(!user.ministry_pending)
+		to_chat(user, span_warning("I have no charter to enter. A faction head must first agree to take me on."))
+		for(var/line in ministry_roster())
+			to_chat(user, span_notice(line))
+		return
+
+	prune_ministries()
+	var/datum/ministry/M = user.ministry_pending
+	var/charter = M.type
+	if(active_ministries[charter])
+		to_chat(user, span_warning("A minister of that house is already seated. My charter is void."))
+		clear_pending(user)
+		return
+	if(QDELETED(M.partner) || M.partner.stat == DEAD || M.partner.ministry_partner != M)
+		to_chat(user, span_warning("My patron's agreement no longer stands."))
+		clear_pending(user)
+		return
+
+	to_chat(user, span_notice("I open the bureau and begin the rite of appointment. Hold still..."))
+	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
+	if(!do_after(user, 10 SECONDS, target = src))
+		to_chat(user, span_warning("I step away before the rite is complete."))
+		return
+
+	// Re-check everything; ten seconds is a long time in this town.
+	if(user.ministry_active || user.ministry_pending != M)
+		return
+	prune_ministries()
+	if(active_ministries[charter])
+		to_chat(user, span_warning("Another was seated while I read. The charter is void."))
+		clear_pending(user)
+		return
+	if(QDELETED(M.partner) || M.partner.stat == DEAD || M.partner.ministry_partner != M)
+		to_chat(user, span_warning("My patron's agreement no longer stands."))
+		clear_pending(user)
+		return
+
+	swear_in(user, M)
+
+// Drops a dead-on-arrival charter and releases the partner's reservation.
+/obj/structure/roguemachine/ministry_bureau/proc/clear_pending(mob/living/carbon/human/user)
+	var/datum/ministry/M = user.ministry_pending
+	user.ministry_pending = null
+	if(!M)
+		return
+	if(M.partner?.ministry_partner == M)
+		M.partner.ministry_partner = null
+	qdel(M)
+
+/obj/structure/roguemachine/ministry_bureau/proc/swear_in(mob/living/carbon/human/user, datum/ministry/M)
+	active_ministries[M.type] = M
+	M.active = TRUE
+	user.ministry_active = M
+	user.ministry_pending = null
+	SStreasury.noble_incomes[user] += M.income_bonus
+
+	issue_regalia(M, user)
+
+	var/turf/T = get_turf(src)
+	for(var/key_type in M.ministry_keys)
+		new key_type(T)
+	for(var/trait in M.archive_traits)
+		ADD_TRAIT(user, trait, "ministry")
+	for(var/skill_type in M.archive_skills)
+		user.adjust_skillrank_up_to(skill_type, M.archive_skills[skill_type], TRUE)
+	M.archive_bonus(user)
+
+	var/obj/effect/proc_holder/spell/petition = user.mind?.get_spell(/obj/effect/proc_holder/spell/self/petition_ministry)
+	if(petition)
+		user.mind.RemoveSpell(petition)
+	to_chat(user, span_notice("The rite is complete. I am [M.display_title], and the knowledge of the [M.name] is mine to draw upon."))
+	to_chat(M.partner, span_notice("[user.real_name] has been sworn in as your [M.display_title]."))
+	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
+
+// Mints the paired ring and seal. The ring goes to the minister, the seal to the mail.
+/obj/structure/roguemachine/ministry_bureau/proc/issue_regalia(datum/ministry/M, mob/living/carbon/human/receiver)
+	var/obj/item/clothing/ring/minister/ring = new M.ring_type(get_turf(src))
+	var/obj/item/seal_of_ministry/seal = new M.seal_type(get_turf(src))
+	ring.paired_seal = seal
+	seal.paired_ring = ring
+	M.ring = ring
+	M.seal = seal
+	if(receiver)
+		receiver.put_in_hands(ring)
+	post_seal(seal, M.councillor, M)
+
+// Ten zenarii mints a fresh pair. The old ring survives as inert loot, the old seal doesn't.
+/obj/structure/roguemachine/ministry_bureau/proc/reissue_regalia(mob/living/carbon/human/user, obj/item/roguecoin/gold/coins)
+	var/datum/ministry/M = user.ministry_active
+	if(!M || !M.active)
+		to_chat(user, span_warning("I hold no office. The bureau has nothing to recast for me."))
+		return
+	if(QDELETED(M.partner))
+		to_chat(user, span_warning("My partner is gone. There is no one to bear the other half."))
+		return
+	if(coins.quantity < MINISTRY_REISSUE_COST)
+		to_chat(user, span_warning("The bureau wants [MINISTRY_REISSUE_COST] zenarii for a recasting."))
+		return
+	if(!do_after(user, 5 SECONDS, target = src))
+		return
+	if(user.ministry_active != M || !M.active || QDELETED(coins) || coins.quantity < MINISTRY_REISSUE_COST)
+		return
+
+	if(coins.quantity > MINISTRY_REISSUE_COST)
+		coins.set_quantity(coins.quantity - MINISTRY_REISSUE_COST)
+	else
+		qdel(coins)
+	SStreasury.give_money_treasury(MINISTRY_REISSUE_COST * 10, "Ministry Recasting")
+
+	// The old ring stays in the world as dead metal - whoever holds it keeps a
+	// trinket, not a channel. The old seal is worthless, so it goes.
+	var/obj/item/clothing/ring/minister/old_ring = M.ring
+	if(old_ring)
+		old_ring.paired_seal = null
+		old_ring.desc = "A signet ring of a ministerial office, its mark scored through. Dead metal."
+		M.ring = null
+	QDEL_NULL(M.seal)
+	issue_regalia(M, user)
+	playsound(src, 'sound/foley/coins1.ogg', 100, TRUE, -1)
+	to_chat(user, span_notice("The bureau strikes a new mark and scores through the old. Whatever became of the last ring, it answers to no one now."))
+
+// Instead of making the councillor walk back, we can send the partner's seal through the mail.
+/obj/structure/roguemachine/ministry_bureau/proc/post_seal(obj/item/seal_of_ministry/seal, mob/living/carbon/human/minister, datum/ministry/M)
+	var/mob/living/carbon/human/partner = M.partner
+	seal.mailer = "[minister.real_name], [M.display_title]"
+	seal.mailedto = partner.real_name
+	var/obj/item/roguemachine/mastermail/master = SSroguemachine.hermailermaster
+	if(!master)
+		seal.forceMove(get_turf(src))
+		return
+	seal.forceMove(master.loc)
+	var/datum/component/storage/STR = master.GetComponent(/datum/component/storage)
+	STR?.handle_item_insertion(seal, prevent_warning = TRUE)
+	master.new_mail = TRUE
+	master.update_icon()
+	partner.apply_status_effect(/datum/status_effect/ugotmail)
+	partner.playsound_local(partner, 'sound/misc/mail.ogg', 100, FALSE, -1)
+	to_chat(partner, span_notice("Your seal of ministry has been posted. Collect it from any HERMES."))
+
+#undef MINISTRY_REISSUE_COST

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -55,6 +55,10 @@
 				to_chat(minister, span_warning("Word reaches the bureau that my sponsor is gone. My office is void, though the learning stays with me."))
 		if(partner && !QDELETED(partner))
 			partner.ministry_partner = null
+		// The seal is spent either way. Leaving it paired blocks the ring being re-cut.
+		QDEL_NULL(M.seal)
+		if(M.ring)
+			M.ring.desc = "A signet ring of a ministerial office, its mark scored through. Dead metal."
 		active_ministries.Cut(i, i + 1)
 		qdel(M)
 

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -202,7 +202,6 @@
 	to_chat(M.partner, span_notice("[user.real_name] has been sworn in as my [M.display_title]."))
 	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
 
-// Pass old_ring to re-cut it instead of striking a new one.
 /obj/structure/roguemachine/ministry_bureau/proc/issue_regalia(datum/ministry/M, mob/living/carbon/human/receiver, obj/item/clothing/ring/minister/old_ring)
 	var/obj/item/clothing/ring/minister/ring = old_ring
 	if(ring)
@@ -242,13 +241,20 @@
 	SStreasury.give_money_treasury(MINISTRY_REISSUE_COST * 10, "Ministry Recasting")
 
 	var/obj/item/clothing/ring/minister/old_ring = M.ring
+	var/obj/item/clothing/ring/minister/recycled
 	if(old_ring)
 		old_ring.paired_writ = null
-		old_ring.desc = "A signet ring of a ministerial office, its mark scored through. Dead metal."
 		M.ring = null
+		if(old_ring.find_items_mob_carrier() == user)
+			recycled = old_ring
+		else
+			old_ring.desc = "A signet ring of a ministerial office, its mark scored through. Dead metal."
 	QDEL_NULL(M.writ)
-	issue_regalia(M, user)
+	issue_regalia(M, user, recycled)
 	playsound(src, 'sound/foley/coins1.ogg', 100, TRUE, -1)
-	to_chat(user, span_notice("The bureau strikes a new mark and scores through the old. Whatever became of the last ring, it answers to no one now."))
+	if(recycled)
+		to_chat(user, span_notice("The bureau allows me to polish my ring to new standing, and posts a new writ to match."))
+	else
+		to_chat(user, span_notice("The bureau strikes a new mark and scores through the old. Whatever became of the last ring, it answers to no one now."))
 
 #undef MINISTRY_REISSUE_COST

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -55,8 +55,11 @@
 				to_chat(minister, span_warning("Word reaches the bureau that my sponsor is gone. My office is void, though the learning stays with me."))
 		if(partner && !QDELETED(partner))
 			partner.ministry_partner = null
-		// The seal is spent either way. Leaving it paired blocks the ring being re-cut.
-		QDEL_NULL(M.seal)
+			to_chat(partner, span_warning("The bureau strikes my minister's name from its records. The writ I was sent is so much paper."))
+		// Leaving the writ paired would block the ring being re-cut.
+		if(M.writ)
+			M.writ.paired_ring = null
+			M.writ = null
 		if(M.ring)
 			M.ring.desc = "A signet ring of a ministerial office, its mark scored through. Dead metal."
 		active_ministries.Cut(i, i + 1)
@@ -74,8 +77,8 @@
 
 // Re-cuts a spent ring for the current partner.
 /obj/structure/roguemachine/ministry_bureau/proc/resync_ring(mob/living/carbon/human/user, obj/item/clothing/ring/minister/ring)
-	if(!QDELETED(ring.paired_seal))
-		to_chat(user, span_warning("This ring still answers to its seal. There is nothing to mend."))
+	if(!QDELETED(ring.paired_writ))
+		to_chat(user, span_warning("This ring still answers to its writ. There is nothing to mend."))
 		return
 	prune_ministries()
 	var/datum/ministry/M = user.ministry_active
@@ -90,13 +93,13 @@
 		return
 	if(!do_after(user, 5 SECONDS, target = src))
 		return
-	if(user.ministry_active != M || !M.active || QDELETED(ring) || !QDELETED(ring.paired_seal))
+	if(user.ministry_active != M || !M.active || QDELETED(ring) || !QDELETED(ring.paired_writ))
 		return
 	QDEL_NULL(M.ring)
-	QDEL_NULL(M.seal)
+	QDEL_NULL(M.writ)
 	issue_regalia(M, user, ring)
 	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
-	to_chat(user, span_notice("The bureau re-cuts the old mark for [M.partner.real_name] and posts them a seal to match."))
+	to_chat(user, span_notice("The bureau re-cuts the old mark for [M.partner.real_name] and posts them a writ to match."))
 
 /obj/structure/roguemachine/ministry_bureau/attack_hand(mob/living/carbon/human/user)
 	. = ..()
@@ -178,7 +181,7 @@
 	var/obj/item/clothing/ring/minister/old_ring
 	if(reforming)
 		for(var/obj/item/clothing/ring/minister/candidate in user.GetAllContents())
-			if(candidate.type == M.ring_type && QDELETED(candidate.paired_seal))
+			if(candidate.type == M.ring_type && QDELETED(candidate.paired_writ))
 				old_ring = candidate
 				break
 	issue_regalia(M, user, old_ring)
@@ -204,23 +207,24 @@
 	to_chat(M.partner, span_notice("[user.real_name] has been sworn in as your [M.display_title]."))
 	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
 
-// Makes the paired ring and seal. Pass old_ring to re-cut instead of striking new.
+// Makes the paired ring and writ. Pass old_ring to re-cut instead of striking new.
 /obj/structure/roguemachine/ministry_bureau/proc/issue_regalia(datum/ministry/M, mob/living/carbon/human/receiver, obj/item/clothing/ring/minister/old_ring)
 	var/obj/item/clothing/ring/minister/ring = old_ring
 	if(ring)
 		ring.desc = initial(ring.desc)
 	else
 		ring = new M.ring_type(get_turf(src))
-	var/obj/item/seal_of_ministry/seal = new M.seal_type(get_turf(src))
-	ring.paired_seal = seal
-	seal.paired_ring = ring
+	var/obj/item/paper/scroll/ministry_writ/writ = new(get_turf(src))
+	writ.finalize(M.councillor, M.partner, M)
+	ring.paired_writ = writ
+	writ.paired_ring = ring
 	M.ring = ring
-	M.seal = seal
+	M.writ = writ
 	if(receiver)
 		receiver.put_in_hands(ring)
-	post_seal(seal, M.councillor, M)
+	post_to_ministry(writ, "[M.councillor.real_name], [M.display_title]", M.partner, "Your writ of ministry has been posted. Collect it from any HERMES.", get_turf(src))
 
-// Paid recast. Old ring goes inert, old seal is deleted.
+// Paid recast. Old ring goes inert, old writ is deleted.
 /obj/structure/roguemachine/ministry_bureau/proc/reissue_regalia(mob/living/carbon/human/user, obj/item/roguecoin/gold/coins)
 	var/datum/ministry/M = user.ministry_active
 	if(!M || !M.active)
@@ -245,15 +249,12 @@
 
 	var/obj/item/clothing/ring/minister/old_ring = M.ring
 	if(old_ring)
-		old_ring.paired_seal = null
+		old_ring.paired_writ = null
 		old_ring.desc = "A signet ring of a ministerial office, its mark scored through. Dead metal."
 		M.ring = null
-	QDEL_NULL(M.seal)
+	QDEL_NULL(M.writ)
 	issue_regalia(M, user)
 	playsound(src, 'sound/foley/coins1.ogg', 100, TRUE, -1)
 	to_chat(user, span_notice("The bureau strikes a new mark and scores through the old. Whatever became of the last ring, it answers to no one now."))
-
-/obj/structure/roguemachine/ministry_bureau/proc/post_seal(obj/item/seal_of_ministry/seal, mob/living/carbon/human/minister, datum/ministry/M)
-	post_to_ministry(seal, "[minister.real_name], [M.display_title]", M.partner, "Your seal of ministry has been posted. Collect it from any HERMES.", get_turf(src))
 
 #undef MINISTRY_REISSUE_COST

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -1,5 +1,4 @@
-// This machine enables and keeps track of the Councillor "minister" datums, allowing
-// Councillor jobs to secure approval of certain power roles for skills + access.
+// Councillor ministry tracking. Ministers are sworn in here.
 
 #define MINISTRY_REISSUE_COST 10
 
@@ -34,8 +33,7 @@
 		var/datum/ministry/M = active_ministries[charter]
 		. += span_notice("[M.display_title] — [M.councillor?.real_name || "vacant"], seated by [M.partner?.real_name || "unknown"].")
 
-// Tears down ministries whose councillor or partner is gone.
-// Walks backwards so cutting entries doesn't skip the next one.
+// Backwards so cutting doesn't skip entries.
 /obj/structure/roguemachine/ministry_bureau/proc/prune_ministries()
 	for(var/i = length(active_ministries), i >= 1, i--)
 		var/charter = active_ministries[i]
@@ -45,23 +43,56 @@
 			continue
 		var/mob/living/carbon/human/minister = M.councillor
 		var/mob/living/carbon/human/partner = M.partner
-		if(minister && !QDELETED(minister) && minister.stat != DEAD && partner && !QDELETED(partner) && partner.stat != DEAD)
+		// Death doesn't prune, only far travel and gibs.
+		if(minister && !QDELETED(minister) && partner && !QDELETED(partner))
 			continue
 		if(minister && !QDELETED(minister))
 			minister.ministry_active = null
 			if(SStreasury.noble_incomes[minister])
 				SStreasury.noble_incomes[minister] = max(0, SStreasury.noble_incomes[minister] - M.income_bonus)
+			if(minister.mind && !minister.mind.has_spell(/obj/effect/proc_holder/spell/self/petition_ministry))
+				minister.mind.AddSpell(new /obj/effect/proc_holder/spell/self/petition_ministry, minister)
+				to_chat(minister, span_warning("Word reaches the bureau that my sponsor is gone. My office is void, though the learning stays with me."))
 		if(partner && !QDELETED(partner))
 			partner.ministry_partner = null
 		active_ministries.Cut(i, i + 1)
 		qdel(M)
 
 /obj/structure/roguemachine/ministry_bureau/attackby(obj/item/P, mob/living/carbon/human/user, params)
-	if(!istype(user) || !istype(P, /obj/item/roguecoin/gold))
+	if(!istype(user) || user.mind?.assigned_role != "Councillor")
 		return ..()
-	if(user.mind?.assigned_role != "Councillor" || !user.ministry_active)
+	if(istype(P, /obj/item/clothing/ring/minister))
+		resync_ring(user, P)
+		return
+	if(!istype(P, /obj/item/roguecoin/gold) || !user.ministry_active)
 		return ..()
 	reissue_regalia(user, P)
+
+// Re-cuts a spent ring for the current partner.
+/obj/structure/roguemachine/ministry_bureau/proc/resync_ring(mob/living/carbon/human/user, obj/item/clothing/ring/minister/ring)
+	if(!QDELETED(ring.paired_seal))
+		to_chat(user, span_warning("This ring still answers to its seal. There is nothing to mend."))
+		return
+	prune_ministries()
+	var/datum/ministry/M = user.ministry_active
+	if(!M || !M.active)
+		to_chat(user, span_warning("I hold no office. A new charter must be agreed before this ring means anything."))
+		return
+	if(M.ring == ring)
+		to_chat(user, span_warning("The bureau has already struck my mark anew. This one is spent."))
+		return
+	if(QDELETED(M.partner))
+		to_chat(user, span_warning("There is no one to bear the other half."))
+		return
+	if(!do_after(user, 5 SECONDS, target = src))
+		return
+	if(user.ministry_active != M || !M.active || QDELETED(ring) || !QDELETED(ring.paired_seal))
+		return
+	QDEL_NULL(M.ring)
+	QDEL_NULL(M.seal)
+	issue_regalia(M, user, ring)
+	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
+	to_chat(user, span_notice("The bureau re-cuts the old mark for [M.partner.real_name] and posts them a seal to match."))
 
 /obj/structure/roguemachine/ministry_bureau/attack_hand(mob/living/carbon/human/user)
 	. = ..()
@@ -88,9 +119,12 @@
 		to_chat(user, span_warning("A minister of that house is already seated. My charter is void."))
 		clear_pending(user)
 		return
-	if(QDELETED(M.partner) || M.partner.stat == DEAD || M.partner.ministry_partner != M)
+	if(QDELETED(M.partner) || M.partner.ministry_partner != M)
 		to_chat(user, span_warning("My patron's agreement no longer stands."))
 		clear_pending(user)
+		return
+	if(M.partner.stat == DEAD)
+		to_chat(user, span_warning("My patron lies dead. The rite must wait on their recovery."))
 		return
 
 	to_chat(user, span_notice("I open the bureau and begin the rite of appointment. Hold still..."))
@@ -99,7 +133,7 @@
 		to_chat(user, span_warning("I step away before the rite is complete."))
 		return
 
-	// Re-check everything; ten seconds is a long time in this town.
+	// Revalidate after the wait.
 	if(user.ministry_active || user.ministry_pending != M)
 		return
 	prune_ministries()
@@ -107,14 +141,17 @@
 		to_chat(user, span_warning("Another was seated while I read. The charter is void."))
 		clear_pending(user)
 		return
-	if(QDELETED(M.partner) || M.partner.stat == DEAD || M.partner.ministry_partner != M)
+	if(QDELETED(M.partner) || M.partner.ministry_partner != M)
 		to_chat(user, span_warning("My patron's agreement no longer stands."))
 		clear_pending(user)
+		return
+	if(M.partner.stat == DEAD)
+		to_chat(user, span_warning("My patron lies dead. The rite must wait on their recovery."))
 		return
 
 	swear_in(user, M)
 
-// Drops a dead-on-arrival charter and releases the partner's reservation.
+// Drops a void charter and frees the partner's reservation.
 /obj/structure/roguemachine/ministry_bureau/proc/clear_pending(mob/living/carbon/human/user)
 	var/datum/ministry/M = user.ministry_pending
 	user.ministry_pending = null
@@ -125,33 +162,51 @@
 	qdel(M)
 
 /obj/structure/roguemachine/ministry_bureau/proc/swear_in(mob/living/carbon/human/user, datum/ministry/M)
+	var/reforming = (user.ministry_spent == M.type)
 	active_ministries[M.type] = M
 	M.active = TRUE
 	user.ministry_active = M
 	user.ministry_pending = null
+	user.ministry_spent = M.type
 	SStreasury.noble_incomes[user] += M.income_bonus
 
-	issue_regalia(M, user)
+	// Reuse a spent ring of this office if they still have it.
+	var/obj/item/clothing/ring/minister/old_ring
+	if(reforming)
+		for(var/obj/item/clothing/ring/minister/candidate in user.GetAllContents())
+			if(candidate.type == M.ring_type && QDELETED(candidate.paired_seal))
+				old_ring = candidate
+				break
+	issue_regalia(M, user, old_ring)
 
-	var/turf/T = get_turf(src)
-	for(var/key_type in M.ministry_keys)
-		new key_type(T)
-	for(var/trait in M.archive_traits)
-		ADD_TRAIT(user, trait, "ministry")
-	for(var/skill_type in M.archive_skills)
-		user.adjust_skillrank_up_to(skill_type, M.archive_skills[skill_type], TRUE)
-	M.archive_bonus(user)
+	// Already trained, don't grant twice.
+	if(!reforming)
+		var/turf/T = get_turf(src)
+		for(var/key_type in M.ministry_keys)
+			new key_type(T)
+		for(var/trait in M.archive_traits)
+			ADD_TRAIT(user, trait, "ministry")
+		for(var/skill_type in M.archive_skills)
+			user.adjust_skillrank_up_to(skill_type, M.archive_skills[skill_type], TRUE)
+		M.archive_bonus(user)
 
 	var/obj/effect/proc_holder/spell/petition = user.mind?.get_spell(/obj/effect/proc_holder/spell/self/petition_ministry)
 	if(petition)
 		user.mind.RemoveSpell(petition)
-	to_chat(user, span_notice("The rite is complete. I am [M.display_title], and the knowledge of the [M.name] is mine to draw upon."))
+	if(reforming)
+		to_chat(user, span_notice("The bureau records my office restored under [M.partner.real_name]. My learning stands as it was."))
+	else
+		to_chat(user, span_notice("The rite is complete. I am [M.display_title], and the knowledge of the [M.name] is mine to draw upon."))
 	to_chat(M.partner, span_notice("[user.real_name] has been sworn in as your [M.display_title]."))
 	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
 
-// Mints the paired ring and seal. The ring goes to the minister, the seal to the mail.
-/obj/structure/roguemachine/ministry_bureau/proc/issue_regalia(datum/ministry/M, mob/living/carbon/human/receiver)
-	var/obj/item/clothing/ring/minister/ring = new M.ring_type(get_turf(src))
+// Makes the paired ring and seal. Pass old_ring to re-cut instead of striking new.
+/obj/structure/roguemachine/ministry_bureau/proc/issue_regalia(datum/ministry/M, mob/living/carbon/human/receiver, obj/item/clothing/ring/minister/old_ring)
+	var/obj/item/clothing/ring/minister/ring = old_ring
+	if(ring)
+		ring.desc = initial(ring.desc)
+	else
+		ring = new M.ring_type(get_turf(src))
 	var/obj/item/seal_of_ministry/seal = new M.seal_type(get_turf(src))
 	ring.paired_seal = seal
 	seal.paired_ring = ring
@@ -161,7 +216,7 @@
 		receiver.put_in_hands(ring)
 	post_seal(seal, M.councillor, M)
 
-// Ten zenarii mints a fresh pair. The old ring survives as inert loot, the old seal doesn't.
+// Paid recast. Old ring goes inert, old seal is deleted.
 /obj/structure/roguemachine/ministry_bureau/proc/reissue_regalia(mob/living/carbon/human/user, obj/item/roguecoin/gold/coins)
 	var/datum/ministry/M = user.ministry_active
 	if(!M || !M.active)
@@ -184,8 +239,6 @@
 		qdel(coins)
 	SStreasury.give_money_treasury(MINISTRY_REISSUE_COST * 10, "Ministry Recasting")
 
-	// The old ring stays in the world as dead metal - whoever holds it keeps a
-	// trinket, not a channel. The old seal is worthless, so it goes.
 	var/obj/item/clothing/ring/minister/old_ring = M.ring
 	if(old_ring)
 		old_ring.paired_seal = null
@@ -196,22 +249,7 @@
 	playsound(src, 'sound/foley/coins1.ogg', 100, TRUE, -1)
 	to_chat(user, span_notice("The bureau strikes a new mark and scores through the old. Whatever became of the last ring, it answers to no one now."))
 
-// Instead of making the councillor walk back, we can send the partner's seal through the mail.
 /obj/structure/roguemachine/ministry_bureau/proc/post_seal(obj/item/seal_of_ministry/seal, mob/living/carbon/human/minister, datum/ministry/M)
-	var/mob/living/carbon/human/partner = M.partner
-	seal.mailer = "[minister.real_name], [M.display_title]"
-	seal.mailedto = partner.real_name
-	var/obj/item/roguemachine/mastermail/master = SSroguemachine.hermailermaster
-	if(!master)
-		seal.forceMove(get_turf(src))
-		return
-	seal.forceMove(master.loc)
-	var/datum/component/storage/STR = master.GetComponent(/datum/component/storage)
-	STR?.handle_item_insertion(seal, prevent_warning = TRUE)
-	master.new_mail = TRUE
-	master.update_icon()
-	partner.apply_status_effect(/datum/status_effect/ugotmail)
-	partner.playsound_local(partner, 'sound/misc/mail.ogg', 100, FALSE, -1)
-	to_chat(partner, span_notice("Your seal of ministry has been posted. Collect it from any HERMES."))
+	post_to_ministry(seal, "[minister.real_name], [M.display_title]", M.partner, "Your seal of ministry has been posted. Collect it from any HERMES.", get_turf(src))
 
 #undef MINISTRY_REISSUE_COST

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -55,7 +55,7 @@
 				to_chat(minister, span_warning("Word reaches the bureau that my sponsor is gone. My office is void, though the learning stays with me."))
 		if(partner && !QDELETED(partner))
 			partner.ministry_partner = null
-			to_chat(partner, span_warning("The bureau strikes my minister's name from its records. The writ I was sent is so much paper."))
+			to_chat(partner, span_warning("The bureau strikes my minister's name from its records. The writ I was sent is no more."))
 		// Leaving the writ paired would block the ring being re-cut.
 		if(M.writ)
 			M.writ.paired_ring = null
@@ -75,7 +75,6 @@
 		return ..()
 	reissue_regalia(user, P)
 
-// Re-cuts a spent ring for the current partner.
 /obj/structure/roguemachine/ministry_bureau/proc/resync_ring(mob/living/carbon/human/user, obj/item/clothing/ring/minister/ring)
 	if(!QDELETED(ring.paired_writ))
 		to_chat(user, span_warning("This ring still answers to its writ. There is nothing to mend."))
@@ -140,7 +139,6 @@
 		to_chat(user, span_warning("I step away before the rite is complete."))
 		return
 
-	// Revalidate after the wait.
 	if(user.ministry_active || user.ministry_pending != M)
 		return
 	prune_ministries()
@@ -158,7 +156,6 @@
 
 	swear_in(user, M)
 
-// Drops a void charter and frees the partner's reservation.
 /obj/structure/roguemachine/ministry_bureau/proc/clear_pending(mob/living/carbon/human/user)
 	var/datum/ministry/M = user.ministry_pending
 	user.ministry_pending = null
@@ -177,7 +174,6 @@
 	user.ministry_spent = M.type
 	SStreasury.noble_incomes[user] += M.income_bonus
 
-	// Reuse a spent ring of this office if they still have it.
 	var/obj/item/clothing/ring/minister/old_ring
 	if(reforming)
 		for(var/obj/item/clothing/ring/minister/candidate in user.GetAllContents())
@@ -186,7 +182,6 @@
 				break
 	issue_regalia(M, user, old_ring)
 
-	// Already trained, don't grant twice.
 	if(!reforming)
 		var/turf/T = get_turf(src)
 		for(var/key_type in M.ministry_keys)
@@ -204,10 +199,10 @@
 		to_chat(user, span_notice("The bureau records my office restored under [M.partner.real_name]. My learning stands as it was."))
 	else
 		to_chat(user, span_notice("The rite is complete. I am [M.display_title], and the knowledge of the [M.name] is mine to draw upon."))
-	to_chat(M.partner, span_notice("[user.real_name] has been sworn in as your [M.display_title]."))
+	to_chat(M.partner, span_notice("[user.real_name] has been sworn in as my [M.display_title]."))
 	playsound(src, 'sound/items/book_open.ogg', 60, FALSE)
 
-// Makes the paired ring and writ. Pass old_ring to re-cut instead of striking new.
+// Pass old_ring to re-cut it instead of striking a new one.
 /obj/structure/roguemachine/ministry_bureau/proc/issue_regalia(datum/ministry/M, mob/living/carbon/human/receiver, obj/item/clothing/ring/minister/old_ring)
 	var/obj/item/clothing/ring/minister/ring = old_ring
 	if(ring)
@@ -222,9 +217,8 @@
 	M.writ = writ
 	if(receiver)
 		receiver.put_in_hands(ring)
-	post_to_ministry(writ, "[M.councillor.real_name], [M.display_title]", M.partner, "Your writ of ministry has been posted. Collect it from any HERMES.", get_turf(src))
+	post_to_ministry(writ, "[M.councillor.real_name], [M.display_title]", M.partner, "My writ of ministry has been posted. I can collect it from any HERMES.", get_turf(src))
 
-// Paid recast. Old ring goes inert, old writ is deleted.
 /obj/structure/roguemachine/ministry_bureau/proc/reissue_regalia(mob/living/carbon/human/user, obj/item/roguecoin/gold/coins)
 	var/datum/ministry/M = user.ministry_active
 	if(!M || !M.active)

--- a/code/modules/roguetown/roguemachine/ministry_bureau.dm
+++ b/code/modules/roguetown/roguemachine/ministry_bureau.dm
@@ -5,7 +5,7 @@
 
 /obj/structure/roguemachine/ministry_bureau
 	name = "ministerial bureau"
-	desc = "A cabinet of sealed correspondence and official records, sorted by house. A councillor bearing an agreed charter may be sworn in here."
+	desc = "A cabinet of sealed correspondence and official records, recording the accomplishments of the Ministers of yore. A councillor bearing an agreed charter may be sworn in here. What's more, a Ministry's signet ring could be re-issued here with ten zenarii."
 	icon = 'icons/roguetown/misc/structure.dmi'
 	icon_state = "closetlord"
 	density = TRUE

--- a/roguetown.dme
+++ b/roguetown.dme
@@ -2602,6 +2602,7 @@
 #include "code\modules\roguetown\roguemachine\hoardmaster.dm"
 #include "code\modules\roguetown\roguemachine\lottery.dm"
 #include "code\modules\roguetown\roguemachine\mail.dm"
+#include "code\modules\roguetown\roguemachine\ministry_bureau.dm"
 #include "code\modules\roguetown\roguemachine\money.dm"
 #include "code\modules\roguetown\roguemachine\potionseller.dm"
 #include "code\modules\roguetown\roguemachine\rogue_flagpole.dm"


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

2nd attempt of #1316 . LLM assisted code.

This PR introduces the Ministry system, which sits on top of the Councillor job slot as an enriching solution to the job without relying on advclass selections. Councillors receive a spell that can be used to prompt various town leadership roles to accept them and create a Ministry. If accepted, the Councillor returns to their chambers and uses the ministerial bureau which is mapped into the Council chamber. The ministerial bureau is a roguemachine that, if not mapped in, doesn't allow councillors to spawn with the spell.

They receive: 
1, skills and traits and items appropriate to that sponsoring job; 
2, a signet ring that can speak to a writ that the partner receives; 
3, keys for appropriate access to that sponsored job's areas; 
4, an increase of 20 mammon per day to their noble estate income. 
The Sponsoring partner receives their writ in the mail, and can use it to speak with the paired signet ring.

The signet ring has a sellprice of 100, which makes it a target for thieves. The ring can be re-issued by clicking the minister bureau with a stack of at least 10 gold coins, costing 100 mammon.

The process is hardened to prevent double-dipping, so a councillor should never have opportunity to train two different ministries. In the event that a sponsor role far travels, the councillor can "re-strike" if someone else joins the round as that same jobslot.

Ministries are as follows,

Ministry of Crafts, Guildmaster
Skills: Blacksmithing Apprentice, Armorsmithing Apprentice, Weaponsmithing Apprentice, Smelting Apprentice, Engineering Novice
Traits: Skilled Appraiser, Expert Forgehand
Keys: Crafter's Guild
Special: N/A

Ministry of the Faith, Bishop
Skills: Holy Apprentice
Traits: Ritualist, Votary
Keys: Church, Graveyard
Special: Ritual chalk. T0 miracles of your own patron, weak passive devotion, cap 400. Could be Ascendant, funnily enough.

Ministry of Vice, Bathmaster
Skills: Sneaking Journeyman, Stealing Journeyman, Lockpicking Apprentice
Traits: Cicerone, Fabled Lover
Keys: Nightmaiden
Special: N/A

Ministry of Orthodoxy, Inquisitor
Skills: Tracking Expert, Climbing Expert, Athletics Expert, Swords Journeyman, Sneaking Journeyman, Holy Novice
Traits: Steelhearted
Keys: Inquisition
Special: Converts patron to Psydon. T0 miracles, weak passive devotion, cap 250. If someone already has different patron devotion from another source (devotee), do nothing.

Ministry of Magic, Court Magician
Skills: Alchemy Journeyman, Arcane Apprentice
Traits: Expert Alchemist
Keys: Tower
Special: Prestidigitation spell, +9 spellpoints.

Ministry of Health, Head Physician
Skills: Medicine Expert, Alchemy Journeyman
Traits: Empath, Expert Physicker, Expert Alchemist
Keys: Physician, Court Physician
Special: Physician's surgery bag.

Ministry of Commons, Innkeeper
Skills: Cooking Journeyman
Traits: Cicerone, Empath, Tavern Fighter
Keys: Tavern
Special: N/A

Ministry of Trade, Merchant
Skills: Riding Journeyman
Traits: Skilled Appraiser, Cicerone
Keys: Shop
Special: +70 noble estate income instead of +20.

The process is straightforward. Most of the squirrelly code is me trying to lock out edge cases and exploits.
Councillor gets a spell on spawn, that works in the presence of potential sponsors.
Using the spell asks the sponsor, who can say yes or no.
If the sponsor says yes, the councillor returns to his chambers and clicks the bureau machine, and "powers up". Gets his key and ring spawned. The sponsor has his writ mailed to him.
If the sponsor fartravels, the Councillor loses his examine tag and his bonus noble income. He "must" re-establish his ministry with any new spawning character of the same job slot, so that he cannot double dip training.

There's a helper function in items.dm to let the writ obj be heard while inside a container. People can keep it in their satchel.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

https://cdn.discordapp.com/attachments/1531525600072696060/1531880531648708668/ministry_test.webm?ex=6a6ad26b&is=6a6980eb&hm=13eb78a7c4614ae852997b2c797a93610139502c17553e91342292546b38ab35&
https://discord.com/channels/1240735983276654733/1531525600072696060/1531880531812155586

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
Something to give the Councillor job role some love without resulting to advclasses. Completely optional, and based on sponsoring player trust / choice opt-in: they could already be given a key previously, this just makes the workflow easier and more for the Councillor so as to encourage re-engaging with it over multiple rounds. Virgin councillors can pursue ministries according to direction by the lord if they so choose, which might help town cohesion.

Any of the skills and traits and bonuses, can all change to whatever is required to balance for merge.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Councillors may now establish ministries with important town roles, improving their skills.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
