### PR TITLE
Fix masterworks being unable to gain the polish buff. Polish_bonus and glint lost on full break rather than <25% integ.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1753,6 +1753,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return "<br><b><u>THERMAL RESISTANCE:</u></b><br>" + jointext(out, "<br>")
 
 /obj/item/obj_break(damage_flag)
+	lose_polish()//call to remove polish bonus on armor/weaps when broken. lives in /blacksmith/items.dm
 	..()
 
 	update_damaged_state()

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -231,8 +231,7 @@
 		force += 2
 		force_wielded += 3
 		update_force_dynamic()
-		if(!GetComponent(/datum/component/metal_glint))
-			AddComponent(/datum/component/metal_glint)
+		AddComponent(/datum/component/metal_glint)
 		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 
 	else if(polished < 4)

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -206,7 +206,7 @@
 		max_integrity -= polish_bonus
 		obj_integrity = min(obj_integrity, max_integrity)
 		update_force_dynamic()
-	else if(polished >= 1 && polished <= 3)//remove partially polished stages if we break the item and its, for some reason, only halfway
+	else if(polished >= 1 && polished <= 3)//remove partially polished stages if we break the item and its, for some reason, only halfway polished
 		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 
 	polished = 0

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -206,14 +206,18 @@
 		max_integrity -= polish_bonus
 		obj_integrity = min(obj_integrity, max_integrity)
 		update_force_dynamic()
-	else if(polished >= 1 && polished <= 3)//remove partially polished stages if we break the item and its, for some reason, only halfway polished
+	else if(polished >= 1 && polished <= 3)//remove partially polished stages if we break the item and its, for some reason, only halfway
 		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 
 	polished = 0
 	polish_bonus = 0
 	remove_atom_colour(FIXED_COLOUR_PRIORITY)
-	if(!GetComponent(/datum/component/silverbless)?.is_blessed && !GetComponent(/datum/component/psyblessed)?.is_blessed)//dont delete the glint from blessed silvers
-		qdel(GetComponent(/datum/component/metal_glint))
+	var/datum/component/silverbless/silver_blessing = GetComponent(/datum/component/silverbless)
+	var/datum/component/psyblessed/psy_blessing = GetComponent(/datum/component/psyblessed)
+//dont delete glint from blessed silver since it's inate unlike masterwork and polish cream
+	if(!silver_blessing?.is_blessed && !psy_blessing?.is_blessed)
+		var/datum/component/glint = GetComponent(/datum/component/metal_glint)
+		qdel(glint)
 
 //below adds polish buff but is called remove_polish because it lowers the amount of polishing cream uses. name sucks and i hate it but it is what it is. proc/lose_polish() is what actually removes the polish buffs and glint.
 /obj/item/proc/remove_polish(datum/source, strength) // kill polska

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -129,7 +129,7 @@
 	var/obj/item/thing = O
 	if(!thing.anvilrepair)
 		return ..()
-	if((HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_SELF_SUSTENANCE) || user.get_skill_level(thing.anvilrepair)) && thing.polished == 0 && obj_integrity <= max_integrity)
+	if((HAS_TRAIT(user, TRAIT_SQUIRE_REPAIR) || HAS_TRAIT(user, TRAIT_SELF_SUSTENANCE) || user.get_skill_level(thing.anvilrepair)) && (!thing.polished || (thing.polished == 4 && !thing.polish_bonus)) && obj_integrity <= max_integrity)//split polish 4 and polish_bonus so we can polish masterworks
 		to_chat(user, span_info("I start applying some compound to \the [thing]..."))
 		if(do_after(user, 50 - user.STASPD*2, target = O))
 			thing.polished = 1
@@ -196,22 +196,26 @@
 				thing.remove_atom_colour(FIXED_COLOUR_PRIORITY)
 				thing.add_atom_colour("#cccccc", FIXED_COLOUR_PRIORITY)
 
