### PR TITLE
Adds a verb for Gnolls to view their Track target's flavortext window

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -102,7 +102,7 @@
 	tracked_target_ref = WEAKREF(selected_target)
 	sync_antag_tracked_target(user, selected_target)
 	notify_tracked_target(selected_target)
-	to_chat(user, "<span class='notice'>You focus your senses on [selected_target.real_name].</span> [selection != last_selection ? "(<a href='?src=[REF(user)];task=gnoll_view_tracked;'>Preview Target</a>)" : ""]")
+	to_chat(user, "<span class='notice'>You focus your senses on [selected_target.real_name].</span> [selection != last_selection ? "(<a href='?src=[REF(user)];task=gnoll_view_tracked;'>View</a>)" : ""]")
 	give_tracking_directions(user)
 	last_selection = selection
 

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -51,7 +51,7 @@
 	if(is_valid_hunted(target) && target != user)
 		tracked_target_ref = WEAKREF(target)
 		sync_antag_tracked_target(user, target)
-		to_chat(user, span_notice("You catch the scent of [target.real_name]. The hunt begins!"))
+		to_chat(user, span_notice("You catch the scent of <a href='?src=[REF(user)];task=gnoll_view_tracked;'>[target.real_name]</a>. The hunt begins!"))
 		notify_tracked_target(target)
 		user.playsound_local(get_turf(user), 'sound/vo/mobs/wwolf/sniff.ogg', 50, TRUE)
 	else if(!tracked_target_ref?.resolve())

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -102,7 +102,7 @@
 	tracked_target_ref = WEAKREF(selected_target)
 	sync_antag_tracked_target(user, selected_target)
 	notify_tracked_target(selected_target)
-	to_chat(user, span_notice("You focus your senses on [selected_target.real_name].") + selection != last_selection ? "(<a href='?src=[REF(user)];task=gnoll_view_tracked;'>Preview Target</a>)" : "")
+	to_chat(user, "<span class='notice'>You focus your senses on [selected_target.real_name].</span> [selection != last_selection ? "(<a href='?src=[REF(user)];task=gnoll_view_tracked;'>Preview Target</a>)" : ""]")
 	give_tracking_directions(user)
 	last_selection = selection
 

--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll_spells.dm
@@ -98,12 +98,13 @@
 		to_chat(user, span_warning("That scent slips away before you can lock onto it."))
 		return
 
-	last_selection = selection
+
 	tracked_target_ref = WEAKREF(selected_target)
 	sync_antag_tracked_target(user, selected_target)
 	notify_tracked_target(selected_target)
-	to_chat(user, span_notice("You focus your senses on [selected_target.real_name]."))
+	to_chat(user, span_notice("You focus your senses on [selected_target.real_name].") + selection != last_selection ? "(<a href='?src=[REF(user)];task=gnoll_view_tracked;'>Preview Target</a>)" : "")
 	give_tracking_directions(user)
+	last_selection = selection
 
 /obj/effect/proc_holder/spell/invoked/gnoll_sniff/proc/add_target_to_list(mob/living/carbon/human/human, list/target_list, list/name_counts)
 	var/base_name = "[human.real_name]"

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -43,6 +43,7 @@
 			var/datum/antagonist/new_antag = new /datum/antagonist/gnoll()
 			H.mind.add_antag_datum(new_antag)
 			H.verbs |= /mob/living/carbon/human/proc/gnoll_inspect_skin
+			H.verbs |= /mob/living/carbon/human/proc/gnoll_view_tracked_char
 
 
 /mob/living/carbon/human/proc/apply_gnoll_preferences(initial_setup = TRUE)
@@ -199,3 +200,27 @@
 		return
 	var/obj/item/clothing/suit/roguetown/armor/regenerating/skin/gnoll_armor/GA = skin_armor
 	GA.Topic(null, list("inspect" = "1"), src)
