### PR TITLE
Adds Importable Hierophant Shawl + Hijab

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -143,6 +143,16 @@
 	cost = 60 // Base sellprice of 30
 	contains = list (/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex)
 
+/datum/supply_pack/rogue/light_armor/import/hierophantshawl
+	name = "Hierophant Shawl"
+	cost = 60
+	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant)
+
+/datum/supply_pack/rogue/light_armor/import/hierophanthijab
+	name = "Hierophant Hijab"
+	cost = 40
+	contains = list(/obj/item/clothing/head/roguetown/roguehood/hierophant)
+
 /datum/supply_pack/rogue/light_armor/import/naleditrou
 	name = "Naledian Hardened Leather Chaqchur (Pants)"
 	cost = 40 // Base sellprice of 20


### PR DESCRIPTION
## About The Pull Request
- Adds the hierophant shawl and hijab to the tailor silverface.

## Testing Evidence
<img width="536" height="521" alt="hierophantsilverface" src="https://github.com/user-attachments/assets/9adbf586-f65d-473f-8e95-a9c7d1187f1c" />

## Why It's Good For The Game
We already have some naledi + desert stuff in there and this was missing. It's nice armor and I see people wearing the lesser loadout version often so I figured why not get a purchasable import version too.

## Changelog
:cl:
add: Adds the hierophant shawl and hijab to the tailor silverface.
/:cl: