### PR TITLE
[Mercenary] FERENTIA Sellblade Athletics buff

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/ferentia.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/ferentia.dm
@@ -187,7 +187,7 @@
 		/datum/skill/combat/swords = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/combat/knives = SKILL_LEVEL_APPRENTICE,
 		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
-		/datum/skill/misc/athletics = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 	)
 	extra_context = "This subclass gains Expert skill in their weapon of choice, be it swords or knives."
 


### PR DESCRIPTION
## About The Pull Request

Buffs the Mercenary FERENTIA Sellblade to have Expert Athletics instead of Journeyman

## Testing Evidence

I've tested the changes to how it affects the stamina consumption in combat. Since it's a rogue class relying on dodging and poke and run tactics, it gives them a little bit more time to stay in a fight without being completely drained afterwards.

## Why It's Good For The Game

It's a class that according to whoever designed it is a shady blade wielder who goes in and out of combat. Comparing stats to other mercenaries and even adventuring classes it does not make sense for them to have Journeyman Athletics skill, specially with so few other skills that they get by default comparing to other classes of the same role or even roles that are meant to be weaker then them. It's also a class that relies on dodging with the Expert Dodger trait, and that consumes more stamina then parrying.

Adventurer Rogues / Eastern Assassins have expert in athletics. Even some medium / heavy armor wearing mercs like Cavalier for dark elves has expert Athletics while the sneaky and rogue-like Sellblade does not. This PR is meant to change that.

## Changelog

1.0 Changing their starting Athletics skill from Journeyman to Expert.




<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
