### PR TITLE
Revert "Skulls for the Madstar—Vorpal for Viscious Axe "

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -583,7 +583,6 @@
 	force_wielded = 40
 	max_blade_int = 250
 	icon = 'icons/roguetown/weapons/64.dmi'
-	vorpal = TRUE
 
 /obj/item/rogueweapon/greataxe/steel/doublehead/graggar/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
Reverts Rotwood-Vale/Ratwood-2.0#2269

After a discussion with a few staff members, and me reaching out to some players, and reading the original notes: Vorpal was not supposed to be given out--but it was. This reverts the PR.