### PR TITLE
Fix Infernal language shortcut collision with Hammerholdian

### DIFF
--- a/code/modules/language/roguetown/hellspeak.dm
+++ b/code/modules/language/roguetown/hellspeak.dm
@@ -1,10 +1,10 @@
 /datum/language/hellspeak
 	name = "Infernal"
-	desc = "(Spoken with ,h) The dark and sinister language of the hells, spoken by demons and those who deal with infernal powers. Its words carry an unnatural weight."
+	desc = "(Spoken with ,z) The dark and sinister language of the hells, spoken by demons and those who deal with infernal powers. Its words carry an unnatural weight."
 	speech_verb = "says"
 	ask_verb = "asks"
 	exclaim_verb = "yells"
-	key = "h"
+	key = "z"
 	space_chance = 66
 	default_priority = 80
 	icon_state = "infernal"


### PR DESCRIPTION
## About The Pull Request

Changes Infernal’s shortcut from `,h` to `,z` and updates its description.

Both Infernal and Hammerholdian used `,h`. The language lookup selects Hammerholdian first, causing characters who
cannot speak it to fall back to their default language.

## Testing Evidence

No testing performed

## Why It's Good For The Game

Allows Infernal speakers to use a shortcut without changing their primary language.

## Changelog

:cl:
fix: Infernal now uses ,z to avoid conflicting with Hammerholdian's ,h shortcut.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
