### PR TITLE
fixes (buffs?) `TRAIT_IGNOREDAMAGESLOWDOWN` by letting you ignore the slowdown. from damage

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2090,7 +2090,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					H.Immobilize(5) //The fastest you can swing a weapon is once each 0.6 seconds, anything higher than 0.5 Immob. opens the door for stunlocking (see: katar).
 					shake_camera(H, 2, 2)
 					H.stuttering += 5
-				if(damage_amount > 10 && !HAS_TRAIT(H, TRAIT_NOPAINSTUN))
+				if(damage_amount > 10 && !HAS_TRAIT(H, TRAIT_NOPAINSTUN) && !HAS_TRAIT(H, TRAIT_IGNOREDAMAGESLOWDOWN))
 					H.Slowdown(clamp(damage_amount/10, 1, 5))
 					shake_camera(H, 1, 1)
 				if(damage_amount < 10)


### PR DESCRIPTION
## About The Pull Request

Adds a check for `TRAIT_IGNOREDAMAGESLOWDOWN` to the if check that makes you slow down whenever taking more than ten damage. I mean, maybe it was intended to be this way? But, I think it's counterintuitive to the name of the trait if the slowdown from damage is not countered by it.

For the curious, `TRAIT_IGNOREDAMAGESLOWDOWN` lets you ignore the damage slowdown specifically from when you have a lot of damage. Well, a lot by TG standards - because here that's equivocal to about four swings from a weak-ish sword.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

I had a skeleton stab me in the ribs as a disciple, and while I got the microstun from taking a lot of damage from one swing, I was power walking the fuck away from him.

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

I'unno. People kept getting deceived by what the trait does, thinking that it does what I just described - when it didn't.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: TRAIT_IGNOREDAMAGESLOWDOWN lets you ignore the slowdown. from damage. specifically when you take damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
