### PR TITLE
the consort update i forgot to finish for a month

### DIFF
--- a/code/__DEFINES/roguetown.dm
+++ b/code/__DEFINES/roguetown.dm
@@ -347,7 +347,8 @@ GLOBAL_LIST_EMPTY(round_join_times)
 #define CTAG_SHERIFF		"CAT_SHERIFF"		// SHERIFF class - Handles SHERIFF class selector (weapons selection)
 #define CTAG_SERGEANT		"CAT_SERGEANT"		// Sergeant class - Handles Sergeant class selector (weapons selection)
 #define CTAG_ROYALGUARD		"CAT_ROYALGUARD"	// Royal Guard class - Handles Royal Guard class selector
-#define CTAG_CONSORT		"CAT_CONSORT"		// Consort/Suitor subclasses
+#define CTAG_CONSORT		"CAT_CONSORT"		// Consort subclasses.
+#define CTAG_SUITOR			"CAT_SUITOR"		// Suitor subclasses. Unmerged from CTAG_CONSORT
 #define CTAG_MERCENARY		"CAT_MERCENARY"		// Mercenary class - Handles Mercenary class selector
 #define CTAG_HAND			"CAT_HAND"			// Hand class - Handles Hand class selector
 #define CTAG_TEMPLAR		"CAT_TEMPLAR"		// Templar class - Handles Templar class selector

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -32,7 +32,7 @@
 /datum/advclass/lady/heartthrob
 // swords-themed consort. since there's only one of them, it's better than suitor and prince. this will be a running theme.
 	name = "Heartthrob"
-	tutorial = "A former swordsman, either through battle or through bravado you won the Grand Duke's heart. Your sword arm may be rusty with inexperience, but you're still more than capable of showing any would-be assassins the meaning of 'til Death do us part'."
+	tutorial = "A former swordsman, either through battle or through bravado you won the Grand Duke's heart. Your sword arm may have gotten rusty with time, but you're still more than capable of showing any would-be assassins the meaning of 'til Death do us part'."
 	outfit = /datum/outfit/job/roguetown/lady/heartthrob
 	category_tags = list(CTAG_CONSORT)
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED, TRAIT_KEENEARS, TRAIT_NOBLE)

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -24,7 +24,6 @@
 	advjob_examine = TRUE
 	job_subclasses = list(
 		/datum/advclass/lady/heartthrob,
-		/datum/advclass/lady/sapio,
 		/datum/advclass/lady/housespouse,
 		/datum/advclass/lady/trophy
 	)

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -36,13 +36,13 @@
 	outfit = /datum/outfit/job/roguetown/lady/heartthrob
 	category_tags = list(CTAG_CONSORT)
 	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED, TRAIT_KEENEARS, TRAIT_NOBLE)
