### PR TITLE
the BUFF pierce weapons have been yearning for: changes penetrating integrity damage calculations

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -36,10 +36,15 @@
 			playsound(loc, get_armor_sound(used.blocksound, blade_dulling), 100)
 		var/intdamage = damage
 		var/consume_debuff = TRUE
-		// Penetrative damage deals significantly less to the armor. Tentative.
+		// Penetrative damage splits its total damage between armor and body,
+		// whatever damage armor protected from still lands on the armor and damages it.
+		// AP weapons will break armor slower on average, but not "five intdamage per stab" slower as before.
 		if((damage + armor_penetration) > protection && d_type != "blunt")
 			consume_debuff = FALSE
 			intdamage = (damage + armor_penetration) - protection
+			intdamage = protection - armor_penetration
+			if(armor_penetration >= protection) // If you get COMPLETELY penetrated, half of the damage will be dealt to the armor as well. Your gear shouldn't stay pristine after being totally cleaved.
+				intdamage = damage / 2
 		if(intdamfactor != 1)
 			intdamage *= intdamfactor
 		if(d_type == "blunt")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -41,8 +41,14 @@
 		// AP weapons will break armor slower on average, but not "five intdamage per stab" slower as before.
 		if((damage + armor_penetration) > protection && d_type != "blunt")
 			consume_debuff = FALSE
-			intdamage = (damage + armor_penetration) - protection
-			intdamage = protection - armor_penetration
+			// WE TAUGHT THIS MONKEY ARMOR PIERCING CODE AND IT KILLED ITSELF IMMEDIATELY.
+			// I'm going to try and explain this to the best of my ability after banging my head against it.
+			// AP effectively strips away armor. Forty five AP hitting fifty armor turns that to effectively five armor.
+			// The remaining armor will reduce the damage of any incoming attack, so fifty damage is dampened to forty five.
+			// Damage that got dampened is what gets dealt to the armor as intdamage.
+			// A fifty damage attack is dampened to forty five, with five being dealt as intdamage.
+			// That's really low, so we generate a number that's forty percent of your total force.
+			intdamage = max(protection - armor_penetration, damage * 0.4) // This number serves as an intdamage floor, we use it instead if your intdamage would've otherwise been lower than it.
 			if(armor_penetration >= protection) // If you get COMPLETELY penetrated, half of the damage will be dealt to the armor as well. Your gear shouldn't stay pristine after being totally cleaved.
 				intdamage = damage / 2
 		if(intdamfactor != 1)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1943,7 +1943,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					H.apply_damage(Iforce * user.used_intent.blunt_chip_strength, BRUTE, def_zone, blunt_chip_block)//, spread_damage = TRUE)
 					H.next_attack_msg += " <span class='warning'>and yet the force punches through!</span>"//But sometimes it lies!
 		if(!nodmg)
-			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block+armor))/100), user, selzone, crit_message = TRUE, weapon = I, armor_penetration = pen)			if(should_embed_weapon(crit_wound, I))
+			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block+armor))/100), user, selzone, crit_message = TRUE, weapon = I, armor_penetration = pen)
+			if(should_embed_weapon(crit_wound, I))
 				var/can_impale = TRUE
 				if(!affecting)
 					can_impale = FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1943,8 +1943,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					H.apply_damage(Iforce * user.used_intent.blunt_chip_strength, BRUTE, def_zone, blunt_chip_block)//, spread_damage = TRUE)
 					H.next_attack_msg += " <span class='warning'>and yet the force punches through!</span>"//But sometimes it lies!
 		if(!nodmg)
-			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block+armor))/100), user, selzone, crit_message = TRUE, weapon = I)
-			if(should_embed_weapon(crit_wound, I))
+			var/datum/wound/crit_wound = affecting.bodypart_attacked_by(user.used_intent.blade_class, (Iforce * weakness) * ((100-(armor_block+armor))/100), user, selzone, crit_message = TRUE, weapon = I, armor_penetration = pen)			if(should_embed_weapon(crit_wound, I))
 				var/can_impale = TRUE
 				if(!affecting)
 					can_impale = FALSE

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -157,7 +157,7 @@
 	return max(round(hud_bleed_rate, 0.1), 0)
 
 /// Called after a bodypart is attacked so that wounds and critical effects can be applied
