### PR TITLE
No blood duping

### DIFF
--- a/code/modules/spells/roguetown/acolyte/general.dm
+++ b/code/modules/spells/roguetown/acolyte/general.dm
@@ -427,6 +427,11 @@
 		var/mob/living/carbon/human/target = targets[1]
 		var/mob/living/carbon/human/UH = user
 
+		if(target == UH)
+			to_chat(UH, span_warning("I cannot transfer my own blood to myself."))
+			revert_cast()
+			return FALSE
+
 		if(UH.doing)
 			to_chat(UH, span_warning("I can't cast this while doing something else."))
 			revert_cast()


### PR DESCRIPTION
## About The Pull Request
Does not allow to replenish your own blood by blood transfer miracle
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="336" height="48" alt="image" src="https://github.com/user-attachments/assets/2b69bc0f-7bf2-493c-9ee6-335639782af3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
No blood duping
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: you can no longer blood transfer miracle yourself

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
