### PR TITLE
Unseen Spite: Chastity examine changes

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -597,6 +597,18 @@
 			if(belt_with_dildo.attached_toy)
 				. += "[m3] [get_examine_item_name_with_hover(user, belt_with_dildo.attached_toy)] attached to [m2] belt. "
 
+	//right belt
+	if(beltr && !(SLOT_BELT_R in obscured))
+		var/str = "[m3] [get_examine_item_name_with_hover(user, beltr)] on [m2] belt. "
+		str += beltr.integrity_check(is_smart)
+		. += str
+
+	//left belt
+	if(beltl && !(SLOT_BELT_L in obscured))
+		var/str = "[m3] [get_examine_item_name_with_hover(user, beltl)] on [m2] belt. "
+		str += beltl.integrity_check(is_smart)
+		. += str
+
 	// chastity cages go HERE, where they SHOULD'VE FUCKING GONE.
 	var/obj/item/chastity/worn_chastity = chastity_device
 	if(worn_chastity)
@@ -611,19 +623,6 @@
 	var/modular_chastity_toy_line = human_modular_chastity_toy_examine_line(user, m2, m3)
 	if(modular_chastity_toy_line)
 		. += modular_chastity_toy_line
-
-
-	//right belt
-	if(beltr && !(SLOT_BELT_R in obscured))
-		var/str = "[m3] [get_examine_item_name_with_hover(user, beltr)] on [m2] belt. "
-		str += beltr.integrity_check(is_smart)
-		. += str
-
-	//left belt
-	if(beltl && !(SLOT_BELT_L in obscured))
-		var/str = "[m3] [get_examine_item_name_with_hover(user, beltl)] on [m2] belt. "
-		str += beltl.integrity_check(is_smart)
-		. += str
 
 	//shoes
 	if(shoes && !(SLOT_SHOES in obscured))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -586,7 +586,7 @@
 				. += "[m3] got weird hands! They don't look right!"
 			else
 				. += "[m3][hand_number > 1 ? "" : " a"] <span class='bloody'>blood-stained</span> hand[hand_number > 1 ? "s" : ""]!"
-
+	
 	//belt
 	if(belt && !(SLOT_BELT in obscured))
 		var/str = "[m3] [get_examine_item_name_with_hover(user, belt)] about [m2] waist. "
@@ -597,6 +597,17 @@
 			if(belt_with_dildo.attached_toy)
 				. += "[m3] [get_examine_item_name_with_hover(user, belt_with_dildo.attached_toy)] attached to [m2] belt. "
 
+	// chastity cages go HERE, where they SHOULD'VE FUCKING GONE.
+	var/obj/item/chastity/worn_chastity = chastity_device
+	if(worn_chastity)
+		var/chastity_name = get_examine_item_name_with_hover(user, worn_chastity)
+		var/cage_exposed = get_location_accessible(src, BODY_ZONE_PRECISE_GROIN)
+		var/do_we_know_chat = (user == src)
+		if(cage_exposed)
+			. += "[m1] secured in [chastity_name]. "
+		else if(do_we_know_chat)
+			. += span_italics("[m1] covertly secured in [chastity_name]. ")
+	
 	var/modular_chastity_toy_line = human_modular_chastity_toy_examine_line(user, m2, m3)
 	if(modular_chastity_toy_line)
 		. += modular_chastity_toy_line

--- a/modular/code/datums/components/intimate_reaction.dm
+++ b/modular/code/datums/components/intimate_reaction.dm
@@ -651,11 +651,11 @@
 	// so they are concatenated directly onto the name without a separating space.
 	// Pain and struggle messages begin with a verb and need the leading space.
 	if(string_key == "chastity_movement_pain")
-		source.visible_message(span_warning("[source] [message]"))
+		source.visible_message(span_warning("[source] [message]"), vision_distance = 2)
 	else if(copytext(string_key, 1, 17) == "chastity_jingle_")
