### PR TITLE
Allows the silver amulet of the Ten to be bought at a silverface

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/luxury.dm
+++ b/code/modules/cargo/packsrogue/merchant/luxury.dm
@@ -18,6 +18,11 @@
 	cost = 120
 	contains = list(/obj/item/clothing/neck/roguetown/psicross/silver)
 
+/datum/supply_pack/rogue/luxury/silvertencross
+	name = "Silver amulet of the Ten"
+	cost = 120
+	contains = list(/obj/item/clothing/neck/roguetown/psicross/silver/undivided)
+
 /datum/supply_pack/rogue/luxury/silverdagger
 	name = "Silver Dagger"
 	cost = 120 //Silver weapons have been made much less powerful but much more common over time

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -1277,13 +1277,13 @@
 	smeltresult = null
 
 /obj/item/clothing/neck/roguetown/psicross/ten
-	name = "amulet of Ten"
+	name = "amulet of the Ten"
 	desc = "The Ten eternal, strength in unity. Stalwart for centuries against the darkness."
 	icon_state = "undivided"
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_HIP|ITEM_SLOT_WRISTS|ITEM_SLOT_RING
 
 /obj/item/clothing/neck/roguetown/psicross/silver/undivided
-	name = "silver amulet of Ten"
+	name = "silver amulet of the Ten"
 	desc = "Ward of silver, sigil of eternity; by the Ten, I command thee back to Hell!"
 	icon_state = "undivided_s"
 	sellprice = 50


### PR DESCRIPTION
## About The Pull Request
Slight wording changes + allowing the silver amulet of the ten to be purchased at a silverface.
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
<img width="515" height="147" alt="image" src="https://github.com/user-attachments/assets/5a2dd803-4f39-4f1c-b68b-30448660f1f3" />

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Cosmetic. With silver psycrosses being more required with the new antags slated to come/already being implemented, it'd be nice to let people get a silver cross of their choice vs being forced to stick with the silver psycross.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The Silver amulet of the Ten may be purchased from the merchants silverface/goldface.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
