### PR TITLE
Jaks Off A Little: Decapitates Churn undead & Adds max targets to Abrorgation

### DIFF
--- a/code/datums/gods/patrons/divine/necra.dm
+++ b/code/datums/gods/patrons/divine/necra.dm
@@ -16,7 +16,6 @@
 					/obj/effect/proc_holder/spell/targeted/abrogation				= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/necra_crows				= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/deaths_door				= CLERIC_T3,//This was bad enough at T1. No, thanks. Cool as it is.
-					/obj/effect/proc_holder/spell/targeted/churn					= CLERIC_T4,//Priest/Acolytes only. Thanks.
 	)
 	confess_lines = list(
 		"ALL SOULS FIND THEIR WAY TO NECRA!",

--- a/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
+++ b/modular_azurepeak/code/modules/spells/pantheon/divine/necra.dm
@@ -63,14 +63,14 @@
 /obj/effect/proc_holder/spell/targeted/abrogation
 	name = "Abrogation"
 	desc = "Debuffs targeted undead as long as they remain near you, slowly getting set on fire if they stay."
-	range = 8
+	range = 5
 	overlay_state = "necra"
 	releasedrain = 30
 	chargedloop = /datum/looping_sound/invokeholy
 	chargetime = 50
 	chargedrain = 0.5
-	recharge_time = 30 SECONDS
-	max_targets = 0
+	recharge_time = 45 SECONDS
+	max_targets = 3
 	cast_without_targets = TRUE
 	req_items = list(/obj/item/clothing/neck/roguetown/psicross)
 	sound = 'sound/magic/churn.ogg'


### PR DESCRIPTION
## About The Pull Request

### **NOTHING IS SET IN STONE, THIS IS FOR DISCUSSION. BE RESPECTABLE**

Churn undead is a spell that even AP has changed. The use of churn undead has trivialized encounters. in saying that, if we are going to nerf skeletons, it needs to be a two-pronged approach. With me REMOVING churn undead, and giving abrogation a max counter for who can hit would go a long way.

I also found out Cyan's clip was a bug. It's been changed, but I think Abrorgation needs to be looked at.

## Testing Evidence

n/a

## Why It's Good For The Game

See above

## Changelog

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl: