### PR TITLE
Revert cuffbreak unatomized nerf

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -89,7 +89,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/edelay_type = 1 //if 1, can be moving while equipping (for helmets etc)
 	var/equip_delay_other = 20 //In deciseconds, how long an item takes to put on another person
 	var/strip_delay = 40 //In deciseconds, how long an item takes to remove from another person
-	var/breakouttime = 0 // str 20 breaks out on this instead of struggling for slipouttime
+	var/breakouttime = 0 // str 15 breaks out on this instead of struggling for slipouttime
 	var/slipouttime = 0
 	var/legcuff_slowdown = 0 //movespeed slowdown while worn as legcuffs, 0 = none
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -464,13 +464,13 @@
 	//min() so this can never be slower than struggling out, nets slip faster than they strip
 	var/untying = (I == legcuffed && !handcuffed && has_active_hand())
 	breakouttime = untying ? min(I.strip_delay, I.slipouttime) : I.slipouttime
-	//0.1 per point above 10, so the scale runs the full way to 20 rather than bottoming out at 15
+	//0.2 per point above 10, so the scale runs the full way to 15
 	if((STASTR > 10))
-		var/time_mod = breakouttime * (STASTR - 10) * 0.1
+		var/time_mod = breakouttime * (STASTR - 10) * 0.2
 		breakouttime = max(0, breakouttime - time_mod)
 	if(!untying && mind && mind.has_antag_datum(/datum/antagonist/zombie))
 		breakouttime = 10 SECONDS
-	if(STASTR >= 20 && !untying)
+	if(STASTR >= 15 && !untying)
 		cuff_break = INSTANT_CUFFBREAK
 		breakouttime = I.breakouttime
 	if(!cuff_break)


### PR DESCRIPTION
## About The Pull Request
Caps cuffbreak scaling at 15 STR again, with 15 STR being an instant cuffbreak.

## Testing Evidence
Compiles.

## Why It's Good For The Game
The nerf was introduced in [Cuffing Refactor, Overhaul, and Fixes with Improved Logging](https://github.com/Rotwood-Vale/Ratwood-2.0/pull/2429) as an unatomized change. My personal opinion on it:

1. This is a **very** bad practice to combine refactoring and balance changes in a single PR. To me, it sounds like: “Do you want your code to work better? Then accept my vision of balance.”
2. I think the name of this PR tries to present it as containing no balance changes, which makes it harder to communicate these changes to and through the community. I may be wrong, but the word “overhaul” sounds too ambiguous to describe a direct nerf.
3. Mentioned PR states: 
   - > Strength now scales all the way to 20 instead of maxing out at 15. Remember when only a legendary beggar roll or maniac could break chains? Well, yeah, let's have insta-chain breaks be actually special.
   - > Chains take roughly two minutes at average strength, one minute at 15, twelve seconds at 19, and only break instantly at 20.
   
    But despite the statement, the changes affect not only chains (and, obviously, ropes), but nets as well. So you can no longer instantly break out of a net thrown at you, and you will generally remove it more slowly. Judging by the description, this is an outcome of the change that is out of scope.

Feel free to argue and discuss.

## Changelog
:cl:
balance: Caps cuffbreak scaling at 15 STR again, with 15 STR being an instant cuffbreak.
/:cl:
