### PR TITLE
Temperature Tweaks

### DIFF
--- a/code/datums/particle_weathers/datum_types/burning_ash.dm
+++ b/code/datums/particle_weathers/datum_types/burning_ash.dm
@@ -37,9 +37,9 @@
 		return
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.apply_weather_temperature(rand(1,3))
+		H.apply_weather_temperature(rand(1,2))
 	else
-		L.adjust_bodytemperature(rand(1,3))
+		L.adjust_bodytemperature(rand(1,2))
 	if(prob(25))
 		L.adjust_fire_stacks(1)
 		to_chat(L, span_danger("You're caught in a haze of burning, flammable ash!"))

--- a/code/datums/particle_weathers/datum_types/hail_storm.dm
+++ b/code/datums/particle_weathers/datum_types/hail_storm.dm
@@ -39,9 +39,9 @@
 	if(L.bodytemperature > BODYTEMP_COLD_LEVEL_ONE_MAX + 3)
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			H.apply_weather_temperature(-rand(2,4))
+			H.apply_weather_temperature(-rand(2,3))
 		else
-			L.adjust_bodytemperature(-rand(2,4))
+			L.adjust_bodytemperature(-rand(2,3))
 	if(prob(50))
 		var/armor_block = L.run_armor_check(BODY_ZONE_HEAD, "blunt", blade_dulling=BCLASS_BLUNT)
 		if(L.apply_damage(rand(5, 10), BRUTE, BODY_ZONE_HEAD, armor_block))

--- a/code/datums/particle_weathers/datum_types/heat_wave.dm
+++ b/code/datums/particle_weathers/datum_types/heat_wave.dm
@@ -52,9 +52,9 @@
 /datum/particle_weather/heat_wave/weather_act(mob/living/L)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.apply_weather_temperature(rand(1.5,5))
+		H.apply_weather_temperature(rand(1.5,4))
 	else
-		L.adjust_bodytemperature(rand(1.5,5))
+		L.adjust_bodytemperature(rand(1.5,4))
 /datum/particle_weather/heat_wave/tick()
 
 	if(!COOLDOWN_FINISHED(src, heat_ripple_spawn))

--- a/code/datums/particle_weathers/datum_types/snow_storm.dm
+++ b/code/datums/particle_weathers/datum_types/snow_storm.dm
@@ -50,9 +50,9 @@
 /datum/particle_weather/snow_gentle/weather_act(mob/living/L)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.apply_weather_temperature(-rand(1,1.5))
+		H.apply_weather_temperature(-rand(0.5,1.5))
 	else
-		L.adjust_bodytemperature(-rand(1,1.5))
+		L.adjust_bodytemperature(-rand(0.5,1.5))
 
 
 /datum/particle_weather/snow_storm
@@ -81,9 +81,9 @@
 /datum/particle_weather/snow_storm/weather_act(mob/living/L)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.apply_weather_temperature(-rand(1.5,5))
+		H.apply_weather_temperature(-rand(1.5,2.5))
 	else
-		L.adjust_bodytemperature(-rand(1.5,5))
+		L.adjust_bodytemperature(-rand(1.5,2.5))
 
 /turf
 	var/turf_flags = TURF_EFFECT_AFFECTABLE

--- a/code/datums/particle_weathers/datum_types/snow_storm.dm
+++ b/code/datums/particle_weathers/datum_types/snow_storm.dm
@@ -50,9 +50,9 @@
 /datum/particle_weather/snow_gentle/weather_act(mob/living/L)
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
-		H.apply_weather_temperature(-rand(0.5,1.5))
+		H.apply_weather_temperature(-rand(1,1.5))
 	else
-		L.adjust_bodytemperature(-rand(0.5,1.5))
+		L.adjust_bodytemperature(-rand(1,1.5))
 
 
 /datum/particle_weather/snow_storm

--- a/code/datums/wounds/types/special.dm
+++ b/code/datums/wounds/types/special.dm
@@ -811,6 +811,11 @@
 	start_time = world.time
 	owner.overlay_fullscreen("hypothermia", /atom/movable/screen/fullscreen/hypothermia)
 
