### PR TITLE
Swaps the bless/smash intents when Golgatha is open

### DIFF
--- a/code/game/objects/items/rogueitems/inquisitionrelics.dm
+++ b/code/game/objects/items/rogueitems/inquisitionrelics.dm
@@ -347,7 +347,7 @@ Inquisitorial armory down here
 			user.update_a_intents()
 		else
 			playsound(src.loc, 'sound/items/censer_on.ogg', 100)
-			possible_item_intents = list(/datum/intent/mace/smash/flail/golgotha, /datum/intent/bless)
+			possible_item_intents = list(/datum/intent/bless, /datum/intent/mace/smash/flail/golgotha)
 			user.update_a_intents()
 			on = TRUE
 			update_brightness()


### PR DESCRIPTION
## About The Pull Request

Title.

## Testing Evidence

Holding Golgatha, you're more likely going to be blessing people with it if you're the absolver.

## Why It's Good For The Game

Reduces the likelihood of accidental sacrilege.

## Changelog

:cl:
qol: Golgatha smash intent is now no longer the default - bless is, instead.
/:cl:
