### PR TITLE
Cuffing Refactor, Overhaul, and Fixes with Improved Logging

### DIFF
--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -179,19 +179,6 @@
 	effectedstats = list(STATKEY_SPD = -5, STATKEY_WIL = -2)
 	duration = 30 SECONDS
 
-/datum/status_effect/debuff/netted/on_apply()
-		. = ..()
-		var/mob/living/carbon/C = owner
-		C.add_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN, multiplicative_slowdown = 3)
-
-/datum/status_effect/debuff/netted/on_remove()
-	. = ..()
-	if(iscarbon(owner))
-		var/mob/living/carbon/C = owner
-		C.legcuffed = null
-		C.update_inv_legcuffed()
-		C.remove_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN)
-
 /atom/movable/screen/alert/status_effect/debuff/sleepytime
 	name = "Tired"
 	desc = "I should get some rest."

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -89,8 +89,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/edelay_type = 1 //if 1, can be moving while equipping (for helmets etc)
 	var/equip_delay_other = 20 //In deciseconds, how long an item takes to put on another person
 	var/strip_delay = 40 //In deciseconds, how long an item takes to remove from another person
-	var/breakouttime = 0 // greater than 15 str get this isnstead
+	var/breakouttime = 0 // str 20 breaks out on this instead of struggling for slipouttime
 	var/slipouttime = 0
+	var/legcuff_slowdown = 0 //movespeed slowdown while worn as legcuffs, 0 = none
 
 	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/list/species_exception = null	// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item

--- a/code/game/objects/items/rogueitems/ropechainbola/net.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/net.dm
@@ -9,6 +9,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "net"
 	slipouttime = 2 SECONDS //ideally you're using this to catch a dodger, not in the middle of combat
+	legcuff_slowdown = 3
 	gender = NEUTER
 	throw_speed = 2
 	var/knockdown = 0
@@ -24,9 +25,7 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/M = loc
 		if(M.legcuffed == src)
-			M.legcuffed = null
-			M.remove_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN, TRUE)
-			M.update_inv_legcuffed()
+			M.set_legcuffed(null)
 			if(M.has_status_effect(/datum/status_effect/debuff/netted))
 				M.remove_status_effect(/datum/status_effect/debuff/netted)
 		forceMove(M.loc)
@@ -39,17 +38,16 @@
 /obj/item/net/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(..() || !iscarbon(hit_atom))//if it gets caught or the target can't be cuffed,
 		return//abort
-	ensnare(hit_atom)
+	ensnare(hit_atom, throwingdatum?.thrower)
 	// Nets always fall off after 10 seconds resist or not, so that the advantage it brings you is limited
 	// Being hit by a net and instalossing isn't fun for anyone because removing can be interrupted
 	addtimer(CALLBACK(src, PROC_REF(remove_effect)), 10 SECONDS, TIMER_OVERRIDE|TIMER_UNIQUE)
 
-/obj/item/net/proc/ensnare(mob/living/carbon/C)
+/obj/item/net/proc/ensnare(mob/living/carbon/C, mob/user)
 	if(!C.legcuffed && C.get_num_legs(FALSE) >= 2)
 		visible_message("<span class='danger'>\The [src] ensnares [C]!</span>")
-		C.legcuffed = src
 		forceMove(C)
-		C.update_inv_legcuffed()
+		C.set_legcuffed(src, user)
 		SSblackbox.record_feedback("tally", "handcuffs", 1, type)
 		to_chat(C, "<span class='danger'>\The [src] entraps you!</span>")
 		C.Knockdown(knockdown)

--- a/code/game/objects/items/rogueitems/ropechainbola/rope.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/rope.dm
@@ -11,6 +11,7 @@
 	throw_range = 3
 	breakouttime = 5 SECONDS
 	slipouttime = 1 MINUTES
+	legcuff_slowdown = 2
 	var/cuffsound = 'sound/blank.ogg'
 	possible_item_intents = list(/datum/intent/tie)
 	firefuel = 5 MINUTES
@@ -38,13 +39,8 @@
 			if(M.buckled && M.buckled.buckle_requires_restraints)
 				M.buckled.unbuckle_mob(M)
 		if(M.legcuffed == src)
-			M.legcuffed = null
-			M.update_inv_legcuffed()
+			M.set_legcuffed(null)
 	return ..()
