### PR TITLE
Let The Herald Keep Their Guitar

### DIFF
--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/herald_of_progress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/herald_of_progress.dm
@@ -103,6 +103,9 @@
 	var/datum/weakref/ztratocaster_ref
 
 /obj/effect/proc_holder/spell/self/right_where_it_belongs/cast(list/targets, mob/living/carbon/human/user = usr)
+	if(user.restrained())
+		revert_cast(user)
+		return FALSE
 	var/obj/item/rogue/instrument/ztratocaster/ztratocaster = ztratocaster_ref?.resolve()
 	if(!ztratocaster || QDELETED(ztratocaster))
 		to_chat(user, span_warning("I can no longer feel my [ztratocaster]."))

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/herald_of_progress.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/wretch/herald_of_progress.dm
@@ -79,6 +79,55 @@
 		H.set_blindness(0)
 		wretch_select_bounty(H)
 
+/datum/outfit/job/roguetown/wretch/herald_of_progress/post_equip(mob/living/carbon/human/H)
+	. = ..()
+	var/obj/item/rogue/instrument/ztratocaster/ztratocaster = H.is_holding_item_of_type(/obj/item/rogue/instrument/ztratocaster)
+	if(!ztratocaster)
+		return
+	var/obj/effect/proc_holder/spell/self/right_where_it_belongs/recall_spell = new
+	recall_spell.ztratocaster_ref = WEAKREF(ztratocaster)
+	H.mind.AddSpell(recall_spell)
+
+/obj/effect/proc_holder/spell/self/right_where_it_belongs
+	name = "Right Where It Belongs"
+	desc = "Recall my ztratocaster to an empty hand."
+	recharge_time = 5 MINUTES
+	cooldown_min = 5 MINUTES
+	is_cdr_exempt = TRUE
+	chargetime = 0
+	releasedrain = 0
+	chargedrain = 0
+	antimagic_allowed = TRUE
+	invocation_type = "none"
+	human_req = TRUE
+	var/datum/weakref/ztratocaster_ref
+
+/obj/effect/proc_holder/spell/self/right_where_it_belongs/cast(list/targets, mob/living/carbon/human/user = usr)
+	var/obj/item/rogue/instrument/ztratocaster/ztratocaster = ztratocaster_ref?.resolve()
+	if(!ztratocaster || QDELETED(ztratocaster))
+		to_chat(user, span_warning("I can no longer feel my [ztratocaster]."))
+		revert_cast(user)
+		return FALSE
+	if(user.is_holding(ztratocaster))
+		to_chat(user, span_warning("I'm already holding it."))
+		revert_cast(user)
+		return FALSE
+
+	if(ismob(ztratocaster.loc))
+		var/mob/current_holder = ztratocaster.loc
+		if(!current_holder.transferItemToLoc(ztratocaster, user.drop_location(), TRUE))
+			to_chat(user, span_warning("[ztratocaster] resists my call.")) //this shouldn't really happen
+			revert_cast(user)
+			return FALSE
+	else if(!ztratocaster.remove_item_from_storage(user.drop_location()))
+		ztratocaster.forceMove(user.drop_location())
+
+	if(user.put_in_hands(ztratocaster))
+		ztratocaster.loc.visible_message(span_notice("[ztratocaster] tears through the air into [user]'s waiting hand!"))
+	else
+		ztratocaster.loc.visible_message(span_notice("[ztratocaster] tears through the air and lands at [user]'s feet!"))
+	return TRUE
+
 /obj/effect/proc_holder/spell/invoked/raise_undead_formation/miracle
 	associated_skill = /datum/skill/magic/holy
 	miracle = TRUE
@@ -93,6 +142,7 @@
 	devotion_cost = 80
 	zizo_spell = TRUE
 	recharge_time = 200 SECONDS
+	antimagic_allowed = TRUE
 	sound = list('sound/magic/sottovoce.ogg')
 	invocations = list("plays a pulsed, dreadful melodic circuit.")
 	invocation_type = "emote"
@@ -119,6 +169,7 @@
 	associated_skill = /datum/skill/misc/music
 	sound = list('sound/magic/heraldblink.ogg')
 	invocations = list("screeches a short, sharp shock of a chord.")
+	antimagic_allowed = TRUE
 	invocation_type = "emote"
 
 /obj/effect/proc_holder/spell/invoked/blink/staccato/cast(list/targets, mob/living/user = usr)
@@ -138,6 +189,7 @@
 	projectile_type = /obj/projectile/magic/lightning/forzando
 	sound = list('sound/magic/heraldzap.ogg')
 	invocations = list("shreds an electric refrain!")
+	antimagic_allowed = TRUE
 	invocation_type = "emote"
 
 /obj/effect/proc_holder/spell/invoked/projectile/lightningbolt/forzando/cast(list/targets, mob/living/user = usr)


### PR DESCRIPTION
## About The Pull Request

adds simple summon weapon reskin - Right Where It Belongs to the herald of progress that lets them resummon the ztratocaster into their hand once every five minutes.

this will (and should) work no matter where the ztrato is stored, whether that's someone's hands, belt, a sack, on the map, in hell, etc.


<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
compiles, pretty simple change, works on my local branch yadda yadda
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
one of a kind weapon that completely neuters herald if they lose it, giving heralds an ability to get it back should be fine tbh.

the alternative is a ritual to let heralds summon a new guitar like lux plate, but this is significantly more work and something i'd rather avoid
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: mushy
add: Right Where It Belongs - a spell allowing the Herald of Progress to return their Ztratocaster.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
