### PR TITLE
Remove confirmation popup from Eoran Heartweave miracle

### DIFF
--- a/code/modules/spells/roguetown/acolyte/eora.dm
+++ b/code/modules/spells/roguetown/acolyte/eora.dm
@@ -279,12 +279,6 @@
 		revert_cast()
 		return FALSE
 
-	var/consent = alert(target, "[user] offers a lifebond. Accept?", "Heartweave", "Yes", "No")
-	if(consent != "Yes" || QDELETED(target))
-		to_chat(user, span_warning("The bond was rejected."))
-		revert_cast()
-		return FALSE
-
 	var/holy_skill = user.get_skill_level(associated_skill)
 	// Add component to both participants without mutual recursion
 	user.AddComponent(/datum/component/eora_bond, target, user, holy_skill)


### PR DESCRIPTION
## About The Pull Request

Super simple: removes a forced confirmation popup on the world's most combat-sensitive miracle that doesn't get as much use as it should.

Heartweave no longer requests target confirmation.

## Testing Evidence

<img width="503" height="361" alt="image" src="https://github.com/user-attachments/assets/d9cd82ce-8f5c-454a-a6c3-e47903e79b73" />

## Why It's Good For The Game

Heartweave's confirmation popup immediately seizes control away from the beneficiary it is cast on and with it being a heavily combat-centric spell, this has resulted in people directly getting dorpelled and killed when you're just trying to help. All this PR does is remove that facet.

I'm not sure why this existed in the first place. There's no real reason why you'd ever want to refuse heartweave - the beneficiary doesn't share the Eoran's damage (only the other way around) and the effects are straight up positive otherwise.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
qol: Heartweave (Eora T2) no longer requests a confirmation popup on its beneficiary, making it actively usable in combat without griefing the person you're trying to help.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
