### PR TITLE
Gives Arbalist Sleuth

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/arbalist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/arbalist.dm
@@ -14,6 +14,7 @@
 	category_tags = list(CTAG_INQUISITION)
 	traits_applied = list(
 		TRAIT_PERFECT_TRACKER,
+		TRAIT_SLEUTH,
 	)
 	subclass_stats = list(//You get PER/STR for the crossbow.
 		STATKEY_PER = 3,


### PR DESCRIPTION
## About The Pull Request

Gives Sleuth Trait to Arbalist.

## Why It's Good For The Game

>Master tracker
>Perfect tracking trait
>Sharpest eye both in desc and in stats

No. Sleuth. 
Everyone knows tracking is useless without sleuth.
Call it a balancejakk but this is an objectively bewildering thing for the role to not have based on all surrounding context.

## Changelog



:cl:
balance: Gave Arbalist Sleuth
/:cl:
