### PR TITLE
Revert "Allows Fluvians to be Underdweller mercenaries", uses erroneous lore from Origins

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/underdweller.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/foreigner/underdweller.dm
@@ -11,7 +11,6 @@
 		/datum/species/kobold,
 		/datum/species/goblinp,				//Might be a little weird but goblins do reside in caves, and they could use a unique merc class type.
 		/datum/species/anthromorphsmall,	//Basically all under-ground races. Perfect for cave-clearing.
-		/datum/species/moth,
 	)
 	outfit = /datum/outfit/job/roguetown/adventurer/underdweller
 	class_select_category = CLASS_CAT_RACIAL
@@ -40,7 +39,7 @@
 		/datum/skill/misc/medicine = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/smelting = SKILL_LEVEL_APPRENTICE,	//Accompanies mining; they know how to smelt, not make armor though.
 	)
-	extra_context = "This subclass is race-limited to: Dwarves, Dark Elves, Kobolds, Fluvians, Goblins & Verminvolk."
+	extra_context = "This subclass is race-limited to: Dwarves, Dark Elves, Kobolds, Goblins & Verminvolk."
 
 /datum/outfit/job/roguetown/adventurer/underdweller/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
Reverts Rotwood-Vale/Ratwood-2.0#2448, as it relies on preceding lore that does not exist on this server, mistakenly believed to be the case due to the origins PR that references "Mercuriam", which is lore from another server mistakenly transplanted here.