### PR TITLE
Make hearts auto-restart when (re)inserting them or reviving patient

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -890,6 +890,9 @@
 		to_chat(src, "<span class='notice'><b>As you return to life, you struggle to recall the circumstances of your death...</b></span>")
 		to_chat(src, "<span class='italic'>Your memories of your final moments are hazy and fragmented.</span>")
 		. = TRUE
+		var/obj/item/organ/heart/heart = getorganslot(ORGAN_SLOT_HEART)
+		if(heart)
+			heart.Restart()
 		if(mind)
 			if(admin_revive)
 				mind.remove_antag_datum(/datum/antagonist/zombie)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -68,6 +68,11 @@
 	if(!special)
 		addtimer(CALLBACK(src, PROC_REF(stop_if_unowned)), 120)
 
+/obj/item/organ/heart/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
+	. = ..()
+	if(owner)
+		Restart()
+
 /obj/item/organ/heart/proc/stop_if_unowned()
 	if(!owner)
 		Stop()


### PR DESCRIPTION
## About The Pull Request
This is a bandage fix for the game not actually letting you know about the need to squeeze a heart in-hand before implanting it. Taking out someone's heart through surgery, letting them die, then putting the heart back in and reviving them doesn't fix their stopped heart. They will quietly take massive oxyloss and die on you again.

No longer! A heart will "restart" when:
- Being surgically inserted.
- You are **revived** with a stopped (but otherwise working) heart by any means. Surgery, miracles, anything.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
This compiled; we tested the actual "bug" of taking my heart out, letting me die, putting it back in, lux reviving me, and watching me succumb to oxyloss. 
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Arcane game mechanics for reviving someone doesn't tend to be something that people like to experience. The guy dying for the second time in your care at Medical Wing isn't Nice. Especially when you're still left scratching your head wondering why they're dead again.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Did you know that hearts needed you to "squeeze" them (use the heart item in-hand) before you inserted them, or else they wouldn't work again? Now they get restarted from the "stopped" state (where possible) if you surgically insert them back in, or revive your dead-but-rehearted patient through any means.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
