### PR TITLE
Fix clothing items that refund more resources when SNIPped vs their crafting reqs

### DIFF
--- a/code/modules/clothing/rogueclothes/headwear/hats.dm
+++ b/code/modules/clothing/rogueclothes/headwear/hats.dm
@@ -214,7 +214,8 @@
 	item_state = "armingcap"
 	flags_inv = HIDEEARS
 	nudist_approved = TRUE
-	salvage_result = /obj/item/natural/hide/cured
+	salvage_result = /obj/item/natural/cloth
+	fiber_salvage = FALSE
 	//dropshrink = 0.75
 	cold_protection = HEAD
 	min_cold_protection_temperature = BODYTEMP_COLD_LEVEL_ONE_MAX
@@ -240,6 +241,7 @@
 	//dropshrink = 0.75
 	dynamic_hair_suffix = null
 	nudist_approved = TRUE
+	fiber_salvage = FALSE
 
 /obj/item/clothing/head/roguetown/headband/bloodied
 	name = "bloodied headband"
@@ -275,6 +277,7 @@
 	icon_state = "headband"
 	color = "#bfb8a9"
 	resistance_flags = FIRE_PROOF
+	fiber_salvage = TRUE
 	armor = ARMOR_SPELLSINGER //Highest preset protection value for head armor, without leaving people unable to sleep with the headband on. Should be appropriate for the Monk's role.
 	body_parts_covered = HEAD|HAIR|EARS
 	max_integrity = ARMOR_INT_SIDE_STEEL //High leather-tier protection and critical resistances, steel-tier integrity.
@@ -355,6 +358,7 @@
 	sellprice = 5
 	nudist_approved = TRUE
 	dropshrink = null
+	fiber_salvage = FALSE
 
 /obj/item/clothing/head/roguetown/hennin
 	name = "hennin"
@@ -441,6 +445,7 @@
 	desc = "Keeps the hair in check, and looks proper."
 	icon_state = "shawl"
 	nudist_approved = TRUE
+	fiber_salvage = FALSE
 
 /obj/item/clothing/head/roguetown/articap
 	name = "artificer's cap"

--- a/code/modules/clothing/rogueclothes/headwear/otherhoods.dm
+++ b/code/modules/clothing/rogueclothes/headwear/otherhoods.dm
@@ -129,6 +129,7 @@
 	min_cold_protection_temperature = BODYTEMP_COLD_LEVEL_ONE_MAX
 	heat_protection = HEAD
 	max_heat_protection_temperature = BODYTEMP_HEAT_LEVEL_ONE_MAX
+	fiber_salvage = FALSE
 
 /obj/item/clothing/head/roguetown/jester
 	name = "jester's hat"

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -1051,6 +1051,7 @@
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_MOUTH
 	salvage_result = /obj/item/natural/cloth
 	salvage_amount = 1
+	fiber_salvage = FALSE
 	color = CLOTHING_BLACK
 	muteinmouth = FALSE
 	spitoutmouth = FALSE

--- a/code/modules/clothing/rogueclothes/pants/cloth.dm
+++ b/code/modules/clothing/rogueclothes/pants/cloth.dm
@@ -70,6 +70,8 @@
 	r_sleeve_status = SLEEVE_NOMOD
 	l_sleeve_status = SLEEVE_NOMOD
 	dropshrink = null
+	salvage_amount = 1
+	fiber_salvage = FALSE
 
 /obj/item/clothing/under/roguetown/loincloth/brown
 	color = CLOTHING_BROWN

--- a/code/modules/clothing/rogueclothes/pants/leather.dm
+++ b/code/modules/clothing/rogueclothes/pants/leather.dm
@@ -44,6 +44,7 @@
 	min_cold_protection_temperature = BODYTEMP_NORMAL_MIN
 	heat_protection = GROIN | LEG_RIGHT | LEG_LEFT
 	max_heat_protection_temperature = BODYTEMP_HEAT_LEVEL_ONE_MAX
+	fiber_salvage = FALSE
 
 /obj/item/clothing/under/roguetown/trou/beltpants
 	name = "belt-buckled trousers"

