### PR TITLE
Vanguard Warehouse Add-On Trash

### DIFF
--- a/_maps/map_files/rockhill/rockhill.dmm
+++ b/_maps/map_files/rockhill/rockhill.dmm
@@ -179,8 +179,6 @@
 /obj/item/clothing/head/roguetown/helmet/skullcap,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
 /obj/item/clothing/head/roguetown/helmet/skullcap,
-/obj/item/clothing/head/roguetown/helmet/skullcap,
-/obj/item/clothing/head/roguetown/helmet/skullcap,
 /obj/item/clothing/head/roguetown/helmet/kettle/iron{
 	pixel_x = 6;
 	pixel_y = 32
@@ -69929,23 +69927,23 @@
 /obj/item/rogueweapon/spear,
 /obj/item/rogueweapon/spear,
 /obj/item/rogueweapon/spear,
+/obj/item/rogueweapon/scabbard/gwstrap{
+	pixel_x = -12;
+	pixel_y = -21
+	},
+/obj/item/rogueweapon/scabbard/gwstrap{
+	pixel_x = -12;
+	pixel_y = -21
+	},
+/obj/item/rogueweapon/scabbard/gwstrap{
+	pixel_x = -12;
+	pixel_y = -21
+	},
+/obj/item/rogueweapon/scabbard/gwstrap{
+	pixel_x = -12;
+	pixel_y = -21
+	},
 /obj/item/rogueweapon/spear,
-/obj/item/rogueweapon/scabbard/gwstrap{
-	pixel_x = -12;
-	pixel_y = -21
-	},
-/obj/item/rogueweapon/scabbard/gwstrap{
-	pixel_x = -12;
-	pixel_y = -21
-	},
-/obj/item/rogueweapon/scabbard/gwstrap{
-	pixel_x = -12;
-	pixel_y = -21
-	},
-/obj/item/rogueweapon/scabbard/gwstrap{
-	pixel_x = -12;
-	pixel_y = -21
-	},
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell/warden)
 "piA" = (
@@ -91333,8 +91331,8 @@
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /obj/item/clothing/suit/roguetown/armor/gambeson,
 /obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
-/obj/item/clothing/suit/roguetown/armor/gambeson,
+/obj/item/clothing/suit/roguetown/armor/chainmail/iron,
+/obj/item/clothing/suit/roguetown/armor/plate/half/iron,
 /turf/open/floor/rogue/concrete,
 /area/rogue/indoors/town/cell/warden)
 "tXC" = (


### PR DESCRIPTION
Mini changes to experiment with mapping! @ The Vanguard Fort deleted two gambesons, added iron breastplate + haubergeon to vanguard warehouse. Reduced skullcap count to match kettle helmet count.

## About The Pull Request

As said above. It was mainly just experimenting to see if it'd work. 
## Testing Evidence

<!--It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Giving Vanguard more variety in their roundstart options, even if just a single one. The change is minimal and the addon was mail weaker than their breastplate. Nothing lost, nothing gained.  I mainly did this to experiment with mapping. 
## Changelog

N/A? Save the listed above. 

:cl:
map: added/modified/removed map content
/:cl:


<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
