### PR TITLE
Fixes erroneous lore in origins.dm

### DIFF
--- a/modular/origins/origins.dm
+++ b/modular/origins/origins.dm
@@ -50,8 +50,8 @@ GLOBAL_LIST_INIT(origins, build_origins())
 
 /datum/origin/underdark
 	name = "The Underdark"
-	desc = "Said to be an immense network of caves and tunnels located all throughout the crust of Grimoria, the Underdark is home to the Dark Elves and the Kobolds, as well \
-	as the elusive Fluvian city-state of Mercuriam. The caverns of the Underdark are filled with many threats from rivers of acid to man-eating spiders; and even exaggerated \
+	desc = "Said to be an immense network of caves and tunnels located all throughout the crust of Grimoria, the Underdark is home to the Dark Elves and the Kobolds. \
+	The caverns of the Underdark are filled with many threats from rivers of acid to man-eating spiders; and even exaggerated \
 	reports of dragons beneath."
 	origin_title = "the Underdark"
 	map_x = 120


### PR DESCRIPTION
## About The Pull Request

<img width="498" height="278" alt="giphy" src="https://github.com/user-attachments/assets/26c3fb9a-30df-4bc0-ab9c-043a58e03dc3" />


## Testing Evidence

<img width="265" height="170" alt="sYZQHhVPLs" src="https://github.com/user-attachments/assets/87dee1ca-8844-476f-a297-9e8654570289" />


## Why It's Good For The Game

Mercuriam is a hallucination from spending too much time in the Underdark, mistakenly believed to exist despite having no actual proof to its existence, whatsoever. This has somehow led people to believed that Fluvians are a subterranean race. Your water supply has been unleaded.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed the collective hallucinated city-state of Mercuriam.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
