### PR TITLE
Whogaze: Bardic inspiration QoL improvements

### DIFF
--- a/code/controllers/subsystem/rogue/bardicinspiration.dm
+++ b/code/controllers/subsystem/rogue/bardicinspiration.dm
@@ -77,8 +77,21 @@ GLOBAL_LIST_INIT(learnable_rhythms, (list(/obj/effect/proc_holder/spell/self/rhy
 		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/crescendo)
 	H.verbs += list(/mob/living/carbon/human/proc/setaudience, /mob/living/carbon/human/proc/clearaudience, /mob/living/carbon/human/proc/checkaudience, /mob/living/carbon/human/proc/picksongs, /mob/living/carbon/human/proc/resetsongs)
 
-
-
+/datum/inspiration/proc/toggle_audience_member(mob/living/carbon/human/target)
+	if(!holder || !target)
+		return FALSE
+	if(target in audience)
+		audience -= target
+		to_chat(holder, span_notice("I stop performing for [target.real_name]."))
+		target.balloon_alert(holder, "removed from audience")
+		return TRUE
+	if(audience.len >= maxaudience)
+		to_chat(holder, span_warning("I cannot maintain an audience larger than [maxaudience]!"))
+		return FALSE
+	audience |= target
+	to_chat(holder, span_notice("I begin performing for [target.real_name]."))
+	target.balloon_alert(holder, "added to audience")
+	return TRUE
 
 /mob/living/carbon/human/proc/setaudience()
 	set name = "Audience Choice"
@@ -284,5 +297,16 @@ GLOBAL_LIST_INIT(learnable_rhythms, (list(/obj/effect/proc_holder/spell/self/rhy
 	inspiration.next_rhythm_reset = world.time + BARD_RESET_COOLDOWN
 	verbs |= list(/mob/living/carbon/human/proc/pickrhythms)
 	to_chat(src, span_notice("The harmonies escape me. I can choose my rhythms again."))
+
+/mob/living/carbon/human/MiddleClickOn(atom/A, params)
+	// if we're holding an instrument and have inspiration with no other intents active, we'll add them to our inspiration audience, if possible
+	if(!mmb_intent && inspiration && A != src && isliving(A))
+		if(istype(get_active_held_item(), /obj/item/rogue/instrument))
+			if(get_dist(src, A) > 7 || A.loc.z != src.loc.z) // cheap quick dist test instead of calling hearers
+				to_chat(src, span_warning("[A] is too far away for me to invite into my audience."))
+				return
+			inspiration.toggle_audience_member(A)
+			return
+	return ..()
 
 #undef BARD_RESET_COOLDOWN

--- a/code/modules/spells/spell_types/bardic/melody-dirges.dm
+++ b/code/modules/spells/spell_types/bardic/melody-dirges.dm
@@ -74,6 +74,6 @@
 		pulse = 0
 		O.energy_add(-12.5)
 		for (var/mob/living/carbon/human/H in hearers(10, owner))
-			if(O.in_audience(H))
+			if(O.in_audience(H) || H == O)
 				var/buff = buffs_to_apply_by_level?[O.inspiration.level] || buff_to_apply
 				H.apply_status_effect(buff)

--- a/code/modules/spells/spell_types/bardic/rhythm_crescendo.dm
+++ b/code/modules/spells/spell_types/bardic/rhythm_crescendo.dm
@@ -97,7 +97,7 @@
 
 /obj/effect/proc_holder/spell/self/rhythm
 	name = "Rhythm"
-	desc = "Attune your weapon to a rhythm. Your next melee hit within 8 seconds triggers its effect."
+	desc = "Attune your weapon to a rhythm. Your next melee hit within 8 seconds triggers its effect. An instrument is required in your off hand, though highly talented bards can make do with their voice, so long as they are able to be heard."
 	action_icon = 'icons/mob/actions/bardsongs.dmi'
 	action_icon_state = "rhythm_resonating"
 	action_background_icon_state = "spell"
@@ -125,9 +125,13 @@
 	if(!user?.inspiration || user.inspiration.level < BARD_T2)
 		to_chat(user, span_warning("I do not know how to hold a battle rhythm."))
 		return FALSE
-	if(!has_instrument(user))
-		to_chat(user, span_warning("I need an instrument in hand to perform!"))
-		return FALSE
+	if(!has_instrument(user)) // T3 inspiration and above can use rhythm without a weapon in hand, but only if otherwise able to speak (mute, mouthgrab stops, etc)
+		if (user.inspiration.level == BARD_T2)
+			to_chat(user, span_warning("I need an instrument in hand to carry a rhythm!"))
+			return FALSE
+		if (!user.can_speak_vocal())
+			to_chat(user, span_warning("I need to be able to sing to keep the rhythm!"))
+			return FALSE
 	prime_rhythm(user)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Three very simple changes:

- Bards now always benefit from their own **beneficial melodies** as if they were a member of the audience. 
   - You could've already done this before these changes by adding yourself to your audience anyway, but that is annoying and clunky and I hate it.
- Bards can now MMB with an instrument in their active hand on human mob targets to quickly toggle between adding to or removing them from their inspiration audience.
   - Having any MMB intent or spell active in the MMB slot overrides this behavior, as you'd expect.
- T3 inspiration bards can use Rhythm without an off-hand instrument if they're able to speak (because they're singing it).
   - Mostly for rule-of-cool and to encourage people to actually use rhythms and try crescendo out.
   - Mute T3 bards will need an instrument in hand to use rhythm, as before.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

<img width="359" height="424" alt="dreamseeker_Xu1CWiTi89" src="https://github.com/user-attachments/assets/41463877-316c-4276-8800-5fc0a0f984ce" />

<img width="447" height="382" alt="dreamseeker_roNhuJpZo5" src="https://github.com/user-attachments/assets/515ec701-e664-430e-9f75-c1b2bc513eec" />

<img width="470" height="365" alt="dreamseeker_cEncbpqJY0" src="https://github.com/user-attachments/assets/3bf1d46d-8339-4f54-9b65-eedfa9be642d" />

<img width="489" height="241" alt="dreamseeker_ml6sbOo2Mw" src="https://github.com/user-attachments/assets/c78f6c8f-7d4b-405c-a481-3486df41248c" />

## Why It's Good For The Game

Inspiration is cool but clunky as shit to use without at *least* twenty seconds of preparation time. If the group you're rolling with is fluid, good fucking luck managing your audience without spending a copious amount of time in menus. With this, you can quickly add and remove people from the effects of your buffs as needed.

The rhythm change is mostly out of cool factor and also to stop you needing to fiddle quite so much with weapon slots in combat to actually make use of the rhythm->crescendo combo. Now, you can just whip out your boot knife and go to town.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
qol: Bards now always benefit from their own beneficial melodies as if they were a member of the audience without needing to spend a slot on themselves.
qol: Bards with inspiration that are holding an instrument in-hand (and with no MMB intents active) can MMB on other people to quickly add or remove them from their inspiration audience list.
qol: T3 bards can now use Rhythm without needing an instrument in their off-hand, but only if they're able to sing. Mouthgrabs, muzzles, silences and muting effects will prevent this as expected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
