### PR TITLE
Failed Squire Evaporation

### DIFF
--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -92,10 +92,10 @@
 					to_chat(recipient, span_notice("As a resident of the vale, you find yourself in the local tavern."))
 
 /datum/virtue/utility/failed_squire
-	name = "Failed Squire (8 TRI)"
+	name = "Failed Squire (5 TRI)"
 	desc = "I was once a squire in training, but failed to achieve knighthood. Though my dreams of glory were dashed, I retained my knowledge of equipment maintenance and repair, including how to polish arms and armor."
 	added_traits = list(TRAIT_SQUIRE_REPAIR)
-	triumph_cost = 8 //Bye.
+	triumph_cost = 5 // Plate armor being the equivalent of better leather armor is fucking horrid for the game.
 	added_stashed_items = list(
 		"Hammer" = /obj/item/rogueweapon/hammer/iron,
 		"Polishing Cream" = /obj/item/polishing_cream,

--- a/modular_azurepeak/virtues/utility.dm
+++ b/modular_azurepeak/virtues/utility.dm
@@ -92,9 +92,10 @@
 					to_chat(recipient, span_notice("As a resident of the vale, you find yourself in the local tavern."))
 
 /datum/virtue/utility/failed_squire
-	name = "Failed Squire"
+	name = "Failed Squire (8 TRI)"
 	desc = "I was once a squire in training, but failed to achieve knighthood. Though my dreams of glory were dashed, I retained my knowledge of equipment maintenance and repair, including how to polish arms and armor."
 	added_traits = list(TRAIT_SQUIRE_REPAIR)
+	triumph_cost = 8 //Bye.
 	added_stashed_items = list(
 		"Hammer" = /obj/item/rogueweapon/hammer/iron,
 		"Polishing Cream" = /obj/item/polishing_cream,


### PR DESCRIPTION
## About The Pull Request
Failed Squire now costs 5 TRI. That's all it does.
Pilgrim costs 3 TRI for something far less powerful.

Your adventurer slop bores me.
:cl:
balance: Failed Squire now costs 5 Triumphs to reflect it's actual utility ingame.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