-/obj/item/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
-	. = ..()
-	if(obj_integrity <= max_integrity * 0.25)
-		if(polished == 4)
-			polished = 0
-			force -= 2
-			force_wielded -= 3
-			max_integrity -= polish_bonus
-			polish_bonus = 0
-			obj_integrity = min(obj_integrity, max_integrity)
-			var/datum/component/glint = GetComponent(/datum/component/metal_glint)
-			qdel(glint)
-		else if(polished >= 1 && polished <= 3)
-			remove_atom_colour(FIXED_COLOUR_PRIORITY)
-			UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
+/obj/item/proc/lose_polish()//called when item's break, if said item is polished, it proceeds.
+	if(!polished)
+		return
 
+	if(polished == 4 && polish_bonus)
+		force -= 2
+		force_wielded -= 3
+		max_integrity -= polish_bonus
+		obj_integrity = min(obj_integrity, max_integrity)
+		update_force_dynamic()
+	else if(polished >= 1 && polished <= 3)
+		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
+
+	polished = 0
+	polish_bonus = 0
+	remove_atom_colour(FIXED_COLOUR_PRIORITY)
+	var/datum/component/glint = GetComponent(/datum/component/metal_glint)
+	qdel(glint)
+
+//below adds polish buff but is called remove_polish because it lowers the amount of polishing cream uses. name sucks and i hate it but it is what it is. proc/lose_polish() is what actually removes the polish buffs and glint.
 /obj/item/proc/remove_polish(datum/source, strength) // kill polska
 	if(polished == 3 && obj_integrity >= max_integrity)
 		polished = 4
@@ -222,7 +226,9 @@
 		obj_integrity += polish_bonus
 		force += 2
 		force_wielded += 3
-		AddComponent(/datum/component/metal_glint)
+		update_force_dynamic()
+		if(!GetComponent(/datum/component/metal_glint))
+			AddComponent(/datum/component/metal_glint)
 		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 
 	else if(polished < 4)

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -200,20 +200,20 @@
 	if(!polished)
 		return
 
-	if(polished == 4 && polish_bonus)
+	if(polished == 4 && polish_bonus)//require both so we dont remove force from a masterwork item that has polished == 4 but not a polish bonus
 		force -= 2
 		force_wielded -= 3
 		max_integrity -= polish_bonus
 		obj_integrity = min(obj_integrity, max_integrity)
 		update_force_dynamic()
-	else if(polished >= 1 && polished <= 3)
+	else if(polished >= 1 && polished <= 3)//remove partially polished stages if we break the item and its, for some reason, only halfway polished
 		UnregisterSignal(src, COMSIG_COMPONENT_CLEAN_ACT)
 
 	polished = 0
 	polish_bonus = 0
 	remove_atom_colour(FIXED_COLOUR_PRIORITY)
-	var/datum/component/glint = GetComponent(/datum/component/metal_glint)
-	qdel(glint)
+	if(!GetComponent(/datum/component/silverbless)?.is_blessed && !GetComponent(/datum/component/psyblessed)?.is_blessed)//dont delete the glint from blessed silvers
+		qdel(GetComponent(/datum/component/metal_glint))
 
 //below adds polish buff but is called remove_polish because it lowers the amount of polishing cream uses. name sucks and i hate it but it is what it is. proc/lose_polish() is what actually removes the polish buffs and glint.
 /obj/item/proc/remove_polish(datum/source, strength) // kill polska


### PR DESCRIPTION
## About The Pull Request

- Polishing cream now checks for a polish_bonus (i.e., 3 force wielded, 2 force one-handed, 10% extra integrity) on the target item, making masterworks and blessed weapons that have the metal glint but not the bonus no longer block polishing attempts.
- Changed polish bonus and glint loss from 25% integrity to a full item break. Easier to intuit for players. Broken item = need to repair and repolish. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/e8377520-3880-465a-8f06-30f76c2984b5


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Punishing someone by denying them their polish buff if the weapon is a masterwork is bad and feels unintended.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
fix: blessed silver and masterwork weapons that have a metal glint are now able to be polished with cream for the associated force and integrity buffs. No more avoiding making masterworks because it denies your squire from buffing the weapon.
balance: polish and glint loss now occurs when an item breaks rather than when below 25% integrity.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
