### PR TITLE
Correct % display in skills

### DIFF
--- a/code/datums/skill_holder.dm
+++ b/code/datums/skill_holder.dm
@@ -356,7 +356,11 @@
 				if(sadv)
 					var/sleep_xp = sadv.get_sleep_xp(i.type)
 					var/needed_xp = sadv.get_requried_sleep_xp_for_skill(i.type, 1)
-					if(needed_xp > 0)
+					if(sleep_xp > needed_xp)
+						sleep_xp -= sadv.get_requried_sleep_xp_for_skill(i.type, 1)
+						needed_xp = sadv.get_requried_sleep_xp_for_skill(i.type, 2) - sadv.get_requried_sleep_xp_for_skill(i.type, 1)
+						percent = 100 + clamp(round(sleep_xp * 100 / needed_xp), 0, 200)
+					else
 						percent = clamp(round(sleep_xp * 100 / needed_xp), 0, 200)
 			else
 				// Below Apprentice, XP is tracked directly on skill_experience


### PR DESCRIPTION
## About The Pull Request
Currently skill progress after 100% progress shows incorrectly
 
Lets say you need 40xp to progress one level and 60xp to progress additional second level
While you have <=40xp, percentage calculates correctly, but when you progress further it gets wrong
For example if you have 90xp, it will calculate that you have more then twice xp to progress one level (out of 40) and show you that you have 200% (cap is at 200) of required xp to progress two level, while in reality you still need more 

This pr fixes tis issue
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="517" height="542" alt="image" src="https://github.com/user-attachments/assets/9635083f-aea6-44ab-a9ef-2e8027f36e19" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
fix
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: % of skill xp after 100% progress shows correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
