### PR TITLE
Fix hook sword dual wielding check

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -2019,7 +2019,7 @@
 			var/obj/item/mainhand = user.get_active_held_item()
 			var/obj/item/offhand = user.get_inactive_held_item()
 			if(HAS_TRAIT(user, TRAIT_DUALWIELDER) && istype(offhand, mainhand))
-				probby += 20	//We give notable bonus to dual-wielders who use two hooked swords.
+				probby += 20	//We give notable bonus to dual-wielders who use two hooked swords, this time for real.
 			if(prob(probby))
 				M.dropItemToGround(I, force = FALSE, silent = FALSE)
 				user.stop_pulling()

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -2018,7 +2018,7 @@
 					probby -= M.get_skill_level(I.associated_skill) * 5
 			var/obj/item/mainhand = user.get_active_held_item()
 			var/obj/item/offhand = user.get_inactive_held_item()
-			if(HAS_TRAIT(src, TRAIT_DUALWIELDER) && istype(offhand, mainhand))
+			if(HAS_TRAIT(user, TRAIT_DUALWIELDER) && istype(offhand, mainhand))
 				probby += 20	//We give notable bonus to dual-wielders who use two hooked swords.
 			if(prob(probby))
 				M.dropItemToGround(I, force = FALSE, silent = FALSE)


### PR DESCRIPTION
## About The Pull Request

- Makes the hook the sword disarm intent check the user for the duel-wielding trait instead of the source, which in this case was the sword itself and not the user.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
one word reference change
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Dual-wielding hook swords is supposed to grant an advantage to disarm intent, a flat 20 bonus to the probability dice. This was unfortunately non-functional, as the intent checked the src for the trait, which would be the sword itself, which cannot possibly have TRAIT_DUALWIELDER, meaning it would never be true. 

The intent now properly checks the USER for TRAIT_DUALWIELDER, meaning the bonus now applies properly. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
fix: Hooksword disarm intent now properly grants bonus success chance when dual-wielded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
