### PR TITLE
HOTFIX - MATTHIOS KNIFE BUGFIX 

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -414,7 +414,7 @@
 
 // Heretical Knives
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/kris/zizo
+/obj/item/rogueweapon/huntingknife/idagger/steel/kris/zizo 
 	name = "avantyne dagger"
 	desc = "It is tyme that you finally met your Lord. </br> The very moment of sacrifice; that imperceptable difference between a dagger's edge and a heart's chamber, crystallized into \
 	a scalpel of bleeding darksteel. In the hands of Her trusted disciples, it serves as an unholy countermandate against order and sanity."
@@ -443,17 +443,17 @@
 	. = ..()
 	AddComponent(/datum/component/cursed_item, TRAIT_HORDE, "DAGGER")
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/matthios
+/obj/item/rogueweapon/huntingknife/idagger/steel/matthios //Master-of-none weapon. Heavier cut, higher WDEF, and a serviceable throwforce. 
 	name = "gilded knife"
 	desc = "Well, well, well; hello there, old sport!"
+	possible_item_intents = list(/datum/intent/dagger/thrust,/datum/intent/dagger/cut/heavy, /datum/intent/dagger/thrust/pick, /datum/intent/dagger/sucker_punch)
 	icon_state = "matthiosknife"
 	sheathe_icon = "matthiosknife"
 	force = 25
+	wdefence = 8
 	max_integrity = 250
 	max_blade_int = 300
-	throwforce = 28
-	armor_penetration = 50
-	icon_state = "throw_knifebs"
+	throwforce = 30 //Aim for something exposed. You don't get AP.
 	embedding = list("embedded_pain_multiplier" = 5, "embed_chance" = 60, "embedded_fall_chance" = 0)
 	smeltresult = null
 

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -453,6 +453,7 @@
 	wdefense = 8
 	max_integrity = 250
 	max_blade_int = 300
+	sellprice = 100
 	throwforce = 30 //Aim for something exposed. You don't get AP.
 	embedding = list("embedded_pain_multiplier" = 5, "embed_chance" = 99, "embedded_fall_chance" = 0)
 	smeltresult = null

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -414,7 +414,7 @@
 
 // Heretical Knives
 
-/obj/item/rogueweapon/huntingknife/idagger/steel/kris/zizo 
+/obj/item/rogueweapon/huntingknife/idagger/steel/kris/zizo
 	name = "avantyne dagger"
 	desc = "It is tyme that you finally met your Lord. </br> The very moment of sacrifice; that imperceptable difference between a dagger's edge and a heart's chamber, crystallized into \
 	a scalpel of bleeding darksteel. In the hands of Her trusted disciples, it serves as an unholy countermandate against order and sanity."

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -450,7 +450,7 @@
 	icon_state = "matthiosknife"
 	sheathe_icon = "matthiosknife"
 	force = 25
-	wdefence = 8
+	wdefense = 8
 	max_integrity = 250
 	max_blade_int = 300
 	throwforce = 30 //Aim for something exposed. You don't get AP.

--- a/code/game/objects/items/rogueweapons/melee/knives.dm
+++ b/code/game/objects/items/rogueweapons/melee/knives.dm
@@ -454,7 +454,7 @@
 	max_integrity = 250
 	max_blade_int = 300
 	throwforce = 30 //Aim for something exposed. You don't get AP.
-	embedding = list("embedded_pain_multiplier" = 5, "embed_chance" = 60, "embedded_fall_chance" = 0)
+	embedding = list("embedded_pain_multiplier" = 5, "embed_chance" = 99, "embedded_fall_chance" = 0)
 	smeltresult = null
 
 /obj/item/rogueweapon/huntingknife/idagger/steel/matthios/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

I was not aware that the armor_piercing value used for throwing knives also applied to melee damage. AP wrote that it did otherwise. Alas. MERGE THIS ASAP.

## Testing Evidence

<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

bug
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

fix: fixed Matthios dagger penetrating all armor

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
