### PR TITLE
Fixes lack of integrity value assigned to heirophant's kandys

### DIFF
--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -210,6 +210,7 @@
 	prevent_crits = list(BCLASS_CUT, BCLASS_BLUNT, BCLASS_CHOP)
 	armor = ARMOR_PADDED_GOOD
 	armor_class = ARMOR_CLASS_LIGHT
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
 	icon_state = "desertgown"
 	item_state = "desertgown"
 	heat_protection = CHEST | GROIN


### PR DESCRIPTION
## About The Pull Request
Armor usually has an integrity value rather than inheriting the default of clothing; Adds a suitable integrity value to the heirophant's kandys, which is a padded gambeson tier item for naledian mercenaries. (It can be crafted, but the recipe is on the same difficulty as a padded gambeson, so!)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="561" height="214" alt="image" src="https://github.com/user-attachments/assets/f779c92f-2b44-4528-b39e-d95f9287074a" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The kandys used to be a niche meta item for wearing on cloak/tabard slot, but since a PR fixed that/changed that it can't be worn there anymore! Ergo it should be brought up to parity with the padded gambeson/padded desert coat, etcera. It already can't be worn alongside a padded gamby and having the mercs unique item being objectively worse is kinda lame.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Heirophant's kandys now has a proper integrity value, equivilient to a padded gambeson.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
