### PR TITLE
qdel signals renamed

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -108,9 +108,9 @@
 /// before a component is removed from a datum because of RemoveComponent: (/datum/component)
 #define COMSIG_COMPONENT_REMOVING "component_removing"
 /// before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
-#define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"
+#define COMSIG_PREQDELETED "parent_preqdeleted"
 /// just before a datum's Destroy() is called: (force), at this point none of the other components chose to interrupt qdel and Destroy will be called
-#define COMSIG_PARENT_QDELETING "parent_qdeleting"
+#define COMSIG_QDELETING "parent_qdeleting"
 /// generic topic handler (usr, href_list)
 #define COMSIG_TOPIC "handle_topic"
 /// job datum has been called to deal with the aftermath of a latejoin spawn

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -107,10 +107,6 @@
 #define COMSIG_COMPONENT_ADDED "component_added"
 /// before a component is removed from a datum because of RemoveComponent: (/datum/component)
 #define COMSIG_COMPONENT_REMOVING "component_removing"
-/// before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
-#define COMSIG_PREQDELETED "parent_preqdeleted"
-/// just before a datum's Destroy() is called: (force), at this point none of the other components chose to interrupt qdel and Destroy will be called
-#define COMSIG_QDELETING "parent_qdeleting"
 /// generic topic handler (usr, href_list)
 #define COMSIG_TOPIC "handle_topic"
 /// job datum has been called to deal with the aftermath of a latejoin spawn

--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -11,7 +11,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 	name = text
 	src.target = target
 	if(isdatum(target)) //Harddel man bad
-		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(cleanup))
+		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(cleanup))
 
 /obj/effect/statclick/Destroy()
 	target = null

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -286,71 +286,83 @@ SUBSYSTEM_DEF(garbage)
 /// Should be treated as a replacement for the 'del' keyword.
 ///
 /// Datums passed to this will be given a chance to clean up references to allow the GC to collect them.
-/proc/qdel(datum/D, force=FALSE, ...)
-	if(!istype(D))
-		del(D)
+/proc/qdel(datum/to_delete, force = FALSE)
+	if(!istype(to_delete))
+		if(isnull(to_delete))
+			return
+		else if(islist(to_delete))
+			stack_trace("Lists should not be directly passed to qdel! You likely want either list.Cut(), QDEL_LIST(list), QDEL_LIST_ASSOC(list), or QDEL_LIST_ASSOC_VAL(list)")
+		else if(to_delete != world)
+			stack_trace("Tried to qdel possibly invalid value: [to_delete]")
+		del(to_delete)
 		return
 
-	var/datum/qdel_item/I = SSgarbage.items[D.type]
-	if (!I)
-		I = SSgarbage.items[D.type] = new /datum/qdel_item(D.type)
-	I.qdels++
+	var/datum/qdel_item/trash = SSgarbage.items[to_delete.type]
+	if (!trash)
+		trash = SSgarbage.items[to_delete.type] = new /datum/qdel_item(to_delete.type)
+	trash.qdels++
 
