### PR TITLE
Noticeboard New Post Alert Fix

### DIFF
--- a/code/modules/roguetown/roguemachine/noticeboard/noticeboard.dm
+++ b/code/modules/roguetown/roguemachine/noticeboard/noticeboard.dm
@@ -28,11 +28,13 @@
 	. = ..()
 	if(!ishuman(user))
 		return
+	if(!length(GLOB.noticeboard_posts) && !length(GLOB.premium_noticeboardposts))
+		return // No need to exclaim there are new posts if there are no posts.
 	if(user in GLOB.board_viewers)
 		return
 	else
 		GLOB.board_viewers += user
-		to_chat(user, span_smallred("A new posting has been made since I last checked!"))
+		. += span_smallred("A new posting has been made since I last checked!")
 
 /obj/structure/roguemachine/noticeboard/update_icon()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The noticeboards will now only alert if there are actually any posts (instead of always alerting at start-of-round/when the last posting is removed). The notice will also now appear in the examine box, instead of above it.

## Why It's Good For The Game

Fixes a nit I had with them.

## Changelog

:cl:
fix: Noticeboards will now only alert that they have a new listing if there's _actually_ a posting, and the alert text will appear in the examine box.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
