### PR TITLE
Fixes Inspector Statlines so they can wield their chosen weapon

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritanclasses/inspector.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritanclasses/inspector.dm
@@ -100,6 +100,7 @@
 			H.put_in_hands(new /obj/item/rogueweapon/whip/antique/psywhip(H), TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
 			H.change_stat(STATKEY_STR, 2)
+			H.change_stat(STATKEY_INT, -1)
 		if("Stigmata (Halberd)")
 			H.put_in_hands(new /obj/item/rogueweapon/halberd/psyhalberd/relic(H), TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H), TRUE)

--- a/code/modules/jobs/job_types/roguetown/Inquisition/puritanclasses/inspector.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/puritanclasses/inspector.dm
@@ -20,9 +20,9 @@
 		TRAIT_OUTLANDER
 		)
 	subclass_stats = list(
-		STATKEY_WIL = 3,
+		STATKEY_WIL = 2,
 		STATKEY_CON = 2,
-		STATKEY_SPD = 2,
+		STATKEY_SPD = 1,
 		STATKEY_PER = 2,
 		STATKEY_INT = 1
 	)
@@ -88,21 +88,30 @@
 			H.put_in_hands(new /obj/item/rogueweapon/sword/long/psysword/preblessed(H), TRUE)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+			H.change_stat(STATKEY_WIL, 1) // the stats for each weapon choice was retuned to ensure appropriate STR values for wielding. Otherwise, returned to original statline.
+			H.change_stat(STATKEY_SPD, 1)
 		if("Psydonic Rapier")
 			H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy/preblessed(H), TRUE)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+			H.change_stat(STATKEY_WIL, 1)
+			H.change_stat(STATKEY_SPD, 1)
 		if("Daybreak (Whip)")
 			H.put_in_hands(new /obj/item/rogueweapon/whip/antique/psywhip(H), TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 5, TRUE)
+			H.change_stat(STATKEY_STR, 2)
 		if("Stigmata (Halberd)")
 			H.put_in_hands(new /obj/item/rogueweapon/halberd/psyhalberd/relic(H), TRUE)
 			H.put_in_hands(new /obj/item/rogueweapon/scabbard/gwstrap(H), TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/polearms, 5, TRUE)
+			H.change_stat(STATKEY_WIL, 1)
+			H.change_stat(STATKEY_STR, 1)
 		if("Eucharist (Rapier)")
 			H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy/relic(H), TRUE)
 			H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L, TRUE)
 			H.adjust_skillrank_up_to(/datum/skill/combat/swords, 5, TRUE)
+			H.change_stat(STATKEY_WIL, 1)
+			H.change_stat(STATKEY_SPD, 1)
 	var/quivers = list("Bolts - Steel-Tipped", "Sunderbolts - Silver-Tipped, Halved Damage")
 	var/bolt_choice = input(H,"CHOOSE YOUR MUNITIONS.", "TAKE UP PSYDON'S MISSILES.") as anything in quivers
 	switch(bolt_choice)


### PR DESCRIPTION
## About The Pull Request

Took 1 WIL 1 SPD away from base statline
Added adjustments to statlines for each weapon type reflecting these 2 points removed

## Why It's Good For The Game

The Inspector as it stands cannot wield either his halberd (1 handed anyways) nor his whip options without dropping them due to strength requirements.
It is **expected** that when choosing a weapon, the base statline should be enough to wield it.

This was not the case.
Inquisitors picking whip and only having 10-11 strength and thus unable to wield it was a big problem.
This fixes that.

## Changelog

:cl:
fix: Retuned Inspector statline/weapon choices so he's able to wield them at all
/:cl: