### PR TITLE
firestack bumps annoyance pass

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1717,17 +1717,21 @@
 	if(HAS_TRAIT(spread_to, TRAIT_NOFIRE) || HAS_TRAIT(src, TRAIT_NOFIRE))
 		return
 
-	if(prob(50))	// 50% chance you don´t catch fire from a bump or walking over a burning corpse. Cause people don´t often bathe in gasoline.
-		return
-
 	var/datum/status_effect/fire_handler/fire_stacks/fire_status = has_status_effect(/datum/status_effect/fire_handler/fire_stacks)
 	var/datum/status_effect/fire_handler/fire_stacks/their_fire_status = spread_to.has_status_effect(/datum/status_effect/fire_handler/fire_stacks)
 	if(fire_status && fire_status.on_fire)
+		if(fire_stacks < 2)// don't spread fire if you have less than two stacks
+			return
+
 		if(their_fire_status && their_fire_status.on_fire)
 			var/firesplit = (fire_stacks + spread_to.fire_stacks) / 2
 			var/fire_type = (spread_to.fire_stacks > fire_stacks) ? their_fire_status.type : fire_status.type
 			set_fire_stacks(firesplit, fire_type)
 			spread_to.set_fire_stacks(firesplit, fire_type)
+			return
+
+		if(!(mobility_flags & MOBILITY_STAND))// don't ignite because we stepped over someone burning
+			to_chat(spread_to, span_notice("You step over [src]'s burning body."))
 			return
 
 		adjust_fire_stacks(-fire_stacks / 2, fire_status.type)
@@ -1737,6 +1741,12 @@
 		return
 
 	if(!their_fire_status || !their_fire_status.on_fire)
+		return
+
+	if(spread_to.fire_stacks < 2)// don't spread fire if you have less than two stacks
+		return
+
+	if(!(spread_to.mobility_flags & MOBILITY_STAND))// same as above, but we're rubbing our buring face on their leg
 		return
 
 	spread_to.adjust_fire_stacks(-spread_to.fire_stacks / 2, their_fire_status.type)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1746,7 +1746,7 @@
 	if(spread_to.fire_stacks < 2)// don't spread fire if you have less than two stacks
 		return
 
-	if(!(spread_to.mobility_flags & MOBILITY_STAND))// same as above, but we're rubbing our buring face on their leg
+	if(!(spread_to.mobility_flags & MOBILITY_STAND))// same as above, but we're rubbing our burning face on their leg
 		return
 
 	spread_to.adjust_fire_stacks(-spread_to.fire_stacks / 2, their_fire_status.type)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1730,7 +1730,7 @@
 			spread_to.set_fire_stacks(firesplit, fire_type)
 			return
 
-		if(!(mobility_flags & MOBILITY_STAND))// don't ignite because we stepped over someone burning
+		if(!(mobility_flags & MOBILITY_STAND) && spread_to.m_intent == MOVE_INTENT_WALK)// don't ignite because we stepped over someone burning unless we are sprinting
 			to_chat(spread_to, span_notice("You step over [src]'s burning body."))
 			return
 


### PR DESCRIPTION
## About The Pull Request

Fuck firestacks. Fuck passing firestacks. I hate firestacks.

A few changes:

- Removed the fifty-fifty when bumping someone on fire to avoid getting lit on fire.
- You need more than two firestacks to halve and pass them to another person, making it so you can't infinitely pass firestacks, e.g. `(10 / 2 = 5 / 2 = 2.5 / 2 = 1.25 / 2 = 0.625 / 2 = 0.31... etc)` If you are below two firestacks, they just won't pass when you bump into someone.
- If someone is lying down, they can't ignite you by bumping into you. You also step over them if they're on fire and you walk over them, avoiding getting ignited.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="303" height="23" alt="image" src="https://github.com/user-attachments/assets/d4482cf0-8f82-4657-8d42-0b62d0b6ff5f" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Firestacks are annoying. Igniting an entire crowd with decimal amounts of firestacks because one guy got one single firestack and decided to spread his flame herpes doesn't make for interesting mechanics, it's just an annoying press of your resist key while you're standing around. Also, an infinitely-burning skeleton in the road that ignites a thousand people over the course of a round because nobody could be assed to move it out of the way is just regular plain old annoying. You have legs. You can step OVER someone who's burning on the floor.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed the fifty-fifty when bumping someone on fire to avoid getting lit on fire.
balance: You need more than two firestacks to halve and pass them to another person, making it so you can't infinitely pass firestacks, e.g. (10 / 2 = 5 / 2 = 2.5 / 2 = 1.25 / 2 = 0.625 / 2 = 0.31... etc) If you are below two firestacks, they just won't pass when you bump into someone.
balance: If someone is lying down, they can't ignite you by bumping into you. You also step over them if they're on fire and you walk over them, avoiding getting ignited. Sprinting over their body will still ignite you however.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
