### PR TITLE
Instruments Quickplay Previous Song in Combat Mode

### DIFF
--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -247,6 +247,8 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 	/// When TRUE, songs will loop (repeat) when they end. Off by default.
 	var/loop_enabled = FALSE
 
+	var/last_played // store the last played thing we have here to use in quick cmode toggle
+
 // Added null-guard on soundloop. During Initialize() the parent chain
 // may trigger equipped() before soundloop is assigned.
 /obj/item/rogue/instrument/equipped(mob/living/user, slot)
@@ -306,6 +308,15 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 			if(!owner_mob)
 				GLOB.instrument_band_lobbies -= lobby_id
 
+/obj/item/rogue/instrument/examine(mob/user)
+	. = ..()
+	if (ishuman(user))
+		var/mob/living/carbon/human/viewer_human = user
+		if (viewer_human.inspiration)
+			. += span_notice("You can quickly add and remove people from your audience by <b>middle-clicking</b> on them with this instrument in your hand.")
+			. += span_notice("If you try to play with combat mode active, you'll automatically play your last song.")
+
+
 /obj/item/rogue/instrument/attack_self(mob/living/user)
 	var/stressevent = /datum/stressevent/music
 	. = ..()
@@ -333,6 +344,21 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 		var/volume_label
 		var/loop_notice
 		var/volume_selection
+		if (user.cmode && last_played)
+			// quickly just play the last song we chose if we do this in combat
+			var/quickfile = song_list[last_played]
+			if(quickfile)
+				user.balloon_alert(user, "quick-playing last song! (combat)")
+				soundloop.set_mid_sounds(list(quickfile))
+				soundloop.volume = clamp(curvol, 10, 100)
+				soundloop.repeat_sound = loop_enabled
+				if(!soundloop.start(user))
+					to_chat(user, span_warning("Could not play - no sound channels available. Try again in a moment."))
+					return
+				playing = TRUE
+				user.apply_status_effect(/datum/status_effect/buff/playing_music, stressevent, note_color)
+				return
+			
 		while(TRUE)
 			loop_state = "Off"
 			if(loop_enabled)
@@ -411,6 +437,7 @@ GLOBAL_LIST_EMPTY(instrument_band_lobbies)
 					song_list[songname] = curfile
 				return
 			curfile = song_list[choice]
+			last_played = choice
 			if(!user || playing || !(src in user.held_items) && !(not_held))
 				return
 			note_color = "#7f7f7f"


### PR DESCRIPTION
## About The Pull Request
atomized continuation of #2527 with permission

> Instruments now remember the last song they've played, and if you use them while in combat mode, they automatically play your last played song without you needing to traverse any additional menus.

>Instruments now have helpful text on their examine that explains the MMB audience-adding behavior and the song replaying described above, if you have inspiration.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
exact same code from #2527 , works fine!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

making clunky bullshit actually not clunky bullshit is good!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
qol: Instruments now play their last-played song immediately if used in combat, instead of needing you to navigate two dialogs while completely still.
qol: Instruments now have helpful examine text for characters with inspiration to explain the above change, and other QoL changes made recently.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
