### PR TITLE
AP port - buff timers

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -105,10 +105,49 @@
 	var/mob/mob_viewer //the mob viewing this alert
 	var/alert_group = ALERT_STATUS //decides where on the screen the alert shows up, if it's a debuff, status effect, or buff
 	nomouseover = FALSE
+	var/atom/movable/screen/maptext_holder/maptext_holder
+	var/last_countdown_text //Cached countdown string so we don't rewrite maptext every fast-process tick
 
 // Alerts track their owner via mob_viewer rather than hud; an observer seeing someone else's alert can't act on it.
 /atom/movable/screen/alert/allow_click_from(mob/user)
 	return !(mob_viewer && mob_viewer != user)
+
+//At or above this, the countdown shows whole minutes ("27m"); below it, M:SS or Ns
+#define ALERT_COUNTDOWN_CUTOFF (3 MINUTES)
+
+/atom/movable/screen/alert/proc/update_countdown(remaining_deciseconds)
+	if(remaining_deciseconds <= 0)
+		if(istype(maptext_holder))
+			maptext_holder.maptext = null
+		last_countdown_text = null
+		return
+
+	var/countdown_text
+	if(remaining_deciseconds >= ALERT_COUNTDOWN_CUTOFF)
+		var/mins_left = max(round(remaining_deciseconds / (1 MINUTES), 1), 1)
+		countdown_text = "[mins_left]m"
+	else
+		var/seconds_left = round(remaining_deciseconds / (1 SECONDS), 0.1)
+		if(seconds_left >= 60)
+			var/mins = round(seconds_left / 60)
+			var/secs = round(seconds_left) % 60
+			countdown_text = "[mins]:[secs < 10 ? "0[secs]" : "[secs]"]"
+		else
+			countdown_text = "[seconds_left]s"
+
+	if(countdown_text == last_countdown_text)
+		return
+	last_countdown_text = countdown_text
+
+	if(!istype(maptext_holder))
+		maptext_holder = new(src)
+		maptext_holder.x = 4
+		maptext_holder.y = 0
+		maptext_holder.color = "#800000"
+		vis_contents.Add(maptext_holder)
+	maptext_holder.maptext = MAPTEXT(countdown_text)
+
+#undef ALERT_COUNTDOWN_CUTOFF
 
 //Gas alerts
 /atom/movable/screen/alert/not_enough_oxy
@@ -490,6 +529,7 @@
 	return 1
 
 /atom/movable/screen/alert/Destroy()
+	QDEL_NULL(maptext_holder)
 	severity = 0
 	master = null
 	mob_viewer = null

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -113,6 +113,9 @@
 		tick_interval = world.time + initial(tick_interval)
 	if(duration != -1 && duration < world.time)
 		qdel(src)
+		return
+	if(linked_alert && duration != -1)
+		linked_alert.update_countdown(max(duration - world.time, 0))
 
 /datum/status_effect/proc/on_apply() //Called whenever the buff is applied; returning FALSE will cause it to autoremove itself.
 	for(var/S in effectedstats)
@@ -183,6 +186,18 @@
 		if(attached_effect.effectedstats[S] < 0)
 			var/newnum = attached_effect.effectedstats[S] * -1
 			inspec += "<br><span class='danger'>[S]</span> \Roman [newnum]"
+
+	if(attached_effect && attached_effect.duration != -1 && attached_effect.duration > world.time)
+		var/remaining = attached_effect.duration - world.time
+		var/total_secs = round(remaining / (1 SECONDS))
+		var/timestring
+		if(total_secs >= 60)
+			var/mins = round(total_secs / 60)
+			var/secs = total_secs % 60
+			timestring = "[mins]:[secs < 10 ? "0[secs]" : "[secs]"]"
+		else
+			timestring = "[total_secs]s"
+		inspec += "<br><span class='smallnotice'>Time remaining: [timestring]</span>"
 
 	inspec += "<br>----------------------"
 	to_chat(user, "[inspec.Join()]")


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/Azure-Peak/Azure-Peak/pull/5720 ~~and like another PR that added some performance stuff but I lost it in my notepad. I don't feel like finding it again.~~ https://github.com/Azure-Peak/Azure-Peak/pull/8117 It was some chunks from this PR, but not the actual balance stuff from it, obviously.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

<img width="884" height="87" alt="image" src="https://github.com/user-attachments/assets/f04ffbff-0c89-40f3-9245-bc2d1a6f4e42" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

It is maybe the single largest QOL for people who like to maintain buffs and keep track of things like that.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Remaining duration is now displayed on status effects as a countdown, except things like thirsty / hungry.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
