### PR TITLE
Decorative Mentor Hat/Mentor Robe/Flowery Robe

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/unique.dm
+++ b/code/modules/clothing/rogueclothes/armor/unique.dm
@@ -61,6 +61,12 @@
 	armor = ARMOR_LEATHER_STUDDED 
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MEDIUM
 
+/obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/decorative
+	name = "decorative mentor robe"
+	desc = "An old dopo robe worn purely for its eastern style."
+	armor = list("blunt" = 0, "slash" = 0, "stab" = 0, "piercing" = 0, "fire" = 0, "acid" = 0)
+	prevent_crits = null
+
 
 /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
 	name = "foreign robes"
@@ -70,6 +76,12 @@
 	armor = ARMOR_LEATHER_STUDDED
 	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER + 25 // Head Honcho gets a buff
 	sellprice = 25
+
+/obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe/decorative
+	name = "decorative flowery robe"
+	desc = "Flower-styled robes worn purely for their eastern style."
+	armor = list("blunt" = 0, "slash" = 0, "stab" = 0, "piercing" = 0, "fire" = 0, "acid" = 0)
+	prevent_crits = null
 
 // this robe spawns on a role that offers no leg protection nor further upgrades to the loadout, in exchange for better roundstart gear
 

--- a/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
+++ b/code/modules/clothing/rogueclothes/headwear/helmet/light_helmet.dm
@@ -218,6 +218,12 @@
 	flags_inv = HIDEEARS
 	body_parts_covered = HEAD|HAIR|EARS|NOSE|EYES
 
+/obj/item/clothing/head/roguetown/mentorhat/decorative
+	name = "decorative bamboo hat"
+	desc = "A bamboo hat woven for style rather than protection."
+	armor = list("blunt" = 0, "slash" = 0, "stab" = 0, "piercing" = 0, "fire" = 0, "acid" = 0)
+	max_integrity = 100
+
 /obj/item/clothing/head/roguetown/horsey
 	name = "head bit"
 	desc = "A restraining head piece made of reinforced leather."

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -245,26 +245,11 @@
 	item_state = "monkcloth"
 	boobed_detail = FALSE
 	color = null
-	detail_color = null
-	detail_tag = "_detail"
 	naledicolor = TRUE
 	r_sleeve_status = SLEEVE_NOMOD
 	l_sleeve_status = SLEEVE_NOMOD
 	heat_protection = CHEST | GROIN | ARM_RIGHT | ARM_LEFT
 	max_heat_protection_temperature = BODYTEMP_HEAT_LEVEL_ONE_MAX
-
-/obj/item/clothing/suit/roguetown/shirt/robe/pointfex/Initialize(mapload)
-	. = ..()
-	update_icon()
-
-/obj/item/clothing/suit/roguetown/shirt/robe/pointfex/update_icon()
-	cut_overlays()
-	if(get_detail_tag())
-		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
-		pic.appearance_flags = RESET_COLOR
-		if(get_detail_color())
-			pic.color = get_detail_color()
-		add_overlay(pic)
 
 /obj/item/clothing/suit/roguetown/shirt/robe/feld
 	name = "feldsher's robe"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -245,11 +245,26 @@
 	item_state = "monkcloth"
 	boobed_detail = FALSE
 	color = null
+	detail_color = CLOTHING_RED
+	detail_tag = "_detail"
 	naledicolor = TRUE
 	r_sleeve_status = SLEEVE_NOMOD
 	l_sleeve_status = SLEEVE_NOMOD
 	heat_protection = CHEST | GROIN | ARM_RIGHT | ARM_LEFT
 	max_heat_protection_temperature = BODYTEMP_HEAT_LEVEL_ONE_MAX
+
+/obj/item/clothing/suit/roguetown/shirt/robe/pointfex/Initialize(mapload)
+	. = ..()
+	update_icon()
+
+/obj/item/clothing/suit/roguetown/shirt/robe/pointfex/update_icon()
+	cut_overlays()
+	if(get_detail_tag())
+		var/mutable_appearance/pic = mutable_appearance(icon(icon, "[icon_state][detail_tag]"))
+		pic.appearance_flags = RESET_COLOR
+		if(get_detail_color())
+			pic.color = get_detail_color()
+		add_overlay(pic)
 
 /obj/item/clothing/suit/roguetown/shirt/robe/feld
 	name = "feldsher's robe"

--- a/code/modules/roguetown/roguecrafting/crafting/clothes.dm
+++ b/code/modules/roguetown/roguecrafting/crafting/clothes.dm
@@ -250,3 +250,15 @@
 		)
 	skillcraft = /datum/skill/craft/crafting
 	craftdiff = 3
+
+/datum/crafting_recipe/roguetown/survival/decorative_mentorhat
+	name = "decorative bamboo hat"
+	category = "Clothes"
+	result = /obj/item/clothing/head/roguetown/mentorhat/decorative
+	reqs = list(
+		/obj/item/grown/log/tree/small = 1,
+		/obj/item/grown/log/tree/stick = 2,
+		/obj/item/natural/fibers = 2,
+		)
+	skillcraft = /datum/skill/craft/crafting
+	craftdiff = 1

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -551,6 +551,20 @@
 				/obj/item/natural/fibers = 2)
 	craftdiff = 3
 
+/datum/crafting_recipe/roguetown/sewing/decorative_mentorsuit
+	name = "decorative mentor robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/decorative)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 2)
+	craftdiff = 1
+
+/datum/crafting_recipe/roguetown/sewing/decorative_captainrobe
+	name = "decorative flowery robe"
+	result = list(/obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe/decorative)
+	reqs = list(/obj/item/natural/cloth = 3,
+				/obj/item/natural/fibers = 2)
+	craftdiff = 1
+
 /datum/crafting_recipe/roguetown/sewing/jesterchest
 	name = "jester's tunick"
 	result = list(/obj/item/clothing/suit/roguetown/shirt/jester)

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -1206,9 +1206,17 @@ GLOBAL_LIST_INIT(loadout_items, init_subtypes(/datum/loadout_item))
 	name = "Eastern Flowery Robe"
 	path = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe
 
+/datum/loadout_item/decorative_captain_robe
+	name = "Decorative Flowery Robe"
+	path = /obj/item/clothing/suit/roguetown/armor/basiceast/captainrobe/decorative
+
 /datum/loadout_item/mentor_suit
 	name = "Eastern Mentor Suit"
 	path = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit
+
+/datum/loadout_item/decorative_mentor_suit
+	name = "Decorative Mentor Robe"
+	path = /obj/item/clothing/suit/roguetown/armor/basiceast/mentorsuit/decorative
 
 /datum/loadout_item/crafteast
 	name = "Eastern Craft Robe"
@@ -1252,6 +1260,10 @@ GLOBAL_LIST_INIT(loadout_items, init_subtypes(/datum/loadout_item))
 /datum/loadout_item/mentorhat
 	name = "conical mentor hat"
 	path = /obj/item/clothing/head/roguetown/mentorhat
+
+/datum/loadout_item/decorative_mentorhat
+	name = "decorative bamboo hat"
+	path = /obj/item/clothing/head/roguetown/mentorhat/decorative
 
 // ROBES - ASTRATA
 /datum/loadout_item/robe_astrata


### PR DESCRIPTION
## About The Pull Request

Adds loadout and craftable decorative versions of these three items. They are identical other than that they have zero armor values, and as such can be used in the head/chest decoration slots. 

Also fixes the pontifex robe, a PR a month ago broke them and made them unable to be dyed so this just fixes that (it looks good)

## Testing Evidence

Tested, works just as expected

## Why It's Good For The Game

Lots of clothing has versions like this (especially for the loadout) that let players customise their look. Kazen stuff meanwhile only has 'armored' variants (but incredibly weak as loadout) so I was requested to add this and I agree. Variety is great

Obligatory image for the inevitable kazen haters:

<img width="755" height="419" alt="kazengunapology" src="https://github.com/user-attachments/assets/6cf939ee-1822-40e2-8cd1-e1b5be246b13" />

## Changelog

:cl:
add: loadout and craftable decorative versions of mentor hat, robe and flowery robe
/:cl: