### PR TITLE
Adds Woodwalker to Harpies

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furry/harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furry/harpy.dm
@@ -54,7 +54,7 @@
 		)
 
 	race_bonus = list(STAT_CONSTITUTION = -3, STAT_STRENGTH = -2, STAT_PERCEPTION = 1, STAT_INTELLIGENCE = 1, STAT_SPEED = 2)
-	inherent_traits = list(TRAIT_CALTROPIMMUNE, TRAIT_NOFALLDAMAGE1, TRAIT_STRONGBITE) // hahahahahh
+	inherent_traits = list(TRAIT_CALTROPIMMUNE, TRAIT_NOFALLDAMAGE1, TRAIT_WOODWALKER, TRAIT_STRONGBITE) // hahahahahh
 	inherent_skills = list(
 		/datum/skill/misc/music = 3,
 	)


### PR DESCRIPTION
## About The Pull Request
See title.

## Testing Evidence
Ignore the expert dodger. I started out as a dendorite adventurer rogue in testing.
<img width="340" height="233" alt="wwharpy" src="https://github.com/user-attachments/assets/57e691f1-9aac-4856-aea9-e17070f87ae4" />

## Why It's Good For The Game
Okay so this is gonna be a bit long.

I was originally going to just **remove** strong bite from them but I wasn't sure if I should. It stays for now, but I am totally up for that if a maintainer wishes for it though to balance things out.

As to WHY harpies should get woodwalker, it comes down to convenience and how it makes sense. Harpies are arguably one of the weakest races in the game if you don't count their ability to fly. Unless you take a class that is good at dodging or use a statpack + a role that helps to balance out your massive CON and STR penalty, you are screwed. You cannot wear any chest/leg armor, and most grapples will take you down. Even a single bolt or fireball is enough to get you out of a fight in the specific case of fighting as a harpy. I'm not just aiming to 'buff' them as a combat race. This is useful for those who build as harpies too. In fact, a lot of harpy players typically build in trees so this is a win for them.

So why woodwalker, then? It makes sense. They have claws for grasping trees. Strong bite feels like it's there because they have beaks and was just put in there for whatever but 80% of the harpies I see do not even have beaks, much less use the trait to bite with. I'm willing to keep that for now instead of removing it outright as I barely see harpies actually use that. They usually just use their talons instead (which actively drains stamina keeping them out). But in my opinion, I feel like they don't really need strong bite.

Continuing on, flying from tree canopy to tree canopy is tedious. Woodwalker helps make that less tedious. A majority of your gameplay as a harpy when flying is going around canopy to canopy if you are not on the roofs. You run out of stamina, wait 10 seconds to regenerate stamina and for the action timer and then take flight again. And that is specifically in cases where you are on roofs or canopies for some reason such as scouting, building or running away. In the case of running away, you could say that the rare knaive harpy player would be buffed in this sense, but they would also have to steal from somewhere that has a lot of trees nearby. And with how harpies are currently, they're already long gone and hiding behind a tree trunk, waiting those 10 seconds while hiding with high stealth and then and flying off. It is a very specific scenario and it's not really that strong if you think about it. It just shaves off those few seconds of having to rest, which people are unlikely to find you anyway if you're in canopies specifically.

In the bog they would just be a bit faster at walking around instead of flying, but I feel like they should get that since they have talons to hang onto foliage and branches. They're masters of the canopy, so they should feel like it instead of the current loop of fly>wait>fly>wait. Also, if you run out of stamina while flying from canopy to canopy and end up landing in a maneater in the bog, you can say goodbye to your round since you are very unlikely to break out, especially if you are winded from falling. In fact, woodwalker might even make you more careless since you have to not accidentally walk off the tree canopy ledge where flying is safer in comparison if you manage your stamina.

On the aspect of how woodwalker makes you climb trees faster. Yes, that is also a boon but it's roughly the same speed you would need to walk and initiate your flight then go up a z-level with the action timer. Probably a bit faster but if you're trying to escape such as being a roguish sort. But in that case, you're already going to be climbing pretty quickly since you get high climbing skill from the get go.

## Changelog
:cl:
add: Harpies innately get woodwalker now.
/:cl: