### PR TITLE
Unfucks adventurer squire inventory

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/noble.dm
@@ -218,8 +218,12 @@
 	beltl = /obj/item/flashlight/flare/torch/lantern
 	backr = /obj/item/storage/backpack/rogue/satchel
 	backpack_contents = list(
-		/obj/item/storage/belt/rogue/pouch/coins/poor = 1, 
-		/obj/item/rogueweapon/hammer/iron = 1, 
+		/obj/item/storage/belt/rogue/pouch/coins/poor = 1,
+		/obj/item/rogueweapon/hammer/iron = 1,
+		/obj/item/armor_brush = 1,
+		/obj/item/polishing_cream = 1,
+		/obj/item/rogueweapon/huntingknife = 1,
+		/obj/item/rogueweapon/scabbard/sheath,
 	)
 	if(H.mind)
 		var/armors = list("Light Armor","Medium Armor")


### PR DESCRIPTION
## About The Pull Request

#2529 Removed all of the contents of the adventurer squire's inventory, this just puts the stuff they used to get back.

## Why It's Good For The Game

Undocumented and I'm assuming accidental change. No CL needed.