### PR TITLE
Gently tunes down Atgervi Shaman

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -71,7 +71,7 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/atgervishaman
 	subclass_languages = list(/datum/language/gronnic)
 	cmode_music = 'sound/music/combat_shaman2.ogg'
-	traits_applied = list(TRAIT_STRONGBITE, TRAIT_CIVILIZEDBARBARIAN)
+	traits_applied = list(TRAIT_STRONGBITE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_NOPAINSTUN)
 	subclass_stats = list(
 		STATKEY_STR = 2,
 		STATKEY_CON = 2,

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -71,9 +71,9 @@
 	outfit = /datum/outfit/job/roguetown/mercenary/atgervishaman
 	subclass_languages = list(/datum/language/gronnic)
 	cmode_music = 'sound/music/combat_shaman2.ogg'
-	traits_applied = list(TRAIT_STRONGBITE, TRAIT_CIVILIZEDBARBARIAN, TRAIT_CRITICAL_RESISTANCE, TRAIT_NOPAINSTUN)
+	traits_applied = list(TRAIT_STRONGBITE, TRAIT_CIVILIZEDBARBARIAN)
 	subclass_stats = list(
-		STATKEY_STR = 3,
+		STATKEY_STR = 2,
 		STATKEY_CON = 2,
 		STATKEY_WIL = 1,
 		STATKEY_SPD = 1,


### PR DESCRIPTION
It's no coincidence that this specific mercenary class is used as a subtype for several of the most objectively overpowered wretch classes in the game.

## About The Pull Request

They lose one point of STR, from 3 to 2, and **critical resistance**. They are a light armor class but atgervi light armor is still very good, and they have access to heretic miracles despite being a town-sided role, which are generally quite powerful. Their most common statpacks were +2 str statpacks as they were often graggarites, which they then paired with the t0 graggar break my chains 2 point strength boost and graggar rage 1 point strength boost to hit strength unbound 19 STR, which made them obscenely oppressive. They often did this in public because people just don't attack atgervi for fear of it being considered 'metaing heretics.'

They'll still be able to hit 18 STR with this, but even a 1.8 mult is better than a 1.9 mult.

While the lore logic of that is questionable at best, since someone else is porting their amulets I don't feel it would be fair to them to invalidate their PR just by removing the whole thing.

They remain capable grapplers with the Gronn Beast Claws as an extremely potent unarmed tool. They are just no longer oppressively strong. They also lost Critical Resistance they're more fragile now.

## Testing Evidence

It's a single line change.

## Changelog

:cl:
balance: Atgervi shamans lost nopainstun, critical resistance, and one point of strength.
/:cl:

