### PR TITLE
Bulk Artificer Recipes + New Recipes

### DIFF
--- a/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
+++ b/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
@@ -86,6 +86,13 @@
 	hammers_per_item = 10
 	skill_level = 3
 
+/datum/artificer_recipe/wood/bulk
+	name = "Bulk Wooden Cogs 3x (+2 Planks)"
+	created_item = list(/obj/item/roguegear/wood/basic, /obj/item/roguegear/wood/basic, /obj/item/roguegear/wood/basic)
+	additional_items = list(/obj/item/natural/wood/plank, /obj/item/natural/wood/plank)
+	hammers_per_item = 10
+	skill_level = 2
+
 /datum/artificer_recipe/bronze
 	name = "Bronze Cog 2x"
 	required_item = /obj/item/ingot/bronze
@@ -93,6 +100,13 @@
 	hammers_per_item = 10
 	skill_level = 1
 	i_type = "General"
+
+/datum/artificer_recipe/bronze/bulk
+	name = "Bulk Bronze Cogs 3x (+2 Bronze Bars)"
+	created_item = list(/obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze)
+	additional_items = list(/obj/item/ingot/bronze, /obj/item/ingot/bronze)
+	hammers_per_item = 10
+	skill_level = 2
 
 /datum/artificer_recipe/iron
 	i_type = "General"
@@ -147,6 +161,13 @@
 	additional_items = list(/obj/item/roguegear/bronze)
 	skill_level = 0
 	hammers_per_item = 5
+
+/datum/artificer_recipe/bronze/tools/skillcore
+	name = "Golem Skill Exhibitor (+2 Cog)"
+	created_item = /obj/item/construct_skill_core
+	additional_items = list(/obj/item/roguegear, /obj/item/roguegear)
+	hammers_per_item = 10
+	skill_level = 3
 
 /datum/artificer_recipe/bronze/tools/headhook
 	name = "Headhook (+2 Fibers)"
@@ -497,6 +518,34 @@
 					)
 	hammers_per_item = 6
 	skill_level = 2
+
+/datum/artificer_recipe/ammunition/bodkinarrows
+	name = "Bodkin Arrows 20x (+2 Planks, +1 Steel)"
+	required_item = /obj/item/natural/wood/plank
+	additional_items = list(/obj/item/natural/wood/plank, /obj/item/natural/wood/plank,  /obj/item/ingot/steel)
+	created_item = list(/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel,
+						/obj/item/ammo_casing/caseless/rogue/arrow/steel
+					)
+	hammers_per_item = 6
+	skill_level = 3
 
 /datum/artificer_recipe/ammunition/bsarrows//faster way to craft blacksteel ammo, not a cheaper craft
 	name = "Blacksteel Arrows 10x (+1 Planks, +1 Silk, +2 Blacksteel)"

--- a/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
+++ b/code/modules/roguetown/roguejobs/artificer/artificer_recipes/artificer_recipes.dm
@@ -102,7 +102,7 @@
 	i_type = "General"
 
 /datum/artificer_recipe/bronze/bulk
-	name = "Bulk Bronze Cogs 3x (+2 Bronze Bars)"
+	name = "Bulk Bronze Cogs 6x (+2 Bronze Bars)"
 	created_item = list(/obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze, /obj/item/roguegear/bronze)
 	additional_items = list(/obj/item/ingot/bronze, /obj/item/ingot/bronze)
 	hammers_per_item = 10


### PR DESCRIPTION
## About The Pull Request
- Adds bulk wooden cog, bulk bronze cog, golem exhibitor, and bodkin arrow recipes to artificer table's recipes.

## Testing Evidence
<img width="1157" height="207" alt="ArtificerRecipes" src="https://github.com/user-attachments/assets/9afb4bac-27e6-4e58-a3cd-687da30a3d37" />

## Why It's Good For The Game
Less menu navigation and adding things that were missing is good. You need a TON of cogs for certain projects so the bulk recipes help shorten the time to make them. Also, we were missing bodkin arrows despite having blacksteel already in there. Did you know that the golem exhibitor was only on the anvil too for some reason? It still is but you can actually make it on the artificer table which makes more sense.

## Changelog
:cl:
add: Adds bulk wooden cog, bulk bronze cog, golem exhibitor, and bodkin arrow recipes to artificer table's recipes.
/:cl: