### PR TITLE
fixes logic order in cure rot surgery

### DIFF
--- a/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/remove_rot.dm
@@ -11,12 +11,10 @@
 	var/has_rot = FALSE
 	var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
 
-	if (was_zombie)
+	if (was_zombie || target.infected || target.has_status_effect(/datum/status_effect/zombie_infection))
 		has_rot = TRUE
-	else if (istype(target, /mob/living/carbon))
+	else
 		has_rot = check_bodyparts_for_rot(target)
-	else if (target.has_status_effect(/datum/status_effect/zombie_infection))
-		has_rot = TRUE
 
 	// Remove rot component
 	remove_rot_component(target)

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -425,7 +425,8 @@
 			S.AOE_flash(user, range = 8)
 
 		var/datum/antagonist/zombie/was_zombie = target.mind?.has_antag_datum(/datum/antagonist/zombie)
-		if(target.stat == DEAD || was_zombie)	//Checks if the target is a dead rotted corpse.
+		var/fully_turned = was_zombie?.has_turned //Don't stink up someone who hasn't yet turned
+		if(target.stat == DEAD || fully_turned)	//Checks if the target is a dead rotted corpse.
 			var/datum/component/rot/rot = target.GetComponent(/datum/component/rot)
 			if(rot && rot.amount && rot.amount >= 5 MINUTES)	//Fail-safe to make sure the dead person has at least rotted for ~5 min.
 				stinky = TRUE


### PR DESCRIPTION
## About The Pull Request

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->
Fixes #2410 
My change to remove the antag datum (on bite but before zombie transformation) #2386 caused this maligned else-if chain to surface, breaking cure rot surgery. The middle else-if, (istype(target, /mob/living/carbon)), "always" returned true, which meant that the cure rot process hung on the truthiness of has_rot = check_bodyparts_for_rot(target), and bodyparts didn't flip .rotted true until after the zombie transformation.

This PR slaps them all into one happy || chain so that all bases are covered.

Also touched the Pestran zombie rot stinky check to share the same stinky check that the surgery does.

## Testing Evidence

https://github.com/user-attachments/assets/5a955612-339b-4189-8f92-3afd7dc1227e


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
sorry about this one
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed cure rot surgery (again, but this time for real)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
