### PR TITLE
Force Inhale Drugs Nerf

### DIFF
--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -118,7 +118,7 @@
 				if(!CH.grabbedby)
 					to_chat(user, span_info("[C.p_they(TRUE)] steals [C.p_their()] face from it."))
 					return FALSE
-			if(!do_mob(user, M, 50))
+			if(!do_mob(user, M, 5 SECONDS))
 				return FALSE
 
 	playsound(M, 'sound/items/sniff.ogg', 100, FALSE)

--- a/code/modules/reagents/reagent_containers/powderspice.dm
+++ b/code/modules/reagents/reagent_containers/powderspice.dm
@@ -106,6 +106,10 @@
 				to_chat(user, span_warning("[C.p_theyre(TRUE)] missing something."))
 			if(!C.can_smell())
 				to_chat(user, span_warning("[C.p_theyre(TRUE)] has no nose!"))
+			for(var/obj/item/clothing/CL in C.get_equipped_items())
+				if(CL.body_parts_covered & NOSE)
+					to_chat(user, span_warning("[C.p_theyre(TRUE)] has something covering [C.p_their()] nose."))
+					return FALSE
 			
 			user.visible_message(span_danger("[user] attempts to force [C] to inhale [src]."), \
 								span_danger("I attempt to force [C] to inhale [src]!"))
@@ -114,7 +118,7 @@
 				if(!CH.grabbedby)
 					to_chat(user, span_info("[C.p_they(TRUE)] steals [C.p_their()] face from it."))
 					return FALSE
-			if(!do_mob(user, M, 10))
+			if(!do_mob(user, M, 50))
 				return FALSE
 
 	playsound(M, 'sound/items/sniff.ogg', 100, FALSE)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

- Adds a delay same as feeding potions to spice and other powders
- Stops force inhaling if nose is covered

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="442" height="130" alt="image" src="https://github.com/user-attachments/assets/3dbadf6f-57df-4f6f-8fd1-977575cb95de" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

It doesn't make any sense to be able to put spice through someone's nose through a mask. It also shouldn't be almost instant, as putting a powder up someone's nose during a fight would NOT be easy to do.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Powders can't be force inhaled through masks.
balance: Powders take just as long as a potion to be force inhaled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