-		source.visible_message(span_notice("[source][message]"))
+		source.visible_message(span_smallnotice("[source][message]"), vision_distance = 2)
 	else
-		source.visible_message(span_notice("[source] [message]"))
+		source.visible_message(span_smallnotice("[source] [message]"), vision_distance = 2)
 	return TRUE
 
 /datum/component/intimate_reaction/chastity_receive_flavor/try_handle_wearer_sex_action_received(mob/living/carbon/human/source, mob/living/carbon/human/acting_mob, datum/sex_controller/acting_sexcon, datum/sex_action/action, receiver_part, giving, arousal_amt, pain_amt, applied_force, applied_speed)

--- a/modular/code/modules/mob/living/carbon/examine_hooks.dm
+++ b/modular/code/modules/mob/living/carbon/examine_hooks.dm
@@ -24,24 +24,6 @@
 			lines += span_warning("A profane, feral scent clings to them.")
 		else
 			lines += span_warning("They have a strange scent about them...")
-	var/perception_level = 15
-	if(isliving(user))
-		var/mob/living/L = user
-		perception_level = L.STAPER
-
-	var/obj/item/chastity/worn_chastity = chastity_device
-	if(worn_chastity)
-		var/chastity_name = get_examine_item_name_with_hover(user, worn_chastity)
-		var/cage_exposed = observer_privilege || get_location_accessible(src, BODY_ZONE_PRECISE_GROIN)
-		if(cage_exposed)
-			if(perception_level >= 15)
-				lines += span_aiprivradio("[m1] secured in [chastity_name].")
-			else if(perception_level >= 8)
-				lines += span_aiprivradio("[m1] wearing [chastity_name].")
-			else
-				lines += span_warning("[m1] wearing some kind of intimate restraint.")
-		else if(perception_level >= 15)
-			lines += span_aiprivradio("[m1] wearing a chastity device under [m2] clothes.")
 
 	return lines
 


### PR DESCRIPTION
## About The Pull Request

This PR is a bounty. If you're a recruiter reading this, I was paid to do it. You should also stop reading here, thanks.

- Chastity device examines have been swapped out of their hot pink post-hook title typically reserved for things like antagonist valid status and neatly relocated below the belt in a standard examine.
- If someone's groin is covered, you can't see their chastity device. If it isn't, you can.
   - The perception checks involved in detecting chastity devices have been removed to preserve the sanity of our hard-working Wardens.
   - Ghosts/observers no longer have Cage Sixth Sense - the person's groin needs to be exposed for them to know they're wearing one.
   - You can always see your own chastity device on examine - it'll show up in italics if it is actively hidden at the moment.
- Chastity movement messages are now in the **small** notice span instead of the **HOLY SHIT THIS PERSON A WHOLE SCREEN AWAY FROM YOU MADE A BARELY AUDIBLE CLINK NOISE!!** (notice) span.
- Chastity movement messages are now only sent to viewers within **2 tiles** of you, down from **15**.

## Testing Evidence

<img width="965" height="939" alt="dreamseeker_Hpn1yE3SLH" src="https://github.com/user-attachments/assets/a2608111-e760-4a97-aede-9860d497e32d" />

<img width="957" height="470" alt="dreamseeker_TnzJyE247f" src="https://github.com/user-attachments/assets/32e3b426-4729-467c-8881-c89ea5dda1f3" />

## Why It's Good For The Game

Whoever did the original PR for this stuff spent a *lot* of effort on it but also obliquely felt that they needed to beat everybody on screen to death with the fact that someone was wearing a device. Messaging now appears where you'd logically expect it to, when you'd logically expect to see it, at the intensity you'd logically expect to see it at.

This is quoted verbatim from the benefactor sponsoring this PR. Definitely.

## Changelog

:cl: Mysterious Benefactor
qol: Chastity messaging is now significantly more subtle, appears more logically on your examine and ghosts or other individuals with exceptional perception are no longer flashbanged into knowing the exact model and make of chastity device you're wearing from 12 tiles away.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
