### PR TITLE
Fixes zombie antag_datum creation even if failed Prob% roll, plus cure rot death fix

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -169,9 +169,6 @@
  * We instead just transform at the end
  */
 /mob/living/carbon/human/proc/zombie_infect_attempt()
-	var/datum/antagonist/zombie/zombie_antag = zombie_check()
-	if(!zombie_antag)
-		return
 	if(stat >= DEAD) //do shit the natural way i guess
 		return
 	var/datum/status_effect/zombie_infection/infection = has_status_effect(/datum/status_effect/zombie_infection)
@@ -180,6 +177,9 @@
 		infection.transformation_time = world.time + (time_remaining * 0.8)
 		return
 	if(!prob(ZOMBIE_INFECTION_PROBABILITY))	//Failed the probability of infection
+		return
+	var/datum/antagonist/zombie/zombie_antag = zombie_check()	//Only grant the antag datum once the infection roll actually succeeds.
+	if(!zombie_antag)
 		return
 	to_chat(src, span_danger("I feel horrible... REALLY horrible..."))
 	mob_timers["puke"] = world.time

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -41,8 +41,9 @@
 			burndam = 0
 
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
+	var/fully_turned = was_zombie?.has_turned //Make sure someone isn't hasn't yet turned before we knock them dead
 	if(target.infected == FALSE)
-		if(target.stat == DEAD || was_zombie)											//Checks if the target is a dead rotted corpse.
+		if(target.stat == DEAD || fully_turned)
 			target.death()	//Kills the target if they are a zombie as a fail-safe.
 			var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
 			if(rot && rot.amount && rot.amount >= 5 MINUTES)	//Fail-safe to make sure the dead person has at least rotted for ~5 min.

--- a/code/modules/surgery/surgeries_hearth/cure_rot.dm
+++ b/code/modules/surgery/surgeries_hearth/cure_rot.dm
@@ -41,7 +41,7 @@
 			burndam = 0
 
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
-	var/fully_turned = was_zombie?.has_turned //Make sure someone isn't hasn't yet turned before we knock them dead
+	var/fully_turned = was_zombie?.has_turned //Make sure someone hasn't yet turned before we knock them dead
 	if(target.infected == FALSE)
 		if(target.stat == DEAD || fully_turned)
 			target.death()	//Kills the target if they are a zombie as a fail-safe.


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
At some point in time, zombie bites were refactored to give antag_datum zombie regardless of whether the infection landed or not. (This read like a bug to me.) This messed up the surgery cure rot step which traditionally was used to preempt and purge the rot before a victim could turn. Basically, if you got bit, and you used cure rot on yourself BUT were not infected, since you had the antag_datum as a consequence of being bit - you were struck dead.

The zombie antag_datum has a var, has_turned, that checks whether someone has turned or not. We check that for the target.death() hit instead of the old fail logic of if the antag_datum exists in the first place.

So basically, two fixes. Only populate zombie antag_datum when we actually succeed the infection roll percentage check. And then check the antag_datum's has_turned in cure rot, instead of just if the datum itself exists.
## Testing Evidence
https://discord.com/channels/1240735983276654733/1240813439245619210/1536901336669364234
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I looked at AP's fix but their way of passing FALSE on the wound seems to conflict with ratwood's sexcon transfer and icba
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Using cure rot surgery to remove rot when you have been bit but not actually infected, will no longer strike you dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
