### PR TITLE
Makes it so that Skeletons no longer get preference virtues

### DIFF
--- a/code/_globalvars/special_traits.dm
+++ b/code/_globalvars/special_traits.dm
@@ -89,6 +89,10 @@ GLOBAL_LIST_INIT(special_traits, build_special_traits())
 		return
 	if (!player.prefs)
 		return
+	if (character.job)
+		var/datum/job/players_job = SSjob.GetJob(character.job)
+		if(players_job && players_job.no_virtue)
+			return
 
 	var/virtuous = FALSE
 	var/heretic = FALSE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -174,6 +174,9 @@
 	///The social rank of the job, determines the examine text when examining others or being examined
 	var/social_rank = SOCIAL_RANK_DIRT
 
+	///Whether or not a job should grant a player their preference virtues
+	var/no_virtue = FALSE
+
 /datum/job/proc/special_job_check(mob/dead/new_player/player)
 	return TRUE
 

--- a/code/modules/jobs/job_types/roguetown/other/greater_skeleton.dm
+++ b/code/modules/jobs/job_types/roguetown/other/greater_skeleton.dm
@@ -18,6 +18,8 @@
 	give_bank_account = FALSE
 	hidden_job = TRUE
 
+	no_virtue = TRUE
+
 /datum/outfit/job/roguetown/greater_skeleton/pre_equip(mob/living/carbon/human/H)
 	..()
 


### PR DESCRIPTION
## About The Pull Request

On request from High Up, skeletons now no longer get preference virtues. This also allows other jobs to be banned from preference virtues in the future, if so desired.
## Testing Evidence

I used the testing define and then spawned in as lich, and spawned myself as a skeleton and greater skeleton to see if I got the virtues. I didn't. I also made sure I normally got virtues by spawning as a towner.

## Why It's Good For The Game

They ain't meant to have those.

## Changelog

:cl:
add: Var on jobs for checking if they should have pref virtues
fix: Made it so that skeletons no longer get pref virtues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
