### PR TITLE
Long Time Coming: Necromancer Nerfs

### DIFF
--- a/code/game/objects/items/rogueitems/necro_relics.dm
+++ b/code/game/objects/items/rogueitems/necro_relics.dm
@@ -8,9 +8,9 @@
 	var/last_use_time = 0
 	var/use_cooldown = 300 // 30 seconds
 	var/list/active_skeletons = list() //List of active skeletons stored here.
-	var/max_summons = 2 //Maximum amount of skeletons that can be summoned at one time.
-	var/max_charges = 2 //Maximum amount of charges the crystal can hold.
-	var/current_charges = 2
+	var/max_summons = 1 //Maximum amount of skeletons that can be summoned at one time.
+	var/max_charges = 1 //Maximum amount of charges the crystal can hold.
+	var/current_charges = 1
 	grid_height = 32
 	grid_width = 32
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -8,7 +8,7 @@
 	class_select_category = CLASS_CAT_MAGE
 	category_tags = list(CTAG_WRETCH)
 	traits_applied = list(TRAIT_ZOMBIE_IMMUNE, TRAIT_MAGEARMOR, TRAIT_GRAVEROBBER, TRAIT_ARCYNE_T3, TRAIT_ALCHEMY_EXPERT, TRAIT_MEDICINE_EXPERT,TRAIT_RITUALIST,TRAIT_OUTLANDER,)
-	maximum_possible_slots = 2 // Going from 1 to 2, because skeleton that are summoned count AGAINST antagonist cap and they don't always shows up
+	maximum_possible_slots = 1
 	subclass_stats = list(
 		STATKEY_INT = 4,
 		STATKEY_PER = 2,


### PR DESCRIPTION
## About The Pull Request

- Dark Crystals can only support 1 sentient minion, down from 2.
- Dark Crystals have 1 starting and maximum charge, down from 2.
- Necromancers are now a single-slot wretch type, down from 2.

## Why It's Good For The Game

Over the past several months, the rounds which consistently cause the most grief, result in the most deaths, and create the most spillover from combatant roles to noncombatant roles have been the result of necromancers/sentient skeleton summoners in general massing large numbers of sentient skeletons (and often other wretch allies) to create exhausting, never-ending hyperwars. 

The fact of the matter is, it isn't reasonable for a single wretch (who, to be clear, shares their job category with classes like Poacher) to be able to amass a coterie of 10 or 12 sentient skeletons, particularly when that number is just an inevitability of time spent sleeping and performing rituals in private. 

Sentient skeletons are able combatants in their own right, particularly when equipped with high-powered ranged weaponry, but when placed in the context of having a necromancer to back them up, and more often than not other wretches to run interference for them, they quickly become an overwhelming addition to an already strong army composition. 

In addition, skeletons are not capable of (and therefore, not expected to) provide roleplay commensurate with their place as antagonists, nor to act with self-preservation in mind. They aren't real players - they aren't characters with a history or real stakes in the round, if they die, they lose nothing. In fact, they can come right back the next time their summoner calls for a new skeleton. I don't feel like this dynamic is healthy for a roleplaying server.

This halves the number of skeletons that a single necromancer can support, and the number of necromancers that can join the round. To be clear, though: **Any Zizite ritualist can still perform the rites and obtain dark crystals**. 

## Changelog

:cl: CameronWoof
balance: Dark Crystals can only support 1 sentient minion, down from 2.
balance: Dark Crystals have 1 starting and maximum charge, down from 2.
balance: Necromancers are limited to 1 slot, down from 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