+
+/mob/living/carbon/human/proc/gnoll_view_tracked_char()
+	set name = "Remember Your Prey"
+	set category = "Gnoll"
+	set desc = "View your Track target's flavortext panel."
+	var/datum/antagonist/gnoll/gnoll_antag = mind?.has_antag_datum(/datum/antagonist/gnoll)
+	if(!gnoll_antag)
+		to_chat(src, span_warning(pick("What?", "Huh?", "How?")))
+		return
+	var/datum/weakref/tracked_target_ref = gnoll_antag.tracked_target_ref
+	if(!tracked_target_ref)
+		to_chat(src, span_warning("Strange! I can't remember anything about it. Is it gone?"))
+		return
+	var/mob/living/carbon/human/tracked_target = tracked_target_ref.resolve()
+	if(!istype(tracked_target))
+		to_chat(src, span_warning("Either I am not tracking true prey, or it is gone..."))
+		return
+
+	to_chat(src, span_warning("I recall my mark with blessed foreknowledge..."))
+	var/datum/examine_panel/mob_examine_panel = new(src)
+	mob_examine_panel.holder = tracked_target
+	mob_examine_panel.viewing = src
+	mob_examine_panel.ui_interact(src)
+

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/gnoll.dm
@@ -211,11 +211,11 @@
 		return
 	var/datum/weakref/tracked_target_ref = gnoll_antag.tracked_target_ref
 	if(!tracked_target_ref)
-		to_chat(src, span_warning("Strange! I can't remember anything about it. Is it gone?"))
+		to_chat(src, span_warning("I can't remember anything. Did I forget to track my prey?"))
 		return
 	var/mob/living/carbon/human/tracked_target = tracked_target_ref.resolve()
 	if(!istype(tracked_target))
-		to_chat(src, span_warning("Either I am not tracking true prey, or it is gone..."))
+		to_chat(src, span_warning("My prey is gone..."))
 		return
 
 	to_chat(src, span_warning("I recall my mark with blessed foreknowledge..."))

--- a/code/modules/mob/living/carbon/human/human_topic.dm
+++ b/code/modules/mob/living/carbon/human/human_topic.dm
@@ -23,6 +23,9 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 		mob_examine_panel.ui_interact(usr)
 		return
 
+	if(href_list["task"] == "gnoll_view_tracked")
+		gnoll_view_tracked_char()
+
 	if(href_list["inspect_limb"] && (observer_privilege || usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY)))
 		var/list/msg = list()
 		var/mob/user = usr


### PR DESCRIPTION
## About The Pull Request
Adds a "Remember Your Prey" verb to the Gnoll tab, allowing you to remotely pull up your Track target's flavortext window. This is mainly for the purposes of viewing their notes, so that you're going in with actual intent, and hopefully some sort of plan.

A link to use this verb also shows up in the chat when you select a new target in Track selection.

It's important to note that this doesn't attempt to bypass Masked Examine or NSFW examine; the real focus of this is for the gnoll to be able to read the target's notes.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Spamming Track on myself (pulling up target selection) and selecting the same target, to show that the hyperlink only pops up once

<img width="1920" height="1080" alt="Screenshot_20260830_171955" src="https://github.com/user-attachments/assets/da7ebf5c-a552-437b-b942-7201324bffe4" />
<img width="1920" height="1080" alt="Screenshot_20260830_172014" src="https://github.com/user-attachments/assets/1afdcb8a-ef59-441f-9c2a-8e4535f73470" />

Spamming the verb with a target that fartraveled (or otherwise doesn't exist)

<img width="607" height="162" alt="Screenshot_20260830_172112" src="https://github.com/user-attachments/assets/ffac5780-96a4-4061-9009-6bc623949630" />

Spamming the verb before a target is selected. Amnesiac gnolls...

<img width="1072" height="461" alt="image" src="https://github.com/user-attachments/assets/115f7b87-a55b-4563-a847-1faa33edd5a7" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The main sport of Gnoll players is playing with their food, and I think it's beneficial that they be able to know more about who it is they're dealing with. Helps resolve the question of shared prefs, and saves gnolls time in a busy round.

Yes, I am giving them a License to Windowshop. They are probably the best candidate for it, them and Assassins. This implementation doesn't make it easy for them to look at *every character*, since there's no big "character directory" for them to just scroll down. But it does let them decide if they actually *want to pursue* whomever they've just selected. Even more importantly, gnolls can actually read their target's notes from an area of safety, then track down and engage with their target in a focused, intentional manner.

**I would also argue** that this softly nudges gnolls away from just being "friendly" and aimlessly walking around town. I believe that to at least partially be a consequence of unnecessary friction, specifically with being able to read their target's notes. They have to go chase their target, then examine them maybe, hope they have no mask or Masked Examine on, then go to the next target, examine them, read notes, repeat.

I think Gnoll players get bored of doing that, so they kinda just give up and do whatever, because they can't find anyone they want to harass. It sucks. It doesn't have to.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a "Remember Your Prey" verb for Gnolls that pulls up their current target's flavortext window, allowing them to view that target's notes before actually finding them in-person.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