-	if(isnull(D.gc_destroyed))
-		if (SEND_SIGNAL(D, COMSIG_PARENT_PREQDELETED, force)) // Give the components a chance to prevent their parent from being deleted
+	if(!isnull(to_delete.gc_destroyed))
+		if(to_delete.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
+			CRASH("[to_delete.type] destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic")
+		return
+
+	if (SEND_SIGNAL(to_delete, COMSIG_PREQDELETED, force)) // Give the components a chance to prevent their parent from being deleted
+		return
+
+	to_delete.gc_destroyed = GC_CURRENTLY_BEING_QDELETED
+	var/start_time = world.time
+	var/start_tick = world.tick_usage
+	SEND_SIGNAL(to_delete, COMSIG_QDELETING, force) // Let the (remaining) components know about the result of Destroy
+	var/hint = to_delete.Destroy(arglist(args.Copy(2))) // Let our friend know they're about to get fucked up.
+
+	if(world.time != start_time)
+		trash.slept_destroy++
+	else
+		trash.destroy_time += TICK_USAGE_TO_MS(start_tick)
+
+	if(isnull(to_delete))
+		return
+
+	switch(hint)
+		if (QDEL_HINT_QUEUE) //qdel should queue the object for deletion.
+			SSgarbage.Queue(to_delete)
+		if (QDEL_HINT_IWILLGC)
+			to_delete.gc_destroyed = world.time
 			return
-		D.gc_destroyed = GC_CURRENTLY_BEING_QDELETED
-		var/start_time = world.time
-		var/start_tick = world.tick_usage
-		SEND_SIGNAL(D, COMSIG_PARENT_QDELETING, force) // Let the (remaining) components know about the result of Destroy
-		var/hint = D.Destroy(arglist(args.Copy(2))) // Let our friend know they're about to get fucked up.
-		if(world.time != start_time)
-			I.slept_destroy++
-		else
-			I.destroy_time += TICK_USAGE_TO_MS(start_tick)
-		if(!D)
-			return
-		switch(hint)
-			if (QDEL_HINT_QUEUE)		//qdel should queue the object for deletion.
-				SSgarbage.Queue(D)
-			if (QDEL_HINT_IWILLGC)
-				D.gc_destroyed = world.time
+		if (QDEL_HINT_LETMELIVE) //qdel should let the object live after calling destory.
+			if(!force)
+				to_delete.gc_destroyed = null //clear the gc variable (important!)
 				return
-			if (QDEL_HINT_LETMELIVE)	//qdel should let the object live after calling destory.
-				if(!force)
-					D.gc_destroyed = null //clear the gc variable (important!)
-					return
-				// Returning LETMELIVE after being told to force destroy
-				// indicates the objects Destroy() does not respect force
-				#ifdef TESTING
-				if(!I.no_respect_force)
-					testing("WARNING: [D.type] has been force deleted, but is \
-						returning an immortal QDEL_HINT, indicating it does \
-						not respect the force flag for qdel(). It has been \
-						placed in the queue, further instances of this type \
-						will also be queued.")
-				#endif
-				I.no_respect_force++
-
-				SSgarbage.Queue(D)
-			if (QDEL_HINT_HARDDEL)		//qdel should assume this object won't gc, and queue a hard delete
-				SSgarbage.Queue(D, GC_QUEUE_HARDDELETE)
-			if (QDEL_HINT_HARDDEL_NOW)	//qdel should assume this object won't gc, and hard del it post haste.
-				SSgarbage.HardDelete(D)
-			#ifdef LEGACY_REFERENCE_TRACKING
-			if (QDEL_HINT_FINDREFERENCE) //qdel will, if LEGACY_REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
-				SSgarbage.Queue(D)
-				D.find_references_legacy()
-			if (QDEL_HINT_IFFAIL_FINDREFERENCE)
-				SSgarbage.Queue(D)
-				SSgarbage.reference_find_on_fail[REF(D)] = TRUE
+			// Returning LETMELIVE after being told to force destroy
+			// indicates the objects Destroy() does not respect force
+			#ifdef TESTING
+			if(!trash.no_respect_force)
+				testing("WARNING: [to_delete.type] has been force deleted, but is \
+					returning an immortal QDEL_HINT, indicating it does \
+					not respect the force flag for qdel(). It has been \
+					placed in the queue, further instances of this type \
+					will also be queued.")
 			#endif
-			else
-				#ifdef TESTING
-				if(!I.no_hint)
-					testing("WARNING: [D.type] is not returning a qdel hint. It is being placed in the queue. Further instances of this type will also be queued.")
-				#endif
-				I.no_hint++
-				SSgarbage.Queue(D)
-	else if(D.gc_destroyed == GC_CURRENTLY_BEING_QDELETED)
-		CRASH("[D.type] destroy proc was called multiple times, likely due to a qdel loop in the Destroy logic")
+			trash.no_respect_force++
+
+			SSgarbage.Queue(to_delete)
+		if (QDEL_HINT_HARDDEL) //qdel should assume this object won't gc, and queue a hard delete
+			SSgarbage.Queue(to_delete, GC_QUEUE_HARDDELETE)
+		if (QDEL_HINT_HARDDEL_NOW) //qdel should assume this object won't gc, and hard del it post haste.
+			SSgarbage.HardDelete(to_delete)
+		#ifdef LEGACY_REFERENCE_TRACKING
+		if (QDEL_HINT_FINDREFERENCE) //qdel will, if LEGACY_REFERENCE_TRACKING is enabled, display all references to this object, then queue the object for deletion.
+			SSgarbage.Queue(to_delete)
+			to_delete.find_references_legacy()
+		if (QDEL_HINT_IFFAIL_FINDREFERENCE)
+			SSgarbage.Queue(to_delete)
+			SSgarbage.reference_find_on_fail[REF(to_delete)] = TRUE
+		#endif
+		else
+			#ifdef TESTING
+			if(!trash.no_hint)
+				testing("WARNING: [to_delete.type] is not returning a qdel hint. It is being placed in the queue. Further instances of this type will also be queued.")
+			#endif
+			trash.no_hint++
+			SSgarbage.Queue(to_delete)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -27,7 +27,7 @@
 	src.controller = controller
 	src.extra_info = extra_info
 	if(extra_info)
-		RegisterSignal(extra_info, COMSIG_PARENT_QDELETING, PROC_REF(info_deleted))
+		RegisterSignal(extra_info, COMSIG_QDELETING, PROC_REF(info_deleted))
 	src.moving = moving
 	src.priority = priority
 	src.flags = flags
@@ -208,7 +208,7 @@
 	target = chasing
 
 	if(!isturf(target))
-		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(handle_no_target)) //Don't do this for turfs, because we don't care
+		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(handle_no_target)) //Don't do this for turfs, because we don't care
 
 /datum/move_loop/has_target/Destroy()
 	target = null

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -69,7 +69,7 @@ SUBSYSTEM_DEF(throwing)
 /datum/thrownthing/New(thrownthing, target, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, force, callback, target_zone, extra)
 	. = ..()
 	src.thrownthing = thrownthing
-	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, PROC_REF(on_thrownthing_qdel))
+	RegisterSignal(thrownthing, COMSIG_QDELETING, PROC_REF(on_thrownthing_qdel))
 	src.target = target
 	src.target_turf = target_turf
 	src.init_dir = init_dir

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -92,7 +92,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 ///Sets the current movement target, with an optional param to override the movement behavior
 /datum/ai_controller/proc/set_movement_target(source, atom/target, datum/ai_movement/new_movement)
 	if(current_movement_target)
-		UnregisterSignal(current_movement_target, list(COMSIG_PARENT_PREQDELETED))
+		UnregisterSignal(current_movement_target, list(COMSIG_PREQDELETED))
 	if(!isnull(target) && !isatom(target))
 		stack_trace("[pawn]'s current movement target is not an atom, rather a [target.type]! Did you accidentally set it to a weakref?")
 		CancelActions()
@@ -100,7 +100,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 	movement_target_source = source
 	current_movement_target = target
 	if(!isnull(current_movement_target))
