### PR TITLE
Assorted instrument & psyaltrist fixes

### DIFF
--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -247,6 +247,8 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 	/// When TRUE, songs will loop (repeat) when they end. Off by default.
 	var/loop_enabled = FALSE
 
+	var/last_played // store the last played thing we have here to use in quick cmode toggle
+
 // Added null-guard on soundloop. During Initialize() the parent chain
 // may trigger equipped() before soundloop is assigned.
 /obj/item/rogue/instrument/equipped(mob/living/user, slot)
@@ -306,6 +308,14 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 			if(!owner_mob)
 				GLOB.instrument_band_lobbies -= lobby_id
 
+/obj/item/rogue/instrument/examine(mob/user)
+	. = ..()
+	if (ishuman(user))
+		var/mob/living/carbon/human/viewer_human = user
+		if (viewer_human.inspiration)
+			. += span_notice("You can quickly add and remove people from your audience by <b>middle-clicking</b> on them with this instrument in your hand.")
+			. += span_notice("If you try to play with combat mode active, you'll automatically play your last song.")
+
 /obj/item/rogue/instrument/attack_self(mob/living/user)
 	var/stressevent = /datum/stressevent/music
 	. = ..()
@@ -333,6 +343,21 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 		var/volume_label
 		var/loop_notice
 		var/volume_selection
+		if (user.cmode && last_played)
+			// quickly just play the last song we chose if we do this in combat
+			var/quickfile = song_list[last_played]
+			if(quickfile)
+				user.balloon_alert(user, "quick-playing last song! (combat)")
+				soundloop.set_mid_sounds(list(quickfile))
+				soundloop.volume = clamp(curvol, 10, 100)
+				soundloop.repeat_sound = loop_enabled
+				if(!soundloop.start(user))
+					to_chat(user, span_warning("Could not play - no sound channels available. Try again in a moment."))
+					return
+				playing = TRUE
+				user.apply_status_effect(/datum/status_effect/buff/playing_music, stressevent, note_color)
+				return
+			
 		while(TRUE)
 			loop_state = "Off"
 			if(loop_enabled)
@@ -411,6 +436,7 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 					song_list[songname] = curfile
 				return
 			curfile = song_list[choice]
+			last_played = choice
 			if(!user || playing || !(src in user.held_items) && !(not_held))
 				return
 			note_color = "#7f7f7f"

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
@@ -50,7 +50,7 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	id = /obj/item/clothing/ring/signet/silver
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)	//Capped to T2 miracles.
+	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_2)	//Capped to T2 miracles.
 	var/datum/inspiration/I = new /datum/inspiration(H)
 	I.grant_inspiration(H, bard_tier = BARD_T3)
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1,

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
@@ -106,8 +106,8 @@
 				H.put_in_hands(new /obj/item/rogueweapon/whip/psywhip_lesser(get_turf(H)), forced = TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
 			if("Psydonic Rapier")
-				H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy(get_turf(H)), forced = TRUE)
-				H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_R, TRUE)
+				H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy(get_turf(H)), del_on_fail = FALSE, forced = TRUE)
+				H.put_in_hands(new /obj/item/rogueweapon/scabbard/sword(get_turf(H)), del_on_fail = FALSE, forced = TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 
 /datum/outfit/job/roguetown/psyaltrist

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
@@ -107,7 +107,7 @@
 				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
 			if("Psydonic Rapier")
 				H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy(get_turf(H)), forced = TRUE)
-				H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L, TRUE)
+				H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_R, TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 
 /datum/outfit/job/roguetown/psyaltrist


### PR DESCRIPTION
## About The Pull Request

Simple stuff:

- **Instruments now remember the last song they've played, and if you use them while in combat mode, they automatically play your last played song without you needing to traverse any additional menus.**
    - I don't know how anyone has ever played a bard in combat before now without this.
- Instruments now have helpful text on their examine that explains the MMB audience-adding behavior and the song replaying described above, if you have inspiration.
- The psyaltrist now spawns a scabbard properly when picking a rapier as its main weapon.
- The psyaltrist now has the appropriate devotion regen rate for a T2 miracle class instead of having T1 capacity and regeneration worse than devotee. (250 -> 400 max devotion, 0.1 (weak) -> 0.5 (minor) regen). They're equal to an adventurer cantor with this change.
    - All psydonite miracles use a shit ton of devotion and at the prior values, a combat-active psyaltrist had to spend nearly **8 minutes** MMB channeling prayer to get enough devotion back to full, and could cast a whopping total of 4 miracles before it'd deplete.

## Testing Evidence

<img width="549" height="262" alt="dreamseeker_7bjKjQETaJ" src="https://github.com/user-attachments/assets/b8f8defc-205b-470b-b4ed-0db2f0dbcfbc" />

<img width="978" height="209" alt="dreamseeker_pvuqL4gVQ0" src="https://github.com/user-attachments/assets/ea575f91-f3fd-40db-bc2b-1f08a45e245e" />

## Why It's Good For The Game

Less control burden with an already VERY control-heavy class (bard) is great for everyone involved. All of these should be pretty self-explanatory, really.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
qol: Instruments now play their last-played song immediately if used in combat, instead of needing you to navigate two dialogs while completely still.
qol: Instruments now have helpful examine text for characters with inspiration to explain the above change, and other QoL changes made recently.
fix: Fixed the psyaltrist's scabbard not spawning when picking the rapier loadout.
fix: Fixed the psyaltrist to use the proper devotion values for a T2 miracle class.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
