### PR TITLE
AP #8507: gnoll satchels, basic gnoll skills, quiet gnoll speech

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -242,3 +242,9 @@
 	miss_text = "strikes the air!"
 	miss_sound = "bluntwooshlarge"
 	attack_verb = list("punches", "strikes", "tears")
+
+
+/obj/item/storage/backpack/rogue/satchel/gnoll 
+	name = "stained satchel"
+	desc = "A fetid sack fashioned into a storage accessory. Whatever's put there inevitably comes out twice the bloody."
+	mob_overlay_icon = null

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_berserker.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_berserker.dm
@@ -22,8 +22,11 @@
 		/datum/skill/misc/swimming = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/athletics = SKILL_LEVEL_MASTER,
 		/datum/skill/misc/climbing = SKILL_LEVEL_MASTER,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_LEGENDARY,
-		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)
 
 /datum/outfit/job/roguetown/gnoll/berserker/pre_equip(mob/living/carbon/human/H)
@@ -31,4 +34,5 @@
 		H.set_species(/datum/species/gnoll)
 		H.skin_armor = new /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor(H)
 		neck = /obj/item/storage/belt/rogue/pouch/healing
+		backr = /obj/item/storage/backpack/rogue/satchel/gnoll
 		don_pelt(H)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_knight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_knight.dm
@@ -21,8 +21,11 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_EXPERT,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_LEGENDARY,
-		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_NOVICE,
 	)
 	cmode_music = 'sound/music/combat_graggar.ogg'
 
@@ -31,6 +34,7 @@
 		H.set_species(/datum/species/gnoll)
 		H.skin_armor = new /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/knight(H)
 		neck = /obj/item/storage/belt/rogue/pouch/healing
+		backr = /obj/item/storage/backpack/rogue/satchel/gnoll
 		don_pelt(H)
 
 /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/knight

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_shaman.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_shaman.dm
@@ -25,8 +25,10 @@
 		/datum/skill/misc/sneaking = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/lockpicking = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/medicine = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
-		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN
+		/datum/skill/craft/crafting = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/craft/alchemy = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/labor/butchering = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/craft/cooking = SKILL_LEVEL_JOURNEYMAN,
 	)
 	category_tags = list(CTAG_GNOLL)
 	cmode_music = 'sound/music/combat_graggar.ogg'
@@ -38,6 +40,7 @@
 		var/obj/item/ritechalk/chalk = new /obj/item/ritechalk(H.loc)
 		H.put_in_r_hand(chalk)
 		neck = /obj/item/storage/belt/rogue/pouch/alchemy
+		backr = /obj/item/storage/backpack/rogue/satchel/gnoll
 		don_pelt(H)
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_miracles(H, cleric_tier = CLERIC_T4, passive_gain = CLERIC_REGEN_MINOR, start_maxed = TRUE)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll/gnoll_templar.dm
@@ -21,8 +21,10 @@
 		/datum/skill/combat/unarmed = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/athletics = SKILL_LEVEL_EXPERT,
 		/datum/skill/misc/climbing = SKILL_LEVEL_JOURNEYMAN,
+		/datum/skill/misc/sneaking = SKILL_LEVEL_JOURNEYMAN,
 		/datum/skill/misc/tracking = SKILL_LEVEL_LEGENDARY,
-		/datum/skill/craft/crafting = SKILL_LEVEL_NOVICE
+		/datum/skill/craft/crafting = SKILL_LEVEL_APPRENTICE,
+		/datum/skill/labor/butchering = SKILL_LEVEL_NOVICE,
 	)
 	cmode_music = 'sound/music/combat_graggar.ogg'
 
@@ -31,6 +33,7 @@
 		H.set_species(/datum/species/gnoll)
 		H.skin_armor = new /obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/templar(H)
 		neck = /obj/item/storage/belt/rogue/pouch
