### PR TITLE
Toiler Adjustments for RW

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
@@ -9,7 +9,7 @@
 	cmode_music = 'sound/music/cmode/antag/combat_thrall.ogg' //We don't have the original .ogg and I'm lazy. You get thrall music now. Change it if you want.
 	class_select_category = CLASS_CAT_TRADER
 	extra_context = "Choose between 2 options: being an EVIL mastermind or a WRETCHED servant" //choose between master and servant
-	maximum_possible_slots = 1 
+	maximum_possible_slots = 0
 
 	// balance isn't real i picked these bc they're funny
 	subclass_stats = list(

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/wretchedtoiler.dm
@@ -13,8 +13,9 @@
 
 	// balance isn't real i picked these bc they're funny
 	subclass_stats = list(
-		STATKEY_STR = -1, //YOU ARE WRETCHED!!!
-		STATKEY_CON = -2, //AND YOU WILL +TOIL+!!!!!!!!!!!
+		STATKEY_STR = -4, //YOU ARE WRETCHED!!!
+		STATKEY_CON = -4, //AND YOU WILL +TOIL+!!!!!!!!!!!
+		STATKEY_SPD = -2, // YOU ARE WRETCHED x99!!!
 		STATKEY_INT = 2, //4 int so you can be a feintbeast with the master swordskill I'm giving yo-HAHAHAHAHA JUST KIDDING! GRIND EXPERT ALCHEMY, WORMS!!!
 		STATKEY_PER = 1, //i like looking into the distance
 		STATKEY_WIL = 1, //i want this to be lower because i like hearing the stamout sfx but i will allow you ONE point of END
@@ -35,7 +36,7 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
-		/datum/skill/combat/knives = SKILL_LEVEL_EXPERT,
+		/datum/skill/combat/knives = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/tanning = SKILL_LEVEL_EXPERT,
 		/datum/skill/magic/arcane = SKILL_LEVEL_EXPERT, //summon monsters? I think?
 		/datum/skill/magic/holy = SKILL_LEVEL_EXPERT, //miracle regen? I think?
@@ -83,8 +84,6 @@
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/brotherhood)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/order/charge)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/convertrole/brotherhood)
-			//MINIONS! ATTACK!
-			H.mind.AddSpell(new /obj/effect/proc_holder/spell/self/call_to_slaughter)
 			//evil ass spells
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/eyebite)
 			H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/bonechill)
@@ -108,7 +107,7 @@
 			neck = /obj/item/clothing/neck/roguetown/leather // No iron gorget vs necro. They will have to acquire one in round.
 			r_hand = /obj/item/scrying //expert should give you good odds with this? if it breaks in one use, blame xylix, not me
 			//you get some spellpoints. if you really wanna take combat spells you can ig
-			H?.mind.adjust_spellpoints(12)
+			H?.mind.adjust_spellpoints(9)
 			var/staffs = list(
 				"ronts-focused staff",
 				"blortz-focused staff",


### PR DESCRIPTION
## About The Pull Request

Flatly: Toiler has morphed into something I'm not happy with. This is the safe option before the nuclear option. The intent behind Toiler was that it was supposed to be a wretch role that acts as an evil mastermind for the other wretches, but it swiftly has been used as a frontlining position, and that isn't what I'm OK with.

This PR shelves some stats and removes the Inhumen Buff miracle for that reason, as it also detracts away from the Willworking/Miracle work of Graggarites and it just doesn't fit.

This PR will also set toiler slots to 0

Saying that, the alternative will be making this role like AP's Munitioneer.

## Testing Evidence

n/a

## Why It's Good For The Game

This role has become something I never wanted it to be.

## Changelog

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
