### PR TITLE
Surrender Or Die: Yield changes nobody asked for

### DIFF
--- a/code/datums/gods/_patron.dm
+++ b/code/datums/gods/_patron.dm
@@ -39,6 +39,9 @@ GLOBAL_LIST_EMPTY(prayers)
 	/// List of traits associated with rank. Trait = Cleric_Tier
 	var/list/traits_tier = list()
 
+	/// Whether the patron hates surrender and punishes faithful who attempt to yield.
+	var/hates_surrender = FALSE
+
 	var/datum/storyteller/storyteller
 
 /datum/patron/proc/on_gain(mob/living/pious)
@@ -133,3 +136,13 @@ GLOBAL_LIST_EMPTY(prayers)
 	SHOULD_CALL_PARENT(TRUE)
 	follower.playsound_local(follower, 'sound/misc/notice (2).ogg', 100, FALSE)
 	follower.add_stress(/datum/stressevent/psyprayer)
+
+/// The follower has yielded and we >>REALLY<< hate surrender. Overload this per patron for bonus messaging/extra grief, etc.
+/datum/patron/proc/punish_surrender(mob/living/follower)
+	if (!ishuman(follower))
+		return
+	var/mob/living/carbon/human/us = follower
+	var/datum/devotion/our_devotion = us.devotion
+	if (us && our_devotion)
+		// by default, lose a quarter of our max devotion immediately
+		our_devotion.update_devotion(-(our_devotion.max_devotion / 4), silent = TRUE)

--- a/code/datums/gods/patrons/divine/astrata.dm
+++ b/code/datums/gods/patrons/divine/astrata.dm
@@ -21,6 +21,7 @@
 		"ASTRATA BRINGS LAW!",
 		"I SERVE THE GLORY OF THE SUN!",
 	)
+	hates_surrender = TRUE
 	storyteller = /datum/storyteller/astrata
 
 // In daylight, church, cross, or ritual chalk.
@@ -55,3 +56,13 @@
 	if(GLOB.tod == "day")
 		*conditional_buff = TRUE
 		*situational_bonus = 2
+
+/datum/patron/divine/astrata/punish_surrender(mob/living/follower)
+	. = ..()
+	if (HAS_TRAIT(follower, TRAIT_NOBLE) && GLOB.tod == "day")
+		var/list/disdain = list(
+			"The silence left between the wake of your thundering heartbeats is DEAFENING. The shame of your surrender, laid bare 'neath the Sun...",
+			"A chill settles in your bones, as if an inherent warmness to your blessed blood has begun to fade...",
+			"What manner of tyrant lies upon the floor, trembling in fear? You. You do. AND SHE SEES YOU.",
+			)
+		to_chat(follower, span_boldwarning(pick(disdain)))

--- a/code/datums/gods/patrons/divine/ravox.dm
+++ b/code/datums/gods/patrons/divine/ravox.dm
@@ -78,6 +78,6 @@
 	. = ..()
 	var/list/disdain = list(
 		"Nothing is glorious about your capitulation, and you know this deep in your heart. Shame floods your veins...",
-		"Fallen before a greater a foe. IT WOULD HAVE BEEN BETTER TO SIMPLY DIE.",
+		"Fallen before a greater foe... IT WOULD HAVE BEEN BETTER TO SIMPLY DIE.",
 		)
 	to_chat(follower, span_boldwarning(pick(disdain)))

--- a/code/datums/gods/patrons/divine/ravox.dm
+++ b/code/datums/gods/patrons/divine/ravox.dm
@@ -21,6 +21,7 @@
 		"THROUGH STRIFE, GRACE!",
 		"THROUGH PERSISTENCE, GLORY!",
 	)
+	hates_surrender = TRUE
 	storyteller = /datum/storyteller/ravox
 	COOLDOWN_DECLARE(lesser_heal_buff_cooldown)
 
@@ -72,3 +73,11 @@
 
 	*conditional_buff = TRUE
 	*situational_bonus = bonus