+		backr = /obj/item/storage/backpack/rogue/satchel/gnoll
 		don_pelt(H)
 		var/datum/devotion/C = new /datum/devotion(H, H.patron)
 		C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, start_maxed = FALSE)

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/gnoll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/gnoll.dm
@@ -82,6 +82,8 @@
 /datum/species/gnoll/send_voice(mob/living/carbon/human/H)
 	if(H.m_intent != MOVE_INTENT_SNEAK)
 		playsound(get_turf(H), pick('sound/vo/mobs/wwolf/wolftalk1.ogg','sound/vo/mobs/wwolf/wolftalk2.ogg'), 100, TRUE, -1)
+	else
+		playsound(get_turf(H), 'sound/misc/talk.ogg', 100, TRUE, -1)
 
 /datum/species/gnoll/proc/cancel_default_bark(datum/source, list/hearers, distance, volume, pitch)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/gnoll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/gnoll.dm
@@ -47,7 +47,7 @@
 	)
 	inherent_biotypes = MOB_HUMANOID
 	armor = 30
-	no_equip = list(SLOT_SHIRT, SLOT_HEAD, SLOT_WEAR_MASK, SLOT_ARMOR, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_CLOAK, SLOT_BELT, SLOT_BACK_R, SLOT_BACK_L, SLOT_S_STORE)
+	no_equip = list(SLOT_SHIRT, SLOT_HEAD, SLOT_WEAR_MASK, SLOT_ARMOR, SLOT_GLOVES, SLOT_SHOES, SLOT_PANTS, SLOT_CLOAK, SLOT_BELT, SLOT_BACK_L, SLOT_S_STORE)
 	nojumpsuit = 1
 	sexes = 1
 	offset_features = list(OFFSET_HANDS = list(0,2), OFFSET_HANDS_F = list(0,2))
@@ -80,7 +80,8 @@
 	examine_relief_event = /datum/stressevent/gnoll_graggar
 
 /datum/species/gnoll/send_voice(mob/living/carbon/human/H)
-	playsound(get_turf(H), pick('sound/vo/mobs/wwolf/wolftalk1.ogg','sound/vo/mobs/wwolf/wolftalk2.ogg'), 100, TRUE, -1)
+	if(H.m_intent != MOVE_INTENT_SNEAK)
+		playsound(get_turf(H), pick('sound/vo/mobs/wwolf/wolftalk1.ogg','sound/vo/mobs/wwolf/wolftalk2.ogg'), 100, TRUE, -1)
 
 /datum/species/gnoll/proc/cancel_default_bark(datum/source, list/hearers, distance, volume, pitch)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
Port Azure-Peak/Azure-Peak#8507. I like the rationale expressed in that PR's thread, go see there for more details.

- If on SNEAK intent, gnolls produce a far quieter, more indistinct speech sound when they talk.
- Gnolls have their **right shoulder** slot opened up, and all classes spawn with a gnoll satchel equipped. The only difference is that the satchel does not show a sprite on the mob.
  - Left shoulder is the backpack shoulder. They can't equip backpacks.
- All Gnoll subclasses now get basic some basic stealth/survival skills. See the diff for more details.
  - Most notably, **Journeyman Sneaking** to Berserker, Knight, Templar. (All three previously had none; Shaman and Impure already have Expert Sneaking.) 
  
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled. Azure tested it for me!

Update: Tested while also testing other gnoll PRs.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
I sought out this PR because people were mentioning gnolls being able to use satchels on AP, and it makes a lot of sense. The other changes are really nice, simple fixes that I don't think would hurt to include. 

Gnolls should probably be able to have a conversation without all of China knowing they're here.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Gnolls now have baseline sneaking and better crafting skills. Gnolls now have an unlocked right back slot, as well as a satchel to go with it. Mind, the right back slot does not allow for larger storage like backpacks.
balance: On SNEAK intent, Gnolls produce a far quieter, more indistinct speech sound when talking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
