### PR TITLE
Admin PQ Adjustment Message Tweak

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -876,7 +876,7 @@
 	if(!fexists("data/player_saves/[copytext(ckey,1,2)]/[ckey]/preferences.sav"))
 		to_chat(src, span_boldwarning("User does not exist."))
 		return
-	var/amt2change = input("How much to modify the PQ by? (20 to -20, or 0 to just add a note)") as null|num
+	var/amt2change = input("How much to modify the PQ by? ([!check_rights(R_ADMIN,0) ? "-20 to 20, or " : ""]0 to just add a note)") as null|num
 	if(!check_rights(R_ADMIN,0))
 		amt2change = CLAMP(amt2change, -20, 20)
 	var/raisin = stripped_input("State a short reason for this change", "Game Master", "", null)

--- a/code/modules/admin/playerquality.dm
+++ b/code/modules/admin/playerquality.dm
@@ -203,7 +203,7 @@
 	if(!fexists("data/player_saves/[copytext(theykey,1,2)]/[theykey]/preferences.sav"))
 		to_chat(src, span_boldwarning("User does not exist."))
 		return
-	var/amt2change = input("How much to modify the PQ by? (20 to -20, or 0 to just add a note)") as null|num
+	var/amt2change = input("How much to modify the PQ by? ([!check_rights(R_ADMIN,0) ? "-20 to 20, or " : ""]0 to just add a note)") as null|num
 	if(!check_rights(R_ADMIN,0))
 		amt2change = CLAMP(amt2change, -20, 20)
 	var/raisin = stripped_input("State a short reason for this change", "Game Master", "", null)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1563,7 +1563,7 @@
 			return
 		var/mob/M = locate(href_list["mob"]) in GLOB.mob_list
 		var/client/mob_client = M.client
-		var/amt2change = input("How much to modify the PQ by? (20 to -20, or 0 to just add a note)") as null|num
+		var/amt2change = input("How much to modify the PQ by? ([!check_rights(R_BAN,0) ? "-20 to 20, or " : ""]0 to just add a note)") as null|num
 		if(!check_rights(R_BAN,0))
 			amt2change = CLAMP(amt2change, -20, 20)
 		var/raisin = stripped_input("State a short reason for this change", "Game Master", "", null)


### PR DESCRIPTION
## About The Pull Request

The prompt that asks an admin how much PQ to adjust by has a hidden gate where, if you have the right permission, doesn't actually clamp how much PQ you can add/deduct.

This PR hides the allowed range if you're able to surpass it; it only changes how the message appears, it does not otherwise change the behavior of those verbs.

## Testing Evidence

<img width="503" height="297" alt="image" src="https://github.com/user-attachments/assets/c96b58a4-f658-4cca-b65f-2eb2d5e488c5" />

Note no +ADMIN permission.

## Why It's Good For The Game

Incorrect information bad.

## Changelog

:cl:
admin: The prompt that appears when adjusting a player's PQ will no longer show the "allowed adjustment range" of -20 to 20 if you have the right permission to ignore that requirement anyways.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
