### PR TITLE
Precise tievery

### DIFF
--- a/code/game/objects/items/rogueweapons/mmb/steal.dm
+++ b/code/game/objects/items/rogueweapons/mmb/steal.dm
@@ -180,7 +180,7 @@
 	if(!isnum(range_add))
 		range_add = 0
 	var/steal_radius = 1 + range_add
-	var/list/stealablezones = list("chest", "neck", "groin", "r_hand", "l_hand", "r_leg", "l_leg")
+	var/list/stealablezones = list("chest", "neck", "groin", "r_hand", "l_hand", "r_leg", "l_leg", "l_arm", "r_arm")
 	// Pickpocketting checks
 	if(get_dist(thief, victim) > steal_radius)
 		to_chat(thief, span_warning("[victim] is too far away."))
@@ -254,8 +254,12 @@
 	var/list/stealpos = list()
 	switch(thief.zone_selected)
 		if("chest")
+			if(victim.get_item_by_slot(SLOT_CLOAK))
+				stealpos.Add(victim.get_item_by_slot(SLOT_CLOAK))
+		if("l_arm")
 			if(victim.get_item_by_slot(SLOT_BACK_L))
 				stealpos.Add(victim.get_item_by_slot(SLOT_BACK_L))
+		if("r_arm")
 			if(victim.get_item_by_slot(SLOT_BACK_R))
 				stealpos.Add(victim.get_item_by_slot(SLOT_BACK_R))
 		if("neck")
@@ -295,7 +299,7 @@
 		thief.changeNext_move(clickcd)
 		return
 
-	if(istype(target, /obj/item/storage))
+	if(istype(target, /obj/item/storage) || istype(target, /obj/item/clothing/cloak))
 		var/obj/item/storage/container = target
 		var/datum/component/storage/storage = container.GetComponent(/datum/component/storage)
 		if(!storage || !length(storage.contents()))


### PR DESCRIPTION
## About The Pull Request
Stealing from somone with left arm selected will steal from left back slot, right from right slot
Stealing from the chest now steals from cloak instead
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="765" height="393" alt="Zrzut ekranu 2026-09-06 180740" src="https://github.com/user-attachments/assets/03c3d3b1-bbf5-4b2a-807b-ae8e1b7109d3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Having to roll 50 50 betwen instantly giving yourself away by stealing lets say shield (very common back item) or stealing from the bag isnt particularly plesant. Arms were also unused zones for tieving and legs gave this precise version alredy for belt stealing, hence me coppying over the logic. 
Cloaks all have storage, coudl be resonably stolen from and the chest target was free, so i added them as posible target 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Pickpocketing while targeting an arm now pickpockets coresponding back zone (no longer will you roll a dice to see if you pick a shield instead)
add: Pickpocketing chest now pickpockets cloak instead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
