### PR TITLE
Moves devotion verbs to IC tab category

### DIFF
--- a/code/controllers/subsystem/rogue/miscprocs.dm
+++ b/code/controllers/subsystem/rogue/miscprocs.dm
@@ -229,7 +229,7 @@
 
 /mob/living/carbon/human/proc/devotionreport()
 	set name = "Check Devotion"
-	set category = "Cleric"
+	set category = "IC"
 
 	if(!devotion)
 		return FALSE
@@ -239,7 +239,7 @@
 
 /mob/living/carbon/human/proc/clericpray()
 	set name = "Give Prayer"
-	set category = "Cleric"
+	set category = "IC"
 
 	if(!devotion)
 		return FALSE

--- a/code/datums/magic_items/superior_items/nomagic.dm
+++ b/code/datums/magic_items/superior_items/nomagic.dm
@@ -1,4 +1,4 @@
-/datum/magic_item/mundane/nomagic
+/datum/magic_item/mundane/nomagicmdips his head
 	name = "no magic"
 	description = "It has red gemstones embedded."
 

--- a/code/datums/magic_items/superior_items/nomagic.dm
+++ b/code/datums/magic_items/superior_items/nomagic.dm
@@ -1,4 +1,4 @@
-/datum/magic_item/mundane/nomagicmdips his head
+/datum/magic_item/mundane/nomagic
 	name = "no magic"
 	description = "It has red gemstones embedded."
 


### PR DESCRIPTION
## About The Pull Request

The "Check Devotion" and "Give Prayer" verbs are the only ones that are given to the Cleric verb tab. I'm moving it to IC, because it doesn't make overmuch sense to give an category *just* for these two. Also, does anyone use the verbs?

This only affects where the verbs show up in the list; hud interaction (ie clicking your devotion bar) is unchanged.

## Why It's Good For The Game

Less categories, I guess?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: The "Check Devotion" and "Give Prayer" verbs have been moved to the IC tab.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
