### PR TITLE
[QoL] Make Examine Panel collapsible/adjustable + allow zooming, & hiding headshot

### DIFF
--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -16,7 +16,7 @@ enum Page {
 const DEFAULT_WIDTH = 1000;
 const DEFAULT_HEIGHT = 700;
 // Headshot is 350px; leftover covers Window content padding.
-const COLLAPSED_WIDTH = 400;
+const COLLAPSED_WIDTH = 450;
 
 export const ExaminePanel = (props) => {
   const { act, data } = useBackend<ExaminePanelData>();

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -13,62 +13,107 @@ enum Page {
   ImageGallery,
 }
 
+const DEFAULT_WIDTH = 1000;
+const DEFAULT_HEIGHT = 700;
+// Headshot is 350px; leftover covers Window content padding.
+const COLLAPSED_WIDTH = 400;
+
 export const ExaminePanel = (props) => {
   const { act, data } = useBackend<ExaminePanelData>();
-  const { is_vet, character_name, is_playing, has_song, img_gallery, nsfw_img_gallery } = data;
+  const {
+    is_vet,
+    character_name,
+    is_playing,
+    has_song,
+    img_gallery,
+    nsfw_img_gallery,
+  } = data;
   const [currentPage, setCurrentPage] = useState(Page.FlavorText);
+  const [collapsed, setCollapsed] = useState(false);
+  const [expandedSize, setExpandedSize] = useState({
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+  });
 
-  let pageContents;
+  const hasGallery = img_gallery.length > 0 || nsfw_img_gallery.length > 0;
+  const showTabs = hasGallery && !collapsed;
 
-  switch (currentPage) {
-    case Page.FlavorText:
-      pageContents = <FlavorTextPage />;
-      break;
-    case Page.ImageGallery:
-      pageContents = <ImageGalleryPage />;
-      break;
-  }
+  const toggleCollapse = () => {
+    if (!collapsed) {
+      setExpandedSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+      setCurrentPage(Page.FlavorText);
+    }
+    setCollapsed(!collapsed);
+  };
+
+  const pageContents =
+    collapsed || currentPage === Page.FlavorText ? (
+      <FlavorTextPage collapsed={collapsed} />
+    ) : (
+      <ImageGalleryPage />
+    );
 
   return (
-    <Window title={character_name} width={1000} height={700} buttons={
-      <>
-      {!!is_vet}
-      <Button
-      color="green"
-      icon="music"
-      tooltip="Music player"
-      tooltipPosition="bottom-start"
-      onClick={() => act('toggle')}
-      disabled={!has_song}
-      selected={!is_playing}
-      />
-      </>}>
+    <Window
+      title={character_name}
+      width={collapsed ? COLLAPSED_WIDTH : expandedSize.width}
+      height={expandedSize.height}
+      buttons={
+        <>
+          {!!is_vet}
+          <Button
+            icon={collapsed ? 'chevron-right' : 'chevron-left'}
+            tooltip={collapsed ? 'Expand' : 'Collapse'}
+            tooltipPosition="bottom-start"
+            selected={collapsed}
+            onClick={toggleCollapse}
+          />
+          <Button
+            color="green"
+            icon="music"
+            tooltip="Music player"
+            tooltipPosition="bottom-start"
+            onClick={() => act('toggle')}
+            disabled={!has_song}
+            selected={!is_playing}
+          />
+        </>
+      }
+    >
       <Window.Content>
         <Stack vertical fill>
-          {(img_gallery.length > 0 || nsfw_img_gallery.length > 0) && (
-          <Stack>
-            <Stack.Item grow>
-              <PageButton
-              currentPage={currentPage}
-              page={Page.FlavorText}
-              setPage={setCurrentPage}
-              >
-                Flavor Text
-              </PageButton>
-            </Stack.Item>
-            <Stack.Item grow>
-              <PageButton
-              currentPage={currentPage}
-              page={Page.ImageGallery}
-              setPage={setCurrentPage}
-              >
-                Image Gallery
-              </PageButton>
-            </Stack.Item>
-          </Stack>
+          {showTabs && (
+            <Stack>
+              <Stack.Item grow>
+                <PageButton
+                  currentPage={currentPage}
+                  page={Page.FlavorText}
+                  setPage={setCurrentPage}
+                >
+                  Flavor Text
+                </PageButton>
+              </Stack.Item>
+              <Stack.Item grow>
+                <PageButton
+                  currentPage={currentPage}
+                  page={Page.ImageGallery}
+                  setPage={setCurrentPage}
+                >
+                  Image Gallery
+                </PageButton>
+              </Stack.Item>
+            </Stack>
           )}
-          {img_gallery.length > 0 && (<Stack.Divider />)}
-          <Stack.Item grow position="relative" overflowX="hidden" overflowY="auto">
+          {showTabs && <Stack.Divider />}
+          <Stack.Item
+            grow
+            position="relative"
+            overflowX="hidden"
+            overflowY="auto"
+          >
             {pageContents}
           </Stack.Item>
         </Stack>

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -15,8 +15,14 @@ enum Page {
 
 const DEFAULT_WIDTH = 1000;
 const DEFAULT_HEIGHT = 700;
-// Headshot is 350px; leftover covers Window content padding.
 const COLLAPSED_WIDTH = 450;
+
+const setWindowSize = (width: number, height: number) => {
+  const ratio = window.devicePixelRatio || 1;
+  Byond.winset(Byond.windowId, {
+    size: `${width * ratio}x${height * ratio}`,
+  });
+};
 
 export const ExaminePanel = (props) => {
   const { act, data } = useBackend<ExaminePanelData>();
@@ -30,37 +36,28 @@ export const ExaminePanel = (props) => {
   } = data;
   const [currentPage, setCurrentPage] = useState(Page.FlavorText);
   const [collapsed, setCollapsed] = useState(false);
-  const [expandedSize, setExpandedSize] = useState({
-    width: DEFAULT_WIDTH,
-    height: DEFAULT_HEIGHT,
-  });
+  const [expandedWidth, setExpandedWidth] = useState(DEFAULT_WIDTH);
 
   const hasGallery = img_gallery.length > 0 || nsfw_img_gallery.length > 0;
   const showTabs = hasGallery && !collapsed;
+  const showGallery = !collapsed && currentPage === Page.ImageGallery;
 
   const toggleCollapse = () => {
     if (!collapsed) {
-      setExpandedSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
+      setExpandedWidth(window.innerWidth);
       setCurrentPage(Page.FlavorText);
+      setWindowSize(COLLAPSED_WIDTH, window.innerHeight);
+    } else {
+      setWindowSize(expandedWidth, window.innerHeight);
     }
     setCollapsed(!collapsed);
   };
 
-  const pageContents =
-    collapsed || currentPage === Page.FlavorText ? (
-      <FlavorTextPage collapsed={collapsed} />
-    ) : (
-      <ImageGalleryPage />
-    );
-
   return (
     <Window
       title={character_name}
-      width={collapsed ? COLLAPSED_WIDTH : expandedSize.width}
-      height={expandedSize.height}
+      width={DEFAULT_WIDTH}
+      height={DEFAULT_HEIGHT}
       buttons={
         <>
           {!!is_vet}
@@ -115,7 +112,10 @@ export const ExaminePanel = (props) => {
             overflowX="hidden"
             overflowY="auto"
           >
-            {pageContents}
+            <div style={{ display: showGallery ? 'none' : 'contents' }}>
+              <FlavorTextPage collapsed={collapsed} />
+            </div>
+            {showGallery && <ImageGalleryPage />}
           </Stack.Item>
         </Stack>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/ExaminePanel.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanel.tsx
@@ -109,6 +109,7 @@ export const ExaminePanel = (props) => {
           )}
           {showTabs && <Stack.Divider />}
           <Stack.Item
+            key="examine-content"
             grow
             position="relative"
             overflowX="hidden"

--- a/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
@@ -80,7 +80,7 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
       {showLeft && (
         <Stack.Item
           grow={collapsed}
-          width={collapsed ? undefined : '350px'}
+          width={collapsed ? undefined : '300px'}
           minWidth={collapsed ? 0 : undefined}
         >
           <Stack fill vertical>

--- a/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
@@ -5,7 +5,12 @@ import { resolveAsset } from '../assets';
 import { useBackend } from '../backend';
 import { ExaminePanelData } from './ExaminePanelData';
 
-export const FlavorTextPage = (props) => {
+type FlavorTextPageProps = {
+  collapsed?: boolean;
+};
+
+export const FlavorTextPage = (props: FlavorTextPageProps) => {
+  const { collapsed = false } = props;
   const { data } = useBackend<ExaminePanelData>();
   const {
     flavor_text,
@@ -20,122 +25,142 @@ export const FlavorTextPage = (props) => {
   } = data;
   const [oocNotesIndex, setOocNotesIndex] = useState('SFW');
   const [flavorTextIndex, setFlavorTextIndex] = useState('SFW');
+  const [showHeadshot, setShowHeadshot] = useState(true);
 
-  const flavorHTML = useMemo(() => ({
-    __html: `<span className='Chat'>${flavor_text}</span>`,
-  }), [flavor_text]);
+  const flavorHTML = useMemo(
+    () => ({
+      __html: `<span className='Chat'>${flavor_text}</span>`,
+    }),
+    [flavor_text],
+  );
 
-  const nsfwHTML = useMemo(() => ({
-    __html: `<span className='Chat'>${flavor_text_nsfw}</span>`,
-  }), [flavor_text_nsfw]);
+  const nsfwHTML = useMemo(
+    () => ({
+      __html: `<span className='Chat'>${flavor_text_nsfw}</span>`,
+    }),
+    [flavor_text_nsfw],
+  );
 
-  const oocHTML = useMemo(() => ({
-    __html: `<span className='Chat'>${ooc_notes}</span>`,
-  }), [ooc_notes]);
+  const oocHTML = useMemo(
+    () => ({
+      __html: `<span className='Chat'>${ooc_notes}</span>`,
+    }),
+    [ooc_notes],
+  );
 
-  const oocnsfwHTML = useMemo(() => ({
-    __html: `<span className='Chat'>${ooc_notes_nsfw}</span>`,
-  }), [ooc_notes_nsfw]);
+  const oocnsfwHTML = useMemo(
+    () => ({
+      __html: `<span className='Chat'>${ooc_notes_nsfw}</span>`,
+    }),
+    [ooc_notes_nsfw],
+  );
 
   return (
-        <Stack fill>
-            <Stack fill vertical>
-                <Stack.Item align="center">
-                  <img
-                    src={resolveAsset(headshot)}
-                    width="350px"
-                    height="350px"
-                    /> 
-                </Stack.Item>
-              <Stack.Item grow>
-                <Stack fill>
-                  <Stack.Item grow width="300px">
-                    <Section
-                      scrollable
-                      fill
-                      title="OOC Notes"
-                      preserveWhitespace
-                      buttons={
-                        <>
-                          <Button
-                            selected={oocNotesIndex === 'SFW'}
-                            bold={oocNotesIndex === 'SFW'}
-                            onClick={() => setOocNotesIndex('SFW')}
-                            textAlign="center"
-                            minWidth="60px"
-                          >
-                            SFW
-                          </Button>
-                          <Button
-                            selected={oocNotesIndex === 'NSFW'}
-                            disabled={!ooc_notes_nsfw}
-                            bold={oocNotesIndex === 'NSFW'}
-                            onClick={() => setOocNotesIndex('NSFW')}
-                            textAlign="center"
-                            minWidth="60px"
-                          >
-                            NSFW
-                          </Button>
-                        </>
-                      }
-                    >
-                      {oocNotesIndex === 'SFW' && (
-                    <Box
-                    dangerouslySetInnerHTML={{
-                      __html: ooc_notes
-                        ? `<span class='Chat'>${ooc_notes}</span>`
-                        : "<i>No OOC notes provided.</i>",
-                      }}
-                    />
-                    )}
-                      {oocNotesIndex === 'NSFW' && (
-                    <Box
-                    dangerouslySetInnerHTML={oocnsfwHTML}
-                    />
-                    )}
-                    </Section>
-                  </Stack.Item>
-                </Stack>
-              </Stack.Item>
-            </Stack>
+    <Stack fill>
+      <Stack.Item
+        grow={collapsed}
+        width={collapsed ? undefined : '350px'}
+        minWidth={collapsed ? 0 : undefined}
+      >
+        <Stack fill vertical>
+          {showHeadshot && (
+            <Stack.Item align="center">
+              <img src={resolveAsset(headshot)} width="350px" height="350px" />
+            </Stack.Item>
+          )}
           <Stack.Item grow>
             <Section
               scrollable
               fill
+              title="OOC Notes"
               preserveWhitespace
-              title="Flavor Text"
               buttons={
                 <>
                   <Button
-                    selected={flavorTextIndex === 'SFW'}
-                    bold={flavorTextIndex === 'SFW'}
-                    onClick={() => setFlavorTextIndex('SFW')}
+                    icon={showHeadshot ? 'chevron-up' : 'chevron-down'}
+                    tooltip={showHeadshot ? 'Hide headshot' : 'Show headshot'}
+                    selected={!showHeadshot}
+                    onClick={() => setShowHeadshot(!showHeadshot)}
+                  />
+                  <Button
+                    selected={oocNotesIndex === 'SFW'}
+                    bold={oocNotesIndex === 'SFW'}
+                    onClick={() => setOocNotesIndex('SFW')}
                     textAlign="center"
-                    width="60px"
+                    minWidth="60px"
                   >
                     SFW
                   </Button>
                   <Button
-                    selected={flavorTextIndex === 'NSFW'}
-                    disabled={!flavor_text_nsfw || (!is_naked && !nsfw_examine_always)}
-                    bold={flavorTextIndex === 'NSFW'}
-                    onClick={() => setFlavorTextIndex('NSFW')}
+                    selected={oocNotesIndex === 'NSFW'}
+                    disabled={!ooc_notes_nsfw}
+                    bold={oocNotesIndex === 'NSFW'}
+                    onClick={() => setOocNotesIndex('NSFW')}
                     textAlign="center"
-                    width="60px"
+                    minWidth="60px"
                   >
                     NSFW
-                  </Button> 
-                </> 
+                  </Button>
+                </>
               }
-            >                  
-              {flavorTextIndex === 'SFW' && (
-                <>
+            >
+              {oocNotesIndex === 'SFW' && (
                 <Box
-              dangerouslySetInnerHTML={{
-                __html: flavor_text
-                  ? `<span class='Chat'>${flavor_text}</span>`
-                  : "<i>No flavor text provided.</i>",
-              }}
+                  dangerouslySetInnerHTML={{
+                    __html: ooc_notes
+                      ? `<span class='Chat'>${ooc_notes}</span>`
+                      : '<i>No OOC notes provided.</i>',
+                  }}
+                />
+              )}
+              {oocNotesIndex === 'NSFW' && (
+                <Box dangerouslySetInnerHTML={oocnsfwHTML} />
+              )}
+            </Section>
+          </Stack.Item>
+        </Stack>
+      </Stack.Item>
+      {!collapsed && (
+        <Stack.Item grow>
+          <Section
+            scrollable
+            fill
+            preserveWhitespace
+            title="Flavor Text"
+            buttons={
+              <>
+                <Button
+                  selected={flavorTextIndex === 'SFW'}
+                  bold={flavorTextIndex === 'SFW'}
+                  onClick={() => setFlavorTextIndex('SFW')}
+                  textAlign="center"
+                  width="60px"
+                >
+                  SFW
+                </Button>
+                <Button
+                  selected={flavorTextIndex === 'NSFW'}
+                  disabled={
+                    !flavor_text_nsfw || (!is_naked && !nsfw_examine_always)
+                  }
+                  bold={flavorTextIndex === 'NSFW'}
+                  onClick={() => setFlavorTextIndex('NSFW')}
+                  textAlign="center"
+                  width="60px"
+                >
+                  NSFW
+                </Button>
+              </>
+            }
+          >
+            {flavorTextIndex === 'SFW' && (
+              <>
+                <Box
+                  dangerouslySetInnerHTML={{
+                    __html: flavor_text
+                      ? `<span class='Chat'>${flavor_text}</span>`
+                      : '<i>No flavor text provided.</i>',
+                  }}
                 />
                 {ooc_extra_image && (
                   <Box
@@ -145,13 +170,11 @@ export const FlavorTextPage = (props) => {
                     }}
                   />
                 )}
-                </>
-              )}
-              {flavorTextIndex === 'NSFW' && (
-                <>
-                <Box
-                dangerouslySetInnerHTML={nsfwHTML}
-                />
+              </>
+            )}
+            {flavorTextIndex === 'NSFW' && (
+              <>
+                <Box dangerouslySetInnerHTML={nsfwHTML} />
                 {nsfw_ooc_extra_image && (
                   <Box
                     mt={1}
@@ -160,12 +183,12 @@ export const FlavorTextPage = (props) => {
                     }}
                   />
                 )}
-                </>
-              )} 
-            </Section>
-          </Stack.Item>
-        </Stack>
-
+              </>
+            )}
+          </Section>
+        </Stack.Item>
+      )}
+    </Stack>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, Image, Section, Stack } from 'tgui-core/components';
 
 import { resolveAsset } from '../assets';
@@ -7,6 +7,39 @@ import { ExaminePanelData } from './ExaminePanelData';
 
 type FlavorTextPageProps = {
   collapsed?: boolean;
+};
+
+const FONT_MIN = 0.8;
+const FONT_MAX = 1.5;
+const FONT_STEP = 0.1;
+
+const bumpEm = (value: number, dir: number) =>
+  Math.min(FONT_MAX, Math.max(FONT_MIN, +(value + dir * FONT_STEP).toFixed(1)));
+
+const EmButtons = (props: {
+  value: number;
+  onChange: (value: number) => void;
+}) => {
+  const atMin = props.value <= FONT_MIN;
+  const atMax = props.value >= FONT_MAX;
+  return (
+    <>
+      <Button
+        color={atMin ? undefined : 'transparent'}
+        compact
+        icon="minus"
+        disabled={atMin}
+        onClick={() => props.onChange(bumpEm(props.value, -1))}
+      />
+      <Button
+        color={atMax ? undefined : 'transparent'}
+        compact
+        icon="plus"
+        disabled={atMax}
+        onClick={() => props.onChange(bumpEm(props.value, 1))}
+      />
+    </>
+  );
 };
 
 export const FlavorTextPage = (props: FlavorTextPageProps) => {
@@ -23,9 +56,20 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
     nsfw_ooc_extra_image,
     nsfw_examine_always,
   } = data;
-  const [oocNotesIndex, setOocNotesIndex] = useState('SFW');
-  const [flavorTextIndex, setFlavorTextIndex] = useState('SFW');
+  const [oocNotesIndex, setOocNotesIndex] = useState<'SFW' | 'NSFW'>('SFW');
+  const [flavorTextIndex, setFlavorTextIndex] = useState<'SFW' | 'NSFW'>('SFW');
   const [showHeadshot, setShowHeadshot] = useState(true);
+  const [hideLeft, setHideLeft] = useState(false);
+  const [oocEm, setOocEm] = useState({ SFW: 1, NSFW: 1 });
+  const [flavorEm, setFlavorEm] = useState({ SFW: 1, NSFW: 1 });
+
+  useEffect(() => {
+    if (collapsed) {
+      setHideLeft(false);
+    }
+  }, [collapsed]);
+
+  const showLeft = collapsed || !hideLeft;
 
   const flavorHTML = useMemo(
     () => ({
@@ -57,69 +101,81 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
 
   return (
     <Stack fill>
-      <Stack.Item
-        grow={collapsed}
-        width={collapsed ? undefined : '350px'}
-        minWidth={collapsed ? 0 : undefined}
-      >
-        <Stack fill vertical>
-          {showHeadshot && (
-            <Stack.Item align="center">
-              <img src={resolveAsset(headshot)} width="350px" height="350px" />
-            </Stack.Item>
-          )}
-          <Stack.Item grow>
-            <Section
-              scrollable
-              fill
-              title="OOC Notes"
-              preserveWhitespace
-              buttons={
-                <>
-                  <Button
-                    icon={showHeadshot ? 'chevron-up' : 'chevron-down'}
-                    tooltip={showHeadshot ? 'Hide headshot' : 'Show headshot'}
-                    selected={!showHeadshot}
-                    onClick={() => setShowHeadshot(!showHeadshot)}
+      {showLeft && (
+        <Stack.Item
+          grow={collapsed}
+          width={collapsed ? undefined : '350px'}
+          minWidth={collapsed ? 0 : undefined}
+        >
+          <Stack fill vertical>
+            {showHeadshot && (
+              <Stack.Item align="center">
+                <img src={resolveAsset(headshot)} width="350px" height="350px" />
+              </Stack.Item>
+            )}
+            <Stack.Item grow>
+              <Section
+                scrollable
+                fill
+                title="OOC Notes"
+                preserveWhitespace
+                buttons={
+                  <>
+                    <EmButtons
+                      value={oocEm[oocNotesIndex]}
+                      onChange={(value) =>
+                        setOocEm({ ...oocEm, [oocNotesIndex]: value })
+                      }
+                    />
+                    <Button
+                      icon={showHeadshot ? 'chevron-up' : 'chevron-down'}
+                      tooltip={showHeadshot ? 'Hide headshot' : 'Show headshot'}
+                      selected={!showHeadshot}
+                      onClick={() => setShowHeadshot(!showHeadshot)}
+                    />
+                    <Button
+                      selected={oocNotesIndex === 'SFW'}
+                      bold={oocNotesIndex === 'SFW'}
+                      onClick={() => setOocNotesIndex('SFW')}
+                      textAlign="center"
+                      minWidth="60px"
+                    >
+                      SFW
+                    </Button>
+                    <Button
+                      selected={oocNotesIndex === 'NSFW'}
+                      disabled={!ooc_notes_nsfw}
+                      bold={oocNotesIndex === 'NSFW'}
+                      onClick={() => setOocNotesIndex('NSFW')}
+                      textAlign="center"
+                      minWidth="60px"
+                    >
+                      NSFW
+                    </Button>
+                  </>
+                }
+              >
+                {oocNotesIndex === 'SFW' && (
+                  <Box
+                    style={{ zoom: oocEm.SFW }}
+                    dangerouslySetInnerHTML={{
+                      __html: ooc_notes
+                        ? `<span class='Chat'>${ooc_notes}</span>`
+                        : '<i>No OOC notes provided.</i>',
+                    }}
                   />
-                  <Button
-                    selected={oocNotesIndex === 'SFW'}
-                    bold={oocNotesIndex === 'SFW'}
-                    onClick={() => setOocNotesIndex('SFW')}
-                    textAlign="center"
-                    minWidth="60px"
-                  >
-                    SFW
-                  </Button>
-                  <Button
-                    selected={oocNotesIndex === 'NSFW'}
-                    disabled={!ooc_notes_nsfw}
-                    bold={oocNotesIndex === 'NSFW'}
-                    onClick={() => setOocNotesIndex('NSFW')}
-                    textAlign="center"
-                    minWidth="60px"
-                  >
-                    NSFW
-                  </Button>
-                </>
-              }
-            >
-              {oocNotesIndex === 'SFW' && (
-                <Box
-                  dangerouslySetInnerHTML={{
-                    __html: ooc_notes
-                      ? `<span class='Chat'>${ooc_notes}</span>`
-                      : '<i>No OOC notes provided.</i>',
-                  }}
-                />
-              )}
-              {oocNotesIndex === 'NSFW' && (
-                <Box dangerouslySetInnerHTML={oocnsfwHTML} />
-              )}
-            </Section>
-          </Stack.Item>
-        </Stack>
-      </Stack.Item>
+                )}
+                {oocNotesIndex === 'NSFW' && (
+                  <Box
+                    style={{ zoom: oocEm.NSFW }}
+                    dangerouslySetInnerHTML={oocnsfwHTML}
+                  />
+                )}
+              </Section>
+            </Stack.Item>
+          </Stack>
+        </Stack.Item>
+      )}
       {!collapsed && (
         <Stack.Item grow>
           <Section
@@ -129,6 +185,18 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
             title="Flavor Text"
             buttons={
               <>
+                <EmButtons
+                  value={flavorEm[flavorTextIndex]}
+                  onChange={(value) =>
+                    setFlavorEm({ ...flavorEm, [flavorTextIndex]: value })
+                  }
+                />
+                <Button
+                  icon={hideLeft ? 'chevron-right' : 'chevron-left'}
+                  tooltip={hideLeft ? 'Show left section' : 'Hide left section'}
+                  selected={hideLeft}
+                  onClick={() => setHideLeft(!hideLeft)}
+                />
                 <Button
                   selected={flavorTextIndex === 'SFW'}
                   bold={flavorTextIndex === 'SFW'}
@@ -156,6 +224,7 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
             {flavorTextIndex === 'SFW' && (
               <>
                 <Box
+                  style={{ zoom: flavorEm.SFW }}
                   dangerouslySetInnerHTML={{
                     __html: flavor_text
                       ? `<span class='Chat'>${flavor_text}</span>`
@@ -174,7 +243,10 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
             )}
             {flavorTextIndex === 'NSFW' && (
               <>
-                <Box dangerouslySetInnerHTML={nsfwHTML} />
+                <Box
+                  style={{ zoom: flavorEm.NSFW }}
+                  dangerouslySetInnerHTML={nsfwHTML}
+                />
                 {nsfw_ooc_extra_image && (
                   <Box
                     mt={1}

--- a/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
+++ b/tgui/packages/tgui/interfaces/ExaminePanelPages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Box, Button, Image, Section, Stack } from 'tgui-core/components';
 
 import { resolveAsset } from '../assets';
@@ -42,6 +42,10 @@ const EmButtons = (props: {
   );
 };
 
+const chatHtml = (text: string, empty?: string) => ({
+  __html: text ? `<span class="Chat">${text}</span>` : (empty ?? ''),
+});
+
 export const FlavorTextPage = (props: FlavorTextPageProps) => {
   const { collapsed = false } = props;
   const { data } = useBackend<ExaminePanelData>();
@@ -71,34 +75,6 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
 
   const showLeft = collapsed || !hideLeft;
 
-  const flavorHTML = useMemo(
-    () => ({
-      __html: `<span className='Chat'>${flavor_text}</span>`,
-    }),
-    [flavor_text],
-  );
-
-  const nsfwHTML = useMemo(
-    () => ({
-      __html: `<span className='Chat'>${flavor_text_nsfw}</span>`,
-    }),
-    [flavor_text_nsfw],
-  );
-
-  const oocHTML = useMemo(
-    () => ({
-      __html: `<span className='Chat'>${ooc_notes}</span>`,
-    }),
-    [ooc_notes],
-  );
-
-  const oocnsfwHTML = useMemo(
-    () => ({
-      __html: `<span className='Chat'>${ooc_notes_nsfw}</span>`,
-    }),
-    [ooc_notes_nsfw],
-  );
-
   return (
     <Stack fill>
       {showLeft && (
@@ -110,7 +86,15 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
           <Stack fill vertical>
             {showHeadshot && (
               <Stack.Item align="center">
-                <img src={resolveAsset(headshot)} width="350px" height="350px" />
+                <img
+                  src={resolveAsset(headshot)}
+                  style={{
+                    width: '100%',
+                    maxWidth: '350px',
+                    height: 'auto',
+                    aspectRatio: '1',
+                  }}
+                />
               </Stack.Item>
             )}
             <Stack.Item grow>
@@ -158,17 +142,16 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
                 {oocNotesIndex === 'SFW' && (
                   <Box
                     style={{ zoom: oocEm.SFW }}
-                    dangerouslySetInnerHTML={{
-                      __html: ooc_notes
-                        ? `<span class='Chat'>${ooc_notes}</span>`
-                        : '<i>No OOC notes provided.</i>',
-                    }}
+                    dangerouslySetInnerHTML={chatHtml(
+                      ooc_notes,
+                      '<i>No OOC notes provided.</i>',
+                    )}
                   />
                 )}
                 {oocNotesIndex === 'NSFW' && (
                   <Box
                     style={{ zoom: oocEm.NSFW }}
-                    dangerouslySetInnerHTML={oocnsfwHTML}
+                    dangerouslySetInnerHTML={chatHtml(ooc_notes_nsfw)}
                   />
                 )}
               </Section>
@@ -222,31 +205,24 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
             }
           >
             {flavorTextIndex === 'SFW' && (
-              <>
+              <Box style={{ zoom: flavorEm.SFW }}>
                 <Box
-                  style={{ zoom: flavorEm.SFW }}
-                  dangerouslySetInnerHTML={{
-                    __html: flavor_text
-                      ? `<span class='Chat'>${flavor_text}</span>`
-                      : '<i>No flavor text provided.</i>',
-                  }}
+                  dangerouslySetInnerHTML={chatHtml(
+                    flavor_text,
+                    '<i>No flavor text provided.</i>',
+                  )}
                 />
                 {ooc_extra_image && (
                   <Box
                     mt={1}
-                    dangerouslySetInnerHTML={{
-                      __html: ooc_extra_image,
-                    }}
+                    dangerouslySetInnerHTML={{ __html: ooc_extra_image }}
                   />
                 )}
-              </>
+              </Box>
             )}
             {flavorTextIndex === 'NSFW' && (
-              <>
-                <Box
-                  style={{ zoom: flavorEm.NSFW }}
-                  dangerouslySetInnerHTML={nsfwHTML}
-                />
+              <Box style={{ zoom: flavorEm.NSFW }}>
+                <Box dangerouslySetInnerHTML={chatHtml(flavor_text_nsfw)} />
                 {nsfw_ooc_extra_image && (
                   <Box
                     mt={1}
@@ -255,7 +231,7 @@ export const FlavorTextPage = (props: FlavorTextPageProps) => {
                     }}
                   />
                 )}
-              </>
+              </Box>
             )}
           </Section>
         </Stack.Item>


### PR DESCRIPTION
## About The Pull Request
This PR allows you to collapse the flavortext window into a single column of headshot and OOC notes, Collapsing the window resizes it, and makes the OOC notes pane scale with the window. If you're looking at the gallery, you'll get switched to the Flavor Text windowpane.

Whenever you're looking at the Flavor Text section, you can also hide the headshot to make the OOC Notes pane absorb its space. This combines well with the flavortext collapse to allow for single-column reading of the notes section.

~~I did not replicate the same behavior for the flavortext section, as that tends to be formatted by players for the specific window size. If I made flavortext viewable in the collapsed state, it'd feel a little weird to me as a designer, like I'm kind of rugpulling them and making their formatting easy to break. But if enough people want to view flavortext like this, I can make it toggleable.~~
**Fixed this now; see the video. I also added zoom in/out for each of the texts.**

OOC notes isn't generally formatted with specific windowpane size in mind. Most text is left to just fill whatever space it wants to occupy.

---

This PR is AI slop. However, it is AI slop that only touches TypeScript (in a React framework), so automatically there is a drastic improvement to its code quality.

I wholeheartedly invite scrutiny onto this PR, as well as feedback on how we could improve things like layout/behavior. I posted a video of my testing session with the new features.

If you can, please submit proposed changes as actual code comment suggestions, so I can just look at them and approve them from GitHub.

Now for the prompts I used.

<details>

<summary>Initial building prompt, for the curious</summary>

[Image 1]
This is a change that I believe will exclusively touch the TypeScript of the examine panel, aka the flavortext window.

I want to have a simple "collapse" button where the orange paint is, to the left of the all the other buttons sitting on the top bar, including the music. Collapsing hides the entire flavortext section of the window, leaving only the headshot and the OOC notes. It resizes the window (which might be a BYOND control here? hope it can just be done in TS). Collapsing assumes that you don't want to look at the image gallery, so the top buttons for switching between "Flavor Text" and "Image Gallery" can be hidden.

Collapsing the window switches the "Collapse" icon button to an "Expand" icon button, which resizes the horizontal dimension of the window back to its original proportions and restores the two hidden buttons and flavortext pane.

Then as a separate change, on top of being able to collapse the window into a slim vertical profile for reading OOC notes, I want to be able to click a button at the top of the windowpane containing OOC notes, a button that is stuck where the green paint is, between where the "OOC Notes" text and the "SFW" and "NSFW" buttons are. Clicking it should hide the headshot picture (in this screenshot, it's the furry artwork) and fill that space with the OOC notes pane. Thus it becomes possible to keep a slim space for the notes when you're trying to also play a game behind that window.

Resizing the flavortext window when it is collapsed down to OOC notes should give that extra space to the normally-horizontally-constrained "OOC Notes" pane. Expanding should adjust everything back to normal.

These buttons should use icons from the same font that is embedded with TGUI, the same font that gives us the musical note symbol.

Keep notes while you work, contained in a separate file within the repo root. Follow the KISS principle when writing them. In fact, follow the KISS principle when you write your code. Find the simplest possible engineering solutions.

</details>

<details>

<summary>Review subagent prompt (calling builtin /review skill)</summary>
Spawn an independent review agent to look at your changes to ExaminePanel.tsx and ExaminePanelPages.tsx. It should have the full history of our conversation

</details>

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
You'll have to forgive the wacky white-flashing windows that happen on my platform, as that's just a consequence of running the game through WINE. It happens with every WebView2 window in my WINEPREFIX. Sadness.

**Updated with commit 6f6c0704cb5efcf62ea8918c6d0691ac948a5a05.**

https://github.com/user-attachments/assets/062ec42a-b91f-4bac-82fa-acca6328d9b5

The buttons look like this without music set, since disabled buttons gain a lot of opacity.

<img width="391" height="238" alt="Screenshot_20260903_150856" src="https://github.com/user-attachments/assets/d8b724fe-8dff-450d-87a7-0b211e4f57ae" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Something like this has been a long time coming. The window's so WIDE. And BIG.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The Examine Panel ("Examine closer") window is now collapsible, hiding the flavortext section and giving you a slim window profile that allows for reading OOC Notes without taking up the whole screen (on 1080p displays). Resizing the collapsed window will also resize the OOC Notes pane.
qol: Headshots in the Examine Panel can now be hidden, giving that space to the OOC Notes pane.
qol: You can now zoom in/out on Flavortext & OOC notes, increasing or decreasing the font size proportionally.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
