### PR TITLE
Fix gnoll perma WIL loss bug, gnolls now benefit from hitting Riposte again

### DIFF
--- a/code/datums/status_effects/rogue/roguebuff.dm
+++ b/code/datums/status_effects/rogue/roguebuff.dm
@@ -2066,17 +2066,14 @@
 	var/blood_restore = 30
 
 /datum/status_effect/buff/adrenaline_rush/on_apply()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		if(H.dna?.species?.type == /datum/species/gnoll)
-			return FALSE
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_ADRENALINE_RUSH, TRAIT_STATUS_EFFECT(id))
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.playsound_local(get_turf(H), 'sound/misc/adrenaline_rush.ogg', 100, TRUE)
-		H.set_blood_volume(min((H.get_blood_volume() + blood_restore), BLOOD_VOLUME_NORMAL))
 		H.stamina -= max((H.stamina - (H.max_stamina / 2)), 0)
+		if(H.dna?.species?.type != /datum/species/gnoll)
+			H.set_blood_volume(min((H.get_blood_volume() + blood_restore), BLOOD_VOLUME_NORMAL))
 
 /datum/status_effect/buff/adrenaline_rush/on_remove()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
See changelog. This was made to fix a bug introduced in commit e26ed5328c161fc43449b390d72ca121d146a7d9. The "Adrenaline Rush" status effect application was `return`ed for gnolls specifically, before it could apply +1 WIL (at `. = ..()`). But the status effect's removal assumes `effectedstats` was already applied successfully, and applied -1 WIL. Thus you are left with -1 WIL *permanently.*

The only way you could reset your WIL mechanically is by far traveling and coming back. It's that bad.

**Balance change:** I decided that excluding gnolls from a combat mechanic is pretty weird, so *very technically* this is also a balance change. When hitting a Riposte, Gnolls still get +1 WIL, and stamina refilled to 50% capacity if below.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
It appeared to me in a dream. We'll be testing to make extra sure it works, but I'm getting the PR up early since it's a very simple logic change.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
This is the worst thing to happen to the game in the history of Ratwood
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed crippling willpower loss bug affecting Gnolls. Previously, every time a gnoll raised their guard, and someone hit that guard with a weapon, the gnoll would permanently lose 1 WIL.
balance: Gnolls weren't benefiting from any mechanics of Adrenaline Rush when they hit a riposte. Now, they get +1 WIL for its duration & stamina refilled to 50% (if below), just like everybody else. Unlike everybody else, they still do NOT get blood replenished (as they can get health potion from biting people).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
