### PR TITLE
Makes bacon obtainable

### DIFF
--- a/code/modules/roguetown/roguestock/stockpile_food.dm
+++ b/code/modules/roguetown/roguestock/stockpile_food.dm
@@ -1,4 +1,4 @@
-// Withdraw Price used to be designed to match export price. 
+// Withdraw Price used to be designed to match export price.
 // However this meant that food were often too expensive to buy as raw materials
 // Now for food the withdraw price is set to be the same as the payout price
 // Theoretically this does create a perverse incentive to export food instead of selling it locally
@@ -111,8 +111,8 @@
 	remote_limit = 8
 
 /datum/roguestock/stockpile/pork
-	name = "Pig meat"
-	desc = "Piggy meat"
+	name = "Pig Meat"
+	desc = "Edible flesh harvested from hogs."
 	item_type = /obj/item/reagent_containers/food/snacks/rogue/meat/fatty
 	held_items = list(0, 3)
 	payout_price = 4
@@ -212,7 +212,7 @@
 	stockpile_limit = 25
 	passive_generation = 1
 	category = "Foodstuffs"
-	generation_price = 4 
+	generation_price = 4
 
 /datum/roguestock/stockpile/onion
 	name = "Onion"

--- a/modular/Neu_Food/code/raw/raw_meat.dm
+++ b/modular/Neu_Food/code/raw/raw_meat.dm
@@ -44,7 +44,7 @@
 				qdel(src)
 		else
 			to_chat(user, span_warning("You need to put [src] on a table to roll it out!"))
-	else 
+	else
 		return ..()
 
 /* ............. Generic Steak ................*/
@@ -65,11 +65,11 @@
 
 /* ............. Pork (Fatty Sprite) ................*/
 /obj/item/reagent_containers/food/snacks/rogue/meat/fatty //pork
-	name = "raw pigflesh"
+	name = "raw pork"
 	icon_state = "pork"
 	fried_type = /obj/item/reagent_containers/food/snacks/rogue/meat/fatty/roast
-	slices_num = 2
-	slice_path = /obj/item/reagent_containers/food/snacks/rogue/meat/mince/beef
+	slices_num = 3
+	slice_path = /obj/item/reagent_containers/food/snacks/rogue/meat/bacon
 	slice_bclass = BCLASS_CHOP
 	chopping_sound = TRUE
 	cooked_smell = /datum/pollutant/food/fried_meat
@@ -119,7 +119,7 @@
 				qdel(src)
 		else
 			to_chat(user, span_warning("You need to put [src] on a table to roll it out!"))
-	else 
+	else
 		return ..()
 
 /* ............. Whole Bird ................*/
@@ -491,7 +491,7 @@
 	user.Knockdown(4 SECONDS)
 
 	sleep(7 SECONDS)
-	
+
 	var/mob/C = pick(candidates)
 	var/mob/living/carbon/human/H = new(get_turf(user))
 	H.key = C.key


### PR DESCRIPTION
## About The Pull Request

Changes pig meat to slice into bacon instead of meat mince. 

## Testing Evidence

I spawned in, purchased pork from the stockpile, and chopped it into bacon.

## Why It's Good For The Game

Oversight from the AP food port. We had our own version of pork locally, and the version AP expected us to have wasn't available from any source.

## Changelog

:cl: CameronWoof
fix: Pork can now be chopped into bacon
/:cl:
