### PR TITLE
SLOOC Bug Fix, LOOC Ban Separation, No LOOC while Dead

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -7,6 +7,7 @@
 #define MUTE_ADMINHELP	(1<<3)
 #define MUTE_DEADCHAT	(1<<4)
 #define MUTE_LOOC		(1<<5)
+#define MUTE_SLOOC		(1<<6)
 #define MUTE_ALL		(~0)
 
 //Some constants for DB_Ban

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -158,7 +158,8 @@
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_PRAY]'><font color='[(muted & MUTE_PRAY)?"red":"blue"]'>PRAY</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ADMINHELP]'><font color='[(muted & MUTE_ADMINHELP)?"red":"blue"]'>ADMINHELP</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT)?"red":"blue"]'>DEADCHAT</font></a> | "
-		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>LOOC</font></a>\]"
+		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_LOOC]'><font color='[(muted & MUTE_LOOC)?"red":"blue"]'>LOOC</font></a> | "
+		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_SLOOC]'><font color='[(muted & MUTE_SLOOC)?"red":"blue"]'>SLOOC</font></a>\]"
 		body += "(<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL)?"red":"blue"]'>toggle all</font></a>)"
 
 	body += "<br><br>"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -238,6 +238,9 @@
 		if(MUTE_LOOC)
 			mute_string = "LOOC"
 			feedback_string = "LOOC"
+		if(MUTE_SLOOC)
+			mute_string = "SLOOC"
+			feedback_string = "SLOOC"
 		if(MUTE_PRAY)
 			mute_string = "pray"
 			feedback_string = "Pray"

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -195,7 +195,8 @@
 			return
 
 	else if((mob?.stat == DEAD || isobserver(mob)) && !(holder && istype(mob, /mob/dead/observer/admin)))
-		to_chat(src, span_danger(isobserver(mob) ? "I cannot use LOOC while ghosted." : "I cannot use LOOC while dead, only SLOOC."))
+		var/refusal = isobserver(mob) ? "I cannot use LOOC while ghosted." : "I cannot use LOOC while dead, only SLOOC."
+		to_chat(src, span_danger(refusal))
 		return
 
 	if(!mob)

--- a/modular_hearthstone/code/interface/LOOC.dm
+++ b/modular_hearthstone/code/interface/LOOC.dm
@@ -36,33 +36,35 @@
 	set category = "OOC"
 	do_subtlelooc(msg)
 
+/// Takes raw text and sanitizes it on the first line, before anything else in here can read it.
+/// Callers must pass the message unsanitized, encoding it twice turns apostrophes into a
+/// literal &#39; in chat.
 /client/proc/do_subtlelooc(msg as text)
+
+	// Sanitizes here. IDK why it was just randomly all the way down there.
+	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+
+	if(!msg)
+		return
 
 	if(GLOB.say_disabled)
 		to_chat(usr, span_danger("Speech is currently admin-disabled."))
 		return
 
-	if(prefs.muted & MUTE_LOOC)
-		to_chat(src, span_danger("I cannot use LOOC (temp muted)."))
-		return
-
-	if(is_banned_from(ckey, "LOOC"))
-		to_chat(src, span_danger("I cannot use LOOC (perma muted)."))
-		return
-
-	if(isobserver(mob) && !holder)
-		to_chat(src, span_danger("I cannot use LOOC while dead."))
+	// SLOOC has its own mute, the LOOC one doesn't reach it and this one doesn't reach LOOC
+	if(prefs.muted & MUTE_SLOOC)
+		to_chat(src, span_danger("I cannot use SLOOC (temp muted)."))
 		return
 
 	if(!holder && istype(mob, /mob/dead/new_player))
 		to_chat(src, span_danger("I cannot use LOOC while in the lobby. Join the round or observe first."))
 		return
 
-	if(!mob)
+	if(isobserver(mob) && !(holder && istype(mob, /mob/dead/observer/admin)))
+		to_chat(src, span_danger("I cannot use SLOOC while ghosted."))
 		return
 
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
-	if(!msg)
+	if(!mob)
 		return
 
 	if(!(prefs.chat_toggles & CHAT_OOC))
@@ -83,12 +85,13 @@
 	var/list/hearers = get_hearers_in_view(distance, S)
 	var/list/recipient_choices = list("1-Tile Range", "Same Tile")
 
+	// L.client, so NPCs and disconnected bodies stay out of the picker
 	for(var/mob/living/L in hearers)
-		if(L.stat == CONSCIOUS && L != S)
+		if(L.client && L.stat == CONSCIOUS && L != S)
 			if(!L.rogue_sneaking && L.name != "Unknown")
 				recipient_choices += L
 
-	var/recipient_choice = input(src, "Pick a target?", "Subtle Emote") in recipient_choices
+	var/recipient_choice = input(src, "Pick a target?", "SLOOC") in recipient_choices
 	if(!recipient_choice)
 		return
 
@@ -110,7 +113,10 @@
 		else
 			recipient_admin_label = recipient_label
 
