### PR TITLE
QoL - Re-dying Curtains

### DIFF
--- a/code/game/objects/structures/curtain.dm
+++ b/code/game/objects/structures/curtain.dm
@@ -96,6 +96,21 @@
 		if(BURN)
 			playsound(loc, 'sound/blank.ogg', 80, TRUE)
 
+/obj/structure/curtain/attackby(obj/item/dyingbrush, mob/living/user)
+	if(!istype(dyingbrush, /obj/item/dye_brush))
+		. = ..()
+		return
+	var/obj/item/dye_brush/brush = dyingbrush
+	if(!brush.dye)
+		to_chat(user, span_warning("The dye brush has no dye loaded."))
+		return
+	if(do_after(user, 2 SECONDS, target = src))
+		user.visible_message(span_notice("[user] finishes <font color=[brush.dye]>painting</font> [src]."), \
+			span_notice("I finish <font color=[brush.dye]>painting</font> [src].")
+		)
+		playsound(loc, "sound/foley/scrubbing[pick(1,2)].ogg", 60, TRUE)
+		color = brush.dye
+
 /obj/structure/curtain/red
 	color = "#a32121"
 


### PR DESCRIPTION
## About The Pull Request
- Lets you re-dye existing curtains of any color with a dye brush.

## Testing Evidence
<img width="321" height="224" alt="recolorcurtains" src="https://github.com/user-attachments/assets/c180e23b-92b4-40b4-860d-a0e181d7ee8e" />

## Why It's Good For The Game
It's a QoL and time saver for builders. It's much nicer to not have to chop your curtains down to recolor them. Also works for pre-placed curtains on towner houses, allowing more customization should you have a dye brush and want to redecorate.

## Changelog
:cl:
qol: Allows the dye brush to re-dye existing curtains without having to chop them down.
/:cl: