### PR TITLE
Little druids fix and QoL

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/druid.dm
+++ b/code/modules/jobs/job_types/roguetown/church/druid.dm
@@ -82,7 +82,6 @@
 	beltr = /obj/item/flashlight/flare/torch/lantern
 	beltl = /obj/item/rogueweapon/whip //The whip itself is not often associated to many jobs. Druids feel like a thematic choice to have a self-defense whip
 	backl = /obj/item/storage/backpack/rogue/satchel
-	backr = /obj/item/rogueweapon/woodstaff
 	head = /obj/item/clothing/head/roguetown/dendormask
 	id = /obj/item/clothing/neck/roguetown/psicross/dendor //Ring slot amulet for wildform so it is not dropping on the ground.
 	shirt = /obj/item/clothing/suit/roguetown/shirt/robe/dendor
@@ -91,10 +90,6 @@
 		H.adjust_skillrank_up_to(/datum/skill/magic/holy, 5, TRUE)
 		H.adjust_skillrank_up_to(/datum/skill/magic/druidic, 5, TRUE)
 	H.ambushable = FALSE
-
-/datum/outfit/job/roguetown/druid/basic/choose_loadout(mob/living/carbon/human/H)
-	. = ..()
-	H.put_in_hands(new /obj/item/rogueweapon/woodstaff(H)) //To encourage them to wander the forests and to help defend themselves
 
 /datum/job/roguetown/druid/after_spawn(mob/living/L, mob/M, latejoin = TRUE)
 	..()

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -10,9 +10,6 @@
 	var/obj/item/stored_neck = wear_neck
 	var/obj/item/stored_ring = wear_ring
 
-	//for(var/obj/item/I in src)
-	//	if (I != underwear && I != cloak && I != backr && I != backl && I != legwear_socks) // keep underwear, socks, back and cloak on, even if said cloak or back clothing remains inaccessible.
-	//		dropItemToGround(I) we have witch forms and etc, in dnd druids also not drop items
 	regenerate_icons()
 	icon = null
 	var/oldinv = invisibility

--- a/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wildshape/wildshape_transformation.dm
@@ -10,9 +10,9 @@
 	var/obj/item/stored_neck = wear_neck
 	var/obj/item/stored_ring = wear_ring
 
-	for(var/obj/item/I in src)
-		if (I != underwear && I != cloak && I != backr && I != backl && I != legwear_socks) // keep underwear, socks, back and cloak on, even if said cloak or back clothing remains inaccessible.
-			dropItemToGround(I)
+	//for(var/obj/item/I in src)
+	//	if (I != underwear && I != cloak && I != backr && I != backl && I != legwear_socks) // keep underwear, socks, back and cloak on, even if said cloak or back clothing remains inaccessible.
+	//		dropItemToGround(I) we have witch forms and etc, in dnd druids also not drop items
 	regenerate_icons()
 	icon = null
 	var/oldinv = invisibility

--- a/code/modules/spells/roguetown/acolyte/dendor.dm
+++ b/code/modules/spells/roguetown/acolyte/dendor.dm
@@ -614,18 +614,26 @@
 
 	var/atom/target_atom = targets[1]
 	var/obj/structure/flora/newtree/target = null
+	var/obj/structure/flora/newtreealt/target2 = null
 
 	// Use for-in-list idiom: the loop var gets the correct static type regardless of source type.
 	for(var/obj/structure/flora/newtree/NT_target in list(target_atom))
 		if(!NT_target.burnt)
 			target = NT_target
 		break  // only check the first (and only) element
-	if(!target && target_atom.loc && (get_dist(user, target_atom.loc) <= 1))
+	for(var/obj/structure/flora/newtreealt/NT_target2 in list(target_atom))
+		if(!NT_target2.burnt)
+			target = NT_target2
+		break 
+	if(!target || !target2 && target_atom.loc && (get_dist(user, target_atom.loc) <= 1))
 		for(var/obj/structure/flora/newtree/NT in target_atom.loc)
 			if(!NT.burnt)
 				target = NT
 				break
-
+		for(var/obj/structure/flora/newtreealt/NT2 in target_atom.loc)
+			if(!NT2.burnt)
+				target = NT2
+				break
 	// If no living newtree found, search for an unsanctified wise tree to bless instead.
 	var/obj/structure/flora/roguetree/wise/wise_target = null
 	if(!target)


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
-Now druids dont drops all clothes. It in comment now.
-Druids now can transform newalt trees on Desert Town.
-Now have only 1 woodstaff (for what 2 wood stafs?)
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->
<img width="321" height="264" alt="image" src="https://github.com/user-attachments/assets/e4f68e23-ad44-418a-8817-bd073481655e" />

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->
-We already have crow/bat-shape (witches, vampires) without droping all clothes. Why are druids worse? In DnD, btw, they too not drops clothes. Also now druids have sense in equip, armor. Not useless.
-Now druids can sanctify trees on DT. Bug fix.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Now druids can sanctify trees on DT and dont drops all clothes in wildshape.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