--- a/code/modules/clothing/rogueclothes/robes.dm
+++ b/code/modules/clothing/rogueclothes/robes.dm
@@ -144,6 +144,7 @@
 	icon_state = "nun"
 	item_state = "nun"
 	allowed_sex = list(MALE, FEMALE)
+	fiber_salvage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/wizard
 	name = "wizard's robe"

--- a/code/modules/clothing/rogueclothes/shirts.dm
+++ b/code/modules/clothing/rogueclothes/shirts.dm
@@ -128,6 +128,7 @@
 	body_parts_covered = CHEST|VITALS
 	heat_protection = CHEST | ARM_RIGHT | ARM_LEFT
 	max_heat_protection_temperature = BODYTEMP_HEAT_LEVEL_ONE_MAX
+	fiber_salvage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/shadowshirt/elflock
 	allowed_race = NON_DWARVEN_RACE_TYPES
@@ -333,6 +334,7 @@
 	detail_tag = "_detail"
 	detail_color = CLOTHING_BLACK
 	boobed_detail = FALSE
+	salvage_amount = 1
 
 /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/red
 	icon_state = "sailorreds"
@@ -386,6 +388,7 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	flags_inv = HIDECROTCH|HIDEBOOB
 	dropshrink = null
+	fiber_salvage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/tribalrag
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
@@ -426,6 +429,7 @@
 	l_sleeve_status = SLEEVE_NORMAL
 	flags_inv = HIDECROTCH|HIDEBOOB
 	dropshrink = null
+	fiber_salvage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/tunic/green
 	color = CLOTHING_GREEN
@@ -623,6 +627,7 @@
 	desc = "A billowing tunic made of the finest silks and softest fabrics. Inlaid with golden thread, this is the height of fashion for the wealthiest of wearers."
 	icon_state = "stewardtunic"
 	item_state = "stewardtunic"
+	fiber_salvage = TRUE
 
 /obj/item/clothing/suit/roguetown/shirt/dress/silkdress/loudmouth
 	color = null

--- a/modular_deserttown/desertclothing.dm
+++ b/modular_deserttown/desertclothing.dm
@@ -187,6 +187,7 @@
 	name = "grey bisht"
 	icon_state = "bluethawb"
 	item_state = "bluethawb"
+	fiber_salvage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/robe/bisht/purple
 	slot_flags = ITEM_SLOT_ARMOR|ITEM_SLOT_SHIRT
@@ -232,6 +233,7 @@
 	icon_state = "thawb"
 	item_state = "thawb"
 	dropshrink = null
+	fiber_salvage = FALSE
 
 /obj/item/clothing/suit/roguetown/shirt/dress/thawb/black
 	color = CLOTHING_BLACK
@@ -346,6 +348,7 @@
 	icon_state = "turban"
 	item_state = "turban"
 	dropshrink = null
+	fiber_salvage = FALSE
 
 /obj/item/clothing/head/roguetown/turban/tan
 	color = "#93714b"
@@ -461,6 +464,8 @@
 	mob_overlay_icon = 'modular_deserttown/icons/clothing/onmob/pants.dmi'
 	icon_state = "sirwal"
 	item_state = "sirwal"
+	salvage_amount = 1
+	fiber_salvage = FALSE
 
 /obj/item/clothing/under/roguetown/sirwal/beige
 	color = "#edc6a5"
@@ -515,6 +520,8 @@
 	icon_state = "thong"
 	item_state = "thong"
 	body_parts_covered = GROIN
+	salvage_amount = 1
+	fiber_salvage = FALSE
 
 /datum/crafting_recipe/roguetown/sewing/thong
 	name = "thong"

--- a/modular_rmh/code/modules/clothing/vladegeg/desert_sorceress.dm
+++ b/modular_rmh/code/modules/clothing/vladegeg/desert_sorceress.dm
@@ -20,6 +20,7 @@
 	nodismemsleeves = TRUE
 	sleevetype = null
 	sleeved = null
+	fiber_salvage = TRUE
 
 /obj/item/clothing/head/roguetown/desert_sorceress
 	name = "desert sorceress hood"