+
+/datum/patron/divine/ravox/punish_surrender(mob/living/follower)
+	. = ..()
+	var/list/disdain = list(
+		"Nothing is glorious about your capitulation, and you know this deep in your heart. Shame floods your veins...",
+		"Fallen before a greater a foe. IT WOULD HAVE BEEN BETTER TO SIMPLY DIE.",
+		)
+	to_chat(follower, span_boldwarning(pick(disdain)))

--- a/code/datums/gods/patrons/inhumen/graggar.dm
+++ b/code/datums/gods/patrons/inhumen/graggar.dm
@@ -19,6 +19,7 @@
 		"THROUGH VIOLENCE, DIVINITY!",
 		"THE GOD OF CONQUEST DEMANDS BLOOD!",
 	)
+	hates_surrender = TRUE
 	storyteller = /datum/storyteller/graggar
 
 /datum/patron/inhumen/graggar/on_lesser_heal(
@@ -83,3 +84,21 @@
 		return TRUE
 	to_chat(follower, span_danger("For Graggar to hear my prayers I must either be in the church of the abandoned, near an inverted psycross, near fresh blood or draw blood of my own!"))
 	return FALSE
+
+/datum/patron/inhumen/graggar/punish_surrender(mob/living/follower)
+	. = ..()
+	var/mob/living/carbon/human/us = follower
+	var/datum/devotion/our_devotion = us.devotion
+	var/list/disdain = list("\"PATHETIC.\"", 
+	"Shame burns molten-hot, then bitter cold in your breast. Your cowardice disappoints HIM.", 
+	"Mewling, simpering weakness floods your quailing self. Thoughts of unworthiness flood your mind...")
+	to_chat(follower, span_boldwarning(pick(disdain)))
+
+	//fun bonus: if you're very close to 0 devo after losing 25% max devo, you simply lose your devotion entirely.
+	//don't surrender :)
+	if (our_devotion && our_devotion.devotion <= 10) // tiny leeway to accomdate for regen ticks
+		to_chat(follower, span_boldwarning("THE GORESTAR TURNS HIS GAZE FROM ME!!! I AM NOTHING!!!"))
+		if(follower.mind && length(our_devotion.granted_spells))
+			for(var/obj/effect/proc_holder/spell/S in our_devotion.granted_spells)
+				follower.mind.RemoveSpell(S)
+		qdel(our_devotion)

--- a/code/datums/gods/patrons/old_god.dm
+++ b/code/datums/gods/patrons/old_god.dm
@@ -21,6 +21,25 @@
 		"FORGIVE THEM, ALLFATHER, FOR THEY KNOW-NOT WHAT THEY DO!",
 		"BARE WITNESS, MY GOD; THE SACRIFICE MADE MANIFEST!",
 	)
+	hates_surrender = TRUE // YOU HAVE NOT FAILED PSYDON. YOU HAVE FAILED YOURSELF.
+
+/datum/patron/old_god/punish_surrender(mob/living/follower)
+	. = ..()
+	var/list/disdain = list(
+		"I can't... go on...",
+		"I DON'T WANT TO DIE!!!",
+		"Like so many others before you, and so many more yet to come.",
+		"All of my lyfe's toil... amounts to this?",
+		"With every broken bone, I swear I--MAKE IT STOP!!!",
+		"No, it cannot be true...",
+		"You will see this moment of weakness again in every drop of rain. Every mote, every speck...",
+		"This is what they will remember you for.",
+		"I CAN'T TAKE IT ANYMORE!!!",
+		"In the dirt, in the muck... your sobbing a choir for the worms.",
+		"You have not failed HIM. You have failed yourself.",
+		"Oh, you poor fool. This was never going to go any other way...",
+		)
+	to_chat(follower, span_boldwarning(pick(disdain)))
 
 
 /obj/effect/proc_holder/spell/self/check_boot
@@ -238,3 +257,4 @@
 
 	revert_cast()
 	return FALSE
+

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1154,7 +1154,7 @@
 	set hidden = 1
 	if(surrendering || stat == DEAD)
 		return
-	if (IsUnconscious())
+	if (stat == UNCONSCIOUS)
 		to_chat(src, span_boldwarning("TOO LATE!!!"))
 		to_chat(src, span_boldwarning("Oblivion swallows you whole, surrender and all..."))
 		return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1154,10 +1154,22 @@
 	set hidden = 1
 	if(surrendering || stat == DEAD)
 		return
+	if (IsUnconscious())
+		to_chat(src, span_boldwarning("TOO LATE!!!"))
+		to_chat(src, span_boldwarning("Oblivion swallows you whole, surrender and all..."))
+		return
 	if(!instant)
 		if(alert(src, "Do you yield?", "SURRENDER", "Yes", "No") == "No")
 			return
 	log_combat(src, null, "surrendered")
+
+	// wuh oh. your god hates surrender and you're a devout cleric. PUNISHMENT.
+	if (ishuman(src))
+		var/mob/living/carbon/human/our = src
+		var/datum/devotion/our_devotion = our.devotion
+		if (our_devotion && our.patron.hates_surrender)
+			our.patron.punish_surrender(src)
+	
 	surrendering = 1
 	record_round_statistic(STATS_YIELDS)
 	toggle_cmode()


### PR DESCRIPTION
## About The Pull Request

Hello again.

- You can no longer yield while unconscious. 
   - Yield before the lights go out or bleed to death in a ditch like PSYDON intended.
- Astrata, Ravox and Graggar now categorically loathe their devotionists/miracle users who dare to surrender/yield.
   - Yielding causes you to immediately lose 25% of your maximum devotion.
   - You'll receive a thematic line informing you of your grand and terrible shame. Varies depending on the God. Astrata only cares if you're cringe when she can see it (during the day, and if you're noble)
   - If you're a Graggarite and are reduced to 0 devotion by the shame of surrender, **you lose access to Graggarite miracles permanently for the rest of the round.**
      - Nothing can restore this.
- Psydonites also experience the same devotion loss upon yield, where appropriate. No miracle loss - same as Astrata and Ravox. Lots of messages for this one, all self-doubt focused.

## Testing Evidence

<img width="700" height="263" alt="image" src="https://github.com/user-attachments/assets/f5003f0b-b362-4928-ae98-7546d41ba292" />

<img width="987" height="114" alt="image" src="https://github.com/user-attachments/assets/871ef1ba-63f1-40fa-b04f-28cb28648267" />

## Why It's Good For The Game

You may be thinking "why the FUCK did you just turf the shit out of something designed to keep people in the game?"

The answer is that people need to just **die** sometimes. I originally floated the bleed reduction on yield thing back in Scarlet Reach and ever since it has become the mainstay staple of people in large zerg fights who get downed and spam the crap out of it while bleeding out in order to have a chance to not die.

Half the time I see specific people (namely one giant-virtue dog woman graggarite) who practically hammer yield the second they see the DYING screen and it irks me to no end, because they could've spent that time roleplaying in the surrender phase of things instead of just being an annoying shit.

So, time your yields. Give up BEFORE you hit the floor.

The patron-based changes provide a little flavor and incentive for clerics to take especial heed of this. Ravoxian templars are notorious for yield-cheesing to avoid consequences and now they've got to countenance praying for five minutes every time they pop a fat yield like the justice-seeking chuds they are.

## Changelog

:cl: Ephemeralis
balance: Yielding while unconscious is no longer possible. Give up before you black out, or bleed out in a ditch like PSYDON intended.
add: Patron-specific responses to surrender/yielding have been added for Astrata, Ravox and Graggar. All three will take 25% of your max devotion upon surrender, and Graggar will remove his miracles from you entirely and permanently for the rest of the round if this takes you to 0 devotion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
