### PR TITLE
[Balance] Disables Wretch Necromancer

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -1275,6 +1275,6 @@
 	keylock = TRUE
 	grant_resident_key = TRUE
 	resident_key_type = /obj/item/roguekey/townie// should be every wretch class - ideally we can get resident_role to accept lists but until then this'll do
-	resident_advclass = list(/datum/advclass/witch, /datum/advclass/wretch/licker, /datum/advclass/wretch/deserter, /datum/advclass/wretch/deserter/maa, /datum/advclass/wretch/berserker, /datum/advclass/wretch/hedgemage, /datum/advclass/wretch/necromancer, /datum/advclass/wretch/heretic, /datum/advclass/wretch/heretic/spy, /datum/advclass/wretch/outlaw, /datum/advclass/wretch/poacher, /datum/advclass/wretch/plaguebearer, /datum/advclass/wretch/pyromaniac, /datum/advclass/wretch/vigilante, /datum/advclass/wretch/blackoakwyrm, /datum/advclass/wretch/antipope, /datum/advclass/wretch/ancientchampion)
+	resident_advclass = list(/datum/advclass/witch, /datum/advclass/wretch/licker, /datum/advclass/wretch/deserter, /datum/advclass/wretch/deserter/maa, /datum/advclass/wretch/berserker, /datum/advclass/wretch/hedgemage, /*/datum/advclass/wretch/necromancer,*/ /datum/advclass/wretch/heretic, /datum/advclass/wretch/heretic/spy, /datum/advclass/wretch/outlaw, /datum/advclass/wretch/poacher, /datum/advclass/wretch/plaguebearer, /datum/advclass/wretch/pyromaniac, /datum/advclass/wretch/vigilante, /datum/advclass/wretch/blackoakwyrm, /datum/advclass/wretch/antipope, /datum/advclass/wretch/ancientchampion)
 	lockid = null //Will be randomized
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/necromancer.dm
@@ -1,3 +1,4 @@
+/*
 /datum/advclass/wretch/necromancer
 	name = "Necromancer"
 	tutorial = "You have been ostracized and hunted by society for your dark magics and perversion of life."
@@ -93,3 +94,5 @@
 			backr = /obj/item/rogueweapon/woodstaff/amethyst
 		if("toper-focused staff")
 			backr = /obj/item/rogueweapon/woodstaff/toper
+
+*/// Necro is being disabled for now, needs to be reworked into a seperate antag

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -37,7 +37,7 @@
 		/datum/advclass/wretch/deserter/maa,
 		/datum/advclass/wretch/berserker,
 		/datum/advclass/wretch/hedgemage,
-		/datum/advclass/wretch/necromancer,
+		///datum/advclass/wretch/necromancer, Necro is being disabled for now, needs to be reworked into a seperate antag
 		/datum/advclass/wretch/heretic,
 		/datum/advclass/wretch/heretic/spy,
 		/datum/advclass/wretch/heretic/monk,


### PR DESCRIPTION
## About The Pull Request
Very basic PR, just disables the Wretch Necromancer subclass. 

## Testing Evidence

Ran, cannot select necromancer. Everything else works as expected. 

## Why It's Good For The Game

Currently we are struggling with significant issues with this specific subclass. With it being available to Wretches (which are almost always in round), it means most of the time it will be present in 9/10 rounds. We have found the class incredibly difficult to balance, and has led to repeated large conflicts with minimal RP due to their ability to summon large numbers of skeletons. 

We are drafting plans to move the Necromancer to a seperate minor antag role, but as this is seen as a pressing concern, it is being disabled right now to prevent further issues in the meantime. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Wretch Necromancer is currently not selectable in round, pending a rework of the subclass to a full blown seperate minor antagonist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
