### PR TITLE
Necra's Sight QOL

### DIFF
--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -388,16 +388,6 @@
 		removing_object = choices[removing_object] 	// then get the correct object from the label...
 		marked_objects -= removing_object 			// ...to remove from the marked list.
 
-		// var/old_obj = marked_objects[last_index]
-		// marked_objects -= old_obj
-
-		// marked_objects[O] = label
-
-		// last_index++
-		// if(last_index > holyskill)
-		// 	last_index = 1
-		// return
-
 	to_chat(user, span_info("I whisper a name and mark the grave for later use..."))
 	marked_objects[O] = label
 

--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -372,17 +372,31 @@
 
 // Replace logic when at cap
 	if(length(marked_objects) >= holyskill)
-		to_chat(user, span_warning("I'm focusing on too many graves already. One slips from my mind..."))
+		// Build a display list: label -> obj
+		var/list/choices = list()
+		for(var/obj/graves as anything in marked_objects)
+			choices[marked_objects[graves]] = graves
 
-		var/old_obj = marked_objects[last_index]
-		marked_objects -= old_obj
+		var/removing_object = tgui_input_list(user, "I'm focusing on too many graves already. Do I let one slip from my mind..?", "FORGET", choices, marked_objects[1])
 
-		marked_objects[O] = label
+		if(!removing_object)
+			to_chat(user, span_warning("I choose to forget nothing."))
+			revert_cast()
+			return FALSE
 
-		last_index++
-		if(last_index > holyskill)
-			last_index = 1
-		return
+		to_chat(user, span_warning("[removing_object] slips from my mind...")) // show the labled grave first
+		removing_object = choices[removing_object] 	// then get the correct object from the label...
+		marked_objects -= removing_object 			// ...to remove from the marked list.
+
+		// var/old_obj = marked_objects[last_index]
+		// marked_objects -= old_obj
+
+		// marked_objects[O] = label
+
+		// last_index++
+		// if(last_index > holyskill)
+		// 	last_index = 1
+		// return
 
 	to_chat(user, span_info("I whisper a name and mark the grave for later use..."))
 	marked_objects[O] = label


### PR DESCRIPTION


## About The Pull Request

Adds a menu if you exceed your allotted graves with Necra's Sight that allows you to choose which grave (if any) you wish to sacrifice to the abyss.

## Testing Evidence

On dropping an object, it repeats which one got dropped, then adds the new one; when rescinding, nothing changes.
<img width="719" height="282" alt="image" src="https://github.com/user-attachments/assets/32bd3208-7e88-4836-a8b0-3cf69b3d8d61" />

Clicking on a marked object will still drop it normally.
<img width="214" height="40" alt="image" src="https://github.com/user-attachments/assets/e1b91f00-4cc1-48e4-8604-0132b7637ffb" />

## Why It's Good For The Game

Nice little QOL.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Necra's Sight now asks which marker to drop if you exceed your limit, including choosing to forget none and cancelling the addition of the new object.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
