### PR TITLE
(Finally) Gives Tanto to Ruma-Clan 

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/rumaclan.dm
@@ -47,6 +47,8 @@
 		/obj/item/roguekey/mercenary = 1,
 		/obj/item/flashlight/flare/torch/lantern = 1,
 		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/rogueweapon/huntingknife/idagger/steel/kazengun = 1, 
+
 		)
 	H.merctype = 9
 


### PR DESCRIPTION
## About The Pull Request

This PR gives the Kazengun Tanto to the Ruma-Clan merc.

## Testing Evidence

It compiles.

## Why It's Good For The Game

Most other merc-classes start with some sort of dagger already, notably so, even Sasu, the archer counterpart of the Ruma-Clan's melee fighter. I doubt this will affect the game in a negative manner, as the change itself seems negligible, and could have just been an oversight on the OG developer's part. This change was also requested very much. 
## Changelog



:cl:
add: Tanto to Ruma-Clan Gun-in's backpack
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
