### PR TITLE
Fixes TRAIT_WEAPONLESS blocking surgical tools used surgically

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -32,9 +32,9 @@
 				return
 		if(HAS_TRAIT(user, TRAIT_WEAPONLESS))//allows tool use, but not weapons. For disciple aurafarmers who go true unarmed.
 			var/obj/item/rogueweapon/weapon = src
-			var/placing_on_furniture = !user.cmode && (istype(target, /obj/structure/table) || istype(target, /obj/structure/rack))//differentiate between placing a weapon on a table or using it to murder someone. Disciple did not forget how to be tidy when they took their oath.
-			var/using_surgical_tool = !user.cmode && iscarbon(target) && (weapon.item_flags & SURGICAL_TOOL)// lets the disciple sign their slip
 			if(istype(weapon))
+				var/placing_on_furniture = !user.cmode && (istype(target, /obj/structure/table) || istype(target, /obj/structure/rack))//differentiate between placing a weapon on a table or using it to murder someone. Disciple did not forget how to be tidy when they took their oath.
+				var/using_surgical_tool = !user.cmode && iscarbon(target) && (weapon.item_flags & SURGICAL_TOOL)// lets the disciple sign their slip
 				if((!weapon.is_tool || ismob(target)) && !placing_on_furniture && !using_surgical_tool)
 					to_chat(user, span_warning("I cannot properly wield this weapon."))
 					return

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -33,9 +33,11 @@
 		if(HAS_TRAIT(user, TRAIT_WEAPONLESS))//allows tool use, but not weapons. For disciple aurafarmers who go true unarmed.
 			var/obj/item/rogueweapon/weapon = src
 			var/placing_on_furniture = !user.cmode && (istype(target, /obj/structure/table) || istype(target, /obj/structure/rack))//differentiate between placing a weapon on a table or using it to murder someone. Disciple did not forget how to be tidy when they took their oath.
-			if(istype(weapon) && (!weapon.is_tool || ismob(target)) && !placing_on_furniture)
-				to_chat(user, span_warning("I cannot properly wield this weapon."))
-				return
+			var/using_surgical_tool = !user.cmode && iscarbon(target) && (weapon.item_flags & SURGICAL_TOOL)// lets the disciple sign their slip
+			if(istype(weapon))
+				if((!weapon.is_tool || ismob(target)) && !placing_on_furniture && !using_surgical_tool)
+					to_chat(user, span_warning("I cannot properly wield this weapon."))
+					return
 	if(tool_behaviour && target.tool_act(user, src, tool_behaviour))
 		return
 	if(pre_attack(target, user, params))


### PR DESCRIPTION
## About The Pull Request

- adds an exception in item_attack.dm that permits TRAIT_WEAPONLESS carbons from using surgical tools off combat mode.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/758698b3-aa30-4420-9ffd-593cb93795a5


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Disciples are able to sign their own slip and don't have to ask the nearest tabaxi confessor to help them cut themselves.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: TRAIT_WEAPONLESS no longer blocks the use of surgical tools. Disciple aboteers can now sign their arrival slips without needing someone else to cut them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