-	subclass_stats = list(
+	subclass_stats = list( // 10 stats total, 7 without the leadership carrot. stats based on Gallant Suitor.
 		STATKEY_INT = 2,
-		STATKEY_PER = 2,
-		STATKEY_WIL = 1,
-		STATKEY_SPD = 2,
+		STATKEY_PER = 1,
+		STATKEY_WIL = 2,
+		STATKEY_SPD = 1,
 		STATKEY_STR = 1,
-		STATKEY_LCK = 2,
+		STATKEY_LCK = 3,
 	)
 	subclass_skills = list(
 		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
@@ -84,13 +84,12 @@
 	outfit = /datum/outfit/job/roguetown/lady/sapio
 	category_tags = list(CTAG_CONSORT)
 	traits_applied = list(TRAIT_ARCYNE_T3, TRAIT_KEENEARS, TRAIT_INTELLECTUAL, TRAIT_NOBLE)
-	subclass_stats = list(
+	subclass_stats = list( // 9 stats total, 6 without the leadership carrot. based on heartfelt magos. i'd consider -2 con too but that's rough.
 		STATKEY_INT = 4,
-		STATKEY_PER = 2,
+		STATKEY_PER = 3,
 		STATKEY_CON = -1,
-		STATKEY_WIL = 1,
-		STATKEY_SPD = 1,
-		STATKEY_STR = -1,
+		STATKEY_WIL = 2,
+		STATKEY_STR = -2,
 		STATKEY_LCK = 3,
 	)
 	subclass_spellpoints = 24
@@ -108,7 +107,7 @@
 		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
 	)
 
-/datum/outfit/job/roguetown/lady/sapio/pre_equip(mob/living/carbon/human/H) //tbd - something mage-y but with drip expected of a noble. should be easy enough
+/datum/outfit/job/roguetown/lady/sapio/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
@@ -146,12 +145,12 @@
 	outfit = /datum/outfit/job/roguetown/lady/trophy
 	category_tags = list(CTAG_CONSORT)
 	traits_applied = list(TRAIT_SEEPRICES, TRAIT_KEENEARS, TRAIT_NUTCRACKER, TRAIT_NOBLE)
-	subclass_stats = list(
-		STATKEY_INT = 3,
+	subclass_stats = list( // 10 stats total, 7 without the carrot. based on consort's current stat block.
+		STATKEY_INT = 2,
 		STATKEY_PER = 2,
-		STATKEY_WIL = 3,
+		STATKEY_WIL = 1,
 		STATKEY_SPD = 2,
-		STATKEY_LCK = 5,
+		STATKEY_LCK = 3,
 	)
 	subclass_skills = list(
 	    /datum/skill/misc/stealing = SKILL_LEVEL_EXPERT,
@@ -199,11 +198,10 @@
 	outfit = /datum/outfit/job/roguetown/lady/housespouse
 	category_tags = list(CTAG_CONSORT)
 	traits_applied = list(TRAIT_CICERONE, TRAIT_SEEDKNOW, TRAIT_KEENEARS, TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_NOBLE)
-	subclass_stats = list(
-		STATKEY_INT = 4,
-		STATKEY_PER = 3,
-		STATKEY_WIL = 2,
-		STATKEY_SPD = 2,
+	subclass_stats = list( //10 stats total, 7 without carrot. based on senechal. high int for skill progression and crafting %
+		STATKEY_INT = 3,
+		STATKEY_PER = 2,
+		STATKEY_SPD = 1,
 		STATKEY_STR = 1,
 		STATKEY_LCK = 3,
 	)

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -77,67 +77,6 @@
 		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
 //		SSticker.rulermob = H
 
-/datum/advclass/lady/sapio
-// wizard consort. better than wizard prince, not QUITE as good statswise as wizard duke or magic-wise as magos. also lacks access to alchemy expert.
-	name = "Sapio"
-	tutorial = "An intellectual of note, your wits and wiles captured the Grand Duke's attention, and later, their heart. They say love is the most powerful magic, but you're still not quite convinced it beats a fireball."
-	outfit = /datum/outfit/job/roguetown/lady/sapio
-	category_tags = list(CTAG_CONSORT)
-	traits_applied = list(TRAIT_ARCYNE_T3, TRAIT_KEENEARS, TRAIT_INTELLECTUAL, TRAIT_NOBLE)
-	subclass_stats = list( // 9 stats total, 6 without the leadership carrot. based on heartfelt magos. i'd consider -2 con too but that's rough.
-		STATKEY_INT = 4,
-		STATKEY_PER = 3,
-		STATKEY_CON = -1,
-		STATKEY_WIL = 2,
-		STATKEY_STR = -2,
-		STATKEY_LCK = 3,
-	)
-	subclass_spellpoints = 24
-	subclass_skills = list(
-		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
-		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
-	)
-
-/datum/outfit/job/roguetown/lady/sapio/pre_equip(mob/living/carbon/human/H)
-	..()
-	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
-	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
-	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
-	beltl = /obj/item/storage/keyring/royal
-	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/special
-	backr = /obj/item/storage/backpack/rogue/satchel
-	backl = /obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff/royal
-	id = /obj/item/scomstone/garrison
-	if(should_wear_femme_clothes(H))
-		cloak = /obj/item/clothing/cloak/lordcloak/ladycloak
-		armor = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
-		pants = /obj/item/clothing/under/roguetown/trou/formal/shorts
-	else if(should_wear_masc_clothes(H))
-		cloak = /obj/item/clothing/cloak/darkcloak/bear
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
-		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
-		pants = /obj/item/clothing/under/roguetown/tights/black
-	backpack_contents = list(
-		/obj/item/roguegem/amethyst = 1,
-		/obj/item/spellbook_unfinished/pre_arcyne = 1,
-		/obj/item/recipe_book/alchemy = 1,
-		/obj/item/recipe_book/magic = 1,
-		/obj/item/chalk = 1,
-	)
-	if(H.mind)
-		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message) 
-//		SSticker.rulermob = H
-
 /datum/advclass/lady/trophy
 // This is just the regular Consort as it is right now, along with the ridiculous 15 points of extra stats.
 	name = "Trophy"

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -5,10 +5,11 @@
 	faction = "Station"
 	total_positions = 0
 	spawn_positions = 0
+	advclass_cat_rolls = list(CTAG_CONSORT = 20)
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
-	tutorial = "Picked out of your political value rather than likely any form of love, you have become the Grand Duke's most trusted confidant--and likely friend--throughout your marriage. Your loyalty and perhaps even your love will be tested this day... for the daggers that threaten your beloved are as equally pointed at your own throat."
+	tutorial = "Whether through love, politics or guile, you have become the Grand Duke's most trusted confidant--and likely friend--throughout your marriage. Your loyalty and perhaps even your love will be tested this day... for the daggers that threaten your beloved are as equally pointed at your own throat."
 
 	spells = list(/obj/effect/proc_holder/spell/self/convertrole/servant,
 	/obj/effect/proc_holder/spell/self/grant_nobility)
@@ -20,6 +21,234 @@
 	min_pq = 5
 	max_pq = null
 	round_contrib_points = 3
+	advjob_examine = TRUE
+	job_subclasses = list(
+		/datum/advclass/lady/heartthrob,
+		/datum/advclass/lady/sapio,
+		/datum/advclass/lady/housespouse,
+		/datum/advclass/lady/trophy
+	)
+
+/datum/advclass/lady/heartthrob
+// swords-themed consort. since there's only one of them, it's better than suitor and prince. this will be a running theme.
+	name = "Heartthrob"
+	tutorial = "A former swordsman, either through battle or through bravado you won the Grand Duke's heart. Your sword arm may be rusty with inexperience, but you're still more than capable of showing any would-be assassins the meaning of 'til Death do us part'."
+	outfit = /datum/outfit/job/roguetown/lady/heartthrob
+	category_tags = list(CTAG_CONSORT)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED, TRAIT_KEENEARS, TRAIT_NOBLE)
+	subclass_stats = list(
+		STATKEY_INT = 2,
+		STATKEY_PER = 2,
+		STATKEY_WIL = 1,
+		STATKEY_SPD = 2,
+		STATKEY_STR = 1,
+		STATKEY_LCK = 2,
+	)
+	subclass_skills = list(
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/swords = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
+	)
+
+/datum/outfit/job/roguetown/lady/heartthrob/pre_equip(mob/living/carbon/human/H) //tbd - ideally i don't want them to start with fantastic armor, but there's very little choice in medium armors. maybe i'll switch them to light instead?
+	..()
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
+	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic
+	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
+	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
+	beltl = /obj/item/storage/keyring/royal
+	beltr = /obj/item/rogueweapon/scabbard/sword/noble
+	backr = /obj/item/storage/backpack/rogue/satchel
+	l_hand = /obj/item/rogueweapon/sword/sabre/dec
+	id = /obj/item/scomstone/garrison
+	if(should_wear_femme_clothes(H))
+		cloak = /obj/item/clothing/cloak/lordcloak/ladycloak
+		armor = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
+	else if(should_wear_masc_clothes(H))
+		cloak = /obj/item/clothing/cloak/darkcloak/bear
+		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
+//		SSticker.rulermob = H
+
+/datum/advclass/lady/sapio
+// wizard consort. better than wizard prince, not QUITE as good statswise as wizard duke or magic-wise as magos. also lacks access to alchemy expert.
+	name = "Sapio"
+	tutorial = "An intellectual of note, your wits and wiles captured the Grand Duke's attention, and later, their heart. They say love is the most powerful magic, but you're still not quite convinced it beats a fireball."
+	outfit = /datum/outfit/job/roguetown/lady/sapio
+	category_tags = list(CTAG_CONSORT)
+	traits_applied = list(TRAIT_ARCYNE_T3, TRAIT_KEENEARS, TRAIT_INTELLECTUAL, TRAIT_NOBLE)
+	subclass_stats = list(
+		STATKEY_INT = 4,
+		STATKEY_PER = 2,
+		STATKEY_CON = -1,
+		STATKEY_WIL = 1,
+		STATKEY_SPD = 1,
+		STATKEY_STR = -1,
+		STATKEY_LCK = 3,
+	)
+	subclass_spellpoints = 24
+	subclass_skills = list(
+		/datum/skill/combat/polearms = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
+	)
+
+/datum/outfit/job/roguetown/lady/sapio/pre_equip(mob/living/carbon/human/H) //tbd - something mage-y but with drip expected of a noble. should be easy enough
+	..()
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
+	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
+	beltl = /obj/item/storage/keyring/royal
+	beltr = /obj/item/rogueweapon/huntingknife/idagger/steel/special
+	backr = /obj/item/storage/backpack/rogue/satchel
+	backl = /obj/item/rogueweapon/woodstaff/emerald/blacksteelstaff/royal
+	id = /obj/item/scomstone/garrison
+	if(should_wear_femme_clothes(H))
+		cloak = /obj/item/clothing/cloak/lordcloak/ladycloak
+		armor = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
+		pants = /obj/item/clothing/under/roguetown/trou/formal/shorts
+	else if(should_wear_masc_clothes(H))
+		cloak = /obj/item/clothing/cloak/darkcloak/bear
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
+		pants = /obj/item/clothing/under/roguetown/tights/black
+	backpack_contents = list(
+		/obj/item/roguegem/amethyst = 1,
+		/obj/item/spellbook_unfinished/pre_arcyne = 1,
+		/obj/item/recipe_book/alchemy = 1,
+		/obj/item/recipe_book/magic = 1,
+		/obj/item/chalk = 1,
+	)
+	if(H.mind)
+		H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/message) 
+//		SSticker.rulermob = H
+
+/datum/advclass/lady/trophy
+// This is just the regular Consort as it is right now, along with the ridiculous 15 points of extra stats.
+	name = "Trophy"
+	tutorial = "You were once an individual of some note. A Noble, an envoy, a suitor. Now, either for politics, metrics or just to save your - or your beloved's, skin, you're nothing but the Grand Duke's armpiece. Smile for the people, wave for the crowds."
+	outfit = /datum/outfit/job/roguetown/lady/trophy
+	category_tags = list(CTAG_CONSORT)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_KEENEARS, TRAIT_NUTCRACKER, TRAIT_NOBLE)
+	subclass_stats = list(
+		STATKEY_INT = 3,
+		STATKEY_PER = 2,
+		STATKEY_WIL = 3,
+		STATKEY_SPD = 2,
+		STATKEY_LCK = 5,
+	)
+	subclass_skills = list(
+	    /datum/skill/misc/stealing = SKILL_LEVEL_EXPERT,
+	    /datum/skill/misc/sneaking = SKILL_LEVEL_EXPERT,
+	    /datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+	    /datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+	    /datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
+	    /datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+	    /datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
+	    /datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
+	    /datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
+	)
+
+/datum/outfit/job/roguetown/lady/trophy/pre_equip(mob/living/carbon/human/H) //tbd - though this might just be fine as is, considering it's base consort
+	..()
+	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	beltl = /obj/item/storage/keyring/royal
+	beltr = /obj/item/rogueweapon/scabbard/sheath
+	id = /obj/item/scomstone/garrison
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backr = /obj/item/storage/backpack/rogue/satchel
+	handr = /obj/item/rogueweapon/huntingknife/idagger/steel
+	if(should_wear_femme_clothes(H))
+		shirt = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		pants = /obj/item/clothing/under/roguetown/trou/formal/shorts
+		cloak = /obj/item/clothing/cloak/lordcloak/ladycloak
+	else if(should_wear_masc_clothes(H))
+		pants = /obj/item/clothing/under/roguetown/tights
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
+		cloak = /obj/item/clothing/cloak/darkcloak/bear
+	backpack_contents = list(
+		/obj/item/storage/belt/rogue/pouch/medicine,
+		/obj/item/lockpick/goldpin,
+	)
+//		SSticker.rulermob = H
+
+/datum/advclass/lady/housespouse
+// Housewife RP class. 15 points of stats along with trophy because why not, honestly.
+	name = "Homemaker"
+	tutorial = "Through your caring ways and dutiful nature, you provide for your beloved and your children in the way you're best at. You're very aware that the household of your beloved is well-manned with servants to cook and clean, but you don't care. After all, food tastes much better when it's made with love."
+	outfit = /datum/outfit/job/roguetown/lady/housespouse
+	category_tags = list(CTAG_CONSORT)
+	traits_applied = list(TRAIT_CICERONE, TRAIT_SEEDKNOW, TRAIT_KEENEARS, TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_NOBLE)
+	subclass_stats = list(
+		STATKEY_INT = 4,
+		STATKEY_PER = 3,
+		STATKEY_WIL = 2,
+		STATKEY_SPD = 2,
+		STATKEY_STR = 1,
+		STATKEY_LCK = 3,
+	)
+	subclass_skills = list(
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/cooking = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/sewing = SKILL_LEVEL_EXPERT,
+		/datum/skill/craft/tanning = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/farming = SKILL_LEVEL_APPRENTICE, //so they can tend to their lovely garden ofc
+	)
+
+/datum/outfit/job/roguetown/lady/housespouse/pre_equip(mob/living/carbon/human/H) //tbd - something cute and homely but still noble.
+	..()
+	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
+	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	beltl = /obj/item/storage/keyring/royal
+	id = /obj/item/scomstone/garrison
+	shoes = /obj/item/clothing/shoes/roguetown/shortboots
+	backr = /obj/item/storage/backpack/rogue/satchel
+	beltr = /obj/item/cooking/pan
+	if(should_wear_femme_clothes(H))
+		shirt = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
+		shoes = /obj/item/clothing/shoes/roguetown/shortboots
+		pants = /obj/item/clothing/under/roguetown/trou/formal/shorts
+		cloak = /obj/item/clothing/cloak/lordcloak/ladycloak
+	else if(should_wear_masc_clothes(H))
+		pants = /obj/item/clothing/under/roguetown/tights
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
+		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
+		cloak = /obj/item/clothing/cloak/darkcloak/bear
+	backpack_contents = list(
+		/obj/item/rogueweapon/huntingknife/scissors/steel,
+		/obj/item/needle,
+		/obj/item/kitchen/rollingpin,
+		/obj/item/rogueweapon/huntingknife/cleaver,
+	)
+//		SSticker.rulermob = H
 
 /datum/job/roguetown/exlady
 	title = "Consort Dowager"
@@ -34,46 +263,6 @@
 /datum/outfit/job/roguetown/lady
 	job_bitflag = BITFLAG_ROYALTY
 
-/datum/outfit/job/roguetown/lady/pre_equip(mob/living/carbon/human/H)
-	. = ..()
-	ADD_TRAIT(H, TRAIT_SEEPRICES, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_NOBLE, TRAIT_GENERIC)
-	ADD_TRAIT(H, TRAIT_NUTCRACKER, TRAIT_GENERIC)
-//		SSticker.rulermob = H
-	if(should_wear_femme_clothes(H))
-		beltl = /obj/item/storage/keyring/royal
-		neck = /obj/item/storage/belt/rogue/pouch/coins/rich
-		belt = /obj/item/storage/belt/rogue/leather/cloth/lady
-		head = /obj/item/clothing/head/roguetown/nyle/consortcrown
-		shirt = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
-		id = /obj/item/scomstone/garrison
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-	else if(should_wear_masc_clothes(H))
-		head = /obj/item/clothing/head/roguetown/nyle/consortcrown
-		pants = /obj/item/clothing/under/roguetown/tights
-		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt/guard
-		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
-		shoes = /obj/item/clothing/shoes/roguetown/shortboots
-		belt = /obj/item/storage/belt/rogue/leather
-		beltl = /obj/item/storage/keyring/royal
-		beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
-		backr = /obj/item/storage/backpack/rogue/satchel
-		id = /obj/item/clothing/ring/silver
-	H.adjust_skillrank(/datum/skill/misc/stealing, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/sneaking, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/reading, 4, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/medicine, 2, TRUE)
-	H.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
-	H.change_stat(STATKEY_INT, 3)
-	H.change_stat(STATKEY_WIL, 3)
-	H.change_stat(STATKEY_SPD, 2)
-	H.change_stat(STATKEY_PER, 2)
-	H.change_stat(STATKEY_LCK, 5)
-
 /obj/effect/proc_holder/spell/self/convertrole/servant
 	name = "Recruit Servant"
 	new_role = "Servant"
@@ -83,3 +272,4 @@
 	accept_message = "FOR THE CROWN!"
 	refuse_message = "I refuse."
 	recharge_time = 100
+

--- a/code/modules/jobs/job_types/roguetown/nobility/consort.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/consort.dm
@@ -35,13 +35,13 @@
 	tutorial = "A former swordsman, either through battle or through bravado you won the Grand Duke's heart. Your sword arm may have gotten rusty with time, but you're still more than capable of showing any would-be assassins the meaning of 'til Death do us part'."
 	outfit = /datum/outfit/job/roguetown/lady/heartthrob
 	category_tags = list(CTAG_CONSORT)
-	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_STEELHEARTED, TRAIT_KEENEARS, TRAIT_NOBLE)
-	subclass_stats = list( // 10 stats total, 7 without the leadership carrot. stats based on Gallant Suitor.
+	traits_applied = list(TRAIT_DODGEEXPERT, TRAIT_KEENEARS, TRAIT_DECEIVING_MEEKNESS, TRAIT_NOBLE)
+	subclass_stats = list(
 		STATKEY_INT = 2,
 		STATKEY_PER = 1,
 		STATKEY_WIL = 2,
-		STATKEY_SPD = 1,
-		STATKEY_STR = 1,
+		STATKEY_SPD = 3,
+		STATKEY_STR = -1,
 		STATKEY_LCK = 3,
 	)
 	subclass_skills = list(
@@ -60,20 +60,20 @@
 	..()
 	head = /obj/item/clothing/head/roguetown/nyle/consortcrown
 	pants = /obj/item/clothing/under/roguetown/heavy_leather_pants/otavan/generic
-	shirt = /obj/item/clothing/suit/roguetown/armor/chainmail
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	shoes = /obj/item/clothing/shoes/roguetown/boots/nobleboot
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
 	beltl = /obj/item/storage/keyring/royal
 	beltr = /obj/item/rogueweapon/scabbard/sword/noble
 	backr = /obj/item/storage/backpack/rogue/satchel
-	l_hand = /obj/item/rogueweapon/sword/sabre/dec
+	l_hand = /obj/item/rogueweapon/sword/rapier/dec
 	id = /obj/item/scomstone/garrison
 	if(should_wear_femme_clothes(H))
 		cloak = /obj/item/clothing/cloak/lordcloak/ladycloak
 		armor = /obj/item/clothing/suit/roguetown/armor/armordress/winterdress/monarch
 	else if(should_wear_masc_clothes(H))
 		cloak = /obj/item/clothing/cloak/darkcloak/bear
+		shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt
 		armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/royal
 //		SSticker.rulermob = H
 
@@ -104,7 +104,7 @@
 		/datum/skill/misc/riding = SKILL_LEVEL_NOVICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_MASTER,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/magic/arcane = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT,
 	)
 
 /datum/outfit/job/roguetown/lady/sapio/pre_equip(mob/living/carbon/human/H)
@@ -141,10 +141,10 @@
 /datum/advclass/lady/trophy
 // This is just the regular Consort as it is right now, along with the ridiculous 15 points of extra stats.
 	name = "Trophy"
-	tutorial = "You were once an individual of some note. A Noble, an envoy, a suitor. Now, either for politics, metrics or just to save your - or your beloved's, skin, you're nothing but the Grand Duke's armpiece. Smile for the people, wave for the crowds."
+	tutorial = "You were once an individual of some note. A Noble, an envoy, a suitor. Now, either for politics, metrics or just to save your - or your beloved's, skin, you're nothing but the Grand Duke's armpiece. Smile for the people, wave for the crowds, scheme from the shadows."
 	outfit = /datum/outfit/job/roguetown/lady/trophy
 	category_tags = list(CTAG_CONSORT)
-	traits_applied = list(TRAIT_SEEPRICES, TRAIT_KEENEARS, TRAIT_NUTCRACKER, TRAIT_NOBLE)
+	traits_applied = list(TRAIT_SEEPRICES, TRAIT_KEENEARS, TRAIT_LIGHT_STEP, TRAIT_NUTCRACKER, TRAIT_NOBLE)
 	subclass_stats = list( // 10 stats total, 7 without the carrot. based on consort's current stat block.
 		STATKEY_INT = 2,
 		STATKEY_PER = 2,
@@ -154,14 +154,14 @@
 	)
 	subclass_skills = list(
 	    /datum/skill/misc/stealing = SKILL_LEVEL_EXPERT,
-	    /datum/skill/misc/sneaking = SKILL_LEVEL_EXPERT,
+	    /datum/skill/misc/sneaking = SKILL_LEVEL_LEGENDARY,
 	    /datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 	    /datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
-	    /datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
+	    /datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
 	    /datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
 	    /datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-	    /datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
-	    /datum/skill/misc/riding = SKILL_LEVEL_APPRENTICE,
+	    /datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
+	    /datum/skill/misc/riding = SKILL_LEVEL_JOURNEYMAN,
 	)
 
 /datum/outfit/job/roguetown/lady/trophy/pre_equip(mob/living/carbon/human/H) //tbd - though this might just be fine as is, considering it's base consort
@@ -197,7 +197,7 @@
 	tutorial = "Through your caring ways and dutiful nature, you provide for your beloved and your children in the way you're best at. You're very aware that the household of your beloved is well-manned with servants to cook and clean, but you don't care. After all, food tastes much better when it's made with love."
 	outfit = /datum/outfit/job/roguetown/lady/housespouse
 	category_tags = list(CTAG_CONSORT)
-	traits_applied = list(TRAIT_CICERONE, TRAIT_SEEDKNOW, TRAIT_KEENEARS, TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_NOBLE)
+	traits_applied = list(TRAIT_CICERONE, TRAIT_SEEDKNOW, TRAIT_KEENEARS, TRAIT_GOODLOVER, TRAIT_HOMESTEAD_EXPERT, TRAIT_SEWING_EXPERT, TRAIT_NOBLE)
 	subclass_stats = list( //10 stats total, 7 without carrot. based on senechal. high int for skill progression and crafting %
 		STATKEY_INT = 3,
 		STATKEY_PER = 2,
@@ -206,18 +206,16 @@
 		STATKEY_LCK = 3,
 	)
 	subclass_skills = list(
-		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_EXPERT,
-		/datum/skill/craft/cooking = SKILL_LEVEL_EXPERT,
-		/datum/skill/misc/medicine = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/cooking = SKILL_LEVEL_LEGENDARY,
+		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_EXPERT,
 		/datum/skill/craft/tanning = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/stealing = SKILL_LEVEL_JOURNEYMAN,
-		/datum/skill/misc/lockpicking = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/misc/climbing = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/labor/farming = SKILL_LEVEL_APPRENTICE, //so they can tend to their lovely garden ofc
+		/datum/skill/misc/climbing = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_NOVICE,
+		/datum/skill/labor/farming = SKILL_LEVEL_JOURNEYMAN, //so they can tend to their lovely garden ofc
 	)
 
 /datum/outfit/job/roguetown/lady/housespouse/pre_equip(mob/living/carbon/human/H) //tbd - something cute and homely but still noble.

--- a/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/suitor.dm
@@ -8,7 +8,7 @@
 
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_races = RACES_NO_CONSTRUCT
-	advclass_cat_rolls = list(CTAG_CONSORT = 20)
+	advclass_cat_rolls = list(CTAG_SUITOR = 20)
 	tutorial = "You are a noble from a foreign court who has travelled to the realm in order to win the hand of the realm's most eligible bachelor and secure a political ally for your house. Competition is fierce, and it seems you're not the only one vying for the duke's favor..."
 
 	outfit = /datum/outfit/job/roguetown/suitor
@@ -30,7 +30,7 @@
 	name = "Envoy"
 	tutorial = "You're a graceful envoy - fluent in flattery, courtesy, and calculated sincerity. You'll charm your way into the Duke's heart, winning favor with warmth, wit, and well-timed smiles."
 	outfit = /datum/outfit/job/roguetown/suitor/envoy
-	category_tags = list(CTAG_CONSORT)
+	category_tags = list(CTAG_SUITOR)
 	traits_applied = list(TRAIT_SEEPRICES, TRAIT_NUTCRACKER, TRAIT_GOODLOVER)
 	subclass_stats = list(
 		STATKEY_INT = 3,
@@ -88,7 +88,7 @@
 	tutorial = "You're a silver-tongued snake - master of whispers, poison, and perfectly timed accidents. Why win hearts when you can twist them? With rivals removed and secrets weaponized, the Duke will have no choice but to choose you."
 	outfit = /datum/outfit/job/roguetown/suitor/schemer
 	traits_applied = list(TRAIT_ALCHEMY_EXPERT)
-	category_tags = list(CTAG_CONSORT)
+	category_tags = list(CTAG_SUITOR)
 	subclass_stats = list(
 		STATKEY_SPD = 3,
 		STATKEY_INT = 1,
@@ -139,7 +139,7 @@
 	name = "Gallant"
 	tutorial = "With honor and the flash of your steel, you meet your rivals in open challenge. You'll win the Duke's favor not with whispers or warmth, but with roaring applause."
 	outfit = /datum/outfit/job/roguetown/suitor/gallant
-	category_tags = list(CTAG_CONSORT)
+	category_tags = list(CTAG_SUITOR)
 	traits_applied = list(TRAIT_MEDIUMARMOR)
 	subclass_stats = list(
 		STATKEY_INT = 2,


### PR DESCRIPTION
## About The Pull Request

ok so what this pr does is add 3 subclasses to consort. it's probably messy as fuck because i do not code but it's not vibecoded and it didn't break when i tested it, so why not just push it.

- **Heartthrob:** _"A former swordsman, either through battle or through bravado you won the Grand Duke's heart. Your sword arm may have gotten rusty with time, but you're still more than capable of showing any would-be assassins the meaning of 'til Death do us part'."_

a generally swords-oriented subclass, equivalent to daring prince or gallant suitor. flavored around the idea of a dashing duelist who won the duke's heart, with a rapier to match.

- **Trophy:** _"You were once an individual of some note. A Noble, an envoy, a suitor. Now, either for politics, metrics or just to save your - or your beloved's, skin, you're nothing but the Grand Duke's armpiece. Smile for the people, wave for the crowds, scheme from the shadows."_

consort's current form, updated and brought into line with a more 'schemer'-type archetype. gets big sneak, medicine smill, lockpicking and such, and a bunch of new items in their loadout to help with whatever goal they may have.

- **Homemaker:** _"Through your caring ways and dutiful nature, you provide for your beloved and your children in the way you're best at. You're very aware that the household of your beloved is well-manned with servants to cook and clean, but you don't care. After all, food tastes much better when it's made with love."_

the long-awaited housewife class. starts with a needle, scissors, a rolling pin, a cleaver and a frying pan to hit people with. also, the only suitor class to come with good lover.

## Testing Evidence

tested on local host, everything seems to be working as intended, no errors, no warnings,.

## Why It's Good For The Game

consort is outdated as fuck, and as a roleplay-oriented role with no mechanical requirements in the round that's limited to 1 it should be brought into the modern day and given some more room to breathe in comparison to suitor that has 3 slots and 3 roles.

## Changelog

:cl:
- adds 3 new Consort subclasses: Heartthrob, Sapio, Trophy and Homemaker
- splits CTAG_CONSORT into CTAG_CONSORT and CTAG_SUITOR to handle both classes.
- applied CTAG_SUITOR to Suitor
- applied CTAG_CONSORT to Consort
/:cl:
