### PR TITLE
Vamps don't ash on death

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -56,11 +56,6 @@
 		SSdroning.kill_rain(client)
 
 	if(mind)
-		if(!gibbed)
-			var/datum/antagonist/vampire/VD = mind.has_antag_datum(/datum/antagonist/vampire)
-			if(VD)
-				dust(just_ash=TRUE,drop_items=TRUE)
-				return
 
 		var/datum/antagonist/lich/L = mind.has_antag_datum(/datum/antagonist/lich)
 		if (L && !L.out_of_lives)


### PR DESCRIPTION
## About The Pull Request

See title.

## Testing Evidence

I didn't bother to test it because some guy said that testing things for bugs isn't possible and I'm salty. It works, though. 
## Why It's Good For The Game

Vampires turning to dust on death might be thematic but unfortunately it kind of sucks for the vampire and also sucks that there's a conversion antagonist that functionally RR's you for clicking 'yes' to being converted and thus guarantees most people will click no. Since we seem to be moving away from RR as a consequence for dying to an antagonist, I don't particularly see why we shouldn't move in the direction of not being RR'd just for dying in general. Hopefully it encourages more people to click 'yes' to being converted.

## Changelog

:cl:
balance: Vampires no longer turn to ash on dying.
/:cl:

