### PR TITLE
Psyaltrist Tuning

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psyalmist.dm
@@ -51,7 +51,7 @@
 	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
 	id = /obj/item/clothing/ring/signet/silver
 	var/datum/devotion/C = new /datum/devotion(H, H.patron)
-	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_WEAK, devotion_limit = CLERIC_REQ_1)	//Capped to T2 miracles.
+	C.grant_miracles(H, cleric_tier = CLERIC_T2, passive_gain = CLERIC_REGEN_MINOR, devotion_limit = CLERIC_REQ_2)	//Capped to T2 miracles.//Capped to T2 miracles.
 	var/datum/inspiration/I = new /datum/inspiration(H)
 	I.grant_inspiration(H, bard_tier = BARD_T3)
 	backpack_contents = list(/obj/item/roguekey/inquisition = 1,
@@ -107,8 +107,8 @@
 				H.put_in_hands(new /obj/item/rogueweapon/whip/psywhip_lesser(get_turf(H)), forced = TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/whipsflails, 4, TRUE)
 			if("Psydonic Rapier")
-				H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy(get_turf(H)), forced = TRUE)
-				H.equip_to_slot_or_del(new /obj/item/rogueweapon/scabbard/sword, SLOT_BELT_L, TRUE)
+				H.put_in_hands(new /obj/item/rogueweapon/sword/rapier/psy(get_turf(H)), del_on_fail = FALSE, forced = TRUE)
+				H.put_in_hands(new /obj/item/rogueweapon/scabbard/sword(get_turf(H)), del_on_fail = FALSE, forced = TRUE)
 				H.adjust_skillrank_up_to(/datum/skill/combat/swords, 4, TRUE)
 
 /datum/outfit/job/roguetown/psyaltrist


### PR DESCRIPTION
## About The Pull Request
atomized continuation of #2527 with permission

> The psyaltrist now spawns a scabbard properly when picking a rapier as its main weapon.

> The psyaltrist now has the appropriate devotion regen rate for a T2 miracle class instead of having T1 capacity and regeneration worse than devotee. (250 -> 400 max devotion, 0.1 (weak) -> 0.5 (minor) regen). They're equal to an adventurer cantor with this change. 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
exact same code as #2527 , works!
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
i think the original pr puts it perfectly:

>All psydonite miracles use a shit ton of devotion and at the prior values, a combat-active psyaltrist had to spend nearly 8 minutes MMB channeling prayer to get enough devotion back to full, and could cast a whopping total of 4 miracles before it'd deplete.

yeah they could use with a bit more devotion regen

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Ephemeralis
balance: Psyaltrist now has proper devotion regeneration for a T2 miracle class. (250 -> 400 max devotion, 0.1 (weak) -> 0.5 (minor) regen)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
