### PR TITLE
Towner thug cosmetic class names & miscreant fix

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -24,12 +24,13 @@
 	armor = /obj/item/clothing/suit/roguetown/armor/leather
 	backpack_contents = list(/obj/item/reagent_containers/glass/bottle/rogue/beer = 1)
 
-	var/classes = list("Goon", "Miscreant", "Big Man", "Longshoreman")
+	var/classes = list("Goon", "Miscreant", "Muscle", "Longshoreman")
 	var/classchoice = input(H, "What kind of thug are you?", "TAKE UP ARMS") as anything in classes
 
 	switch(classchoice)
 
 		if("Goon")
+			H.mind.cosmetic_class_title = "Goon"
 			to_chat(H, span_warning("You're a goon, a low-lyfe thug in a painful world - not good enough for war, not smart enough for peace. What you lack in station you make up for in daring."))
 			H.set_blindness(0)
 
@@ -72,6 +73,7 @@
 					ADD_TRAIT(H, TRAIT_CIVILIZEDBARBARIAN, TRAIT_GENERIC)
 
 		if("Miscreant")
+			H.mind.cosmetic_class_title = "Miscreant"
 			to_chat(H, span_warning("You're smarter than the rest, by a stone's throw - and you know better than to get up close and personal. Unlike most others, you can read."))
 			H.set_blindness(0)
 
@@ -116,7 +118,8 @@
 					ADD_TRAIT(H, TRAIT_LIGHT_STEP, TRAIT_GENERIC)
 					r_hand = /obj/item/lockpickring/mundane
 
-		if("Big Man")
+		if("Muscle")
+			H.mind.cosmetic_class_title = "Muscle"
 			to_chat(H, span_warning("More akin to a corn-fed monster than a normal man, your size and strength are your greatest weapons; though they hardly supplement what's missing of your brains."))
 			H.set_blindness(0)
 
@@ -155,6 +158,7 @@
 					r_hand = /obj/item/rogueweapon/mace
 
 		if("Longshoreman")
+			H.mind.cosmetic_class_title = "Longshoreman"
 			to_chat(H, span_warning("You answered Abyssor's call when you were young, though in troublesome ways, \
 	pilaging for treasury from anyone who'd cross your path. Now your captain retires from a life of crime, \
 	settling down as do you. Still, there is coin to be made on land."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/pilgrim/thug.dm
@@ -111,6 +111,7 @@
 				if("Magic Bricks")
 					H.adjust_skillrank_up_to(/datum/skill/magic/arcane, SKILL_LEVEL_EXPERT, TRUE)
 					H.mind?.AddSpell(new /obj/effect/proc_holder/spell/self/magicians_brick)
+					ADD_TRAIT(H, TRAIT_ARCYNE_T1, TRAIT_GENERIC)
 				if("Lockpicking Equipment")
 					H.adjust_skillrank_up_to(/datum/skill/misc/sneaking, SKILL_LEVEL_EXPERT, TRUE)
 					H.adjust_skillrank_up_to(/datum/skill/misc/stealing, SKILL_LEVEL_EXPERT, TRUE)


### PR DESCRIPTION
## About The Pull Request

- Renamed the Big Man towner thug subclass to "Muscle". More gender neutral and also sounds cooler.
- Towner thug subclasses now use cosmetic class titles similar to how Commoner/homesteader works, so it's more obvious what variety of thug you're interacting with.
- Gave Thug miscreant arcyne T1 ONLY IF THEY PICK MAGICAL BRICK SPECIALIZATION to fix an odd interaction w/ arcyne potential where you just straight up wouldn't get *anything* from it. They do not receive any spellpoints natively as before - they'll only ever get the 3 from picking AP, if they pick it at all.

## Testing Evidence

<img width="296" height="119" alt="dreamseeker_Adg2jWE4mF" src="https://github.com/user-attachments/assets/560100c6-6e50-4365-a616-a5e1cf03df99" />

<img width="307" height="109" alt="dreamseeker_mhxXFdSJ1P" src="https://github.com/user-attachments/assets/65c277dd-f15a-4dab-9bf0-99b7df7f8c18" />

## Why It's Good For The Game

The thug subclasses are all really fun and more people should try them out. Being able to see what kind of thug someone is also helps a lot.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
qol: Towner thug subclasses now show properly on examine.
fix: Miscreant thugs who take magical brick specialization have been given arcyne T1 to make it function properly with Arcyne Potential.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
