### PR TITLE
AHelp logging to DB.

### DIFF
--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -282,6 +282,25 @@ Versioning
 	key = new_key
 	key_type = new_key_type
 
+/datum/controller/subsystem/blackbox/proc/LogAhelp(ticket, action, message, recipient, sender)
+	if(!SSdbcore.Connect())
+		return
+	var/datum/DBQuery/query_log_ahelp = SSdbcore.NewQuery({"
+		INSERT INTO [format_table_name("ticket")] (ticket, action, message, recipient, sender, server_ip, server_port, round_id, timestamp)
+		VALUES (:ticket, :action, :message, :recipient, :sender, INET_ATON(:server_ip), :server_port, :round_id, NOW())
+	"}, list(
+		"ticket" = ticket,
+		"action" = action,
+		"message" = message,
+		"recipient" = recipient,
+		"sender" = sender,
+		"server_ip" = world.internet_address || "0",
+		"server_port" = world.port,
+		"round_id" = GLOB.round_id,
+	))
+	query_log_ahelp.Execute()
+	qdel(query_log_ahelp)
+
 /datum/controller/subsystem/blackbox/proc/ReportDeath(mob/living/L)
 	set waitfor = FALSE
 	if(sealed)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -102,11 +102,13 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		C.current_ticket.initiator = C
 		C.current_ticket.initiator_mob = C.mob
 		C.current_ticket.AddInteraction("Client reconnected.")
+		SSblackbox.LogAhelp(C.current_ticket.id, "Reconnected", "Client reconnected", C.ckey)
 
 //Dissasociate ticket
 /datum/admin_help_tickets/proc/ClientLogout(client/C)
 	if(C.current_ticket)
 		C.current_ticket.AddInteraction("Client disconnected.")
+		INVOKE_ASYNC(SSblackbox, TYPE_PROC_REF(/datum/controller/subsystem/blackbox, LogAhelp), C.current_ticket.id, "Disconnected", "Client disconnected", C.ckey)
 		C.current_ticket.initiator = null
 		C.current_ticket = null
 
@@ -234,7 +236,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			log_admin_private("Ticket #[ticket.id]: [key_name(user)] -> [ticket.initiator_key_name]: [log_msg]")
 			// Notify other admins in chat with real identity
 			message_admins(span_adminnotice("<font color='blue'>Ticket #[ticket.id] [ticket.TicketHref("Show Ticket")] - [key_name_admin(user)] replied to [ticket.initiator_key_name]: [log_msg]</font>"))
-
+			SSblackbox.LogAhelp(ticket.id, "Admin Reply", message, ticket.initiator_ckey, usr.ckey)
 			return TRUE
 		
 		if("jump_to", "observe", "pm")
@@ -485,6 +487,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			log_admin_private("Ticket #[ticket.id]: [key_name(user)] embedded [embed_type]: [url]")
 			// Notify other admins in chat with a placeholder - no raw URLs to prevent flashbanging
 			message_admins(span_adminnotice("<font color='blue'>Ticket #[ticket.id] [ticket.TicketHref("Show Ticket")] - [key_name_admin(user)] sent [ticket.initiator_key_name] an (embedded [embed_type]).</font>"))
+			SSblackbox.LogAhelp(ticket.id, "Admin Embed", url, ticket.initiator_ckey, usr.ckey)
 			return TRUE
 	
 	return FALSE
@@ -569,12 +572,11 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	if(is_bwoink)
 		AddInteraction("<font color='blue'>PM from [key_name_ahelp(usr)]: [msg]</font>")
 		message_admins("<font color='blue'>Ticket [TicketHref("#[id]")] created</font>")
+		SSblackbox.LogAhelp(id, "Admin Message", msg, C.mob, usr.ckey)
 	else
 		// Add a clean initial message for the player's view
 		AddInteraction("<font color='green'>Ticket opened. Your message has been sent to the admin team.</font>")
-		
 		MessageNoRecipient(msg)
-
 		//send it to irc if nobody is on and tell us how many were on
 		var/admin_number_present = send2irc_adminless_only(initiator_ckey, "Ticket #[id]: [name]")
 		log_admin_private("Ticket #[id]: [key_name(initiator)]: [name] - heard by [admin_number_present] non-AFK admins who have +BAN.")
@@ -663,6 +665,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 	//show it to the person adminhelping too
 	to_chat(initiator, type = MESSAGE_TYPE_ADMINPM, html = span_adminnotice("PM to-<b>Admins</b>: <font color='#FFA040'><span class='linkify'>[msg]</span></font>"))
+	SSblackbox.LogAhelp(id, "Player Message", msg, null, initiator.ckey)
 
 //Reopen a closed ticket
 /datum/admin_help/proc/Reopen()
@@ -692,6 +695,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	var/msg = span_adminhelp("Ticket [TicketHref("#[id]")] reopened by [key_name_admin(usr)].")
 	message_admins(msg)
 	log_admin_private(msg)
+	SSblackbox.LogAhelp(id, "Reopened", "Reopened by [usr.key]", usr.ckey)
 	SSblackbox.record_feedback("tally", "ahelp_stats", 1, "reopened")
 	// TGUI will auto-update
 
@@ -718,6 +722,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "closed")
 		var/msg = "Ticket [TicketHref("#[id]")] closed by [key_name]."
 		message_admins(msg)
+		SSblackbox.LogAhelp(id, "Closed", "Closed by [usr.key]", null, usr.ckey)
 		log_admin_private(msg)
 
 //Mark open ticket as resolved/legitimate, returns ahelp verb
@@ -736,6 +741,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		SSblackbox.record_feedback("tally", "ahelp_stats", 1, "resolved")
 		var/msg = "Ticket [TicketHref("#[id]")] resolved by [key_name]"
 		message_admins(msg)
+		SSblackbox.LogAhelp(id, "Resolved", "Resolved by [usr.key]", null, usr.ckey)
 		log_admin_private(msg)
 
 //Close and return ahelp verb, use if ticket is incoherent
@@ -757,6 +763,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Rejected by [display_name].")
+	SSblackbox.LogAhelp(id, "Rejected", "Rejected by [usr.key]", null, usr.ckey)
 	Close(silent = TRUE)
 
 //Resolve ticket with IC Issue message
@@ -774,6 +781,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Marked as IC issue by [display_name]")
+	SSblackbox.LogAhelp(id, "IC Issue", "Marked as IC issue by [usr.key]", null,  usr.ckey)
 	Resolve(silent = TRUE)
 
 //Let the initiator know their ahelp is being handled
@@ -791,6 +799,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	message_admins(msg)
 	log_admin_private(msg)
 	AddInteraction("Being handled by [display_name]")
+	SSblackbox.LogAhelp(id, "Handled", "Handled by [usr.key]", null, usr.ckey)
 
 //Show the ticket panel
 /datum/admin_help/proc/TicketPanel()
@@ -811,6 +820,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		message_admins(msg)
 		log_admin_private(msg)
 		AddInteraction("Retitled by [key_name_ahelp(usr)]")
+		SSblackbox.LogAhelp(id, "Retitled", msg, null, usr.ckey)
 
 //Forwarded action from admin/Topic
 /datum/admin_help/proc/Action(action)
@@ -988,8 +998,8 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 			// Send the message
 			MessageNoRecipient(message, FALSE)
+			SSblackbox.LogAhelp(id, "Admin Reply", message, initiator_ckey, usr.ckey)
 			TimeoutVerb()
-			
 			return TRUE
 		
 		if("embed_media")
@@ -1011,6 +1021,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			if(initiator)
 				to_chat(initiator, span_adminhelp("<b>[key_name_ahelp(usr)] embedded a [embed_type] in your ticket.</b>"))
 			log_admin_private("Ticket #[id]: [key_name(usr)] embedded [embed_type]: [url]")
+			SSblackbox.LogAhelp(id, "Admin Reply", url, initiator_ckey, usr.ckey)
 			return TRUE
 
 /datum/admin_help/ui_state(mob/user)
@@ -1126,12 +1137,14 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 		var/datum/admin_help/AH = C.current_ticket
 		// Only log to admin logs; do not expose as a ticket chat message
 		log_admin_private("Ticket #[AH.id]: [message]")
+		SSblackbox.LogAhelp(AH.id, "Interaction", strip_html(message), C.ckey, usr.ckey)
 		return AH
 	if(istext(what))	//ckey
 		var/datum/admin_help/AH = GLOB.ahelp_tickets.CKey2ActiveTicket(what)
 		if(AH)
 			// Only log to admin logs; do not expose as a ticket chat message
 			log_admin_private("Ticket #[AH.id]: [message]")
+			SSblackbox.LogAhelp(AH.id, "Interaction", strip_html(message), C.ckey, usr.ckey)
 			return AH
 
 //


### PR DESCRIPTION
## About The Pull Request

This brings back db logging of ahelps to RW.
This thing requires rigorous testing from RW Staff.
Amongst obvious problems this thing have certain actions, e.g. Cake, which carry a massive chunk of HTML garbage with them into BD log.

## Testing Evidence

<img width="1129" height="141" alt="{9939E5C3-7CD4-475E-9D20-85237C2BE402}" src="https://github.com/user-attachments/assets/14e5e90a-ba89-48f4-bb08-f5fd48719289" />

## Why It's Good For The Game

Logging is generally good for situations when you have to recall certain events, such as disputes and reports.

## Changelog

It doesn't really change anything. It adds a few procs here and there 

:cl:
server: Ahelp recieves logging to DB
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
