### PR TITLE
Mounted knight grand mace > steel mace

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
@@ -66,10 +66,10 @@
 				beltr = /obj/item/quiver/arrows
 				beltl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/recurve
 				H.adjust_skillrank_up_to(/datum/skill/combat/polearms, SKILL_LEVEL_MASTER, TRUE)
-			if("Grand Mace + Longbow")
+			if("Steel Mace + Longbow")
 				backl = /obj/item/gun/ballistic/revolver/grenadelauncher/bow/longbow
 				beltr = /obj/item/quiver/arrows
-				beltl = /obj/item/rogueweapon/mace/goden/steel
+				beltl = /obj/item/rogueweapon/mace/steel
 				H.adjust_skillrank_up_to(/datum/skill/combat/maces, SKILL_LEVEL_MASTER, TRUE)
 			if("Sabre + Recurve Bow")
 				l_hand = /obj/item/rogueweapon/scabbard/sword/noble

--- a/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/knight/knight_mounted.dm
@@ -47,7 +47,7 @@
 		var/weapons = list(
 			"Longsword + Crossbow",
 			"Billhook + Recurve Bow",
-			"Grand Mace + Longbow",
+			"Steel Mace + Longbow",
 			"Sabre + Recurve Bow",
 			"Lance + Kite Shield"
 		)


### PR DESCRIPTION
## About The Pull Request
Changes the mounted knight's grand mace + longbow option to steel mace + longbow instead.

## Testing Evidence

## Why It's Good For The Game
Currently, the mounted knight's grand mace does not spawn because it can no longer go in the belt slot like it could when the loadout was introduced. While this could be fixed by setting the grand mace to spawn in hand, it would probably make more sense for the loadout to spawn with a smaller mace that they can put on the belt while using the bow - currently they would have to clear out a back slot for a greatweapon strap to stow their grand mace or drop it to use their ranged weapon.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: changes the mounted knight's longbow and grand mace option to longbow and steel mace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
