### PR TITLE
Dodge Fix for Simplemobs.

### DIFF
--- a/code/modules/mob/living/combat/dodge.dm
+++ b/code/modules/mob/living/combat/dodge.dm
@@ -113,10 +113,9 @@
 	var/drained_npc = 5
 	if(ishuman(src))
 		H = src
-	if(ishuman(user))
-		UH = user
-		if (UH.used_intent)
-			I = UH.used_intent.masteritem
+	UH = user
+	if (UH.used_intent)
+		I = UH.used_intent.masteritem
 	var/prob2defend = U.defprob
 	if(L.stamina >= L.max_stamina)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

I don't know what happened to simplemobs and why suddenly they've become undodgable, but I think I found a problem and the stupidest fix to it.
Before any calculations to a dodge there was a check if an attacker is a human (ishuman). Because of this simplemobs attacking a player triggered a dodge attempt which ended up in a runtime error.

I'm not sure why it broke now and not some time earlier because this code was written about 13 months ago.
I don't know if it will cause more problems down the line, but it seems like it is working.


## Testing Evidence

https://github.com/user-attachments/assets/29245e95-4dbe-4fdf-bb37-11f1090750c4


## Why It's Good For The Game

People asked me to fix it. I assume it is a good thing making dodge builds viable.

## Changelog


:cl:
fix: do_dodge should work on simplemobs too.
:cl:

