### PR TITLE
Minor changes to second wind (abysor T0)

### DIFF
--- a/code/modules/spells/roguetown/acolyte/abyssor.dm
+++ b/code/modules/spells/roguetown/acolyte/abyssor.dm
@@ -87,8 +87,8 @@
 	sound = 'sound/magic/abyssor_splash.ogg'
 	associated_skill = /datum/skill/magic/holy
 	antimagic_allowed = FALSE
-	invocations = list("What is drowned shall rise anew!")
-	invocation_type = "shout"
+	invocations = list("is lifted up by spectral waves!")
+	invocation_type = "emote"
 	recharge_time = 120 SECONDS
 	devotion_cost = 30
 	miracle = TRUE
@@ -99,10 +99,13 @@
 		revert_cast()
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	if(H.IsStun() || H.IsImmobilized() || H.IsOffBalanced())
+	if(H.IsStun()||H.IsParalyzed())
 		to_chat(user, span_warning("I am too incapacitated!"))
 		revert_cast()
 		return FALSE
+	H.remove_status_effect(/datum/status_effect/incapacitating/knockdown)
+	H.remove_status_effect(/datum/status_effect/incapacitating/off_balanced)
+	H.remove_status_effect(/datum/status_effect/incapacitating/immobilized)
 	var/msg = span_warning("[user] ")
 	if(H.resting)
 		H.set_resting(FALSE, FALSE)


### PR DESCRIPTION
## About The Pull Request
Second wind incantation has been changed from shout to emote
Knockdown is now clensed
Immbolise and of balance are clensed instead of blocking the cast
Paralisis now blocks the cast (stun still blocks it to)
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="423" height="69" alt="Zrzut ekranu 2026-09-07 021749" src="https://github.com/user-attachments/assets/96d94662-7945-406c-a9f7-5a49e01e549f" />

<img width="246" height="186" alt="Zrzut ekranu 2026-09-07 021822" src="https://github.com/user-attachments/assets/62a88662-ac67-44f3-a2dc-e9d9a059ab9c" />

<img width="225" height="246" alt="Zrzut ekranu 2026-09-07 021915" src="https://github.com/user-attachments/assets/b53ca721-3753-41e9-b99c-327af353e153" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Speaking incantation stoped the spell from being used while downed in watter. At least for me it feels like gods of the sea stand up spell should be usable in sea
Knockdown not being removed means you coudl have stood up and then instantly fallen down because of the status. Paralisis not stoping the spell is an issue for the same reson.
It feels like immbolise and of balance are the kind of things this spell shoudl help you against instead of stoping you from casting. Unlike garagorite stuns and paralise arent cleansed, so it is meaningfully worse then the ascendand version
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Second wind (abyssors T0) has now emote incantation (so usable when under water)
balance: some mobility reducing  effects are now clensed instead of stoping the cast of second wind
fix: You should no longer have to worry about instantly falling down after using the second wind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
