### PR TITLE
Squires for Templars: Neophyte churchling advclass (and buffs)

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/_advclass.dm
@@ -173,7 +173,7 @@
 	if(length(allowed_ages) && !(H.age in allowed_ages))
 		return FALSE
 
-	if(length(allowed_patrons) && !(H.patron in allowed_patrons))
+	if(length(allowed_patrons) && !(H.patron.type in allowed_patrons))
 		return FALSE
 
 	if(maximum_possible_slots > -1)

--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -18,16 +18,17 @@
 	min_pq = -10
 	max_pq = null
 	round_contrib_points = 2
+	advjob_examine = TRUE
 	social_rank = SOCIAL_RANK_PEASANT
 
 	//You've given up your life for the Church. Why would you be noble?
 	virtue_restrictions = list(/datum/virtue/utility/noble)
 
-	advclass_cat_rolls = list(CTAG_CHURCHLING = 2)
+	advclass_cat_rolls = list(CTAG_CHURCHLING = 20)
 	job_subclasses = list(
-		/datum/advclass/churchling
+		/datum/advclass/churchling,
+		/datum/advclass/churchling/neophyte,
 	)
-	job_traits = list(TRAIT_HOMESTEAD_EXPERT)
 
 /datum/advclass/churchling
 	name = "Churchling"
@@ -35,6 +36,7 @@
 	outfit = /datum/outfit/job/roguetown/churchling/basic
 	cmode_music = 'sound/music/combat_holy.ogg'
 	category_tags = list(CTAG_CHURCHLING)