--- a/modular_rmh/code/modules/clothing/vladegeg/selune.dm
+++ b/modular_rmh/code/modules/clothing/vladegeg/selune.dm
@@ -6,6 +6,7 @@
 	mob_overlay_icon = 'modular_rmh/icons/clothing/vladegeg/onmob/selune.dmi'
 	sleeved = 'modular_rmh/icons/clothing/vladegeg/onmob/helpers/selune_sleeves.dmi'
 	slot_flags = ITEM_SLOT_SHIRT | ITEM_SLOT_ARMOR
+	fiber_salvage = FALSE
 
 //CRAFTING
 


### PR DESCRIPTION
## About The Pull Request
Only salvage refunds from scissors were adjusted. Crafting recipes were not changed. Adjustments were made to clothing that gets 
<details>


<summary>List of scissor salvage nerfs</summary>

Cap
  path: /obj/item/clothing/head/roguetown/armingcap
  was: 1 cured hide + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/headwear/hats.dm

Headband
  path: /obj/item/clothing/head/roguetown/headband
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/headwear/hats.dm

Monk's headband (padded)
  path: /obj/item/clothing/head/roguetown/headband/monk
  change: fiber_salvage set TRUE so the padded recipe still refunds its fiber after the parent headband lost it
  file: code/modules/clothing/rogueclothes/headwear/hats.dm

Nun's veil
  path: /obj/item/clothing/head/roguetown/nun
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/headwear/hats.dm

Shawl
  path: /obj/item/clothing/head/roguetown/shawl
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/headwear/hats.dm

Free man's shroud
  path: /obj/item/clothing/head/roguetown/menacing/bandit
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/headwear/otherhoods.dm

Woolen collar / wool collar
  path: /obj/item/clothing/neck/roguetown/collar/woolen
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/neck.dm

Loincloth
  path: /obj/item/clothing/under/roguetown/loincloth
  was: 2 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/pants/cloth.dm

Silk tights
  path: /obj/item/clothing/under/roguetown/trou/shadowpants
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: code/modules/clothing/rogueclothes/pants/leather.dm

Nun's habit
  path: /obj/item/clothing/suit/roguetown/shirt/robe/nun
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: code/modules/clothing/rogueclothes/robes.dm

Silk shirt
  path: /obj/item/clothing/suit/roguetown/shirt/shadowshirt
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: code/modules/clothing/rogueclothes/shirts.dm

Striped shirt
  path: /obj/item/clothing/suit/roguetown/shirt/undershirt/sailor/colored
  was: 2 cloth + 1 fiber
  now: 1 cloth + 1 fiber
  file: code/modules/clothing/rogueclothes/shirts.dm

Rags
  path: /obj/item/clothing/suit/roguetown/shirt/rags
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: code/modules/clothing/rogueclothes/shirts.dm

Tunic
  path: /obj/item/clothing/suit/roguetown/shirt/tunic
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: code/modules/clothing/rogueclothes/shirts.dm

Ornate silk tunic
  path: /obj/item/clothing/suit/roguetown/shirt/tunic/silktunic
  change: fiber_salvage set TRUE so the silk-tunic recipe still refunds its fiber after the parent tunic lost it
  file: code/modules/clothing/rogueclothes/shirts.dm

Fine bisht (grey bisht)
  path: /obj/item/clothing/suit/roguetown/shirt/robe/bisht/bluegrey
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: modular_deserttown/desertclothing.dm

Thawb
  path: /obj/item/clothing/suit/roguetown/shirt/dress/thawb
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: modular_deserttown/desertclothing.dm

Turban
  path: /obj/item/clothing/head/roguetown/turban
  was: 1 cloth + 1 fiber
  now: 1 cloth
  file: modular_deserttown/desertclothing.dm

Sirwal
  path: /obj/item/clothing/under/roguetown/sirwal
  was: 2 cloth + 1 fiber
  now: 1 cloth
  file: modular_deserttown/desertclothing.dm

Thong
  path: /obj/item/clothing/under/roguetown/thong
  was: 2 cloth + 1 fiber
  now: 1 cloth
  file: modular_deserttown/desertclothing.dm

Moon robe
  path: /obj/item/clothing/suit/roguetown/shirt/robe/selune
  was: 2 cloth + 1 fiber
  now: 2 cloth
  file: modular_rmh/code/modules/clothing/vladegeg/selune.dm

</details>

<details>

<summary>Subtypes that inherit one of these changes from their parent type</summary>
These types were not edited line-by-line, but their salvage refund changed because a parent was.

Headband parent (/obj/item/clothing/head/roguetown/headband):
  /obj/item/clothing/head/roguetown/headband/bloodied
  /obj/item/clothing/head/roguetown/headband/red
  (monk and monk/barbarian do not inherit the fiber cut; monk was set TRUE)

Loincloth parent:
  /obj/item/clothing/under/roguetown/loincloth/brown   (Brown loincloth from the source list)
  /obj/item/clothing/under/roguetown/loincloth/pink
  /obj/item/clothing/under/roguetown/loincloth/desert_sorceress  (fiber refund kept: 1 cloth + 1 fiber)

Silk shirt parent:
  /obj/item/clothing/suit/roguetown/shirt/shadowshirt/elflock

Tunic parent (/obj/item/clothing/suit/roguetown/shirt/tunic):
  /obj/item/clothing/suit/roguetown/shirt/tunic/green
  /obj/item/clothing/suit/roguetown/shirt/tunic/blue
  /obj/item/clothing/suit/roguetown/shirt/tunic/red
  /obj/item/clothing/suit/roguetown/shirt/tunic/purple
  /obj/item/clothing/suit/roguetown/shirt/tunic/white
  /obj/item/clothing/suit/roguetown/shirt/tunic/black
  /obj/item/clothing/suit/roguetown/shirt/tunic/ucolored
  /obj/item/clothing/suit/roguetown/shirt/tunic/random
  /obj/item/clothing/suit/roguetown/shirt/tunic/noblecoat
  (silktunic does not inherit the fiber cut; it was set TRUE)

Thawb parent:
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/black
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/blue
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/red
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/beige
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/brown
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/grey
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/random
  /obj/item/clothing/suit/roguetown/shirt/dress/thawb/gold

Turban parent:
  /obj/item/clothing/head/roguetown/turban/tan
  /obj/item/clothing/head/roguetown/turban/brown
  /obj/item/clothing/head/roguetown/turban/dark
  /obj/item/clothing/head/roguetown/turban/grey
  /obj/item/clothing/head/roguetown/turban/red
  /obj/item/clothing/head/roguetown/turban/random
  /obj/item/clothing/head/roguetown/turban/fancypurple

Sirwal parent:
  /obj/item/clothing/under/roguetown/sirwal/beige
  /obj/item/clothing/under/roguetown/sirwal/brown
  /obj/item/clothing/under/roguetown/sirwal/black
  /obj/item/clothing/under/roguetown/sirwal/plainrandom
  /obj/item/clothing/under/roguetown/sirwal/fancy
  /obj/item/clothing/under/roguetown/sirwal/fancy/red
  /obj/item/clothing/under/roguetown/sirwal/fancy/blue
  /obj/item/clothing/under/roguetown/sirwal/fancy/purple
  /obj/item/clothing/under/roguetown/sirwal/fancy/yellow
  /obj/item/clothing/under/roguetown/sirwal/fancy/random

Monk's headband parent (fiber refund kept):
  /obj/item/clothing/head/roguetown/headband/monk/barbarian
</details>

<details>

<summary>Items that were brought up in the report, but remained unchanged</summary>

Fingerless gloves
Low cut tunic
Shirt
Work trousers
Tights
Right eye patch
Left eye patch
Scarf
Regal silks
Scholar's robes
Cold dress
Skirt
Sailor's pants
Apothecary trousers
Royal sleeves
Grenzelhoftian hat
Artificer's cap
Spellsinger hat
Surgeon's collar (not salvageable: sewrepair FALSE, salvage_result null)
Maid headband
Maid apron
Trouser shorts
Strapless dress
Strapless dress alt
Toga
Knee-high skirt
Knee-high skirt (colorable)
Leopard robe
</details>
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiled and partially tested on my box. This is just modifying variables that control refunds, not much to it.
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Exploits are Not Great and they're a real economic issue.
Maintainers wanted this to happen before the Tailor could get a trait to use the loom more efficiently.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixes some material duplication exploits that involve scissors refunding more material than the item cost to make.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