-		RegisterSignal(current_movement_target, COMSIG_PARENT_PREQDELETED, PROC_REF(on_movement_target_delete))
+		RegisterSignal(current_movement_target, COMSIG_PREQDELETED, PROC_REF(on_movement_target_delete))
 	if(new_movement)
 		change_ai_movement_type(new_movement)
 
@@ -554,7 +554,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 	else if(isdatum(tracked_datum)) { \
 		var/datum/_tracked_datum = tracked_datum; \
 		if(!HAS_TRAIT_FROM(_tracked_datum, TRAIT_AI_TRACKING, "[REF(src)]_[key]")) { \
-			RegisterSignal(_tracked_datum, COMSIG_PARENT_QDELETING, PROC_REF(sig_remove_from_blackboard), override = TRUE); \
+			RegisterSignal(_tracked_datum, COMSIG_QDELETING, PROC_REF(sig_remove_from_blackboard), override = TRUE); \
 			ADD_TRAIT(_tracked_datum, TRAIT_AI_TRACKING, "[REF(src)]_[key]"); \
 		}; \
 	}; \
@@ -571,7 +571,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 		var/datum/_tracked_datum = tracked_datum; \
 		REMOVE_TRAIT(_tracked_datum, TRAIT_AI_TRACKING, "[REF(src)]_[key]"); \
 		if(!HAS_TRAIT(_tracked_datum, TRAIT_AI_TRACKING)) { \
-			UnregisterSignal(_tracked_datum, COMSIG_PARENT_QDELETING); \
+			UnregisterSignal(_tracked_datum, COMSIG_QDELETING); \
 		}; \
 	}; \
 } while(FALSE)

--- a/code/datums/ai/hostile/_hostile_controller.dm
+++ b/code/datums/ai/hostile/_hostile_controller.dm
@@ -37,7 +37,7 @@
 		COMSIG_PARENT_EXAMINE,
 		COMSIG_CLICK_ALT,
 		COMSIG_LIVING_DEATH,
-		COMSIG_PARENT_QDELETING
+		COMSIG_QDELETING
 	))
 	unfriend()
 	return ..() //Run parent at end

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -27,7 +27,7 @@
 	if(!nuser)
 		return
 	user = nuser
-	RegisterSignal(user, COMSIG_PARENT_QDELETING, PROC_REF(user_deleted))
+	RegisterSignal(user, COMSIG_QDELETING, PROC_REF(user_deleted))
 	window_id = nwindow_id
 	if(!no_close_movement)
 		if(ismob(nuser))
@@ -44,7 +44,7 @@
 		height = nheight
 	if (nref)
 		ref = nref
-		RegisterSignal(ref, COMSIG_PARENT_QDELETING, PROC_REF(ref_deleted))
+		RegisterSignal(ref, COMSIG_QDELETING, PROC_REF(ref_deleted))
 
 /datum/browser/proc/user_deleted(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -81,7 +81,7 @@
 /datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
 	// Register client who owns this message
 	owned_by = owner.client
-	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, PROC_REF(on_parent_qdel))
+	RegisterSignal(owned_by, COMSIG_QDELETING, PROC_REF(on_parent_qdel))
 
 	// Clip message
 	var/maxlen = owned_by.prefs.max_chat_length

--- a/code/datums/components/baothajoyride.dm
+++ b/code/datums/components/baothajoyride.dm
@@ -17,7 +17,7 @@
 	partner = partner_mob
 	caster = caster_mob
 
-	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(on_deletion))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_deletion))
 
 	START_PROCESSING(SSprocessing, src)
 	addtimer(CALLBACK(src, PROC_REF(remove_bond)), duration)
@@ -39,7 +39,7 @@
 	if(L)
 		L.remove_status_effect(/datum/status_effect/baotha_joyride)
 		UnregisterSignal(L, list(
-			COMSIG_PARENT_QDELETING
+			COMSIG_QDELETING
 		))
 
 	if(partner)

--- a/code/datums/components/connect/connect_containers.dm
+++ b/code/datums/components/connect/connect_containers.dm
@@ -32,13 +32,13 @@
 
 /datum/component/connect_containers/proc/set_tracked(atom/movable/new_tracked)
 	if(tracked)
-		UnregisterSignal(tracked, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+		UnregisterSignal(tracked, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 		unregister_signals(tracked)
 	tracked = new_tracked
 	if(!tracked)
 		return
 	RegisterSignal(tracked, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
-	RegisterSignal(tracked, COMSIG_PARENT_QDELETING, PROC_REF(handle_tracked_qdel))
+	RegisterSignal(tracked, COMSIG_QDELETING, PROC_REF(handle_tracked_qdel))
 	update_signals(tracked)
 
 /datum/component/connect_containers/proc/handle_tracked_qdel()

--- a/code/datums/components/connect/connect_range.dm
+++ b/code/datums/components/connect/connect_range.dm
@@ -54,14 +54,14 @@
 		unregister_signals(isturf(tracked) ? tracked : tracked.loc, turfs)
 		UnregisterSignal(tracked, list(
 			COMSIG_MOVABLE_MOVED,
-			COMSIG_PARENT_QDELETING,
+			COMSIG_QDELETING,
 		))
 	tracked = new_tracked
 	if(!tracked)
 		return
 	//Register signals on the new tracked atom and its surroundings.
 	RegisterSignal(tracked, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
-	RegisterSignal(tracked, COMSIG_PARENT_QDELETING, PROC_REF(handle_tracked_qdel))
+	RegisterSignal(tracked, COMSIG_QDELETING, PROC_REF(handle_tracked_qdel))
 	update_signals(tracked)
 
 /datum/component/connect_range/proc/handle_tracked_qdel()

--- a/code/datums/components/movable_lighting.dm
+++ b/code/datums/components/movable_lighting.dm
@@ -179,14 +179,14 @@
 	parent_attached_to = new_parent_attached_to
 	if(.)
 		var/atom/movable/old_parent_attached_to = .
-		UnregisterSignal(old_parent_attached_to, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
+		UnregisterSignal(old_parent_attached_to, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
 		if(old_parent_attached_to == current_holder)
-			RegisterSignal(old_parent_attached_to, COMSIG_PARENT_QDELETING, PROC_REF(on_holder_qdel))
+			RegisterSignal(old_parent_attached_to, COMSIG_QDELETING, PROC_REF(on_holder_qdel))
 			RegisterSignal(old_parent_attached_to, COMSIG_MOVABLE_MOVED, PROC_REF(on_holder_moved))
 	if(parent_attached_to)
 		if(parent_attached_to == current_holder)
-			UnregisterSignal(current_holder, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
-		RegisterSignal(parent_attached_to, COMSIG_PARENT_QDELETING, PROC_REF(on_parent_attached_to_qdel))
+			UnregisterSignal(current_holder, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
+		RegisterSignal(parent_attached_to, COMSIG_QDELETING, PROC_REF(on_parent_attached_to_qdel))
 		RegisterSignal(parent_attached_to, COMSIG_MOVABLE_MOVED, PROC_REF(on_parent_attached_to_moved))
 	check_holder()
 
@@ -197,7 +197,7 @@
 		return
 	if(current_holder)
 		if(current_holder != parent && current_holder != parent_attached_to)
-			UnregisterSignal(current_holder, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
+			UnregisterSignal(current_holder, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
 		if(overlay_lighting_flags & LIGHTING_ON)
 			remove_dynamic_lumi(current_holder)
 	current_holder = new_holder
@@ -207,7 +207,7 @@
 	if(overlay_lighting_flags & LIGHTING_ON)
 		add_dynamic_lumi(new_holder)
 	if(new_holder != parent && new_holder != parent_attached_to)
-		RegisterSignal(new_holder, COMSIG_PARENT_QDELETING, PROC_REF(on_holder_qdel))
+		RegisterSignal(new_holder, COMSIG_QDELETING, PROC_REF(on_holder_qdel))
 		RegisterSignal(new_holder, COMSIG_MOVABLE_MOVED, PROC_REF(on_holder_moved))
 
 
@@ -230,7 +230,7 @@
 ///Called when the current_holder is qdeleted, to remove the light effect.
 /datum/component/overlay_lighting/proc/on_holder_qdel(atom/movable/source, force)
 	SIGNAL_HANDLER
-	UnregisterSignal(current_holder, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
+	UnregisterSignal(current_holder, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
 	set_holder(null)
 
 
@@ -257,7 +257,7 @@
 ///Called when the current_holder is qdeleted, to remove the light effect.
 /datum/component/overlay_lighting/proc/on_parent_attached_to_qdel(atom/movable/source, force)
 	SIGNAL_HANDLER
-	UnregisterSignal(parent_attached_to, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_MOVED))
+	UnregisterSignal(parent_attached_to, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
 	if(parent_attached_to == current_holder)
 		set_holder(null)
 	set_parent_attached_to(null)

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -21,7 +21,7 @@
 	if(_max_mobs)
 		max_mobs=_max_mobs
 
-	RegisterSignal(parent, list(COMSIG_PARENT_QDELETING), PROC_REF(stop_spawning))
+	RegisterSignal(parent, list(COMSIG_QDELETING), PROC_REF(stop_spawning))
 	START_PROCESSING(SSprocessing, src)
 
 /datum/component/spawner/process()

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -34,7 +34,7 @@
 		return ELEMENT_INCOMPATIBLE
 	SEND_SIGNAL(target, COMSIG_ELEMENT_ATTACH, src)
 	if(element_flags & ELEMENT_DETACH)
-		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(Detach), override = TRUE)
+		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(Detach), override = TRUE)
 	if(element_flags & ELEMENT_DETACH_ON_HOST_DESTROY)
 		RegisterSignal(target, COMSIG_QDELETING, PROC_REF(OnTargetDelete), override = TRUE)
 

--- a/code/datums/elements/mob_overlay_effect.dm
+++ b/code/datums/elements/mob_overlay_effect.dm
@@ -19,7 +19,7 @@
 	RegisterSignal(get_turf(target), COMSIG_TURF_ENTERED, PROC_REF(on_add), override = TRUE)
 	RegisterSignal(target, COMSIG_MOB_OVERLAY_FORCE_REMOVE, PROC_REF(on_remove), override = TRUE)
 	RegisterSignal(target, COMSIG_MOB_OVERLAY_FORCE_UPDATE, PROC_REF(on_add), override = TRUE)
-	RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(remove_all), override = TRUE)
+	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(remove_all), override = TRUE)
 
 /datum/element/mob_overlay_effect/Detach(datum/source)
 	. = ..()
@@ -29,7 +29,7 @@
 	UnregisterSignal(source, list(
 		COMSIG_MOB_OVERLAY_FORCE_REMOVE,
 		COMSIG_MOB_OVERLAY_FORCE_UPDATE,
-		COMSIG_PARENT_QDELETING
+		COMSIG_QDELETING
 	))
 
 /datum/element/mob_overlay_effect/proc/on_remove(datum/source, datum/target)

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -313,10 +313,10 @@ GLOBAL_LIST_EMPTY(created_sound_groups)
 
 /datum/looping_sound/proc/set_parent(new_parent)
 	if(parent)
-		UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
+		UnregisterSignal(parent, COMSIG_QDELETING)
 	if(new_parent)
 		parent = new_parent
-		RegisterSignal(new_parent, COMSIG_PARENT_QDELETING, PROC_REF(handle_parent_del))
+		RegisterSignal(new_parent, COMSIG_QDELETING, PROC_REF(handle_parent_del))
 
 /datum/looping_sound/proc/handle_parent_del(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/proximity_monitor/proximity_monitor.dm
+++ b/code/datums/proximity_monitor/proximity_monitor.dm
@@ -23,17 +23,17 @@
 	if(new_host == host)
 		return
 	if(host) //No need to delete the connect range and containers comps. They'll be updated with the new tracked host.
-		UnregisterSignal(host, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+		UnregisterSignal(host, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 	if(hasprox_receiver)
-		UnregisterSignal(hasprox_receiver, COMSIG_PARENT_QDELETING)
+		UnregisterSignal(hasprox_receiver, COMSIG_QDELETING)
 	if(new_receiver)
 		hasprox_receiver = new_receiver
 		if(new_receiver != new_host)
-			RegisterSignal(new_receiver, COMSIG_PARENT_QDELETING, PROC_REF(on_host_or_receiver_del))
+			RegisterSignal(new_receiver, COMSIG_QDELETING, PROC_REF(on_host_or_receiver_del))
 	else if(hasprox_receiver == host) //Default case
 		hasprox_receiver = new_host
 	host = new_host
-	RegisterSignal(new_host, COMSIG_PARENT_QDELETING, PROC_REF(on_host_or_receiver_del))
+	RegisterSignal(new_host, COMSIG_QDELETING, PROC_REF(on_host_or_receiver_del))
 	var/static/list/containers_connections = list(
 		COMSIG_MOVABLE_MOVED = PROC_REF(on_moved),
 		COMSIG_MOVABLE_Z_CHANGED = PROC_REF(on_z_change),

--- a/code/game/machinery/trams_and_elevators/industrial_lift.dm
+++ b/code/game/machinery/trams_and_elevators/industrial_lift.dm
@@ -129,7 +129,7 @@ GLOBAL_LIST_INIT(all_radial_directions, list(
 	REMOVE_TRAIT(potential_rider, TRAIT_TRAM_MOVER, REF(src))
 	changed_gliders -= potential_rider
 
-	UnregisterSignal(potential_rider, list(COMSIG_PARENT_QDELETING, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE))
+	UnregisterSignal(potential_rider, list(COMSIG_QDELETING, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE))
 
 	if(!length(held_cargo))
 		SEND_SIGNAL(src, COMSIG_TRAM_EMPTY)
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(all_radial_directions, list(
 	new_lift_contents.plane = 3
 	new_lift_contents.layer++
 	ADD_TRAIT(new_lift_contents, TRAIT_TRAM_MOVER, REF(src))
-	RegisterSignal(new_lift_contents, COMSIG_PARENT_QDELETING, PROC_REF(RemoveItemFromLift))
+	RegisterSignal(new_lift_contents, COMSIG_QDELETING, PROC_REF(RemoveItemFromLift))
 
 	return TRUE
 

--- a/code/game/machinery/trams_and_elevators/lift_master.dm
+++ b/code/game/machinery/trams_and_elevators/lift_master.dm
@@ -65,7 +65,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 
 	new_lift_platform.lift_master_datum = src
 	LAZYADD(lift_platforms, new_lift_platform)
-	RegisterSignal(new_lift_platform, COMSIG_PARENT_QDELETING, PROC_REF(remove_lift_platforms))
+	RegisterSignal(new_lift_platform, COMSIG_QDELETING, PROC_REF(remove_lift_platforms))
 
 	check_for_landmarks(new_lift_platform)
 
@@ -80,7 +80,7 @@ GLOBAL_LIST_EMPTY(active_lifts_by_type)
 
 	old_lift_platform.lift_master_datum = null
 	LAZYREMOVE(lift_platforms, old_lift_platform)
-	UnregisterSignal(old_lift_platform, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(old_lift_platform, COMSIG_QDELETING)
 	if(!length(lift_platforms))
 		qdel(src)
 

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -30,7 +30,7 @@
 	// /atom doesn't have vis_contents, /turf and /atom/movable do
 	var/atom/movable/lie_about_areas = parent
 	lie_about_areas.vis_contents += src
-	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(parent_deleted))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(parent_deleted))
 
 	if(particle_flags & PARTICLE_ATTACH_MOB)
 		RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))

--- a/code/game/objects/effects/temporary_visuals/offered_item_effect.dm
+++ b/code/game/objects/effects/temporary_visuals/offered_item_effect.dm
@@ -34,7 +34,7 @@
 	RegisterSignal(offered_to, COMSIG_MOVABLE_MOVED, PROC_REF(someone_moved))
 	RegisterSignal(offerer, COMSIG_LIVING_STOPPED_OFFERING_ITEM, PROC_REF(stopped_offering))
 	RegisterSignal(offered_thing, COMSIG_OBJ_HANDED_OVER, PROC_REF(handover))
-	RegisterSignal(offerer, COMSIG_PARENT_QDELETING, PROC_REF(timed_out))
+	RegisterSignal(offerer, COMSIG_QDELETING, PROC_REF(timed_out))
 	calculate_offset()
 
 /obj/effect/temp_visual/offered_item_effect/timed_out()

--- a/code/game/objects/items/bedsheets.dm
+++ b/code/game/objects/items/bedsheets.dm
@@ -53,7 +53,7 @@ LINEN BINS
 	RegisterSignal(src, COMSIG_ITEM_PICKUP, PROC_REF(on_pickup))
 	RegisterSignal(sleeper, COMSIG_MOVABLE_MOVED, PROC_REF(smooth_sheets))
 	RegisterSignal(sleeper, COMSIG_LIVING_SET_RESTING, PROC_REF(smooth_sheets))
-	RegisterSignal(sleeper, COMSIG_PARENT_QDELETING, PROC_REF(smooth_sheets))
+	RegisterSignal(sleeper, COMSIG_QDELETING, PROC_REF(smooth_sheets))
 
 /obj/item/bedsheet/proc/smooth_sheets(mob/living/sleeper)
 	SIGNAL_HANDLER
@@ -61,7 +61,7 @@ LINEN BINS
 	UnregisterSignal(src, COMSIG_ITEM_PICKUP)
 	UnregisterSignal(sleeper, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(sleeper, COMSIG_LIVING_SET_RESTING)
-	UnregisterSignal(sleeper, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(sleeper, COMSIG_QDELETING)
 	to_chat(sleeper, span_notice("I smooth [src] out beneath you."))
 	layer = initial(layer)
 	plane = initial(plane)
@@ -77,7 +77,7 @@ LINEN BINS
 	UnregisterSignal(src, COMSIG_ITEM_PICKUP)
 	UnregisterSignal(sleeper, COMSIG_MOVABLE_MOVED)
 	UnregisterSignal(sleeper, COMSIG_LIVING_SET_RESTING)
-	UnregisterSignal(sleeper, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(sleeper, COMSIG_QDELETING)
 	signal_sleeper = null
 
 /obj/item/bedsheet/rogue/cloth

--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -91,17 +91,17 @@
 		return
 	build_odds_labels()
 	RegisterSignal(thief, COMSIG_MOB_CLICKON, PROC_REF(on_click))
-	RegisterSignal(thief, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(on_disturbed))
-	RegisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING), PROC_REF(on_disturbed))
+	RegisterSignal(thief, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING), PROC_REF(on_disturbed))
+	RegisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING), PROC_REF(on_disturbed))
 
 /datum/pickpocket_session/Destroy()
 	clear_odds_labels()
 	if(thief)
-		UnregisterSignal(thief, list(COMSIG_MOB_CLICKON, COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+		UnregisterSignal(thief, list(COMSIG_MOB_CLICKON, COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 		if(STR && thief.active_storage == STR)
 			STR.hide_from(thief)
 	if(victim)
-		UnregisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_PARENT_QDELETING))
+		UnregisterSignal(victim, list(COMSIG_MOVABLE_MOVED, COMSIG_QDELETING))
 	thief = null
 	victim = null
 	container = null

--- a/code/modules/admin/verbs/schizohelp.dm
+++ b/code/modules/admin/verbs/schizohelp.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 	. = ..()
 	if(owner)
 		src.owner = owner
-		RegisterSignal(owner, COMSIG_PARENT_QDELETING, PROC_REF(owner_qdeleted))
+		RegisterSignal(owner, COMSIG_QDELETING, PROC_REF(owner_qdeleted))
 	GLOB.schizohelps += src
 	if(timeout)
 		QDEL_IN(src, timeout)
@@ -116,5 +116,5 @@ GLOBAL_LIST_EMPTY_TYPED(schizohelps, /datum/schizohelp)
 /datum/schizohelp/proc/owner_qdeleted(mob/source)
 	if(QDELETED(src))
 		return
-	UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(owner, COMSIG_QDELETING)
 	qdel(src)

--- a/code/modules/roguetown/roguejobs/artificer/contraptions.dm
+++ b/code/modules/roguetown/roguejobs/artificer/contraptions.dm
@@ -208,7 +208,7 @@
 		remove_buffer(src.buffer)
 	src.buffer = buffer
 	if(!QDELETED(buffer))
-		RegisterSignal(buffer, COMSIG_PARENT_QDELETING, PROC_REF(remove_buffer))
+		RegisterSignal(buffer, COMSIG_QDELETING, PROC_REF(remove_buffer))
 
 /**
  * Called when the buffer's stored object is deleted
@@ -219,7 +219,7 @@
 /obj/item/contraption/linker/proc/remove_buffer(datum/source)
 	SIGNAL_HANDLER
 	SEND_SIGNAL(src, COMSIG_MULTITOOL_REMOVE_BUFFER, source)
-	UnregisterSignal(buffer, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(buffer, COMSIG_QDELETING)
 	buffer = null
 
 

--- a/code/modules/roguetown/roguejobs/blacksmith/items.dm
+++ b/code/modules/roguetown/roguejobs/blacksmith/items.dm
@@ -248,7 +248,7 @@
 /datum/component/metal_glint/Initialize()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
-	RegisterSignal(parent, list(COMSIG_PARENT_QDELETING), PROC_REF(stop_process))
+	RegisterSignal(parent, list(COMSIG_QDELETING), PROC_REF(stop_process))
 	START_PROCESSING(SSobj, src)
 
 /datum/component/metal_glint/process()

--- a/code/modules/roguetown/roguemachine/questing/items/parcel.dm
+++ b/code/modules/roguetown/roguemachine/questing/items/parcel.dm
@@ -20,7 +20,7 @@
 		if(quest && quest.quest_type == QUEST_COURIER && quest.target_delivery_location)
 			delivery_area_type = quest.target_delivery_location
 			allowed_jobs = get_area_jobs(delivery_area_type)
-			RegisterSignal(courier_quest, COMSIG_PARENT_QDELETING, PROC_REF(on_quest_component_deleted))
+			RegisterSignal(courier_quest, COMSIG_QDELETING, PROC_REF(on_quest_component_deleted))
 
 	invisibility = INVISIBILITY_OBSERVER
 	proximity_monitor = new(src, 7)

--- a/code/modules/roguetown/roguemachine/questing/questing_components.dm
+++ b/code/modules/roguetown/roguemachine/questing/questing_components.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(quest_components)
 			RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_item_dropped))
 			RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_item_dropped))
 
-	RegisterSignal(target_quest, COMSIG_PARENT_QDELETING, PROC_REF(on_quest_deleted))
+	RegisterSignal(target_quest, COMSIG_QDELETING, PROC_REF(on_quest_deleted))
 	GLOB.quest_components += src
 
 /datum/component/quest_object/Destroy()

--- a/code/modules/spells/roguetown/acolyte/astrata.dm
+++ b/code/modules/spells/roguetown/acolyte/astrata.dm
@@ -254,7 +254,7 @@
 	// Set up processing and expiration
 	START_PROCESSING(SSprocessing, src)
 	RegisterSignal(parent, COMSIG_LIVING_MIRACLE_HEAL_APPLY, PROC_REF(on_heal))
-	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(on_deletion))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_deletion))
 	addtimer(CALLBACK(src, PROC_REF(remove_immolation)), duration)
 
 	// Apply visual effect
@@ -351,7 +351,7 @@
 		L.remove_status_effect(/datum/status_effect/immolation)
 		UnregisterSignal(L, list(
 			COMSIG_LIVING_MIRACLE_HEAL_APPLY,
-			COMSIG_PARENT_QDELETING
+			COMSIG_QDELETING
 		))
 
 	if(partner)

--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -165,7 +165,7 @@
 	// Correct signal name
 	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMGE, PROC_REF(on_damage))
 	RegisterSignal(parent, COMSIG_LIVING_MIRACLE_HEAL_APPLY, PROC_REF(on_heal))
-	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(on_deletion))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_deletion))
 
 	START_PROCESSING(SSprocessing, src)
 	addtimer(CALLBACK(src, PROC_REF(remove_bond)), duration)
@@ -229,7 +229,7 @@
 		UnregisterSignal(L, list(
 			COMSIG_MOB_APPLY_DAMGE,
 			COMSIG_LIVING_MIRACLE_HEAL_APPLY,
-			COMSIG_PARENT_QDELETING
+			COMSIG_QDELETING
 		))
 
 	if(partner)

--- a/code/modules/spells/roguetown/acolyte/pestra/pestra_components.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra/pestra_components.dm
@@ -111,7 +111,7 @@
 
 	apply_outline()
 	RegisterSignal(parent_weapon, COMSIG_ITEM_ATTACK_SUCCESS, PROC_REF(on_attack_success))
-	RegisterSignal(parent_weapon, COMSIG_PARENT_QDELETING, PROC_REF(on_qdel))
+	RegisterSignal(parent_weapon, COMSIG_QDELETING, PROC_REF(on_qdel))
 	addtimer(CALLBACK(src, PROC_REF(remove_enchantment)), duration)
 
 /datum/component/pestilent_blade_enchant/proc/apply_outline()

--- a/code/modules/vampire_neu/covens/_base_coven.dm
+++ b/code/modules/vampire_neu/covens/_base_coven.dm
@@ -122,8 +122,8 @@
 	if(new_owner == owner)
 		return
 	if(owner)
-		UnregisterSignal(owner, COMSIG_PARENT_QDELETING)
-	RegisterSignal(new_owner, COMSIG_PARENT_QDELETING, PROC_REF(on_owner_qdel))
+		UnregisterSignal(owner, COMSIG_QDELETING)
+	RegisterSignal(new_owner, COMSIG_QDELETING, PROC_REF(on_owner_qdel))
 	owner = new_owner
 
 	// Set owner for all known powers

--- a/code/modules/vampire_neu/covens/coven_powers/_base_power.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/_base_power.dm
@@ -94,8 +94,8 @@
 	if(owner == new_owner)
 		return
 	if(owner)
-		UnregisterSignal(owner, list(COMSIG_PARENT_QDELETING, COMSIG_POWER_ACTIVATE))
-	RegisterSignal(new_owner, COMSIG_PARENT_QDELETING, PROC_REF(on_owner_qdel))
+		UnregisterSignal(owner, list(COMSIG_QDELETING, COMSIG_POWER_ACTIVATE))
+	RegisterSignal(new_owner, COMSIG_QDELETING, PROC_REF(on_owner_qdel))
 	owner = new_owner
 	if(power_group != COVEN_POWER_GROUP_NONE)
 		RegisterSignal(owner, COMSIG_POWER_ACTIVATE, PROC_REF(on_other_power_activate))

--- a/code/modules/vampire_neu/covens/coven_powers/presence.dm
+++ b/code/modules/vampire_neu/covens/coven_powers/presence.dm
@@ -332,7 +332,7 @@
 	RegisterSignal(owner, COMSIG_MOB_SAY, PROC_REF(on_say))
 
 	//the compulsion has no duration of its own, so it has to die with whoever cast it
-	RegisterSignal(majesty_user, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH), PROC_REF(on_majesty_user_gone))
+	RegisterSignal(majesty_user, list(COMSIG_QDELETING, COMSIG_LIVING_DEATH), PROC_REF(on_majesty_user_gone))
 
 	if(owner.mind)
 		owner.add_stress(/datum/stressevent/majesty_compelled)
@@ -346,7 +346,7 @@
 	))
 
 	if(majesty_user)
-		UnregisterSignal(majesty_user, list(COMSIG_PARENT_QDELETING, COMSIG_LIVING_DEATH))
+		UnregisterSignal(majesty_user, list(COMSIG_QDELETING, COMSIG_LIVING_DEATH))
 		majesty_user = null
 
 	if(owner.mind)

--- a/modular/code/game/objects/tent_kit.dm
+++ b/modular/code/game/objects/tent_kit.dm
@@ -254,7 +254,7 @@
         wall.dir = get_wall_dir(center_turf, wall_turf)
         wall.invisibility = 0
         wall.alpha = 255
-        RegisterSignal(wall, COMSIG_PARENT_QDELETING, PROC_REF(part_destroyed))
+        RegisterSignal(wall, COMSIG_QDELETING, PROC_REF(part_destroyed))
 
     // --- ROOF TILES (The Flooring) ---
     for(var/turf/roof_floor_turf in roof_floor_coords)
@@ -274,7 +274,7 @@
         wall.name = "tent roof wall"
         wall.invisibility = 0
         wall.alpha = 255
-        RegisterSignal(wall, COMSIG_PARENT_QDELETING, PROC_REF(part_destroyed))
+        RegisterSignal(wall, COMSIG_QDELETING, PROC_REF(part_destroyed))
 
     // --- DOORS ---
     for(var/turf/door_turf in door_coords)
@@ -286,7 +286,7 @@
         door.alpha = 255
         door.density = TRUE
         door.update_icon()
-        RegisterSignal(door, COMSIG_PARENT_QDELETING, PROC_REF(part_destroyed))
+        RegisterSignal(door, COMSIG_QDELETING, PROC_REF(part_destroyed))
 
     // --- INTERNAL ROOF LOGIC ---
     var/list/internal_coords = get_tent_coordinates(center_turf, assembly_dir)
@@ -308,12 +308,12 @@
         if(!do_after(user, 8 SECONDS, target = src)) return
 
     for(var/obj/structure/tent_wall/wall in tent_walls)
-        UnregisterSignal(wall, COMSIG_PARENT_QDELETING)
+        UnregisterSignal(wall, COMSIG_QDELETING)
         wall.forceMove(src)
         wall.name = initial(wall.name)
         wall.alpha = initial(wall.alpha)
     for(var/obj/structure/roguetent/door in tent_doors)
-        UnregisterSignal(door, COMSIG_PARENT_QDELETING)
+        UnregisterSignal(door, COMSIG_QDELETING)
         door.forceMove(src)
     for(var/turf/T in roof_tiles)
         T.pseudo_roof = FALSE

--- a/modular_hearthstone/code/game/objects/effects/track.dm
+++ b/modular_hearthstone/code/game/objects/effects/track.dm
@@ -231,7 +231,7 @@
 //Handles value settings done for a track that need to be done.
 /obj/effect/track/proc/handle_creation(mob/living/track_source)
 	creator = track_source
-	RegisterSignal(track_source, COMSIG_PARENT_QDELETING, PROC_REF(clear_creator_reference), TRUE)
+	RegisterSignal(track_source, COMSIG_QDELETING, PROC_REF(clear_creator_reference), TRUE)
 	creation_time = world.time
 	track_source.get_track_info(src)
 	if(track_source.m_intent == MOVE_INTENT_SNEAK)
@@ -272,12 +272,12 @@
 				LAZYADD(highlighted, tracker)
 		if(tracker.client)
 			tracker.client.images += real_image
-	RegisterSignal(tracker, COMSIG_PARENT_QDELETING, PROC_REF(remove_knower), override = TRUE)
+	RegisterSignal(tracker, COMSIG_QDELETING, PROC_REF(remove_knower), override = TRUE)
 
 ///Removes a knower from the known ones. Usually only done when qdeleted.
 /obj/effect/track/proc/remove_knower(mob/living/tracker)
 	SIGNAL_HANDLER
-	UnregisterSignal(tracker, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(tracker, COMSIG_QDELETING)
 	if(tracker.client)
 		tracker.client.images -= real_image
 	LAZYREMOVE(highlighted, tracker)
@@ -288,7 +288,7 @@
 ///Clears the reference to the creator. Is replaced by the above proc if the creator analyzes it.
 /obj/effect/track/proc/clear_creator_reference(mob/living/creator_arg)
 	SIGNAL_HANDLER
-	UnregisterSignal(creator, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(creator, COMSIG_QDELETING)
 	creator = null
 
 ///Called when the track's time expires, at which point it becomes indistinguishable (aka, deleted)
@@ -477,7 +477,7 @@
 
 /obj/effect/track/structure/handle_creation(mob/living/track_source)
 	creator = track_source
-	RegisterSignal(track_source, COMSIG_PARENT_QDELETING, PROC_REF(clear_creator_reference))
+	RegisterSignal(track_source, COMSIG_QDELETING, PROC_REF(clear_creator_reference))
 	creation_time = world.time
 	track_source.get_track_info(src)
 	real_image = image(icon, src, real_icon_state, ABOVE_OPEN_TURF_LAYER, track_source.dir)
@@ -541,7 +541,7 @@
 
 /obj/effect/track/thievescant/handle_creation(mob/living/track_source, thiefmessage)
 	creator = track_source
-	RegisterSignal(track_source, COMSIG_PARENT_QDELETING, PROC_REF(clear_creator_reference))
+	RegisterSignal(track_source, COMSIG_QDELETING, PROC_REF(clear_creator_reference))
 	creation_time = world.time
 	track_source.get_track_info(src)
 	real_image = image(icon, src, real_icon_state, BULLET_HOLE_LAYER, track_source.dir)


### PR DESCRIPTION
## About The Pull Request
clean up the code in /proc/qdel()
Rename the signals to no longer be component
Fixes some cases where the qdel signal was being registered but not being sent from anywhere (unified under the same name)

Nothing player-facing

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

