### PR TITLE
Various Fixes (and slight balancejaking) for the Dopo Robes

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
+++ b/code/modules/cargo/packsrogue/merchant/armor/merch_armor_light.dm
@@ -113,6 +113,16 @@
 	cost = 40 // Base sellprice of 20
 	contains = list (/obj/item/clothing/under/roguetown/heavy_leather_pants/kazengun)
 
+/datum/supply_pack/rogue/light_armor/import/kazenrobe/t2
+	name = "Kazengunese Decorated Dopo Robe"
+	cost = 40 // Base sellprice of 20
+	contains = list (/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast)
+
+/datum/supply_pack/rogue/light_armor/import/kazenrobe/t3
+	name = "Kazengunese Fortified Dopo Robe"
+	cost = 60 // Base sellprice of 20, added cost due to the increased integrity
+	contains = list (/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/mastercraft)
+
 /datum/supply_pack/rogue/light_armor/import/grenzhat
 	name = "Grenzelhoftian Plume Hat"
 	cost = 40 // Base sellprice of 20

--- a/code/modules/clothing/rogueclothes/armor/unique.dm
+++ b/code/modules/clothing/rogueclothes/armor/unique.dm
@@ -43,14 +43,21 @@
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/crafteast
 	name = "decorated dopo robe"
-	desc = "A dopo robe with a red tassel. Leather inlays are sewn in. It looks sturdier than a simple robe."
+	desc = "A dopo robe with a red tassel. Leather inlays have been sewn in, increasing its durability."
 	icon_state = "eastsuit2"
 	item_state = "eastsuit2"
-	armor = ARMOR_LEATHER_STUDDED // Makes it the equivalence of studded with less integrity and better armor 
+	armor = ARMOR_LEATHER_STUDDED // Makes it the equivalence of studded with less integrity and better armor
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
 
 //craftable variation of eastsuit, essentially requiring the presence of a tailor with relevant materials
 //still weak against blunt
+
+/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/mastercraft
+	name = "fortified dopo robe"
+	desc = "A dopo robe sporting a red tassel. This one has been masterfully reinforced with layers of silk and hardened leather, granting it increased durability at no cost to comfort or protection."
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
+
+// T3 dopo robe. Requires a Master skill leatherworker which is somewhat rarer than a tailor/smith. Upgrade to Studded Leather Armor, sidegrade to Light Brigantine.
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
 	name = "old dopo robe"
@@ -58,7 +65,7 @@
 	icon_state = "eastsuit1"
 	item_state = "eastsuit1"
 	sleeved = 'icons/roguetown/clothing/onmob/helpers/sleeves_armor.dmi'
-	armor = ARMOR_LEATHER_STUDDED 
+	armor = ARMOR_LEATHER_STUDDED
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
 
 

--- a/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
+++ b/code/modules/roguetown/roguecrafting/leather/leather_unique_recipes.dm
@@ -131,14 +131,12 @@
 	tools = list(/obj/item/needle)
 	craftdiff = 6 //Can be a bit strong, reduce to 5 if too high.
 
-/datum/crafting_recipe/roguetown/leather/unique/crafteast
-	name = "decorated dopo robe"
-	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast)
+/datum/crafting_recipe/roguetown/leather/unique/crafteast/mastercraft //t3 dopo robe. Equal to the Warden's light armor.
+	name = "fortified dopo robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast/mastercraft)
 	reqs = list(
 		/obj/item/natural/hide/cured = 2,
-		/obj/item/reagent_containers/food/snacks/tallow = 1,
-		/obj/item/natural/fibers = 2,
-		/obj/item/clothing/suit/roguetown/armor/basiceast = 1)
+		/obj/item/natural/silk = 2,
+		/obj/item/clothing/suit/roguetown/armor/basiceast/crafteast = 1) // requires you to have the previous tier instead of just the base item
 	tools = list(/obj/item/needle)
 	craftdiff = 5
-


### PR DESCRIPTION
## About The Pull Request

Fixes the redundant crafting recipes for the Dopo Robe, gives it a third tier you can work towards, and finally adds them to the exotic imports of the Tailor's Silverface.

## Testing Evidence

<img width="486" height="574" alt="proof03" src="https://github.com/user-attachments/assets/b16e4237-735f-4cf9-9f10-3919b3541d8f" />
<img width="1270" height="850" alt="proof02" src="https://github.com/user-attachments/assets/0688080e-38cc-4e89-a3c1-c35bf6786966" />
<img width="313" height="56" alt="proof01" src="https://github.com/user-attachments/assets/8eb80c29-bb84-4f6a-b12a-f124741bc1f2" />


## Why It's Good For The Game

The fixes: Should be obvious. It's not great for players, veteran or new, to see two items that appear identical in the crafting menu with the exact same material costs only one has a higher skill requirement. Especially when you make the more difficult item and there's no actual difference in flavor or mechanics than the easier item.

The balance: Gives Light Brigandine, the Hardened Leather Coat, steel Haubergon, and the Warden's (unupgraded) armor some more competition for being the best Light AC item to wear in the chest slot. The warden's unique Light Brigandine is still the objective best, but that's also a semi-unique item. Plus, like most tailoring/leatherworking items, it's a lot more annoying to gather all these materials as compared to just smithing them so it should help balance things out.

The import: Makes the item easier to access for people who have the coin to buy it, or for the (many) rounds where there's no tailor. Exorbitantly expensive so you're still always better off actually just going to a craftsman. Even the T3 version is materially cheaper to make despite requiring the previous tier.

Something to note is that the Fortified Robe should probably get an adjustment to its sprite to help differentiate it from the Decorated version, _but_ considering it's still light armor and doesn't have any change in resistances I'm of the opinion this should be fine until someone who's actually good at that sort of thing can go in and adjust it.

## Changelog

:cl:
add: Fortified Dopo Robe, the final upgrade to the Dopo Robe. No additional protection stats, but it has a bit more integrity than the Decorated (T2) version.
add: Added the Decorated and Fortified Dopo Robes to the Tailor's Silverface under the Import section.
fix: The Master skill leatherworking recipe for the Dopo Robe now actually gives you a variant of the item with better stats. It also requires different materials, including the previous tier of the item.
/:cl:
