### PR TITLE
Balancejack Tiny QoL: Astrata's Lighting Spear Costs Less Devotion

### DIFF
--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -521,7 +521,7 @@
 	chargetime = 0
 	releasedrain = 5
 	miracle = TRUE
-	devotion_cost = 100//See below as to why. Slowdown and funny damage.
+	devotion_cost = 50//See below as to why. Slowdown and funny damage.
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	associated_skill = /datum/skill/magic/holy
 	var/obj/item/rogueweapon/conjured_spear = null


### PR DESCRIPTION
## About The Pull Request

Lighting Spear costs less devotion: 100 > 50

## Testing Evidence

Balancejack stuff touching only devotion cost. Shouldn't cause any error, I hope.

## Why It's Good For The Game

I've been discussing with a friend about how ridiculously expensive is to cast this spell, 100 devotion should mean is a good spell for Astata, but in reality after a few tests, we think is of the same bad tier as Pestra's Infestation. What do you say?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: CloverIsLucky
qol: Astrata's Lighting Spear(javeline) costs less devotion cost: From 100 to 50.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
