### PR TITLE
Fortitude Spell: Remove (fix) Stamina Regen Reduction, Nerf Stamina Usage Reduction

### DIFF
--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -109,7 +109,7 @@
 	if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA))
 		return TRUE
 	if(HAS_TRAIT(src, TRAIT_FORTITUDE) && added > 0) // 2nd check is to halve stamina SPEND, not stamina GAIN
-		added = added * 0.5
+		added = added * 0.7
 	if(added < 0 && HAS_TRAIT(src, TRAIT_FROZEN_STAMINA))
 		added = 0
 	if(bodytemperature > BODYTEMP_HEAT_LEVEL_ONE_MAX && added >=1)	//being max heat(level 2) makes you regen half as much stamina

--- a/code/modules/mob/living/carbon/energystamina.dm
+++ b/code/modules/mob/living/carbon/energystamina.dm
@@ -108,7 +108,7 @@
 /mob/living/stamina_add(added as num, emote_override, force_emote = TRUE) //call update_stamina here and set last_fatigued, return false when not enough fatigue left
 	if(HAS_TRAIT(src, TRAIT_INFINITE_STAMINA))
 		return TRUE
-	if(HAS_TRAIT(src, TRAIT_FORTITUDE))
+	if(HAS_TRAIT(src, TRAIT_FORTITUDE) && added > 0) // 2nd check is to halve stamina SPEND, not stamina GAIN
 		added = added * 0.5
 	if(added < 0 && HAS_TRAIT(src, TRAIT_FROZEN_STAMINA))
 		added = 0

--- a/code/modules/spells/spell_types/wizard/buffs_debuffs/fortitude.dm
+++ b/code/modules/spells/spell_types/wizard/buffs_debuffs/fortitude.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/spell/invoked/fortitude
 	name = "Fortitude"
-	desc = "Harden one's humors to the fatigues of the body. (-50% Stamina Usage)"
-	cost = 3 // Halving stamina cost is INSANE so it cost the same as before adjustment to 3x spellpoint basis.
+	desc = "Harden one's humors to the fatigues of the body. (-30% Stamina Usage)"
+	cost = 3 // Reducing stamina cost is INSANE so it cost the same as before adjustment to 3x spellpoint basis.
 	xp_gain = TRUE
 	releasedrain = 60
 	chargedrain = 1
@@ -43,7 +43,7 @@
 
 /atom/movable/screen/alert/status_effect/buff/fortitude
 	name = "Fortitude"
-	desc = "My humors has been hardened to the fatigues of the body. (-50% Stamina Usage)"
+	desc = "My humors has been hardened to the fatigues of the body. (-30% Stamina Usage)"
 	icon_state = "buff"
 
 #define FORTITUDE_FILTER "fortitude_glow"


### PR DESCRIPTION
## About The Pull Request
<img width="572" height="82" alt="image" src="https://github.com/user-attachments/assets/08f4df4b-caab-489a-9fe4-8ecb8bddc9bf" />

Currently this spell is kinda useless, because it affects stamina regen as well. Ends up being a wasted slot in most cases.

**update:** After a discord discussion, there was a suggestion saying that stamina usage reduction should be reduced to -30% down from -50%. This has been implemented.

So *in other words*, for those of you in the back:
- Before this PR: -50% Stamina Usage, -50% Stamina Regen
- After this PR: -30% Stamina Usage, Unaffected Stamina Regen
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Elite ball knowledge (and smacking a mob with an axe)
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Fortitude useful again
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The Fortitude spell that is supposed to halve stamina usage was also halving stamina regen. Fixed now. It was possible to cast this spell on someone offensively, for the purposes of debuffing their stamina regen (like during a fight).
balance: To compensate for Fortitude actually working as-written, stamina usage reduction is now -30% down from -50%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
