### PR TITLE
Gives Drow Dark Vision

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/elf/elfd.dm
@@ -20,7 +20,7 @@
 	individual, such as a kinder heart fleeing from a brutal society that scorns them for their \
 	less cruel nature. However, not every dark elf seen on the surface can be safely assumed as \
 	kind, for some leave the Underdark simply to find their own greater heights of power.<br>\
-	(+1 Intellect, +1 Perception, Webwalker Trait)"
+	(+1 Intellect, +1 Perception, Webwalker and Dark Vision Traits)"
 
 /*
 	Former RT Desc: These guys were undead which doesn't really fit considering now you have a ton of them walking around.
@@ -70,7 +70,7 @@
 		OFFSET_SHIRT_F = list(0,0), OFFSET_ARMOR_F = list(0,0), OFFSET_UNDIES_F = list(0,-1), \
 		OFFSET_BREASTS_F = list(0,-1), \
 		)
-	inherent_traits = list(TRAIT_WEBWALK)//Not nearly as useful as Woodwalker, but it's something.
+	inherent_traits = list(TRAIT_WEBWALK, TRAIT_DARKVISION) // They come from the Underdark, makes sense they should be able to see in it.
 	race_bonus = list(STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1)
 	enflamed_icon = "widefire"
 	organs = list(


### PR DESCRIPTION
## About The Pull Request
* Gives the Underdark's most iconic race the ability to see in it!

## Testing Evidence
Simply adds one trait to the Dark Elves, should be fine
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Drow give others a racism stress moodlet when being examined, and what is their saving grace? They aren't held up by some cobweb?

With this change, they have a stronger identity and truly belong in the Underdark and the shadows as they're renowned to be.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Added Dark Vision to Dark Elves
/:cl: