### PR TITLE
Fixes Headless Behavior, Fixes Gnoll Invisibility Exploits

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -368,6 +368,10 @@
 			changeNext_move(adf)
 		UnarmedAttack(A,1,params)
 
+	break_invisibility()
+
+///Drops any active invisibility spell. Call from anything that should give away a hidden mob.
+/mob/proc/break_invisibility()
 	var/invis_timer = mob_timers[MT_INVISIBILITY]
 	if(invis_timer > world.time)
 		mob_timers[MT_INVISIBILITY] = world.time

--- a/code/datums/ai/controllers/headless.dm
+++ b/code/datums/ai/controllers/headless.dm
@@ -4,7 +4,7 @@
 	ai_movement = /datum/ai_movement/hybrid_pathing
 
 	blackboard = list(
-		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/allow_items()
+		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/allow_items/not_own_contents()
 
 	)
 

--- a/code/datums/ai/targetting_datum/simple_targetting_allow_item.dm
+++ b/code/datums/ai/targetting_datum/simple_targetting_allow_item.dm
@@ -6,3 +6,11 @@
 	if(isitem(the_target))
 		// trust fall exercise
 		return TRUE
+
+/// Subtype that ignores anything held inside, such as the consumed victim.
+/// Going after somebody else.
+/datum/targetting_datum/basic/allow_items/not_own_contents
+/datum/targetting_datum/basic/allow_items/not_own_contents/can_attack(mob/living/living_mob, atom/the_target)
+	if(the_target?.loc == living_mob)
+		return FALSE
+	return ..()

--- a/code/game/objects/items/rogueweapons/mmb/bite.dm
+++ b/code/game/objects/items/rogueweapons/mmb/bite.dm
@@ -45,6 +45,7 @@
 			. = ..()
 			return
 	user.changeNext_move(clickcd)
+	user.break_invisibility()
 	target.onbite(user)
 	. = ..()
 	return
@@ -241,6 +242,7 @@
 		return FALSE*/
 
 	user.changeNext_move(CLICK_CD_GRABBING)
+	user.break_invisibility()
 	var/mob/living/carbon/C = grabbed
 	var/armor_block = C.run_armor_check(sublimb_grabbed, d_type, armor_penetration = BLUNT_DEFAULT_PENFACTOR)
 	var/damage = user.get_punch_dmg()
@@ -318,6 +320,8 @@
 	if(!limb_grabbed.get_bleed_rate())
 		to_chat(user, span_warning("Sigh. It's not bleeding."))
 		return
+
+	user.break_invisibility()
 
 	if(HAS_TRAIT(user, TRAIT_VAMPBITE))
 		if(isliving(grabbed))

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -233,6 +233,8 @@
 	if(ismob(AM))
 		var/mob/user = AM
 		if(HAS_TRAIT(user, TRAIT_BASHDOORS))
+			// Throwing your weight through a door is not a subtle act, so it should break invisibility
+			user.break_invisibility()
 			if(locked)
 				user.visible_message(span_warning("[user] bashes into [src]!"))
 				take_damage(200, "brute", "blunt", 1)

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -96,13 +96,13 @@
 /*
 	Deadite transformation is 2 ways. First is on the initial bite (low chance) and second is on being chewed on.
 
-	Initial bite is: other_mobs.dm, /mob/living/carbon/onbite(mob/living/carbon/human/user) ->
+	Initial bite is: rogueweapons/mmb/bite.dm, /mob/living/carbon/onbite(mob/living/carbon/human/user) ->
 	bite_victim.zombie_infect_attempt() ->
 	attempt_zombie_infection(src, "bite", ZOMBIE_BITE_CONVERSION_TIME) -> rng check here
 	time passes ->
 	wake_zombie.
 
-	Wound transformation goes: grabbing.dm, /obj/item/grabbing/bite/proc/bitelimb(mob/living/carbon/human/user) ->
+	Wound transformation goes: rogueweapons/mmb/bite.dm, /obj/item/grabbing/bite/proc/bitelimb(mob/living/carbon/human/user) ->
 	/datum/wound/proc/zombie_infect_attempt() ->
 	human_owner.attempt_zombie_infection(src, "wound", zombie_infection_time) ->
 	time passes ->

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -747,32 +747,6 @@
 	desc = ""
 	icon_state = "intake"
 
-/obj/item/grabbing/bite
-	name = "bite"
-	icon_state = "bite"
-	d_type = "stab"
-	slot_flags = ITEM_SLOT_MOUTH
-	bleed_suppressing = 1
-
-/obj/item/grabbing/bite/Click(location, control, params)
-	var/list/modifiers = params2list(params)
-	if(!valid_check())
-		return
-	if(iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		if(C != grabbee || C.incapacitated() || C.stat == DEAD)
-			qdel(src)
-			return 1
-		if(modifiers["right"])
-			qdel(src)
-			return 1
-		var/_y = text2num(params2list(params)["icon-y"])
-		if(_y>=17)
-			bitelimb(C)
-		else
-			drinklimb(C)
-	return 1
-
 /datum/status_effect/buff/oiled
 	id = "oiled"
 	duration = 5 MINUTES

--- a/code/modules/mob/living/simple_animal/rogue/creacher/headless.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/headless.dm
@@ -65,6 +65,9 @@
 	AddElement(/datum/element/ai_flee_while_injured, 0.75, retreat_health)
 
 /mob/living/simple_animal/hostile/retaliate/rogue/headless/AttackingTarget()
+	// No biting what we're already digesting, so it can attack other mobs.
+	if(swallowed_mob && target == swallowed_mob)
+		return FALSE
 	//If its a carbon, your cooldown is up, and your above 30% health you can eat them
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
@@ -79,8 +82,11 @@
 
 /mob/living/simple_animal/hostile/retaliate/rogue/headless/Life()
 	if(isliving(swallowed_mob))
+		// If someone pulls them out, stop treating them as swallowed
+		if(swallowed_mob.loc != src)
+			LoseCaptive()
 		//Vomit your captive if you take 40 damage since swallowing them
-		if(health < health_at_swallow - 40)
+		else if(health < health_at_swallow - 40)
 			SpitUp()
 		if(swallowed_mob)
 			if(stomach_burn_cooldown < world.time)
@@ -160,6 +166,20 @@
 	SpitUp()
 	return ..()
 
+/mob/living/simple_animal/hostile/retaliate/rogue/headless/Destroy()
+	SpitUp()
+	return ..()
+
+/mob/living/simple_animal/hostile/retaliate/rogue/headless/Exited(atom/movable/gone, atom/newLoc)
+	. = ..()
+	if(gone == swallowed_mob)
+		LoseCaptive()
+
+/mob/living/simple_animal/hostile/retaliate/rogue/headless/handle_atom_del(atom/A)
+	if(A == swallowed_mob)
+		LoseCaptive()
+	return ..()
+
 /mob/living/simple_animal/hostile/retaliate/rogue/headless/proc/SwallowEnemy(mob/living/L)
 	if(swallowed_mob)
 		return
@@ -171,8 +191,15 @@
 
 /mob/living/simple_animal/hostile/retaliate/rogue/headless/proc/SpitUp()
 	if(swallowed_mob)
-		visible_message(span_notice("[src] vomits a disheveled [swallowed_mob]."))
-		playsound(loc, 'sound/vo/vomit.ogg', 25, TRUE)
-		swallowed_mob.forceMove(get_turf(src))
+		// Only vomit them if they're actually still in there, and we have somewhere to put them
+		var/turf/spit_turf = get_turf(src)
+		if(spit_turf && swallowed_mob.loc == src)
+			visible_message(span_notice("[src] vomits a disheveled [swallowed_mob]."))
+			playsound(loc, 'sound/vo/vomit.ogg', 25, TRUE)
+			swallowed_mob.forceMove(spit_turf)
 		swallowed_mob = null
+	swallow_cooldown = world.time + swallow_cooldown_delay
+
+/mob/living/simple_animal/hostile/retaliate/rogue/headless/proc/LoseCaptive()
+	swallowed_mob = null
 	swallow_cooldown = world.time + swallow_cooldown_delay

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -475,9 +475,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	before_cast(targets, user = user)
 	if(user && user.ckey)
 		user.log_message(span_danger("cast the spell [name]."), LOG_ATTACK)
-	if(breaks_invisibility && user.mob_timers[MT_INVISIBILITY] > world.time)
-		user.mob_timers[MT_INVISIBILITY] = world.time
-		user.update_sneak_invis(reset = TRUE)
+	if(breaks_invisibility)
+		user.break_invisibility()
 	if(cast(targets, user = user))
 		invocation(user)
 		start_recharge()


### PR DESCRIPTION
## About The Pull Request

**Headless fixes**

- Fixes the issue with the headless still incurring damage on those who were swallowed but pulled out. You could be healed up in the church and still be taking damage from a headless on the other side of the map. No longer.
- Whenever someone is pulled out of the headless and the headless later dies, the person inside gets teleported back to the headless, this no longer happens
- If a headless was deleted while you were inside it, you were deleted along with it. It now spits you out first.
- Headless will prioritize other targets besides those consumed. It will attack others, while the one inside incurs burn damage. Beforehand, it would just attack the victim inside.

**Invisibility exploits**

- Gnoll Stalk claims it "lasts until you attack", but several attacks didn't count as attacking: biting, chewing on a limb, drinking someone's blood, and shoulder-charging a door open.
- A gnoll could go invisible and kill someone with bites and chews without ever being revealed. All of those now break invisibility like any normal attack does.

**Cleanup**

- Deleted a duplicate bite code in grabbing.dm. It doesn't seem like it's really being used anywhere, as it was added later. Someone should double-check to make sure.
- Invisibility Break gets a helper, so it remains consistent in behavior.


## Testing Evidence

Headless spits up target properly when the target is pulled out. Confirmed.

Gnoll bites break invisibility. Confirmed.

Biting seems to work normally after cleaning up the duplicate bite code in grabbing.dm. 

## Why It's Good For The Game

Bug fixes good. Exploits bad.

## Changelog

:cl:
fix: The headless no longer burns or teleports players it isn't actually holding.
fix: Players swallowed by a headless are no longer deleted if it despawns.
fix: A headless no longer chews on whoever is in its stomach, and will go after other targets instead.
balance: Being swallowed by a headless is much more survivable, but the headless will now turn on whoever is trying to rescue you.
fix: Biting, chewing and drinking blood now break invisibility.
fix: Charging through a door now breaks invisibility.
code: Removed a duplicate bite grab definition that SEEMS to be overshadowing the old one. 
refactor: Invisibility breaking is now handled in one place.
/:cl: