### PR TITLE
Prince(ss) loadout and skill updates

### DIFF
--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -264,8 +264,8 @@
 /datum/outfit/job/roguetown/heir/inbred/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/circlet
-	wrists = /obj/item/storage/keyring/heir
 	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
+	wrists = /obj/item/storage/keyring/heir
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
 	beltr = /obj/item/rogueweapon/scabbard/sheath/noble
@@ -345,6 +345,7 @@
 	head = /obj/item/clothing/head/roguetown/circlet
 	mask = /obj/item/clothing/head/roguetown/roguehood/black
 	neck = /obj/item/storage/keyring/heir
+	wrists = /obj/item/lockpickring/mundane
 	belt = /obj/item/storage/belt/rogue/leather
 	beltl = /obj/item/quiver/sling/iron
 	beltr = /obj/item/gun/ballistic/revolver/grenadelauncher/sling
@@ -375,7 +376,6 @@
 			head = /obj/item/clothing/head/roguetown/circlet
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
-		/obj/item/lockpickring/mundane = 1,
 		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
 		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
 	)

--- a/code/modules/jobs/job_types/roguetown/nobility/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/prince.dm
@@ -192,16 +192,22 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/tanning = SKILL_LEVEL_JOURNEYMAN,
 	)
 
 /datum/outfit/job/roguetown/heir/aristocrat/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/circlet
+	wrists = /obj/item/storage/keyring/heir
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/keyring/heir
+	beltl = /obj/item/rogueweapon/huntingknife/scissors/steel
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/clothing/ring/signet
+	backpack_contents = list(
+		/obj/item/needle,
+		/obj/item/natural/bundle/fibers,
+	)
 	if(should_wear_masc_clothes(H))
 		pants = /obj/item/clothing/under/roguetown/tights
 		shirt = /obj/item/clothing/suit/roguetown/shirt/dress/royal/prince
@@ -251,15 +257,18 @@
 		/datum/skill/misc/reading = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/sewing = SKILL_LEVEL_NOVICE,
+		/datum/skill/craft/tanning = SKILL_LEVEL_NOVICE,
 		/datum/skill/craft/alchemy = SKILL_LEVEL_APPRENTICE,
 	)
 
 /datum/outfit/job/roguetown/heir/inbred/pre_equip(mob/living/carbon/human/H)
 	..()
 	head = /obj/item/clothing/head/roguetown/circlet
+	wrists = /obj/item/storage/keyring/heir
+	neck = /obj/item/storage/belt/rogue/pouch/coins/rich
 	belt = /obj/item/storage/belt/rogue/leather
-	beltl = /obj/item/storage/keyring/heir
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
+	beltl = /obj/item/rogueweapon/huntingknife/idagger/steel
+	beltr = /obj/item/rogueweapon/scabbard/sheath/noble
 	backr = /obj/item/storage/backpack/rogue/satchel
 	id = /obj/item/clothing/ring/decrepit
 	backpack_contents = list(
@@ -366,7 +375,10 @@
 			head = /obj/item/clothing/head/roguetown/circlet
 	backpack_contents = list(
 		/obj/item/storage/belt/rogue/pouch/coins/rich = 1,
-		/obj/item/lockpickring/mundane = 1)
+		/obj/item/lockpickring/mundane = 1,
+		/obj/item/rogueweapon/scabbard/sheath/noble = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel = 1,
+	)
 
 
 


### PR DESCRIPTION
## About The Pull Request

see changelog

## Testing Evidence

simple line edits, man

## Why It's Good For The Game

Having only sewing and not skincrafting seems like an oversight, especially with skincrafting being much harder to train
Having to do a roundstart supply run every time you want to actually do some sewing is kinda crazy
The wannabe rogue dipshit should actually have a dagger
The inbred little affront to PSYDON that already starts with 2 bottles of poison should DEFINITELY have a dagger :)

## Changelog

:cl:
add: Added Skincrafting Journeyman to sheltered princess, Novice to inbred princess to match their Sewing skills
add: Gives the sheltered princess a needle, scissors and some fibers
add: Gives the sneaky and inbred princess steel daggers and noble sheathes
/:cl:
