### PR TITLE
NPCs no longer bait, or specifically detect player ripostes to feint them

### DIFF
--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -62,6 +62,9 @@
 	//If we utilize our intents further outside of strong intent.
 	var/smart_combatant = FALSE
 
+	//If we utilize straight-up unfair tactics.
+	var/unfair_tactician = FALSE
+
 /mob/living/carbon/human/Initialize(mapload)
 	. = ..()
 	our_cells = new(interesting_dist, interesting_dist, 1)
@@ -578,7 +581,7 @@
 		return retaliator.aggressive
 	else if(istype(L, /mob/living/simple_animal/hostile))
 		return TRUE
-	
+
 	return FALSE
 
 /mob/living/carbon/human/proc/npc_try_backstep()
@@ -837,7 +840,7 @@
 	OffWeapon = get_inactive_held_item()
 
 	//Feint Riposte check before we do any further attacks to teach our enemy a lesson.
-	if(smart_combatant && istype(Weapon, /obj/item/rogueweapon)) //Make sure we have a proper weapon in hand. No feinting with a stick or some shit.
+	if(unfair_tactician && istype(Weapon, /obj/item/rogueweapon)) //Make sure we have a proper weapon in hand. No feinting with a stick or some shit.
 		if(!has_status_effect(/datum/status_effect/debuff/feintcd) && target.has_status_effect(/datum/status_effect/buff/clash))
 			if(possible_rmb_intents & /datum/rmb_intent/feint)
 				swap_rmb_intent(/datum/rmb_intent/feint)
@@ -881,20 +884,20 @@
 			var/obj/item/rogueweapon/actual_weapon = Weapon
 			var/weapon_intents = actual_weapon.possible_item_intents
 			var/weapon_special_intents = actual_weapon.special
-			
+
 			if(length(weapon_intents) > 1 && !has_status_effect(/datum/status_effect/debuff/swapped_intent_npc))
 				did_we_change_intent = TRUE
-				rog_intent_change(rand(1, length(weapon_intents))) 
+				rog_intent_change(rand(1, length(weapon_intents)))
 				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
 
-			if(special_attacker && prob(50) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
+			if(special_attacker && prob(10) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
 				if(weapon_special_intents)
 					if(possible_rmb_intents & /datum/rmb_intent/strong)
 						swap_rmb_intent(/datum/rmb_intent/strong)
 						try_special_attack(target)
 						return TRUE //We used our special intent on the target as soon as we could.
 
-			if(smart_combatant && prob(50)) // Only if we use rmb intents...
+			if(smart_combatant && prob(10)) // Only if we use rmb intents...
 				if(possible_rmb_intents)
 					if(!has_status_effect(/datum/status_effect/debuff/feintcd))
 						if(possible_rmb_intents & /datum/rmb_intent/feint && rmb_intent != /datum/rmb_intent/feint && prob(50))
@@ -907,7 +910,7 @@
 							try_special_attack(target)
 							return TRUE
 					else if(!has_status_effect(/datum/status_effect/debuff/baitcd)) //May work sometimes; more than likely it wont however.
-						if(possible_rmb_intents & /datum/rmb_intent/aimed && rmb_intent != /datum/rmb_intent/aimed) //Default to aimed as the final choice to attempt baiting.
+						if(unfair_tactician && possible_rmb_intents & /datum/rmb_intent/aimed && rmb_intent != /datum/rmb_intent/aimed) //Default to aimed as the final choice to attempt baiting.
 							swap_rmb_intent(/datum/rmb_intent/aimed)
 							try_special_attack(target)
 							return TRUE

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -578,7 +578,7 @@
 		return retaliator.aggressive
 	else if(istype(L, /mob/living/simple_animal/hostile))
 		return TRUE
-	
+
 	return FALSE
 
 /mob/living/carbon/human/proc/npc_try_backstep()
@@ -836,15 +836,6 @@
 	Weapon = get_active_held_item()
 	OffWeapon = get_inactive_held_item()
 
-	//Feint Riposte check before we do any further attacks to teach our enemy a lesson.
-	if(smart_combatant && istype(Weapon, /obj/item/rogueweapon)) //Make sure we have a proper weapon in hand. No feinting with a stick or some shit.
-		if(!has_status_effect(/datum/status_effect/debuff/feintcd) && target.has_status_effect(/datum/status_effect/buff/clash))
-			if(possible_rmb_intents & /datum/rmb_intent/feint)
-				swap_rmb_intent(/datum/rmb_intent/feint)
-				if(Adjacent(target))
-					try_special_attack(target)
-					return TRUE //Attempt to feint and ruin their clash...
-
 	// What is the chance we try to grab with our offhand?
 	var/make_grab_chance = Weapon ? 5 : 20 // If unarmed, 20% chance; otherwise 5%
 	var/use_grab_chance = 30 // 30% chance to use a grab if we already have one
@@ -881,10 +872,10 @@
 			var/obj/item/rogueweapon/actual_weapon = Weapon
 			var/weapon_intents = actual_weapon.possible_item_intents
 			var/weapon_special_intents = actual_weapon.special
-			
+
 			if(length(weapon_intents) > 1 && !has_status_effect(/datum/status_effect/debuff/swapped_intent_npc))
 				did_we_change_intent = TRUE
-				rog_intent_change(rand(1, length(weapon_intents))) 
+				rog_intent_change(rand(1, length(weapon_intents)))
 				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
 
 			if(special_attacker && prob(50) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
@@ -904,11 +895,6 @@
 					else if(!has_status_effect(/datum/status_effect/debuff/clashcd))
 						if(possible_rmb_intents & /datum/rmb_intent/riposte && rmb_intent != /datum/rmb_intent/riposte && prob(50))
 							swap_rmb_intent(/datum/rmb_intent/riposte)
-							try_special_attack(target)
-							return TRUE
-					else if(!has_status_effect(/datum/status_effect/debuff/baitcd)) //May work sometimes; more than likely it wont however.
-						if(possible_rmb_intents & /datum/rmb_intent/aimed && rmb_intent != /datum/rmb_intent/aimed) //Default to aimed as the final choice to attempt baiting.
-							swap_rmb_intent(/datum/rmb_intent/aimed)
 							try_special_attack(target)
 							return TRUE
 

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -890,14 +890,14 @@
 				rog_intent_change(rand(1, length(weapon_intents)))
 				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
 
-			if(special_attacker && prob(10) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
+			if(special_attacker && prob(5) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
 				if(weapon_special_intents)
 					if(possible_rmb_intents & /datum/rmb_intent/strong)
 						swap_rmb_intent(/datum/rmb_intent/strong)
 						try_special_attack(target)
 						return TRUE //We used our special intent on the target as soon as we could.
 
-			if(smart_combatant && prob(10)) // Only if we use rmb intents...
+			if(smart_combatant && prob(5)) // Only if we use rmb intents...
 				if(possible_rmb_intents)
 					if(!has_status_effect(/datum/status_effect/debuff/feintcd))
 						if(possible_rmb_intents & /datum/rmb_intent/feint && rmb_intent != /datum/rmb_intent/feint && prob(50))

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -578,7 +578,7 @@
 		return retaliator.aggressive
 	else if(istype(L, /mob/living/simple_animal/hostile))
 		return TRUE
-
+	
 	return FALSE
 
 /mob/living/carbon/human/proc/npc_try_backstep()
@@ -836,6 +836,15 @@
 	Weapon = get_active_held_item()
 	OffWeapon = get_inactive_held_item()
 
+	//Feint Riposte check before we do any further attacks to teach our enemy a lesson.
+	if(smart_combatant && istype(Weapon, /obj/item/rogueweapon)) //Make sure we have a proper weapon in hand. No feinting with a stick or some shit.
+		if(!has_status_effect(/datum/status_effect/debuff/feintcd) && target.has_status_effect(/datum/status_effect/buff/clash))
+			if(possible_rmb_intents & /datum/rmb_intent/feint)
+				swap_rmb_intent(/datum/rmb_intent/feint)
+				if(Adjacent(target))
+					try_special_attack(target)
+					return TRUE //Attempt to feint and ruin their clash...
+
 	// What is the chance we try to grab with our offhand?
 	var/make_grab_chance = Weapon ? 5 : 20 // If unarmed, 20% chance; otherwise 5%
 	var/use_grab_chance = 30 // 30% chance to use a grab if we already have one
@@ -872,10 +881,10 @@
 			var/obj/item/rogueweapon/actual_weapon = Weapon
 			var/weapon_intents = actual_weapon.possible_item_intents
 			var/weapon_special_intents = actual_weapon.special
-
+			
 			if(length(weapon_intents) > 1 && !has_status_effect(/datum/status_effect/debuff/swapped_intent_npc))
 				did_we_change_intent = TRUE
-				rog_intent_change(rand(1, length(weapon_intents)))
+				rog_intent_change(rand(1, length(weapon_intents))) 
 				apply_status_effect(/datum/status_effect/debuff/swapped_intent_npc) //45 seconds before we swap to a new weapon intent entirely.
 
 			if(special_attacker && prob(50) && !has_status_effect(/datum/status_effect/debuff/specialcd)) //Only if we use specials...
@@ -895,6 +904,11 @@
 					else if(!has_status_effect(/datum/status_effect/debuff/clashcd))
 						if(possible_rmb_intents & /datum/rmb_intent/riposte && rmb_intent != /datum/rmb_intent/riposte && prob(50))
 							swap_rmb_intent(/datum/rmb_intent/riposte)
+							try_special_attack(target)
+							return TRUE
+					else if(!has_status_effect(/datum/status_effect/debuff/baitcd)) //May work sometimes; more than likely it wont however.
+						if(possible_rmb_intents & /datum/rmb_intent/aimed && rmb_intent != /datum/rmb_intent/aimed) //Default to aimed as the final choice to attempt baiting.
+							swap_rmb_intent(/datum/rmb_intent/aimed)
 							try_special_attack(target)
 							return TRUE
 

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -62,7 +62,7 @@
 	//If we utilize our intents further outside of strong intent.
 	var/smart_combatant = FALSE
 
-	//If we utilize straight-up unfair tactics.
+	/// If TRUE, the NPC uses straight-up unfair tactics like baiting and aggressive feinting.
 	var/unfair_tactician = FALSE
 
 /mob/living/carbon/human/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

NPC behavior of using baits and intentionally spoiling ripostes has been moved to a new variable, unfair_tactician.
NPCs will generally use special abilities less often. 

Currently, unfair_tactician is not used by any NPCs, but could be given to specific, particularly dangerous SINGLE UNIT bosses or contract targets, or some future addition. 

## Testing Evidence

Compiled, ran a local server and fought some bogmen. 

## Why It's Good For The Game

The smarter AI adds *some* interesting variance to NPC fights, but misses the mark on creating an enjoyable experience for melee adventurers who actually need to fight the things. We designed POIs with the idea that the AI would need to swarm players with numbers in order to provide a challenge because they were essentially weapons with legs and stats. They swarm, they come 2-3 to a room (or sometimes more), and just generally don't need to do as much as they currently do.

Specifically, they will no longer attempt to bait the player - there is simply no way for this to feel fair, you are often fighting multiple enemies and a certain level of expedient lethality is required of you, especially as an adventurer. This means you are aiming neck and doing everything within your power to end the fight quickly, and getting baited constantly is overbearing when used in conjunction with feints, ripostes, and specials used on-cooldown. 

They also do not **intentionally** prioritize feinting when you are trying to riposte. They may still do so as a matter of timing, but they are not **guaranteed** to screw you over because you weren't accurately tracking the feint cooldowns of several NPCs you're fighting simultaneously.

They should perform special actions less often, though in testing this proved not to be especially effective because they still use abilities basically on-cooldown regardless. In a 1v1 (warden forester vs. advanced bogman), they used their weapon special twice, feinted twice, and defended once.

I think that we could stand to be a little nicer to adventurers, particularly new adventurers, than throwing them to the wolves with bogmen who fight better than half of our actual players do. 

I do not care that you (the reader) can fight your way through six bogmen with no gear, apprentice weapon skills, and a kitchen knife. I'm *relatively good* at the game and I found this incredibly unfun to deal with.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: CameronWoof
balance: Slightly reduces the "intelligence" of NPC enemies. They will no longer bait or intentionally feint against guards, and will use special attacks and combat abilities slightly less.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