-/obj/item/bodypart/proc/bodypart_attacked_by(bclass = BCLASS_BLUNT, dam, mob/living/user, zone_precise = src.body_zone, silent = FALSE, crit_message = FALSE, armor, obj/item/weapon)
+/obj/item/bodypart/proc/bodypart_attacked_by(bclass = BCLASS_BLUNT, dam, mob/living/user, zone_precise = src.body_zone, silent = FALSE, crit_message = FALSE, armor, obj/item/weapon, armor_penetration)
 	RETURN_TYPE(/datum/wound)
 	if(!bclass || !dam || !owner || (owner.status_flags & GODMODE))
 		return null
@@ -170,7 +170,8 @@
 			acheck_dflag = "slash"
 		if(BCLASS_PICK, BCLASS_STAB)
 			acheck_dflag = "stab"
-	armor = owner.run_armor_check(zone_precise, acheck_dflag, damage = 0)
+		//More AP means the less effective bleed clamping is.
+	armor = owner.run_armor_check(zone_precise, acheck_dflag, damage = 0, armor_penetration = armor_penetration)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		if(human_owner.checkcritarmor(zone_precise, bclass))


### PR DESCRIPTION
## About The Pull Request

This PR buffs piercing weapons. It maybe even makes them usable compared to using a blunt or even just a sword. Moreover, it removes that odd feeling where, when your weapon force was high enough, you might've felt like you were breaking people's armor SLOWER than if it was lower.

Why is this? This is because ANY damage that penetrated ANY amount of armor drastically had its integrity damage reduced. The calculation goes like this. You add your damage with your AP. If you have more total effective 'damage' than your opponent does armor, it takes the excess and goes through. Let me give you an example.

Your opponent has forty cut armor on their torso. You have a sword that has thirty cutting damage and fifteen AP. This is effectively forty five damage. Forty five beats forty, obviously - so you penetrate. Five damage goes through to their body. Five damage is dealt to their armor.

In order to deal five damage to their body - and give them a TINY, microscopic bleed that'd take hours to die by, and has its bleed rate clamped because armor just Does this while it's not broken... you exchanged dealing what could've been forty five damage to their integrity, to instead deal five integrity damage and five damage to their body.

As expected, this is REALLY FUCKING BAD. Penetration weapons SUCK. ASS. FOR THIS SHITASS REASON!

Here's the new math. I can't be fucked to explain it again, so read these comments I put in the code to explain how it works. I wanted to actually die after spending two hours drooling at math.

```
Penetrative damage splits its total damage between armor and body, whatever damage armor protected from still lands on the armor and damages it.
AP weapons will break armor slower on average, but not "five intdamage per stab" slower as before.
		
I'm going to try and explain this to the best of my ability after banging my head against it.
AP effectively strips away armor. Forty five AP hitting fifty armor turns that to effectively five armor.
The remaining armor will reduce the damage of any incoming attack, so fifty damage is dampened to forty five.
Damage that got dampened is what gets dealt to the armor as intdamage.
A fifty damage attack is dampened to forty five, with five being dealt as intdamage.
That's really low, so we generate a number that's forty percent of your total force.

This number serves as an intdamage floor, we use it instead if your intdamage would've otherwise been lower than it.
If you get COMPLETELY penetrated, half of the damage will be dealt to the armor as well. Your gear shouldn't stay pristine after being totally cleaved.
 ```
 
 Besides that, a very minor change - higher AP means the bleeding clamp is higher through armor. If you have super high AP, you'll deal worse bleeds than someone who's barely able to poke past.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

I can't really do at-length testing of this. Maintainers will have to testmerge it and players will have to share how they feel about it, whether it's too strong or too weak. Here's a picture of me breaking a gambeson with a rapier.

<img width="595" height="312" alt="image" src="https://github.com/user-attachments/assets/831122cc-1f49-46fe-a752-6d258cf70452" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Read the above paragraphs and you tell me this math is good. Stabbing weapons suck ass right now, and if you deal too much damage and start accidentally penning someone, your ability to kill them quickly by destroying their armor falls off a fucking CLIFF. I've had fights personally go on for way longer than they should've because my sword was TOO STRONG and couldn't destroy their gambeson because I was dealing single digit integrity damage with each slash.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: redid the way integrity damage is calculated when piercing armor. the short of it is that you won't be dealing single digit integrity damage to armor for the crime of doing too much damage and penetrating it. spear and rapier users rejoice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
