### PR TITLE
Small Keeper changes

### DIFF
--- a/code/modules/jobs/job_types/roguetown/church/keeper.dm
+++ b/code/modules/jobs/job_types/roguetown/church/keeper.dm
@@ -120,7 +120,7 @@
 							/obj/item/heart_blood_vial/filled = 2,
 							/obj/item/heart_blood_canister/filled = 1,
 							/obj/item/heart_blood_vial = 5,
-							/obj/item/heart_blood_canister = 1,
+							/obj/item/heart_blood_canister = 4,
 							/obj/item/rogueweapon/huntingknife/idagger/steel/parrying = 1,
 							/obj/item/roguekey/keeper = 1,
 							/obj/item/roguekey/keeper_inner = 1,

--- a/code/modules/roguetown/roguemachine/heartbeast/heart_status_effects.dm
+++ b/code/modules/roguetown/roguemachine/heartbeast/heart_status_effects.dm
@@ -83,7 +83,7 @@
 	
 	if(to_remove)
 		C.visible_message(span_userdanger("[C]'s [to_remove.name] is torn off by the tendrils!"))
-		to_remove.dismember()
+		to_remove.dismember(damage = 999)
 
 		var/obj/effect/temp_visual/dir_setting/bloodsplatter/splatter = new(get_turf(C), pick(GLOB.cardinals))
 		splatter.color = "#880000"
@@ -93,7 +93,7 @@
 	var/obj/item/bodypart/head = C.get_bodypart(BODY_ZONE_HEAD)
 	if(head)
 		C.visible_message(span_userdanger("[C]'s head is violently torn off by the tendrils!"))
-		head.dismember()
+		head.dismember(damage = 999, vorpal = TRUE)
 		C.adjustBruteLoss(200)
 		var/obj/effect/temp_visual/dir_setting/bloodsplatter/splatter = new(get_turf(C), pick(GLOB.cardinals))
 		splatter.color = "#880000"


### PR DESCRIPTION
## About The Pull Request
Made the hearbeast use damage value for dismember, meaning armour will no longer stop it from riping limbs off (frankly a bug fix)
Give keeper extra 3 carnisters in their starting bag
<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Compiles
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
The masive hearbeast rips of your arm, spawns blood and the text says just how much your arm has been riped, but och no, a gambelson exists and so it actualy wasnt. Again, frankly a bug fix. Pestrian get bodypart reatachement as a miracle anyway, its practicly made for this
Keepers have to run to smiths for more carnisters basicly every game they show up in, now they shoudl have a resonable amount of them roundstart meaning they will not have to bog smithy down quite as often
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Gave keepers extra 3 hearblood containers at roundstart
fix: Hearbeast tentacles are no longer is beaten by a gambelson
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
