### PR TITLE
Makes medical EXP scale with wound severity and the time spent sewing

### DIFF
--- a/code/game/objects/items/rogueitems/needle.dm
+++ b/code/game/objects/items/rogueitems/needle.dm
@@ -29,6 +29,9 @@
 #define XP_ON_SUCCESS 0.5
 /// The minimum delay between automatic sewing attempts.
 #define AUTO_SEW_DELAY CLICK_CD_MELEE
+#define SEW_HP_EXP_NORMALIZER 600
+#define SEW_EXP_PER_STEP 0.05
+#define SEW_EXP_FINISH 2.5
 
 /obj/item/needle
 	name = "needle"
@@ -232,6 +235,8 @@
 		stringamt >= 1)
 		if(!do_after(doctor, 2 SECONDS, target = patient))
 			break
+		if(doctor.mind)
+			doctor.mind.add_sleep_experience(skill_used, doctor.STAINT * SEW_EXP_PER_STEP)
 		playsound(loc, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 		target_wound.sew_progress = min(target_wound.sew_progress + moveup, target_wound.sew_threshold)
 
@@ -249,7 +254,9 @@
 		if(target_wound.sew_progress < target_wound.sew_threshold)
 			continue
 		if(doctor.mind)
-			doctor.mind.add_sleep_experience(skill_used, doctor.STAINT * 2.5)
+			var/exp_scale = target_wound.sew_threshold / SEW_HP_EXP_NORMALIZER
+			var/base_exp = doctor.STAINT * SEW_EXP_FINISH
+			doctor.mind.add_sleep_experience(skill_used, base_exp * exp_scale)
 		use(1)
 		target_wound.sew_wound()
 		if(patient == doctor)
@@ -298,3 +305,6 @@
 #undef XP_ON_FAIL
 #undef XP_ON_SUCCESS
 #undef AUTO_SEW_DELAY
+#undef SEW_HP_EXP_NORMALIZER
+#undef SEW_EXP_PER_STEP
+#undef SEW_EXP_FINISH


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/Azure-Peak/Azure-Peak/pull/6864
For the people too lazy to click the PR.

BEFORE :
I want to level medical EXP! I'm a powergamer!
=> cuts self with baby rock that gives a cut that takes like 2-3 sew actions.
=> Level up to expert in less than a minute.

BEFORE :
I'm a good player! I'm sewing my wounds as I get them in a dungeon. God this is a big wound...
=> Gets 5-10 wounds that take a cumulative 5-10 minutes to sew.
=> Level up to apprentice across half an hour.

AFTER :
=> get 40% of a huge wound that takes about 2 minutes to sew up from apprentice to jman skill with 10 int.

Overall you get MORE EXP for sewing up huge wounds now. EXP scales with sewHP & you get a little bit of exp per sew action. 0.5EXP

This makes it rewarding to sew wounds even if you don't finish sewing them wholly, but you still get the biggest chunk at the end.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="306" height="206" alt="image" src="https://github.com/user-attachments/assets/0d304eb2-db20-471a-8eb5-b6b2711d4133" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

It just is, okay?

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Makes medical EXP scale with wound severity and the time spent sewing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
