### PR TITLE
Stasis spell restoring resting/standing

### DIFF
--- a/code/modules/spells/spell_types/naledi.dm
+++ b/code/modules/spells/spell_types/naledi.dm
@@ -190,6 +190,12 @@
 	var/sunderfirestacks = 0
 	var/blood = 0
 	var/list/datum/wound/snapshot_wounds
+	var/static/list/purged_effects = list(
+	/datum/status_effect/incapacitating/immobilized,
+	/datum/status_effect/incapacitating/paralyzed,
+	/datum/status_effect/incapacitating/stun,
+	/datum/status_effect/incapacitating/knockdown,)
+	var/position = FALSE
 	miracle = TRUE
 	devotion_cost = 70
 
@@ -244,6 +250,7 @@
 		divinefirestacks = divine_status?.stacks
 		// Snapshot current wounds so we can remove new ones on revert
 		snapshot_wounds = target.get_wounds()
+		position = target.resting
 
 		to_chat(target, span_warning("I feel a part of me was left behind..."))
 		play_indicator(target,'icons/mob/overhead_effects.dmi', "timestop", 100, OBJ_LAYER)
@@ -287,6 +294,9 @@
 			wound.bodypart_owner.remove_wound(wound)
 		else
 			target.simple_remove_wound(wound)
+	for(var/effect in purged_effects)
+		human.remove_status_effect(effect)
+	target.set_resting(position, TRUE)
 
 	playsound(target.loc, 'sound/magic/timereverse.ogg', 100, FALSE)
 

--- a/code/modules/spells/spell_types/naledi.dm
+++ b/code/modules/spells/spell_types/naledi.dm
@@ -295,7 +295,7 @@
 		else
 			target.simple_remove_wound(wound)
 	for(var/effect in purged_effects)
-		human.remove_status_effect(effect)
+		target.remove_status_effect(effect)
 	target.set_resting(position, TRUE)
 
 	playsound(target.loc, 'sound/magic/timereverse.ogg', 100, FALSE)


### PR DESCRIPTION
## About The Pull Request
Stasis spell (viseir exclusive) when restoring everythign else also restores your position, that being either standing or laying down
It also removes mobility related effects like garagarite rage when doing so (quite literally copied over the list)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="666" height="576" alt="Zrzut ekranu 2026-09-07 015323" src="https://github.com/user-attachments/assets/de4cce06-15dc-4f6e-847c-d044ef34992a" />

<img width="534" height="468" alt="Zrzut ekranu 2026-09-07 015348" src="https://github.com/user-attachments/assets/501badaa-1e54-4772-bf78-76bc14ceafc8" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Stasis is basicly taking snapshot of somones state and then restoring it after 10 seconds. It restores damage, fire, the place of standing and wounds but if you for example fallen down or stood up, you ended up laying down or standing when restored, even if the snapshot had difrent position. Now that is also taken into acount
The status effect removal is for the same reson (and i dont think accuratly adding those statuses back is posible, so only removal is active). It also prevent instantly falling down if you have one of the statuses with force it.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Visseir stasis now remeber whether you were up or down when spell was cast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