-
-/obj/item/rope/dropped(mob/user, silent)
-	user.remove_movespeed_modifier(MOVESPEED_ID_CUFFED_LEG_SLOWDOWN)
-	. = ..()
 
 /obj/item/rope/attack(mob/living/carbon/C, mob/living/user)
 	if(user.used_intent.type != /datum/intent/tie)
@@ -82,7 +78,10 @@
 						span_userdanger("[user] is trying to tie my arms with [src.name]!"))
 	playsound(loc, cuffsound, 100, TRUE, -2)
 
-	if(!(do_mob(user, C, 60 * surrender_mod, double_progress = TRUE) && C.get_num_arms(FALSE)))
+	//do_mob watches neither party's position on its own, so re-check reach every tick or the tie
+	//completes at any range once it has started
+	var/datum/callback/in_reach = CALLBACK(user, TYPE_PROC_REF(/atom, Adjacent), C)
+	if(!(do_mob(user, C, 60 * surrender_mod, extra_checks = in_reach, double_progress = TRUE) && C.get_num_arms(FALSE)))
 		to_chat(user, span_warning("I fail to tie up [C]!"))
 		return
 
@@ -90,7 +89,7 @@
 	C.visible_message(span_warning("[user] ties [C] with [src.name]."), \
 						span_danger("[user] ties me up with [src.name]."))
 	SSblackbox.record_feedback("tally", "handcuffs", 1, type)
-	log_combat(user, C, "handcuffed")
+	log_combat(user, C, "handcuffed", src)
 
 /obj/item/rope/proc/try_cuff_legs(mob/living/carbon/C, mob/living/user)
 	if(C.legcuffed)
@@ -113,7 +112,8 @@
 
 	playsound(loc, cuffsound, 30, TRUE, -2)
 
-	if(!do_mob(user, C, 60 * surrender_mod) || C.get_num_legs(FALSE) < 2)
+	var/datum/callback/in_reach = CALLBACK(user, TYPE_PROC_REF(/atom, Adjacent), C)
+	if(!do_mob(user, C, 60 * surrender_mod, extra_checks = in_reach) || C.get_num_legs(FALSE) < 2)
 		to_chat(user, span_warning("I fail to tie up [C]!"))
 		return
 
@@ -121,8 +121,6 @@
 	C.visible_message(span_warning("[user] ties [C]'s legs with [src.name]."), \
 						span_danger("[user] ties my legs with [src.name]."))
 	SSblackbox.record_feedback("tally", "legcuffs", 1, type)
-
-	log_combat(user, C, "legcuffed", TRUE)
 
 /obj/item/rope/proc/apply_cuffs(mob/living/carbon/target, mob/user, leg = FALSE)
 	if(!leg)
@@ -149,9 +147,6 @@
 		var/obj/item/cuffs = src
 
 		cuffs.forceMove(target)
-		target.legcuffed = cuffs
-
-		target.update_inv_legcuffed()
-		target.add_movespeed_modifier(MOVESPEED_ID_CUFFED_LEG_SLOWDOWN, update=TRUE, priority=100, multiplicative_slowdown=2, movetypes=GROUND)
+		target.set_legcuffed(cuffs, user)
 		return
 

--- a/code/game/objects/items/rogueitems/ropechainbola/rope.dm
+++ b/code/game/objects/items/rogueitems/ropechainbola/rope.dm
@@ -58,6 +58,9 @@
 		try_cuff_legs(C, user)
 		return
 
+/obj/item/rope/proc/still_in_reach(mob/user, mob/living/carbon/C)
+	return user.Adjacent(C)
+
 /obj/item/rope/proc/try_cuff_arms(mob/living/carbon/C, mob/living/user)
 	if(C.handcuffed)
 		return
@@ -78,9 +81,7 @@
 						span_userdanger("[user] is trying to tie my arms with [src.name]!"))
 	playsound(loc, cuffsound, 100, TRUE, -2)
 
-	//do_mob watches neither party's position on its own, so re-check reach every tick or the tie
-	//completes at any range once it has started
-	var/datum/callback/in_reach = CALLBACK(user, TYPE_PROC_REF(/atom, Adjacent), C)
+	var/datum/callback/in_reach = CALLBACK(src, PROC_REF(still_in_reach), user, C)
 	if(!(do_mob(user, C, 60 * surrender_mod, extra_checks = in_reach, double_progress = TRUE) && C.get_num_arms(FALSE)))
 		to_chat(user, span_warning("I fail to tie up [C]!"))
 		return
@@ -112,8 +113,8 @@
 
 	playsound(loc, cuffsound, 30, TRUE, -2)
 
-	var/datum/callback/in_reach = CALLBACK(user, TYPE_PROC_REF(/atom, Adjacent), C)
-	if(!do_mob(user, C, 60 * surrender_mod, extra_checks = in_reach) || C.get_num_legs(FALSE) < 2)
+	var/datum/callback/in_reach = CALLBACK(src, PROC_REF(still_in_reach), user, C)
+	if(!do_mob(user, C, 60 * surrender_mod, extra_checks = in_reach, double_progress = TRUE) || C.get_num_legs(FALSE) < 2)
 		to_chat(user, span_warning("I fail to tie up [C]!"))
 		return
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -433,18 +433,37 @@
 		cuff_resist(I)
 
 
+/mob/living/carbon/cancel_restraint_struggle()
+	if(!doing) //without this the fast path could START a struggle, skipping the breakout cooldown
+		return FALSE
+	for(var/obj/item/I in list(handcuffed, legcuffed))
+		if(I.item_flags & BEING_REMOVED)
+			cuff_resist(I)
+			return TRUE
+	return FALSE
+
 /mob/living/carbon/proc/cuff_resist(obj/item/I, breakouttime = 600, cuff_break = 0)
-	if(I.item_flags & BEING_REMOVED)
-		to_chat(src, "<span class='warning'>You're already attempting to remove [I]!</span>")
+	//resisting again gives up, do_after breaks out once doing clears. A flag set with nothing running
+	//outlived its attempt, so fall through and start fresh rather than lock the item forever
+	if((I.item_flags & BEING_REMOVED) && doing)
+		doing = FALSE
+		visible_message("<span class='warning'>[src] stops struggling with [I].</span>", \
+						"<span class='warning'>I stop struggling with [I].</span>")
+		log_message("stopped struggling out of [I]", LOG_ATTACK, color = "orange")
 		return
 	I.item_flags |= BEING_REMOVED
-	breakouttime = I.slipouttime
+	log_message("began struggling out of [I]", LOG_ATTACK, color = "orange")
+	//with free hands you untie your own legs at the speed someone else could untie them for you.
+	//min() so this can never be slower than struggling out, nets slip faster than they strip
+	var/untying = (I == legcuffed && !handcuffed && has_active_hand())
+	breakouttime = untying ? min(I.strip_delay, I.slipouttime) : I.slipouttime
+	//0.1 per point above 10, so the scale runs the full way to 20 rather than bottoming out at 15
 	if((STASTR > 10))
-		var/time_mod = breakouttime * (STASTR - 10) * 0.2
+		var/time_mod = breakouttime * (STASTR - 10) * 0.1
 		breakouttime = max(0, breakouttime - time_mod)
-	if(mind && mind.has_antag_datum(/datum/antagonist/zombie))
+	if(!untying && mind && mind.has_antag_datum(/datum/antagonist/zombie))
 		breakouttime = 10 SECONDS
-	if(STASTR > 15)
+	if(STASTR >= 20 && !untying)
 		cuff_break = INSTANT_CUFFBREAK
 		breakouttime = I.breakouttime
 	if(!cuff_break)
@@ -465,6 +484,8 @@
 		clear_cuffs(I, cuff_break)
 	I.item_flags &= ~BEING_REMOVED
 
+//drops both cuffs to the floor. This is from SS13, not Roguetown.
+//predates nets, so it needs netted status cleanup before anything calls it again
 /mob/living/carbon/proc/uncuff()
 	if (handcuffed)
 		var/obj/item/W = handcuffed
@@ -483,8 +504,7 @@
 		changeNext_move(0, override = TRUE)
 	if (legcuffed)
 		var/obj/item/W = legcuffed
-		legcuffed = null
-		update_inv_legcuffed()
+		set_legcuffed(null)
 		if (client)
 			client.screen -= W
 		if (W)
@@ -500,6 +520,9 @@
 		return FALSE
 	if(I != handcuffed && I != legcuffed)
 		return FALSE
+	//getting free clears the breakout cooldown, or a fast escape leaves you locked out of everything
+	//for the remainder of the 10 seconds resist_restraints charged up front. Same as uncuff() does
+	changeNext_move(0, override = TRUE)
 	visible_message("[cuff_break ? "<span class='danger'>" : "<span class='warning'>"][src] manages to [cuff_break ? "break" : "slip"] out of [I]!</span>")
 	if(cuff_break)
 		playsound(src, 'sound/misc/chain_snap.ogg', 100, FALSE, 10)
@@ -524,10 +547,9 @@
 			update_handcuffed()
 			return TRUE
 		if(I == legcuffed)
-			legcuffed.forceMove(drop_location())
-			legcuffed.dropped()
-			legcuffed = null
-			update_inv_legcuffed()
+			set_legcuffed(null)
+			I.forceMove(drop_location())
+			I.dropped(src)
 			return TRUE
 
 /mob/living/carbon/get_standard_pixel_y_offset(lying = 0)
@@ -1120,6 +1142,30 @@
 	update_inv_handcuffed()
 	update_hud_handcuffed()
 	update_mobility()
+
+// sole owner of legcuffed, every path that changes the slot comes through here
+// There are three states that must be maintained consistently with the slot:
+// the movespeed slowdown, the alert, and the overlay!
+// Otherwise, it will keep breaking. If we know it's always true,
+// encapsulate instead of writing it directly every time you need itz`
+/mob/living/carbon/proc/set_legcuffed(obj/item/cuffs, mob/user)
+	if(legcuffed == cuffs)
+		return
+	var/obj/item/old_cuffs = legcuffed
+	legcuffed = cuffs
+	//must hold: the movespeed slowdown is applied exactly when the slot holds a slowing item
+	remove_movespeed_modifier(MOVESPEED_ID_CUFFED_LEG_SLOWDOWN)
+	if(legcuffed)
+		if(legcuffed.legcuff_slowdown)
+			add_movespeed_modifier(MOVESPEED_ID_CUFFED_LEG_SLOWDOWN, update=TRUE, priority=100, multiplicative_slowdown=legcuffed.legcuff_slowdown, movetypes=GROUND)
+		//must hold: the alert shows exactly when the slot is occupied, this branch and the else are its halves
+		throw_alert("legcuffed", /atom/movable/screen/alert/restrained/legcuffed, new_master = legcuffed)
+		log_combat(user || src, src, "legcuffed", legcuffed)
+	else
+		clear_alert("legcuffed")
+		log_combat(user || src, src, "removed legcuffs from", old_cuffs)
+	//must hold: the overlay matches the slot
+	update_inv_legcuffed()
 
 /mob/living/carbon/fully_heal(admin_revive = FALSE, break_restraints = FALSE)
 	if(reagents)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1617,11 +1617,9 @@ There are several things that need to be remembered:
 
 /mob/living/carbon/human/update_inv_legcuffed()
 	remove_overlay(LEGCUFF_LAYER)
-	clear_alert("legcuffed")
 	if(legcuffed)
 		overlays_standing[LEGCUFF_LAYER] = mutable_appearance('icons/roguetown/mob/bodies/cuffed.dmi', "[legcuffed.icon_state]down", -LEGCUFF_LAYER)
 		apply_overlay(LEGCUFF_LAYER)
-		throw_alert("legcuffed", /atom/movable/screen/alert/restrained/legcuffed, new_master = src.legcuffed)
 
 /proc/wear_female_version(t_color, icon, layer, type)
 	var/index = t_color

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -71,8 +71,7 @@
 			handcuffed = I
 			update_handcuffed()
 		if(SLOT_LEGCUFFED)
-			legcuffed = I
-			update_inv_legcuffed()
+			set_legcuffed(I)
 		if(SLOT_HANDS)
 			put_in_hands(I)
 			update_inv_hands()
@@ -130,9 +129,10 @@
 		if(!QDELETED(src))
 			update_handcuffed()
 	else if(I == legcuffed)
-		legcuffed = null
 		if(!QDELETED(src))
