### PR TITLE
Reworks the prude chastity PR to actually gate content instead of just removing it (you're welcome)

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -615,7 +615,7 @@
 		var/chastity_name = get_examine_item_name_with_hover(user, worn_chastity)
 		var/cage_exposed = get_location_accessible(src, BODY_ZONE_PRECISE_GROIN)
 		var/do_we_know_chat = (user == src)
-		if(cage_exposed)
+		if(cage_exposed || modular_chastity_observer_on(user))
 			. += "[m1] secured in [chastity_name]. "
 		else if(do_we_know_chat)
 			. += span_italics("[m1] covertly secured in [chastity_name]. ")

--- a/modular/code/datums/components/intimate_reaction.dm
+++ b/modular/code/datums/components/intimate_reaction.dm
@@ -631,7 +631,7 @@
 		return FALSE
 
 	if(device.chastity_move_sound)
-		playsound(source, device.chastity_move_sound, device.chastity_move_volume, TRUE)
+		modular_chastity_sounds_on(source, device.chastity_move_sound, device.chastity_move_volume)
 
 	var/datum/sex_controller/wearer_sexcon = source.sexcon
 	if(!wearer_sexcon || !wearer_sexcon.modular_chastity_content_enabled_for(source))

--- a/modular/code/datums/sexcon/chastity_helpers.dm
+++ b/modular/code/datums/sexcon/chastity_helpers.dm
@@ -1,3 +1,23 @@
+/// Returns TRUE if the observing mob has the "Enable Chastity Content" preference toggle on.
+/// Gates whether an observer can always see/hear someone else's chastity device regardless of clothing coverage.
+/// Mobs with no client (NPCs, etc.) never bypass the coverage check via this proc.
+/proc/modular_chastity_observer_on(mob/user)
+	return !!(user?.client?.prefs?.chastenable)
+
+/// Plays a chastity movement sound to nearby mobs, gated by each individual listener's chastity preference.
+/// The wearer always hears their own device. Other listeners within range only hear it if they have
+/// chastity content enabled — this keeps the ambient jingle from broadcasting to players who opted out.
+/proc/modular_chastity_sounds_on(mob/living/carbon/human/wearer, soundin, volume, range = 5)
+	if(!wearer || !soundin)
+		return
+	var/turf/source_turf = get_turf(wearer)
+	if(!source_turf)
+		return
+	for(var/mob/M as anything in get_hearers_in_range(range, source_turf))
+		if(M != wearer && !modular_chastity_observer_on(M))
+			continue
+		M.playsound_local(source_turf, soundin, volume, TRUE)
+
 /// Plays a chastity movement sound (jingle, rattle, etc.) when a sex action involves a wearer.
 /// Checks both user and action_target for a chastity device — whichever has one produces the sound.
 /// Probability scales with action speed. Volume scales with sex force tier (MID→HIGH→EXTREME).

--- a/modular/code/datums/sexcon/chastity_helpers.dm
+++ b/modular/code/datums/sexcon/chastity_helpers.dm
@@ -13,7 +13,9 @@
 	var/turf/source_turf = get_turf(wearer)
 	if(!source_turf)
 		return
-	for(var/mob/M as anything in get_hearers_in_range(range, source_turf))
+	// Must scope to client mobs only — the default hearing-sensitive contents list also includes
+	// non-mob atoms (bells, scomm devices, etc.), which have no playsound_local() to call.
+	for(var/mob/M as anything in get_hearers_in_range(range, source_turf, RECURSIVE_CONTENTS_CLIENT_MOBS))
 		if(M != wearer && !modular_chastity_observer_on(M))
 			continue
 		M.playsound_local(source_turf, soundin, volume, TRUE)

--- a/modular/code/modules/mob/living/carbon/examine_hooks.dm
+++ b/modular/code/modules/mob/living/carbon/examine_hooks.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/proc/carbon_modular_examine_extension(mob/user, t_He, m1, m2, m3)
 	var/list/lines = list()
-	if(sexcon?.has_chastity_cage() && get_location_accessible(src, BODY_ZONE_PRECISE_GROIN))
+	if(sexcon?.has_chastity_cage() && (get_location_accessible(src, BODY_ZONE_PRECISE_GROIN) || modular_chastity_observer_on(user)))
 		lines += "[t_He] is wearing a chastity device!\n"
 	return lines
 


### PR DESCRIPTION
## About The Pull Request

Recently someone made a prudish spite pr (https://github.com/Rotwood-Vale/Ratwood-2.0/pull/2374) to shit on people who want to make use of chastity content. Gating fetishes behind prefs is the proper solution here, where they made it so that you can never see chastity devices through clothing ever. Now it is gated on ghosting/through clothes by the chastity content toggle, as is hearing the noises (you will not hear them at all if the toggle is off).

Just because a fetish is not your thing or you do not understand it does not mean it's fair to remove it for everyone. Part of the fetish is the exhibitionism/humiliation, removing that completely (and breaking it) just kills that completely.

On top of that, it doesn't even work properly. Currently looking at someone who is completely nude with a chastity device on, and you can't even see it still, yet it was full merged. Tsk.

If you hate fetish content, don't just spite remove it. Listen to feedback and do the job properly, or don't do it at all.

## Testing Evidence

Examine of someone naked in device, toggle on
<img width="570" height="337" alt="image" src="https://github.com/user-attachments/assets/8a9d70d9-d45a-400b-9474-91587345c460" />

Examine of someone naked in device, toggle off
<img width="613" height="396" alt="image" src="https://github.com/user-attachments/assets/4fffcacb-a18a-4794-b372-0d6874feb182" />

Examine of someone clothed, toggle on
<img width="621" height="341" alt="image" src="https://github.com/user-attachments/assets/de4096a4-ba41-4b4f-8af4-dd973d8b6e19" />

Examine of someone clothed, toggle off
<img width="667" height="313" alt="image" src="https://github.com/user-attachments/assets/dfd45a8b-7872-4bfa-bd47-e3edc4f890a2" />


## Why It's Good For The Game

Ratwood is supposed to be a place that permits fetish content. Allowing stuff for everyone is reasonably not wanted, but spitefully going completely the other way and gutting a system completely when we have systems in place to allow this to be gated to those who want it is entirely unnecessary, and on top of that, was done poorly and not tested breaking it entirely. This now properly gates the content without ruining it for those of us who do enjoy it.

## Changelog

:cl:
fix: Fixes the sad spite PR that tried to kill half the chastity system and instead was not tested and broke it entirely. Now chastity content is gated behind the toggle. With toggle on you can see devices through clothes, hear jingles and see them as a ghost. With the toggle off you will only see them when someone is unclothed, and will never hear the sounds nor see them as a ghost.
/:cl:
