### PR TITLE
Equalizes psydonic grand mace defense value with regular grand mace

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/blunt.dm
+++ b/code/game/objects/items/rogueweapons/melee/blunt.dm
@@ -460,6 +460,7 @@
 	force_wielded = 35
 	minstr = 12
 	smelt_bar_num = 2
+	wdefense_wbonus = 5
 	is_silver = TRUE
 	smeltresult = /obj/item/ingot/silverblessed
 


### PR DESCRIPTION
## About The Pull Request
As said on the tin, equalizes the Psydonic Grand Mace's defense values with the regular grand mace.
Basically a copy paste of the bonus that the grand mace gets, given to the Psydonic Grand Mace.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="657" height="195" alt="image" src="https://github.com/user-attachments/assets/1a173c14-0752-4a36-a5ae-82ceef640b0a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The psydonic grand mace should not be inferior to a regular grand mace. It unironically ends up with 8 defense (vs grand mace 9) when wielded even with the blessing bonuses, due to lacking the notable wdefense bonus that the grand mace gets but the psydonic does not.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Psydonic Grand Mace now has the same wielded defense bonus as the Grand Mace.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