-			update_inv_legcuffed()
+			set_legcuffed(null)
+		else
+			legcuffed = null
 
 //handle stuff to update when a mob equips/unequips a mask.
 /mob/living/proc/wear_mask_update(obj/item/I, toggle_off = 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1094,6 +1094,9 @@
 	set name = "Resist"
 	set category = "IC"
 	set hidden = 1
+	//giving up on a struggle must not wait on the breakout cooldown that same struggle charged up front
+	if(cancel_restraint_struggle())
+		return
 	if(!can_resist() || surrendering)
 		return
 	if(HAS_TRAIT(src, TRAIT_PARALYSIS))
@@ -1340,6 +1343,10 @@
 
 /mob/living/proc/resist_restraints()
 	return
+
+///Routes a resist press to cuff_resist's give-up branch while a struggle is running. TRUE if it handled it
+/mob/living/proc/cancel_restraint_struggle()
+	return FALSE
 
 /mob/living/proc/get_visible_name()
 	return name

--- a/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
+++ b/code/modules/surgery/bodyparts/bodypart_dismemberment.dm
@@ -458,10 +458,10 @@
 	//OV edit end
 	if(C && !special)
 		if(C.legcuffed)
-			C.legcuffed.forceMove(C.drop_location()) //At this point bodypart is still in nullspace
-			C.legcuffed.dropped(C)
-			C.legcuffed = null
-			C.update_inv_legcuffed()
+			var/obj/item/W = C.legcuffed
+			C.set_legcuffed(null)
+			W.forceMove(C.drop_location()) //At this point bodypart is still in nullspace
+			W.dropped(C)
 		if(C.shoes && (C.get_num_legs(FALSE) < 1))
 			C.dropItemToGround(C.shoes, force = TRUE)
 		C.update_inv_shoes()
@@ -476,10 +476,10 @@
 	//OV edit end
 	if(C && !special)
 		if(C.legcuffed)
-			C.legcuffed.forceMove(C.drop_location())
-			C.legcuffed.dropped(C)
-			C.legcuffed = null
-			C.update_inv_legcuffed()
+			var/obj/item/W = C.legcuffed
+			C.set_legcuffed(null)
+			W.forceMove(C.drop_location())
+			W.dropped(C)
 		if(C.shoes && (C.get_num_legs(FALSE) < 1))
 			C.dropItemToGround(C.shoes, force = TRUE)
 		C.update_inv_shoes()
@@ -492,10 +492,10 @@
 		if(HAS_TRAIT_FROM(C, TRAIT_PONYGIRL_RIDEABLE, BODY_ZONE_TAUR))
 			REMOVE_TRAIT(C, TRAIT_PONYGIRL_RIDEABLE, BODY_ZONE_TAUR)
 		if(C.legcuffed)
-			C.legcuffed.forceMove(C.drop_location())
-			C.legcuffed.dropped(C)
-			C.legcuffed = null
-			C.update_inv_legcuffed()
+			var/obj/item/W = C.legcuffed
+			C.set_legcuffed(null)
+			W.forceMove(C.drop_location())
+			W.dropped(C)
 		if(C.shoes && (C.get_num_legs(FALSE) < 1))
 			C.dropItemToGround(C.shoes, force = TRUE)
 		C.update_inv_shoes()

--- a/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/inhumen/graggar.dm
@@ -77,9 +77,8 @@
 	net.slipouttime = max(2 SECONDS, 13 SECONDS - max(0, carbon.STASTR - 10) * 0.5 SECONDS)
 	visible_message(span_danger("\The [src] ensnares [carbon] in vicera!"))
 	to_chat(carbon, span_danger("\The [src] ensnares you!"))
-	carbon.legcuffed = net
 	net.forceMove(carbon)
-	carbon.update_inv_legcuffed()
+	carbon.set_legcuffed(net, firer)
 	carbon.Knockdown(knockdown)
 	carbon.apply_status_effect(/datum/status_effect/debuff/netted)
 	playsound(src, 'sound/combat/caught.ogg', 50, TRUE)
@@ -93,9 +92,7 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/M = loc
 		if(M.legcuffed == src)
-			M.legcuffed = null
-			M.remove_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN, TRUE)
-			M.update_inv_legcuffed()
+			M.set_legcuffed(null)
 			if(M.has_status_effect(/datum/status_effect/debuff/netted))
 				M.remove_status_effect(/datum/status_effect/debuff/netted)
 		var/turf/T = get_turf(M)
@@ -106,9 +103,7 @@
 	if(iscarbon(loc))
 		var/mob/living/carbon/M = loc
 		if(M.legcuffed == src)
-			M.legcuffed = null
-			M.remove_movespeed_modifier(MOVESPEED_ID_NET_SLOWDOWN, TRUE)
-			M.update_inv_legcuffed()
+			M.set_legcuffed(null)
 		if(M.has_status_effect(/datum/status_effect/debuff/netted))
 			M.remove_status_effect(/datum/status_effect/debuff/netted)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

