### PR TITLE
Adds an assortment of unarmed options to steel-tier Conjure Weapon

### DIFF
--- a/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
+++ b/code/modules/spells/spell_types/wizard/conjure/conjure_weapon.dm
@@ -49,10 +49,14 @@
 		"Zweihander" = /obj/item/rogueweapon/greatsword/grenz,
 		"Battle Axe" = /obj/item/rogueweapon/stoneaxe/battle,
 		"Steel Dagger" = /obj/item/rogueweapon/huntingknife/idagger/steel,
+		"Punch Dagger" = /obj/item/rogueweapon/katar/punchdagger,
+		"Katar" = /obj/item/rogueweapon/katar,
 		"Halberd" = /obj/item/rogueweapon/halberd,
 		"Steel Warhammer" = /obj/item/rogueweapon/mace/warhammer/steel,
 		"Steel Flail" = /obj/item/rogueweapon/flail/sflail,
 		"Whip" = /obj/item/rogueweapon/whip,
+		"Steel Knuckles" = /obj/item/rogueweapon/knuckles,
+		"Hound Claws" = /obj/item/rogueweapon/handclaw,
 	)
 
 /obj/effect/proc_holder/spell/invoked/conjure_weapon/cast(list/targets, mob/living/user = usr)


### PR DESCRIPTION
## About The Pull Request

Really simple. This adds the following to the Conjure Weapon 12+ int summon list:

- Punch dagger
- Katar (standard)
- Steel knuckles
- Hound Claws (iron)

## Testing Evidence

<img width="302" height="232" alt="dreamseeker_I8zZTCLJiU" src="https://github.com/user-attachments/assets/087059c3-2b2a-4db3-b01e-42dadde574d7" />

## Why It's Good For The Game

No unarmed options in this list has been the woe of people who want to play spellfist type adventurers for a long, long while. I decided against putting mantis claws in because most builds have enchant weapon + conjure weapon and it was just way too much force, especially on something with rend.

Not sure if claws should be in there at all, to be honest. Commenters will be pretty quick to make this apparent.

## Changelog

:cl: Ephemeralis
add: Punch daggers, katars, steel knuckles and hound claws are now available as options for the Conjure Weapon spell, as long as you have at least 12 intelligence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
