### PR TITLE
Excommunication & Apostasy changes.

### DIFF
--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -440,13 +440,13 @@
 	timer = INFINITY
 
 /datum/stressevent/excommunicated
-	stressadd = 5
+	stressadd = 10
 	desc = span_boldred("The Ten have forsaken me!")
 	timer = INFINITY
 
 /datum/stressevent/apostasy
-	stressadd = 3
-	desc = span_boldred("The apostasy's mark is upon me!")
+	stressadd = 20
+	desc = span_boldred("The apostates mark is upon me!")
 	timer = INFINITY
 
 /datum/stressevent/heretic_on_sermon

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -446,7 +446,7 @@
 
 /datum/stressevent/apostasy
 	stressadd = 20
-	desc = span_boldred("The apostates mark is upon me!")
+	desc = span_boldred("I have been decreed an apostate! My connection to the Divine is SEVERED!")
 	timer = INFINITY
 
 /datum/stressevent/heretic_on_sermon

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -445,7 +445,7 @@
 	timer = INFINITY
 
 /datum/stressevent/apostasy
-	stressadd = 20
+	stressadd = 15
 	desc = span_boldred("I have been decreed an apostate! My connection to the Divine is SEVERED!")
 	timer = INFINITY
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -368,18 +368,6 @@ GLOBAL_LIST_EMPTY(priest_swap_timers)
 		to_chat(src, span_warning("This one's connection to the ten is too shallow."))
 		return FALSE
 
-	//Flavor messages for cursing certain god's faithful.
-	//Dendor works in mysterious ways.
-	if (istype(H.patron, /datum/patron/divine/dendor))
-		to_chat(src, span_warning("The mad god Dendor is felt strongly. The wolf in this one balks and trashes as it is faintly restrained."))
-		//If we check this here there's no need to apply this trait preemtively to a bunch of people, and allows for greater fluff feedback.
-		ADD_TRAIT(H, TRAIT_CURSE_RESIST, TRAIT_GENERIC)
-
-	//Abyssor's clergy are gripped by his dream.
-	if (istype(H.patron, /datum/patron/divine/abyssor))
-		to_chat(src, span_warning("The Dreamer, Abyssor has his clutches grasped firmly around this one. The light of the ten only barely penetrates the depths."))
-		ADD_TRAIT(H, TRAIT_CURSE_RESIST, TRAIT_GENERIC)
-
 	//Let's not curse heretical antags.
 	if(HAS_TRAIT(H, TRAIT_HERESIARCH))
 		to_chat(src, span_warning("The patron of this one shields them from being suppressed."))

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -383,7 +383,7 @@ GLOBAL_LIST_EMPTY(priest_swap_timers)
 		return
 
 	var/found = FALSE
-	var/inputty = input("Put an apostasy on someone, removing their ability to use miracles... (apostasy them again to remove it)", "Sinner Name") as text|null
+	var/inputty = input("Mark a member of the clergy as an apostate, removing their ability to use miracles... (apostasy them again to remove it)", "Sinner Name") as text|null
 
 	if (!inputty)
 		return


### PR DESCRIPTION
## About The Pull Request
This PR does the following.
-> Increases the stress added from being excommunicated from 5 -> 10 and drastically increases the stress added from Apostasy from 3 -> 15.
-> Removes the code that prevents Abyssorites and Dendorites from being marked as apostate or cursed.
-> Some small flavor text changes to make it a bit more obvious what apostasy is intended for + better grammar.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="534" height="147" alt="image" src="https://github.com/user-attachments/assets/b3e3bea1-7b5c-4ed2-95dd-7a64d321d244" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The Bishop is a joke half of the time already and it isn't helped that being excommunicated is a small inconvienence for Tennite followers.

Apostasy did even less stress and its explicitly designed to punish the faithful and clergy that disobey the Bishop. Being forcibly cut from your divine connection to your God should absolutely obliterate your mental state. Hello???

The fact that Dendorites and Abyssorites get a random dice roll to negate consequences is frankly, dumb as fuck. If you piss off the Prelate sufficently as a devout you should suffer greatly. This doesn't just go for curses. Apostasy explicitly checks for curse immunity, which was just granted to every dendorite and abyssorite apparently??
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Excommunication and Apostasy have had their stress values increased, with the former now being more than a small inconvinenence and the latter being a crippling mood debuff for any clergy afflicted.
balance: Abyssorites and Dendorites are no longer immune to Apostasy or Divine Curse.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
