### PR TITLE
Adds organ eater to feral appetite

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -157,8 +157,8 @@
 
 /datum/virtue/utility/feral_appetite
 	name = "Feral Appetite"
-	desc = "Raw, toxic or spoiled food doesn't bother my superior digestive system."
-	added_traits = list(TRAIT_NASTY_EATER)
+	desc = "I can eat just about ANYTHING, rotten or poisonous food and tainted water, even entrails..."
+	added_traits = list(TRAIT_NASTY_EATER, TRAIT_ORGAN_EATER)
 
 /datum/virtue/utility/feral_appetite/handle_traits(mob/living/carbon/human/recipient)
 	..()


### PR DESCRIPTION
## About The Pull Request

Gives feral appetite the organ_eater trait

## Testing Evidence

<img width="620" height="47" alt="image" src="https://github.com/user-attachments/assets/5a254b88-5d61-416e-ae2c-79ad38edc91e" />

<img width="356" height="75" alt="image" src="https://github.com/user-attachments/assets/4dbe5163-e32a-4db8-8ae4-7bfac38e24ba" />


## Why It's Good For The Game

Requested by someone for RP reasoning which is fairly sound, and makes this virtue a little better.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Feral Appetite lets you eat organs as well now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
