### PR TITLE
fix chat overlay issues

### DIFF
--- a/code/modules/vampire_neu/vampire_sight.dm
+++ b/code/modules/vampire_neu/vampire_sight.dm
@@ -197,17 +197,6 @@ GLOBAL_VAR_INIT(blood_sight_viewers, 0)
 	ma = glow
 	carrier.add_overlay(glow)
 
-/mob/living/carbon/proc/debug_blood_glow_leak()
-	var/datum/component/blood_glow/glow = GetComponent(/datum/component/blood_glow)
-	if(!glow)
-		glow = AddComponent(/datum/component/blood_glow)
-	display_typing_indicator()
-	glow.build(TRUE)
-	var/leaked = glow.ma && (typing_indicator_current in glow.ma.overlays)
-	clear_typing_indicator()
-	to_chat(usr, span_notice("[src] blood-glow typing-overlay leak: [leaked ? "LEAK — bug present" : "CLEAN — fixed"]"))
-	return leaked
-
 /atom/movable/vampire_sight_relay
 	plane = GAME_PLANE_HIGHEST
 	blend_mode = BLEND_DEFAULT

--- a/code/modules/vampire_neu/vampire_sight.dm
+++ b/code/modules/vampire_neu/vampire_sight.dm
@@ -176,6 +176,14 @@ GLOBAL_VAR_INIT(blood_sight_viewers, 0)
 		carrier.cut_overlay(ma)
 		ma = null
 	var/mutable_appearance/glow = new(carrier)
+	// UI/effect overlays (typing bubble on FULLSCREEN_PLANE, KEEP_APART point bubbles/anims) don't flatten
+	// into the glow and would leak red onto their own plane, so drop them from the copy
+	var/list/leaky_overlays
+	for(var/mutable_appearance/overlay as anything in glow.overlays)
+		if((overlay.appearance_flags & KEEP_APART) || overlay.plane == FULLSCREEN_PLANE)
+			LAZYADD(leaky_overlays, overlay)
+	if(leaky_overlays)
+		glow.overlays -= leaky_overlays
 	glow.plane = BLOOD_GLOW_PLANE
 	glow.transform = matrix()
 	glow.pixel_x = 0
@@ -188,6 +196,17 @@ GLOBAL_VAR_INIT(blood_sight_viewers, 0)
 	glow.filters = null
 	ma = glow
 	carrier.add_overlay(glow)
+
+/mob/living/carbon/proc/debug_blood_glow_leak()
+	var/datum/component/blood_glow/glow = GetComponent(/datum/component/blood_glow)
+	if(!glow)
+		glow = AddComponent(/datum/component/blood_glow)
+	display_typing_indicator()
+	glow.build(TRUE)
+	var/leaked = glow.ma && (typing_indicator_current in glow.ma.overlays)
+	clear_typing_indicator()
+	to_chat(usr, span_notice("[src] blood-glow typing-overlay leak: [leaked ? "LEAK — bug present" : "CLEAN — fixed"]"))
+	return leaked
 
 /atom/movable/vampire_sight_relay
 	plane = GAME_PLANE_HIGHEST


### PR DESCRIPTION
## About The Pull Request
fix chat overlay persisting and point at showing up red
fixes https://github.com/Rotwood-Vale/Ratwood-2.0/issues/2231
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
build it, tried to repro the issue, couldn't
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
bug fix gud
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: talk overlay should no longer get stuck and point in hand shouldn't stay red anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