+	traits_applied = list(TRAIT_HOMESTEAD_EXPERT)
 	subclass_stats = list(
 		STATKEY_SPD = 2,
 		STATKEY_PER = 1,
@@ -66,21 +68,12 @@
 	shoes = /obj/item/clothing/shoes/roguetown/simpleshoes
 	beltl = /obj/item/storage/keyring/churchie
 
-/datum/job/roguetown/churchling/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
-	..()
-	if(!ishuman(L))
-		return
+/datum/outfit/job/roguetown/churchling/basic/post_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	if (H && H.mind)
+		_delayed_path_choice(H)
 
-	var/mob/living/carbon/human/H = L
-	H.advsetup = 1
-	H.invisibility = INVISIBILITY_MAXIMUM
-	H.become_blind("advsetup")
-
-	spawn(50)
-		if(H && H.client)
-			_delayed_path_choice(H)
-
-/datum/job/roguetown/churchling/proc/_delayed_path_choice(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/churchling/basic/proc/_delayed_path_choice(mob/living/carbon/human/H)
 	if(!H || !H.client || !H.mind)
 		return
 
@@ -91,20 +84,134 @@
 	else
 		grant_old_path(H)
 
-/datum/job/roguetown/churchling/proc/grant_old_path(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/churchling/basic/proc/grant_old_path(mob/living/carbon/human/H)
 	if(!H || !H.mind || !H.patron)
 		return
 
 	REMOVE_TRAIT(H, TRAIT_CLERGYRADICAL, "job")
-	H.reset_clergy_devotion(CLERIC_T1, CLERIC_REGEN_DEVOTEE, FALSE, CLERIC_REQ_1)
+	H.reset_clergy_devotion(CLERIC_T2, CLERIC_REGEN_DEVOTEE, FALSE, CLERIC_REQ_2)
 	to_chat(H, span_notice("I remain on the old path of devotion."))
 
-/datum/job/roguetown/churchling/proc/grant_radical_path(mob/living/carbon/human/H)
+/datum/outfit/job/roguetown/churchling/basic/proc/grant_radical_path(mob/living/carbon/human/H)
 	if(!H || !H.mind || !H.patron)
 		return
 
 	ADD_TRAIT(H, TRAIT_CLERGYRADICAL, "job")
 	H.church_favor += 1200
-	H.reset_clergy_devotion(CLERIC_T1, CLERIC_REGEN_DEVOTEE, FALSE, CLERIC_REQ_1)
+	H.reset_clergy_devotion(CLERIC_T2, CLERIC_REGEN_DEVOTEE, FALSE, CLERIC_REQ_2)
 	to_chat(H, span_notice("I embrace the radical path."))
 
+/datum/advclass/churchling/neophyte
+	name = "Neophyte"
+	tutorial = "You are a Templar-in-training, a prospective holy warrior of the Church with much to learn, and much more to prove. You've been given some hand-me-downs from the Church's armory, and the barest blessings of your chosen Divine."
+	outfit = /datum/outfit/job/roguetown/churchling/neophyte
+	category_tags = list(CTAG_CHURCHLING)
+	traits_applied = list(TRAIT_MEDIUMARMOR, TRAIT_SQUIRE_REPAIR)
+	subclass_stats = list(
+		STATKEY_CON = 2,
+		STATKEY_STR = 1,
+		STATKEY_WIL = 1,
+	)
+	subclass_skills = list(
+		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/magic/holy = SKILL_LEVEL_NOVICE,
+		/datum/skill/misc/athletics = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/swimming = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/misc/reading = SKILL_LEVEL_NOVICE,
+		/datum/skill/combat/unarmed = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/combat/wrestling = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/combat/shields = SKILL_LEVEL_APPRENTICE,
+	)
+	allowed_patrons = list(
+		/datum/patron/divine/astrata,
+		/datum/patron/divine/noc,
+		/datum/patron/divine/abyssor,
+		/datum/patron/divine/dendor,
+		/datum/patron/divine/necra,
+		/datum/patron/divine/malum,
+		/datum/patron/divine/eora,
+		/datum/patron/divine/ravox,
+		/datum/patron/divine/xylix,
+		/datum/patron/divine/pestra
+	)
+	extra_context = "Tennite only, and lacks the per-God bonuses Templars usually get. Bears T1 miracles of your chosen patron (loyalist only), and Journeyman level combat skills in one of the following: Swords (and Shields), Maces, Whips/Flails, Polearms and Axes "
+
+/datum/outfit/job/roguetown/churchling/neophyte/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	H.adjust_blindness(-3)
+	head = /obj/item/clothing/neck/roguetown/chaincoif/iron
+	armor = /obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/iron
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	backl = /obj/item/storage/backpack/rogue/satchel
+	belt = /obj/item/storage/belt/rogue/leather/rope
+	beltl = /obj/item/storage/keyring/churchie
+	pants = /obj/item/clothing/under/roguetown/chainlegs/iron
+	gloves = /obj/item/clothing/gloves/roguetown/chain/iron
+	shoes = /obj/item/clothing/shoes/roguetown/boots/leather
+	backpack_contents = list(
+		/obj/item/rogueweapon/hammer/wood = 1,
+		/obj/item/needle = 1
+
+	)
+	switch(H.patron?.type)
+		if(/datum/patron/divine/astrata)
+			cloak = /obj/item/clothing/cloak/templar/astrata
+			neck = /obj/item/clothing/neck/roguetown/psicross/astrata
+		if(/datum/patron/divine/noc)
+			cloak = /obj/item/clothing/cloak/templar/noc
+			neck = /obj/item/clothing/neck/roguetown/psicross/noc
+		if(/datum/patron/divine/abyssor)
+			cloak = /obj/item/clothing/cloak/abyssortabard
+			neck = /obj/item/clothing/neck/roguetown/psicross/abyssor
+		if(/datum/patron/divine/dendor)
+			cloak = /obj/item/clothing/cloak/templar/dendor
+			neck = /obj/item/clothing/neck/roguetown/psicross/dendor
+		if(/datum/patron/divine/necra)
+			cloak = /obj/item/clothing/cloak/templar/necra
+			neck = /obj/item/clothing/neck/roguetown/psicross/necra
+		if (/datum/patron/divine/malum)
+			cloak = /obj/item/clothing/cloak/templar/malum
+			neck = /obj/item/clothing/neck/roguetown/psicross/malum
+		if (/datum/patron/divine/eora)
+			cloak = /obj/item/clothing/cloak/templar/eora
+			neck = /obj/item/clothing/neck/roguetown/psicross/eora
+		if (/datum/patron/divine/ravox)
+			cloak = /obj/item/clothing/cloak/cleric/ravox
+			neck = /obj/item/clothing/neck/roguetown/psicross/ravox
+		if (/datum/patron/divine/xylix)
+			cloak = /obj/item/clothing/cloak/templar/xylix
+			neck = /obj/item/clothing/neck/roguetown/psicross/xylix
+		if (/datum/patron/divine/pestra)
+			cloak = /obj/item/clothing/cloak/templar/pestra
+			neck = /obj/item/clothing/neck/roguetown/psicross/pestra
+	
+	var/weapons = list("Longsword","Mace","Flail","Whip","Spear","Axe")
+	var/weapon_choice = input(H, "Choose your WEAPON.", "TAKE UP YOUR GOD'S ARMS.") as anything in weapons
+	switch(weapon_choice)
+		if("Longsword")
+			H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			beltr = /obj/item/rogueweapon/sword/long
+			r_hand = /obj/item/rogueweapon/scabbard/sword
+		if("Mace")
+			H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			beltr = /obj/item/rogueweapon/mace
+		if("Flail")
+			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			beltr = /obj/item/rogueweapon/flail
+		if("Whip")
+			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			beltr = /obj/item/rogueweapon/whip
+		if("Spear")
+			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			r_hand = /obj/item/rogueweapon/spear
+			backr = /obj/item/rogueweapon/scabbard/gwstrap
+			beltr = /obj/item/rogueweapon/shield/buckler
+		if("Axe")
+			H.adjust_skillrank_up_to(/datum/skill/combat/axes, SKILL_LEVEL_JOURNEYMAN, TRUE)
+			r_hand = /obj/item/rogueweapon/stoneaxe/woodcut
+	H.set_blindness(0)
+
+/datum/outfit/job/roguetown/churchling/neophyte/post_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	H.reset_clergy_devotion(CLERIC_T1, CLERIC_REGEN_DEVOTEE, FALSE, CLERIC_REQ_1)
+	

--- a/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/churchling.dm
@@ -214,4 +214,3 @@
 /datum/outfit/job/roguetown/churchling/neophyte/post_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	H.reset_clergy_devotion(CLERIC_T1, CLERIC_REGEN_DEVOTEE, FALSE, CLERIC_REQ_1)
-	


### PR DESCRIPTION
## About The Pull Request

Brought to you by the same idiot who made Vagabond fun. You're welcome.

This PR does the following:

- fixes a long-standing and frankly embarrassing bug with advclass allowed_patrons checking that meant the field did fundamentally nothing. Oops.
   - If anything breaks when this is TM'd, this is probably why. I've done due diligence and tested basic joining and the like to see and everything *seems* fine, but you never know.
- Adds the Neophyte churchling subclass.
   - This is essentially a medium armor squire in shit iron chain gear with journeyman weapons, T1 miracles, medium armor training and squire repair. Locked to Tennite faiths only, unlike standard Churchling.
   - **LOYALIST ONLY**.
   - It doesn't get *any* of the skill, trait or teaching bonuses that Templars get, or any of their cool weapons,
   - This entire class exists so you can reasonably and realistically play the niche of 'templar-in-training' without depriving the round of an actual bonafide Templar slot.
   - Note: churchlings have **devotee** level regen. It's slow as HELL. They're not spamming miracles, period.
   - Its stat bonuses are con-favored and deliberately kind of bad.
   - No, I'm not adding a dodge expert variant, and neither should anybody else.
- Churchling can now access up to T2 miracles, raised from T1.
   - This is largely because churchling sucks hot horrible ass at T1 and has basically nothing else to show for it. It's a learner role, sure, but it has historically been the *least popular* of its type because you can't realistically learn anything when you can't **do** anything.


## Testing Evidence

<img width="885" height="653" alt="dreamseeker_rKt1zpGGZY" src="https://github.com/user-attachments/assets/31284d5e-57d8-41e5-bf1e-7bd8d0bca264" />

<img width="960" height="674" alt="dreamseeker_UVwoTPexFY" src="https://github.com/user-attachments/assets/46c3206b-923b-453b-ade9-225fcdfcb25e" />

<img width="224" height="303" alt="image" src="https://github.com/user-attachments/assets/60e4c8e1-584d-44a9-aabd-c231bbaf496f" />

<img width="655" height="584" alt="image" src="https://github.com/user-attachments/assets/0920db30-e12f-473b-ba4b-9f16832a9b9e" />

## Why It's Good For The Game

A friend of mine said 'yooriss I wish I could be a templar squire and not take a slot' and I said 'friend, I wish you could be a templar squire and not take a slot'. I then remembered that nobody plays churchling ever because it's awful, and endeavored to belt two things over the head with one stone.

This adds at *max*, two towner-level combatants to a fully-stacked Church lineup. Duo with your pal, experience crises of faith, die together in the bog to 8 wretch zizites and a suspiciously dog-shaped wretched toiler, as Psydon intended.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
balance: Churchlings can now use T2 miracles, up from T1.
add: Added the 'Neophyte' churchling advclass, essentially a medium-armored templar squire with journeyman weapons. Starts with awful gear and T1 miracles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