-	var/admin_info = " ([s_ckey]) [ADMIN_FLW(S)] <A href='?_src_=holder;[HrefToken()];mute=[s_ckey];mute_type=[MUTE_LOOC]'><font color='[(prefs.muted & MUTE_LOOC) ? "red" : "blue"]'>\[MUTE\]</font></a>"
+	// Both links, so a SLOOC line can shut down SLOOC alone or LOOC alongside it
+	var/mute_slooc_link = "<A href='?_src_=holder;[HrefToken()];mute=[s_ckey];mute_type=[MUTE_SLOOC]'><font color='[(prefs.muted & MUTE_SLOOC) ? "red" : "blue"]'>\[MUTE SLOOC\]</font></a>"
+	var/mute_looc_link = "<A href='?_src_=holder;[HrefToken()];mute=[s_ckey];mute_type=[MUTE_LOOC]'><font color='[(prefs.muted & MUTE_LOOC) ? "red" : "blue"]'>\[MUTE LOOC\]</font></a>"
+	var/admin_info = " ([s_ckey]) [ADMIN_FLW(S)] [mute_slooc_link] [mute_looc_link]"
 	var/prefix_text = span_prefix("[pfx]:")
 
 	var/msg_reg = "<font color='#9DCCFF'><b>[prefix_text] <EM>[s_name] → [recipient_label]:</EM> <span class='message'>[msg]</span></b></font>"
@@ -154,16 +160,20 @@
 		to_chat(C, msg_rem)
 
 /client/proc/do_looc(msg as text, wp)
-	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
 	if(!msg)
 		return
 
-	// If LOOC message starts with @, treat as SLOOC
+	// If LOOC message starts with @, treat as SLOOC. Hand over the raw text, do_subtlelooc
+	// sanitizes its own input and encoding it a second time here would mangle apostrophes
 	if(copytext(msg, 1, 2) == "@")
 		var/slooc_msg = copytext(msg, 2)
 		if(length(slooc_msg) && copytext(slooc_msg, 1, 2) == " ")
 			slooc_msg = copytext(slooc_msg, 2)
 		do_subtlelooc(slooc_msg)
+		return
+
+	msg = copytext_char(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	if(!msg)
 		return
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
@@ -178,13 +188,14 @@
 		to_chat(src, span_danger("I cannot use LOOC (perma muted)."))
 		return
 
-	if(isobserver(mob) && !holder)
-		to_chat(src, span_danger("I cannot use LOOC while dead."))
-		return
-
 	// Lobby restriction: disable LOOC for normal players still in the lobby (new_player)
-	if(!holder && istype(mob, /mob/dead/new_player))
-		to_chat(src, span_danger("I cannot use LOOC while in the lobby. Join the round or observe first."))
+	if(istype(mob, /mob/dead/new_player))
+		if(!holder)
+			to_chat(src, span_danger("I cannot use LOOC while in the lobby. Join the round or observe first."))
+			return
+
+	else if((mob?.stat == DEAD || isobserver(mob)) && !(holder && istype(mob, /mob/dead/observer/admin)))
+		to_chat(src, span_danger(isobserver(mob) ? "I cannot use LOOC while ghosted." : "I cannot use LOOC while dead, only SLOOC."))
 		return
 
 	if(!mob)


### PR DESCRIPTION
## About The Pull Request

Someone should double-check the code and then TM. I was not able to test this fully due to limitations.

As discussed and requested by players, this disables LOOC after death. Yet, it allows some flexibility. Furthermore, players can be safely LOOC banned, while allowing SLOOC usage. That way there is always an ability from a player to communicate if need be.

**Death Restrictions**

- LOOC is disabled after death once more.
- SLOOC still works while you are dead in your body, so a corpse can still talk to whoever is nearby.
- Admins are exempt only while aghosted. An admin whose character dies and ghosts normally is blocked like any other player until they aghost.

**LOOC and SLOOC Ban Separation**

- A LOOC ban no longer blocks SLOOC. So, existing rows keep role = 'LOOC' and are simply no longer queried by the SLOOC path.
- No SLOOC ban role was added. Server ban remains the permanent escalation for SLOOC misuse.
- Added MUTE_SLOOC, independent of MUTE_LOOC in both directions. Wired into the player panel mute row and into cmd_admin_mute so the mute is logged with the right channel name.
- SLOOC chat lines now carry two links, [MUTE SLOOC] and [MUTE LOOC], each toggling only its own channel.

**Bugs Fixed**

- Fixed the @ prefix path double sanitizing the message. 
- Moved do_subtlelooc's sanitize to the first line of the proc, matching do_looc
- The SLOOC target picker now only lists mobs with a client. NPCs and disconnected bodies used to appear as valid targets. No more of that!
- The target dialog was titled "Subtle Emote". It now says "SLOOC".

## Testing Evidence

It compiles and runs. Tested it using some local workarounds to avoid using the DB and you can ban LOOC usage without banning SLOOC usage. You can no longer LOOC while dead. The SLOOC and LOOC temporary mute buttons work as intended. Also, it seems to block out targets that do not have a client.

## Why It's Good For The Game

LOOC while being dead cause unnecessary disruption, however, we allow them to SLOOC if needed.

Also, bug fixes good.

## Changelog

:cl:
del: LOOC no longer works after death. SLOOC still works while your body is on the floor, but ghosts lose both.
admin: LOOC bans and LOOC mutes no longer apply to SLOOC, and SLOOC has its own temp mute on the player panel.
admin: SLOOC lines in chat now carry separate MUTE SLOOC and MUTE LOOC links.
fix: Apostrophes and quotes no longer show up as &#39; when sending SLOOC through the @ prefix.
qol: The SLOOC target list no longer offers NPCs or disconnected players.
qol: The SLOOC target window is no longer titled "Subtle Emote".
/:cl:
