### PR TITLE
Removes the 'Warcaster' class from Wretch Fighter.

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/deserter.dm
@@ -325,7 +325,7 @@
 	beltl = /obj/item/rogueweapon/mace/cudgel
 	backr = /obj/item/storage/backpack/rogue/satchel
 	if(H.mind)
-		var/archetype = list("Heavy Infantry", "Light Infantry", "Bogguard/Cavalryman", "Feldsher", "Warcaster", "Veteran")
+		var/archetype = list("Heavy Infantry", "Light Infantry", "Bogguard/Cavalryman", "Feldsher", "Veteran")
 		var/archetype_choice = input (H, "Choose your primary training.", "HOW DO YOU KILL?") as anything in archetype
 		switch(archetype_choice)
 			if("Heavy Infantry") //Classic Deserter. Master Athletics, Expert Swimming and Expert Shields. Otherwise nothing special.
@@ -357,19 +357,6 @@
 				cloak = /obj/item/clothing/suit/roguetown/shirt/robe/feld
 				beltl = /obj/item/storage/belt/rogue/surgery_bag
 				to_chat(H, span_warning("You were a field chirurgeon, a healer rather than a killer. In time, you learned how to murder and became both."))
-			if("Warcaster") //Wretch Spellblade that's not exclusive to racist elfs! T2 Arcyne, Magearmor, Apprentice Arcyne, 12 spell points, but worse stats -- weighted stat total of +5.
-				ADD_TRAIT(H, TRAIT_ARCYNE_T2, TRAIT_GENERIC)
-				ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)
-				H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_APPRENTICE, TRUE)
-				H.change_stat(STATKEY_STR, -1)
-				H.change_stat(STATKEY_CON, -1)
-				H.change_stat(STATKEY_PER, -1)
-				H.mind?.adjust_spellpoints(12)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/projectile/airblade)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/enchant_weapon)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/invoked/conjure_weapon)
-				cloak = /obj/item/clothing/cloak/tabard
-				to_chat(H, span_warning("You trained in the difficult skill of casting magic while clad in burdening armour. Your training paid off, but left little time or energy for physical education."))
 			if("Veteran") //Master in primary weapon skills and Expert in all other weapon skills except Unarmed, but worse stats -- weighted stat total of +5.
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_MASTER, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, SKILL_LEVEL_MASTER, TRUE)


### PR DESCRIPTION
## About The Pull Request

See title.

## Testing Evidence

<img width="405" height="303" alt="dreamseeker_2026-08-18_13-41-25" src="https://github.com/user-attachments/assets/8869e5e7-01b8-4117-b168-e4be3614631e" />

## Why It's Good For The Game

Class is busted. We've seen it in action. Wretch deathballs don't need a guy armed to the teeth who can also cast the likes of blink, repulse, enchant weapons, etc. etc. without being a dedicated wizard. It's unbalanced and unfun. I'm surprised it took this long for anyone to care to axe it, frankly.

## Changelog


:cl:
del: Removed the 'Warcaster' wretch Fighter subclass.
/:cl:
