### PR TITLE
Doll plain

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/construct/doll.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/construct/doll.dm
@@ -106,6 +106,7 @@
 		/datum/body_marking/diagonal_eyes,
 		/datum/body_marking/wide_eyes,
 		/datum/body_marking/stripes,
+		/datum/body_marking/plain,
 	)
 
 /datum/species/construct/metal/porcelain/check_roundstart_eligible()


### PR DESCRIPTION
## About The Pull Request

Adds the plain marking to dolls, which is used for covering up an odd browning effect.

## Testing Evidence

It's one line

## Why It's Good For The Game

It's a bandaid fix for a minor graphical uglyness on player characters.

## Changelog

:cl:
add: Dolls get plain marking for their face.

/:cl: