### PR TITLE
Add aerosolize as a pestrian miracle

### DIFF
--- a/code/datums/gods/patrons/divine/pestra.dm
+++ b/code/datums/gods/patrons/divine/pestra.dm
@@ -15,8 +15,10 @@
 					/obj/effect/proc_holder/spell/invoked/pestilent_blade		= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/pestra_heal			= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/attach_bodypart		= CLERIC_T2,
+					/obj/effect/proc_holder/spell/invoked/aerosolize/miracle	= CLERIC_T2,
 					/obj/effect/proc_holder/spell/invoked/heal					= CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/cure_rot				= CLERIC_T3,
+					/obj/effect/proc_holder/spell/invoked/aerosolize/wave/miracle = CLERIC_T3,
 					/obj/effect/proc_holder/spell/invoked/resurrect/pestra		= CLERIC_T4,
 	)
 	confess_lines = list(

--- a/code/modules/spells/roguetown/acolyte/pestra.dm
+++ b/code/modules/spells/roguetown/acolyte/pestra.dm
@@ -673,3 +673,19 @@
 
 	revert_cast()
 	return FALSE
+
+
+/obj/effect/proc_holder/spell/invoked/aerosolize/miracle
+	name = "Pestras Smoke"
+	miracle = TRUE
+	devotion_cost = 50
+	invocations = list("Pestra, spread my work!")
+	associated_skill = /datum/skill/magic/holy
+
+
+/obj/effect/proc_holder/spell/invoked/aerosolize/wave/miracle
+	name = "Pestras Wave"
+	miracle = TRUE
+	devotion_cost = 75
+	invocations = list("Godes of medicine and disease, spread your gifts and banes!")
+	associated_skill = /datum/skill/magic/holy


### PR DESCRIPTION
## About The Pull Request
Added Areolise spell as T2 miracle for 50 devotion
Added areolise wawe spell as T3 miracle for 75
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Gone into testing map, miracles present or acolite, work as they shoudl

Inidently aerosolise incantation is broken and isnt shouted, i tested spell version and the problem is inhereted from there, but i got 0 idea whats causing it so I left it alone
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Pestras is goddess of medicine and godes of poisons (if she is goddess of somthing, she is also goddes of thats thing oposite, thats her consistent feature) and as such a spell with makes it posible to spread medicine and poisons fits inside her spellist.

Since rework using the normal areolise is a risky afair, since you are surounded by your own smoke and unlike the zizos undead priest wisards, you are not immune to your own gases. So any ofensive uses for the spell are self sacrificing in nature. Hence the templars with the T2 being their limit are limited to the base spell.
The way i imagine it being used is mostly sharing buffinng potions and/or healing ones before a fight, maybe as a smokescreen in battle. 
T3 version same as wisard one has more ofensive aplication, but is dogeble and is mostly limited to not combat oriented acolite/keeper (i dont remeber any notable T3 casters, most are either T2 or T4). It can also be used to flood the hospital with healing mixes with i think will be the main use of it with how often the resident pestrian there has to deal with 5 people dying at once.

In the end my main resoning is that if its fine for wisards to have after the rework, with i do belive is a case, then it shoudl be fine for acolites of goddes of medicine/poison to use to.

It also helps give a bit more variaty to pestras list as its curently: heal prep, tox/blood heal, minor tox resuorce generator, resource using mele debuff (the only two not heals), resource using heal, lost limb heal, zombie heal (this shoudl realy be more widly aplicable), healing buff, death heal, hidden uber heal
Ritual is also just a very strong heal
I think you see why i wish there was a bit more variety in this spellist?

This can be test merged of course and rejected if it turns out to actualy cause some major problems i didnt foresee.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: New T2 pestrian miracle, aerosolize
add: New T3 pestrian miracle, aerosolize wave
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