This ended up being more than I intended. I just wanted to add logs for cuffing people. Then, in the process of testing logging, I come across another bug. Then, as I fix that bug and make sure it's all good, I come across two more bugs. This is so stupid. 

For example, leg cuffs had several different calls, each one individually needing slowdown, alert, and overlay being implemented each time along with writing the log. Literal psychopath code.

**Anyways, there are probably edge cases that I didn't cover. So, please, let me know if something breaks horribly. Better to fix now rather than later. My mind went numb at a certain point.**

**Main Change**
- All leg restraint handling now goes through one piece of code (`set_legcuffed`). Nothing else touches the leg slot directly.
- Restraints now simply state how much they slow you instead of each one manually switching the effect on and off in two different places and hoping they match. Some people are masochists I guess.
- The "restrained" alert used to live in the human sprite code, which is why only humans ever got one. It's been moved somewhere every creachure can reach.
- Deleted a bunch of unnecessary code. 
- Struggling out of restraints, and giving up, are now logged.


**Bugs Fixed**
- Burn or delete a rope tied to someone's legs and they stayed slowed **forever**. This SHOULD stop happening now, but I couldn't be fucked to test out every edge case.
- Slipping out of leg restraints threw a runtime error in theory.
- Dropping a spare rope from your hands removed the slowdown from a *different* rope tied to your legs, so you could walk normally while still visibly tied up. ???
- Leg restraints put on by an admin, or through the strip panel, did nothing at all. No slowdown, no alert.
- Non-human characters never got the alert, so it wasn't easy for them to struggle out of it.
- If you got netted, shook the net off, then got tied with a rope, the net's timer would expire half a minute later and silently untie the rope.
- The admin log didn't read correctly
- Nets, the weird Graggar net spell, admin equips and every single removal wrote nothing to the log at all.
- You can (in theory) no longer start tying someone up and then walk away. Both arm and leg tying now check you're still next to each other. **By the way, I couldn't test this one locally. So, this will have to be tested live.**

**Overhaul**
- Strength now scales all the way to 20 instead of maxing out at 15. Remember when only a legendary beggar roll or maniac could break chains? Well, yeah, let's have insta-chain breaks be actually special. 
- Chains take roughly two minutes at average strength, one minute at 15, twelve seconds at 19, and only break instantly at 20.
- Untying your own legs when your hands are free now takes about four seconds, the same speed someone else could untie you. You're not stupid. You know how to use your hands.
- Pressing resist again now gives up on struggling, instead of telling you that you're already struggling. Bystanders see you stop.
- Giving up is instant. It used to be blocked for ten seconds by the cooldown that the struggle itself had charged.
- Getting free no longer leaves you frozen and unable to act. That cooldown was charged when you *started*, so anyone escaping quickly came out free but couldn't use their hands for a while.
- If something went wrong mid-struggle, a restraint could get permanently stuck as un-resistable. It now recovers on its own in theory. Again, I'm not testing every edge case.

**P.S.**

The whole telekinetic chaining problem isn't just with chains. The problem seems to rest with the do_mob shit. Apparently, RT characters have latent telekinetic powers. Who knew? Way out of scope for this PR.

## Testing Evidence

It compiled and worked for most things that I tested, but I honestly got tired of hopping on and off to test out one bug fix, only to find another bug.

## Why It's Good For The Game

Read above.

## Changelog
cl:
fix: Leg restraints no longer leave you slowed forever after the rope is destroyed somehow
fix: Slipping out of leg restraints no longer throws a runtime (in theory)
fix: Dropping a rope from your hands no longer removes the slowdown from a different rope tied to your legs.
fix: An expiring net no longer unties whatever restraint you are wearing at the time.
fix: Non-human creachures can now see and click the restrained alert to struggle free.
fix: Leg restraints applied by admins or through the strip panel now actually work.
fix: You can no longer start tying someone up, walk away, and still have it work.
balance: You now need 20 strength to break out of restraints instantly instead of 15. 
balance: Escapes can be interrupted by stuns and movement again at every strength below 20.
balance: Untying your own legs with your hands free is now as fast as someone else untying them
qol: Pressing resist again now gives up on struggling out of restraints
qol: Getting free of restraints no longer leaves you unable to use your hands for several seconds after
admin: Leg restraints now log every time they go on or come off, including nets, spells and admin equips. Thrown nets record who threw them (in theory).
admin: Struggling out of restraints, and giving up on it, are now logged.
refactor: Leg restraint handling is now in one place instead of spread across several.
/:cl: