### PR TITLE
Allows Fluvians to be Underdweller mercenaries

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/underdweller.dm
@@ -40,7 +40,7 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,	//Accompanies mining; they know how to smelt, not make armor though.
 	)
-	extra_context = "This subclass is race-limited to: Dwarves, Dark Elves, Kobolds, Goblins & Verminvolk."
+	extra_context = "This subclass is race-limited to: Dwarves, Dark Elves, Kobolds, Fluvians, Goblins & Verminvolk."
 
 /datum/outfit/job/roguetown/adventurer/underdweller/pre_equip(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/underdweller.dm
@@ -11,6 +11,7 @@
 		/datum/species/kobold,
 		/datum/species/goblinp,				//Might be a little weird but goblins do reside in caves, and they could use a unique merc class type.
 		/datum/species/anthromorphsmall,	//Basically all under-ground races. Perfect for cave-clearing.
+		/datum/species/moth,
 	)
 	outfit = /datum/outfit/job/roguetown/adventurer/underdweller
 	class_select_category = CLASS_CAT_RACIAL


### PR DESCRIPTION
## About The Pull Request

Adds Fluvians to the list of allowed species for Underdweller mercs.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

The in-game map references a Fluvian population in the Underdark city of "Mercuriam", therefore it is reasonable for Fluvians to become Underdwellers - at least as much as verminvolk anyway.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Fluvians can now be Underdwllers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
