### PR TITLE
Makes (some) previously unselectable voicepacks selectable

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -152,8 +152,11 @@ GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_FEM, VOICE_T
 #define VOICE_PACK_MASC_ELF "Elvish (Masc)"
 #define VOICE_PACK_MASC_DWARF "Dwarvish (Masc)"
 #define VOICE_PACK_FOP	"Foppish (Masc)"
+#define VOICE_PACK_EVIL "Evil (Masc)"
+#define VOICE_PACK_ZETH "Zeth (Masc)"
 #define VOICE_PACK_KNIGHT "Knightly (Masc)"
 #define VOICE_PACK_WARRIOR "Warrior (Masc)"
+#define VOICE_PACK_WIZARD "Wizardly (Masc)"
 #define VOICE_PACK_ROTMAN "Rotman (Masc)"
 #define VOICE_PACK_FEM	"Feminine"
 #define VOICE_PACK_FEM_DAINTY "Dainty (Fem)"
@@ -166,13 +169,20 @@ GLOBAL_LIST_INIT(voice_types_list, list(VOICE_TYPE_MASC, VOICE_TYPE_FEM, VOICE_T
 GLOBAL_LIST_INIT(voice_packs_list, list(
 	VOICE_PACK_DEFAULT = null,
 	VOICE_PACK_MASC = /datum/voicepack/male,
+	VOICE_PACK_MASC_ELF = /datum/voicepack/male/elf,
+	VOICE_PACK_MASC_DWARF = /datum/voicepack/male/dwarf,
+	VOICE_PACK_EVIL = /datum/voicepack/male/evil,
+	VOICE_PACK_ZETH = /datum/voicepack/male/zeth,
 	VOICE_PACK_FOP = /datum/voicepack/male/foppish,
 	VOICE_PACK_KNIGHT = /datum/voicepack/male/knight,
 	VOICE_PACK_WARRIOR = /datum/voicepack/male/warrior,
+	VOICE_PACK_WIZARD = /datum/voicepack/male/wizard,
+	VOICE_PACK_ROTMAN = /datum/voicepack/male/rotman,
 	VOICE_PACK_FEM = /datum/voicepack/female,
 	VOICE_PACK_FEM_WARRIOR = /datum/voicepack/female/warrior,
 	VOICE_PACK_FEM_DAINTY = /datum/voicepack/female/dainty,
 	VOICE_PACK_FEM_HAUGHTY = /datum/voicepack/female/haughty,
-	VOICE_PACK_ROTMAN = /datum/voicepack/male/rotman,
+	VOICE_PACK_FEM_ELF = /datum/voicepack/female/elf,
+	VOICE_PACK_FEM_DWARF = /datum/voicepack/female/dwarf,
 	VOICE_PACK_ROTWOMAN = /datum/voicepack/female/rotman
 ))


### PR DESCRIPTION
## About The Pull Request

Title. It allows players to select some of the voicepacks that were previously unselectable for whatever reason (example: "Elvish" (elf/tiefling/kobold racial voicepack, "Evil (Masc)" "Dwarfish" etc.)

## Testing Evidence

<img width="327" height="666" alt="Screenshot 2026-08-21 201935" src="https://github.com/user-attachments/assets/291ae22c-902d-4bc7-b9dc-d4601f95af83" />


## Why It's Good For The Game

More variety in character creation, allows people to keep their race specific voicepacks even when playing roles that would normally override them because their voicepack is set as 'Default'.

## Changelog

:cl:
add: masc and fem versions of elvish/dwarvish, evil, zeth, and wizardly voicepacks made available.
sound: Makes (some) previously unselectable voicepacks selectable
/:cl: