### PR TITLE
Gives Revenants more ear options

### DIFF
--- a/code/modules/client/customizer/customizers/organ/ears.dm
+++ b/code/modules/client/customizer/customizers/organ/ears.dm
@@ -305,6 +305,7 @@
 		/datum/sprite_accessory/ears/rabbit,
 		/datum/sprite_accessory/ears/bunny,
 		/datum/sprite_accessory/ears/bunny_perky,
+		/datum/sprite_accessory/ears/bunny_long,
 		/datum/sprite_accessory/ears/big/rabbit_large,
 		/datum/sprite_accessory/ears/cat_big,
 		/datum/sprite_accessory/ears/cat_normal,
@@ -343,6 +344,11 @@
 		/datum/sprite_accessory/ears/big/acrador_short,
 		/datum/sprite_accessory/ears/big/sandfox_large,
 		/datum/sprite_accessory/ears/lynx,
+		/datum/sprite_accessory/ears/four_ears,
+		/datum/sprite_accessory/ears/dendorite,
+		/datum/sprite_accessory/ears/eoran,
+		/datum/sprite_accessory/ears/pestran,
+		/datum/sprite_accessory/ears/zorzor
 		)
 
 /datum/customizer/organ/ears/harpy


### PR DESCRIPTION
## About The Pull Request

It gives them the same exact option for ears that halfkin have.

## Testing Evidence

it compiles

## Why It's Good For The Game

Why are Revenant ears arbitrarily limited? From my own testing, it didn't seem like them having more ears caused any particular issues. 

## Changelog

:cl:
add: more ears for revenants
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
