### PR TITLE
Cleric Missionary has a [Great]Sword Path

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -705,7 +705,7 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_3)//Only T4 NOT to start maxed, with a devotion cap.
 	C.update_devotion(C.max_devotion / 4 - 50, C.max_devotion / 4 - 50, silent = TRUE) // Start at ~25% of devotion cap
 	if(H.mind)
-		var/weapons = list("Path of the Preacher", "Path of the Shepard")
+		var/weapons = list("Path of the Preacher", "Path of the Shepard", "Path of the Sword Maiden", "Path of the Bell")
 		var/weapon_choice = input(H, "Choose your path.", "CHOOSE YOUR DISCIPLINE.") as anything in weapons
 		switch(weapon_choice)
 			if("Path of the Preacher")//Discount homesteader. No trait so you can't level these skills up, nor do you have starting tools.
@@ -719,6 +719,10 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 3, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/unarmed, 3, TRUE)//Good luck fighting like a monk without monk stats or Dodge Expert.
+			if("Path of the Sword Maiden")//I see...
+				r_hand = /obj/item/rogueweapon/greatsword/zwei //Claymore
+				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)//So you won't feel like carrying dead weight in your hands.
+				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 2, TRUE)
 
 	if(istype(H.patron, /datum/patron/divine))
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -722,7 +722,6 @@
 			if("Path of the Sword Maiden")//I see...
 				r_hand = /obj/item/rogueweapon/greatsword/zwei //Claymore
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 3, TRUE)//So you won't feel like carrying dead weight in your hands.
-				H.adjust_skillrank_up_to(/datum/skill/combat/wrestling, 2, TRUE)
 
 	if(istype(H.patron, /datum/patron/divine))
 		H.mind?.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/divineblast)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/cleric.dm
@@ -705,7 +705,7 @@
 	C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MAJOR, devotion_limit = CLERIC_REQ_3)//Only T4 NOT to start maxed, with a devotion cap.
 	C.update_devotion(C.max_devotion / 4 - 50, C.max_devotion / 4 - 50, silent = TRUE) // Start at ~25% of devotion cap
 	if(H.mind)
-		var/weapons = list("Path of the Preacher", "Path of the Shepard", "Path of the Sword Maiden", "Path of the Bell")
+		var/weapons = list("Path of the Preacher", "Path of the Shepard", "Path of the Sword Maiden")
 		var/weapon_choice = input(H, "Choose your path.", "CHOOSE YOUR DISCIPLINE.") as anything in weapons
 		switch(weapon_choice)
 			if("Path of the Preacher")//Discount homesteader. No trait so you can't level these skills up, nor do you have starting tools.


### PR DESCRIPTION
## About The Pull Request

Adds a third path for the Cleric Missionary which is a combat path just like the Sheperd but you're given a Claymore instead of an Iron Quarterstaff.

Path of the Sword Maiden:

Claymore(Iron Greatswod)
Journeyman Swords.

## Testing Evidence

I hope I didn't mess it up.

## Why It's Good For The Game

A bit more of variety for missionary paths looks good, right? Like how I explained, is just Sheperd but with a greatsword but no unarmed skill and barely some wrestling skill.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: CloverIsLucky
add: Missionary obtains a third path: "Sword Maiden"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
