### PR TITLE
Fix bug with projectiles passing their full scaled damage to wound and embed rolls when dealing any amount of penetrating damage.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -70,7 +70,7 @@
 			if(P.dismemberment)
 				check_projectile_dismemberment(P, def_zone,armor)
 			if(P.woundclass)
-				check_projectile_wounding(P, def_zone)
+				check_projectile_wounding(P, def_zone, armor)
 
 			if(P.poisontype)// New proc for poisoning that respects if armor stopped damage from the projectile, by blocking or through reduction. Only called if poison type is defined.
 				if(!P.poisonamount)
@@ -81,7 +81,7 @@
 					if(P.poisonfeel)
 						M.show_message(span_danger("You feel an intense [P.poisonfeel] sensation spreading swiftly from the area!"))
 
-			if(P.embedchance && !check_projectile_embed(P, def_zone))
+			if(P.embedchance && !check_projectile_embed(P, def_zone, armor))
 				P.handle_drop()
 
 		else


### PR DESCRIPTION
## About The Pull Request

- Added "armor" argument to projectile wound and embed call
- Projectiles no longer pass their entire scaled damage when doing any amount of penetrating damage.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
This is something I found in #2445 and went over there, below is the math from the prior markdown. 
living_defense.dm line 65 /mob/living/bullet_act(obj/projectile/P, def_zone = BODY_ZONE_CHEST) calls apply_damage()
```dm
if(!apply_damage(P.damage, P.damage_type, def_zone, armor))
``` 

species.dm line 2040 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE) subtracts armor from damage:
```dm
damage = max((damage - blocked) * (1 - armor / 100), 0)
```

living_defense.dm line 69 runs the wound call, which OMITS "armor"
```dm
if(P.woundclass)
    check_projectile_wounding(P, def_zone)
```

Because blocked is null, carbon_defense.dm line 72 treats the argument as 0
```dm
/mob/living/carbon/check_projectile_wounding(obj/projectile/P, def_zone, blocked)
    var/obj/item/bodypart/BP = get_bodypart(check_zone(def_zone))
    if(BP)
        var/newdam = P.damage * (100-blocked)/100
        BP.bodypart_attacked_by(P.woundclass, newdam, ...)
```
bow scaled with 15 PER comes to 60; wound calc uses 60 regardless of armor block. 
P.damage = 60 so...
```dm
newdam = P.damage × (100 − 0) / 100
       = P.damage
       
 newdam = 60 x (100-0)/100
        = 60
```
> [!IMPORTANT]
>  Layman's terms: 10 HP through a brigandine from a 15-PER broadhead is treated as the full 60 damage during wound calculation. ANY PENETRATION can cause crit wounds quickly, regardless of actual raw damage. This is exacerbated by most armor lacking BCLASS_PIERCE crit protection.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Bugfix. Projectiles are no longer feeding wound math 40 force when only doing 4 real damage through someone's armor. This is already the case with check_projectile_dismemberment.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
fix: fixed projectiles passing their entire scaled damage when doing any amount of penetrating damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