+
+// If warmed up, remove hypothermia, check once every minute for 50% removing wound if normal temp
+/datum/wound/hypothermia
+	var/next_removal_check = 0
+
 /datum/wound/hypothermia/on_life()
 	. = ..()
 
@@ -819,22 +824,16 @@
 
 	var/mob/living/carbon/C = owner
 
-	// If warmed up, remove hypothermia
-	if(C.bodytemperature >= BODYTEMP_NORMAL_MIN)
-		to_chat(C, span_notice("Feeling returns to my body as I warm up."))
-		C.clear_fullscreen("hypothermia")
-		qdel(src)
-		return
+	if(C.bodytemperature >= BODYTEMP_NORMAL_MIN && world.time >= next_removal_check)
+		next_removal_check = world.time + 1 MINUTES
+
+		if(prob(50))
+			to_chat(C, span_notice("Feeling returns to my body as I warm up."))
+			C.clear_fullscreen("hypothermia")
+			qdel(src)
+			return
 
 	// Occasional discomfort message
 	if(!C.stat && prob(5))
 		to_chat(C, span_warning("I can't stop shivering..."))
 
-	// After 2 minutes, convert to frostbite
-	if(world.time >= start_time + duration)
-		var/obj/item/bodypart/BP = bodypart_owner
-		if(BP)
-			to_chat(C, span_userdanger("I feel pins and needles in [BP]!"))
-			BP.add_wound(/datum/wound/frostbite)
-			C.clear_fullscreen("hypothermia")
-		qdel(src)

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -53,7 +53,7 @@
 			L.visible_message(span_info("[user] starts to warm their hands."), span_info("You warm your hands."))
 			if(do_after(L, 4 SECONDS, target = src))
 				if(L.bodytemperature < BODYTEMP_NORMAL_MIN)
-					L.adjust_bodytemperature(50)
+					L.adjust_bodytemperature(35)
 		return
 
 

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -46,6 +46,17 @@
 				icon_state = "[base_state]0"
 			return
 
+/obj/machinery/light/rogue/firebowl/attack_right(mob/user)	// warm your hands a little at a more accessible spot than fireplaces
+	if(isliving(user))
+		var/mob/living/L = user
+		if(on)
+			L.visible_message(span_info("[user] starts to warm their hands."), span_info("You warm your hands."))
+			if(do_after(L, 4 SECONDS, target = src))
+				if(L.bodytemperature < BODYTEMP_NORMAL_MIN)
+					L.adjust_bodytemperature(50)
+		return
+
+
 /obj/machinery/light/rogue/firebowl/off
 	icon_state = "stonefire0"
 	base_state = "stonefire"

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -53,7 +53,7 @@
 			L.visible_message(span_info("[user] starts to warm their hands."), span_info("You warm your hands."))
 			if(do_after(L, 4 SECONDS, target = src))
 				if(L.bodytemperature < BODYTEMP_NORMAL_MIN)
-					L.adjust_bodytemperature(35)
+					L.adjust_bodytemperature(20)
 		return
 
 

--- a/code/game/objects/lighting/rogue_fires.dm
+++ b/code/game/objects/lighting/rogue_fires.dm
@@ -53,7 +53,7 @@
 			L.visible_message(span_info("[user] starts to warm their hands."), span_info("You warm your hands."))
 			if(do_after(L, 4 SECONDS, target = src))
 				if(L.bodytemperature < BODYTEMP_NORMAL_MIN)
-					L.adjust_bodytemperature(20)
+					L.adjust_bodytemperature(10)
 		return
 
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2332,16 +2332,18 @@ GLOBAL_VAR_INIT(cold_breath_overlay, mutable_appearance(
 /datum/species/proc/handle_fire(mob/living/carbon/human/H, no_protection = FALSE)
 	if(!Canignite_mob(H))
 		return TRUE
-
+	
+	// Stops maxing out temp from firestacks alone
+	if(H.bodytemperature > BODYTEMP_HEAT_LEVEL_ONE_MAX)	
+		return
 	var/thermal_protection = H.get_thermal_protection()
 
 	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT && !no_protection)
 		return
-
 	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
 		H.adjust_bodytemperature(1)
 	else
-		H.adjust_bodytemperature(5)	//arbitrary value, but our temp scale runs from 0 to 600 behind the scenes- 455 to heat level 2. standard is 300, thats 30 seconds of being on fire to heatstroke
+		H.adjust_bodytemperature(2)	//arbitrary value, but our temp scale runs from 0 to 600 behind the scenes- 455 to heat level 2. standard is 300, thats 50 seconds of being on fire to top out at lvl 2
 
 /datum/species/proc/Canignite_mob(mob/living/carbon/human/H)
 	if(HAS_TRAIT(H, TRAIT_NOFIRE))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1659,8 +1659,7 @@
  */
 
 /mob/living/proc/on_fire_stack(seconds_per_tick, datum/status_effect/fire_handler/fire_stacks/fire_handler)
-	adjust_bodytemperature(((fire_handler.stacks)) * 0.5 * seconds_per_tick)
-
+	adjust_bodytemperature(((fire_handler.stacks)) * 0.1 * seconds_per_tick)
 /**
  * Adjust the amount of fire stacks on a mob
  *
@@ -1706,6 +1705,9 @@
 		return
 
 	if(HAS_TRAIT(spread_to, TRAIT_NOFIRE) || HAS_TRAIT(src, TRAIT_NOFIRE))
+		return
+
+	if(prob(50))	// 50% chance you don´t catch fire from a bump or walking over a burning corpse. Cause people don´t often bathe in gasoline.
 		return
 
 	var/datum/status_effect/fire_handler/fire_stacks/fire_status = has_status_effect(/datum/status_effect/fire_handler/fire_stacks)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1659,7 +1659,7 @@
  */
 
 /mob/living/proc/on_fire_stack(seconds_per_tick, datum/status_effect/fire_handler/fire_stacks/fire_handler)
-	adjust_bodytemperature(((fire_handler.stacks)) * 0.1 * seconds_per_tick)
+	adjust_bodytemperature(((fire_handler.stacks)) * 0.5 * seconds_per_tick)
 /**
  * Adjust the amount of fire stacks on a mob
  *


### PR DESCRIPTION
## About The Pull Request

I like the temperature system in general. In practice it got some parts thats feels unfinished, tweaks that were needed left undone. This PR tries to fix that.

* Temp increases from firestacks reduced and capped. For max heat death you need warm weather or turf effects too, not just firestacks. Reason - gameplay: quickly maxing up heatstroke on all in fireball range is not good design IMO. This makes it slightly less cancer to bring back people who been left burning for a while, and keeps players in the fight a little bit longer vs fire.

* Bumping into mobs while on fire, and walking over burning mobs, has chance to transmit fire reduced to 50% (from 100)
A little less feeling of being drenched in gasoline, while keeping the potential for chaotic fire spreading, only not quite so fast.

* The temp damage over time on several weathers tweaked a little to allow some more exposure time without being immediatly crippling

* Frostbite dont occur any more. Max low temp still gives you hypothermia, and the healing of hypothermia no longer instant once you heat up, it got a 50% to fire each minute, to give some short/medium-term consequences of the exposure.
Reason - Frostbite is terribly implemented, inflicting unique wounds on players with no clear feedback how to fix that also messes up your screen slightly etc is not great. If reworked it could work, or simply flesh out hypothermia a bit, but in this state its better to not have it. Fleshing out hypo is the better choice anyways.

* Braziers got the ability to warm your hands readded. Modest heat boost after 4 second interaction. Reason - its minor, and theres way too few easy to grasp ways to interact with the temp system.

## Testing Evidence

Tested locally by fireballing and weatherspamming the little dudes.
<img width="1101" height="597" alt="temp" src="https://github.com/user-attachments/assets/5e309cef-d87e-4c6a-a5dd-4c906c00f042" />

## Why It's Good For The Game

Doesn´t solve every issue concerning temp, and the values might need tweaking again a little in the future, but overall it solves several glaring issues. Needs TM for tweaks of course, local testing worked well.

## Changelog

:cl:
add: brazier heat hands on r-click (+temp)
del: hypothermia no longer progress to frostbite
qol: several weathers tweaked average temp per tick effect
balance: firestacks slower to raise temp and caps out before the max on their own, still give mega heatstroke but less time to cool down
code: bumping into mobs while on fire, and walking over burning mobs now 50% chance to spread not 100
/:cl:
