### PR TITLE
Removes roundstart steel crossbow from Crossbow Levy | Replaced for more bolts

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -124,10 +124,10 @@
 
 /datum/virtue/combat/crossbowman
 	name = "Crossbow Levy"
-	desc = "A crossbow is a simple weapon to use, but that's what makes it so effective. I've always kept a crossbow and some bolts around, just in case."
+	desc = "A crossbow is a simple weapon to use, but that's what makes it so effective. I've always kept an extra supply of special bolts around, just in case."
 	custom_text = "+1 to Crossbows, Up to Legendary, Minimum Apprentice"
-	added_stashed_items = list("Crossbow" = /obj/item/gun/ballistic/revolver/grenadelauncher/crossbow,
-								"Quiver (Bolts)" = /obj/item/quiver/bolts
+	added_stashed_items = list("Quiver (Heavy Bolts)" = /obj/item/quiver/heavybluntbolts,
+								"Quiver (Regular Bolts)" = /obj/item/quiver/bolts
 	)
 
 /datum/virtue/combat/crossbowman/apply_to_human(mob/living/carbon/human/recipient)

--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -125,7 +125,7 @@
 /datum/virtue/combat/crossbowman
 	name = "Crossbow Levy"
 	desc = "A crossbow is a simple weapon to use, but that's what makes it so effective. I've always kept an extra supply of special bolts around, just in case."
-	custom_text = "+1 to Crossbows, Up to Legendary, Minimum Apprentice"
+	custom_text = "+1 to Crossbows, Up to Expert, Minimum Apprentice"
 	added_stashed_items = list("Quiver (Heavy Bolts)" = /obj/item/quiver/heavybluntbolts,
 								"Quiver (Regular Bolts)" = /obj/item/quiver/bolts
 	)
@@ -134,7 +134,7 @@
 	if(recipient.get_skill_level(/datum/skill/combat/crossbows) < SKILL_LEVEL_APPRENTICE)
 		recipient.adjust_skillrank_up_to(/datum/skill/combat/crossbows, SKILL_LEVEL_APPRENTICE, silent = TRUE)
 	else
-		added_skills = list(list(/datum/skill/combat/crossbows, 1, 6))
+		added_skills = list(list(/datum/skill/combat/crossbows, 1, 4))
 
 /datum/virtue/combat/shepherd
 	name = "Capable Shepherd"


### PR DESCRIPTION
## About The Pull Request

Bye bye roundstart steel crossbow!!! You get an extra quiver of heavy bolts, don't worry.

You can only level up to expert skill as well. Sorry Vanguards, no more Master crossbows. 
## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

Crossbow Levy is a notoriously overused virtue for Wardens, Vanguards, Squires, or literally any role with crossbow skills, but no crossbow to spawn with. 

A Vanguard could, for example, take Crossbow Levy, _instantly hit master crossbows_, take a +2 PER statpack, and _immediately spawn in with a steel crossbow and a full quiver of bolts_. 

This can be done at ROUNDSTART. This is not good for balance.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

balance: removed stashed crossbow from crossbow levy, replaced with an extra quiver of bolts.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
