### PR TITLE
Gives corroded dagger a sheathed sprite

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -400,7 +400,7 @@
 	name = "corroded dagger"
 	desc = "A wicked deliverer of poison, serrated and notched. Curved steel cradles the knuckles, ensuring that the wielder doesn't inflict the fatal dose on themselves. </br>I can coat this dagger in most poisons, ensuring that my next strike leaves a festering surprise."
 	icon_state = "pdagger"
-	sheathe_icon = "pdagger"
+	sheathe_icon = "combatknife"
 
 /obj/item/rogueweapon/huntingknife/idagger/warden_machete
 	possible_item_intents = list(/datum/intent/dagger/thrust/weak, /datum/intent/dagger/cut/heavy, /datum/intent/dagger/chop/cleaver, /datum/intent/dagger/sucker_punch) // Stronger cut and chop, but no pick.


### PR DESCRIPTION
## About The Pull Request

Corroded dagger has no sheath sprite. Combat knife sheathed looks almost the same. Easiest temporary fix for a literal invisible item I've spent 30 minutes looking for one round.
<img width="118" height="126" alt="image" src="https://github.com/user-attachments/assets/5fb8ff9f-0253-4822-b418-b05ff6f7555a" />

## Testing Evidence

<img width="400" height="260" alt="are-you-serious-spiderman" src="https://github.com/user-attachments/assets/c2deaba7-d3a4-4ff0-b91a-87faecb08e66" />

The worst that could happen is it stays invisible

## Why It's Good For The Game

Because bugs are for fixing

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: corroded dagger sheathed sprite
/:cl:
