### PR TITLE
Duelist Coat buff

### DIFF
--- a/code/modules/clothing/rogueclothes/armor/leather.dm
+++ b/code/modules/clothing/rogueclothes/armor/leather.dm
@@ -341,11 +341,13 @@
 	icon_state = "bwleathercoat"
 	item_state = "bwleathercoat"
 	boobed = TRUE
+	resistance_flags = FIRE_PROOF
 
 	slot_flags = ITEM_SLOT_ARMOR
 	armor = ARMOR_LEATHER_GOOD
 	body_parts_covered = COVERAGE_ALL_BUT_LEGS
-	prevent_crits = list(BCLASS_CUT, BCLASS_TWIST, BCLASS_STAB)
+	prevent_crits = list(BCLASS_CUT, BCLASS_STAB, BCLASS_BLUNT, BCLASS_CHOP, BCLASS_SMASH)
+	max_integrity = ARMOR_INT_CHEST_LIGHT_MASTER
 
 	detail_tag = "_detail"
 	detail_color = "#FFFFFF"


### PR DESCRIPTION
## About The Pull Request

The Duelist Coat is a reskin of the hardened leather coat... except that it's worse and costs more to make. Oh, and it covers the arms instead of the legs.

This PR makes it _actually_ a full on reskin (minus the arm coverage instead of legs, which it had before this) instead of being a shitter, yet more expensive version. It also makes it fireproof, which I believe gambesons and other leather armor is, including the hardened leather coat.

I am not exactly a coder, so the "FIRE_PROOF" thing may not work how I believe it works, and hey, maybe I'm schizo and the gambeson and leather armor is actually not fireproof and turns into ash when burning.

## Testing Evidence

It doth compile, milord.

## Why It's Good For The Game

It's cool as hell drip, and the loss of the kickass heavy leather coat from RW1.0 that was good AND stylish into this little cucked coat that one class gets and nobody uses is sad. It's also more expensive than the hardened leather coat- why is it worse?

## Changelog

:cl:
balance: duelist coat is now on par with the hardened leather coat
/:cl:

