### PR TITLE
Gave Naziby masks sandstone immunity

### DIFF
--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -647,13 +647,12 @@
 /obj/item/clothing/mask/rogue/lordmask/naledi/equipped(mob/user, slot)
 	..()
 	if(slot == SLOT_WEAR_MASK || slot == SLOT_HEAD)
-		ADD_TRAIT(user, TRAIT_SANDSTORM_GOGGLES, "generic")
+		ADD_TRAIT(user, TRAIT_SANDSTORM_GOGGLES, CLOTHING_TRAIT)
 	user.update_fov_angles()
 
 /obj/item/clothing/mask/rogue/lordmask/naledi/dropped(mob/user)
 	..()
-	if(HAS_TRAIT(user, TRAIT_SANDSTORM_GOGGLES))
-		REMOVE_TRAIT(user, TRAIT_SANDSTORM_GOGGLES, "generic")
+	REMOVE_TRAIT(user, TRAIT_SANDSTORM_GOGGLES, CLOTHING_TRAIT)
 	user.update_fov_angles()
 
 

--- a/code/modules/clothing/rogueclothes/mask.dm
+++ b/code/modules/clothing/rogueclothes/mask.dm
@@ -644,6 +644,19 @@
 	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_CHOP, BCLASS_BLUNT)
 	sellprice = 0
 
+/obj/item/clothing/mask/rogue/lordmask/naledi/equipped(mob/user, slot)
+	..()
+	if(slot == SLOT_WEAR_MASK || slot == SLOT_HEAD)
+		ADD_TRAIT(user, TRAIT_SANDSTORM_GOGGLES, "generic")
+	user.update_fov_angles()
+
+/obj/item/clothing/mask/rogue/lordmask/naledi/dropped(mob/user)
+	..()
+	if(HAS_TRAIT(user, TRAIT_SANDSTORM_GOGGLES))
+		REMOVE_TRAIT(user, TRAIT_SANDSTORM_GOGGLES, "generic")
+	user.update_fov_angles()
+
+
 /obj/item/clothing/mask/rogue/lordmask/naledi/sojourner
 	name = "sojourner's mask"
 	item_state = "naledimask"


### PR DESCRIPTION
## About The Pull Request
Naziby golden masks now give the same sandstone immunity that: Spectacles, engieniring ones and sand gogles have
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="1542" height="684" alt="Zrzut ekranu 2026-08-20 195421" src="https://github.com/user-attachments/assets/26f98b42-9bc5-4bd8-b9b0-a2db7827a414" />

<img width="1923" height="729" alt="Zrzut ekranu 2026-08-20 195444" src="https://github.com/user-attachments/assets/7abd0f92-385b-4557-bac6-9f5bdb9c8bc0" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
First, naziby canot not wear their masks since jins exist lore wise and steep penalty exists game wise
Second they are from the desert, to be even more exact from the deepest, demon infested part of the desert. Them making masks in a way that lets them survive sandstorms have every reason to be true.
Combining - they cant use other masks with grant this trait and there are lore reasons aplenty for their masks to provide it hence now they do.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Naziby golden masks now provide the same sandstorm immunity sand gogles do
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
