### PR TITLE
Sallet hides ears

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -138,6 +138,7 @@
 	name = "sallet"
 	icon_state = "sallet"
 	desc = "A steel helmet which protects the ears."
+	flags_inv = HIDEEARS
 	smeltresult = /obj/item/ingot/steel
 	body_parts_covered = HEAD|HAIR|EARS
 

--- a/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/medium_helmet.dm
@@ -188,7 +188,7 @@
 	desc = "A steel helmet which protects the ears, nose, and eyes."
 	icon_state = "sallet_visor"
 	adjustable = CAN_CADJUST
-	flags_inv = HIDEFACE|HIDESNOUT|HIDEHAIR
+	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT|HIDEHAIR
 	flags_cover = HEADCOVERSEYES
 	body_parts_covered = HEAD|EARS|HAIR|NOSE|EYES
 	block2add = FOV_BEHIND


### PR DESCRIPTION
## About The Pull Request

Makes the sallet, iron sallet, visored sallet, and iron visored sallet disable the ear sprites when worn.

## Testing Evidence

<img width="166" height="226" alt="Screenshot 2026-08-29 121928" src="https://github.com/user-attachments/assets/ebcc8178-0e98-40ca-b90e-f24cf0c627b0" />

## Why It's Good For The Game

At the moment ear sprites can appear on top of the player character, including on top of the helmet, poking through the metal, which is ugly. A lack of ears is less ugly. Also, wearing a full visored sallet and a bevor, your ears can still poke out, which is dumb looking.

## Changelog

:cl:

image: Sallets now hide the ears, no longer will your precious fragile little knife ears be visible under your ironclad armor.

/:cl:
