### PR TITLE
Removes ooze noblood

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/other/ooze.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/other/ooze.dm
@@ -9,7 +9,7 @@
 	When an ooze consumes a corpse fresh, mummified, or skeletal, they retain the memories and skills of the fallen adventurers or commoners that litter the ruins. \
 	Taking on new life, they adopt the mannerisms of this formative meal even if they can realize and mentally separate from their template, although many think of themselves as these dead peoples, insisting this is but a second chance at life..<br>\
 	(+1 CON | +1 WIL | -1 INT) <br>\
-	Easy Dismember | Limb Regrowth | No Bones | No Blood</b></span><br><br>"
+	Easy Dismember | Limb Regrowth | No Bones </b></span><br><br>"
 
 
 	default_color = "79F299"
@@ -43,7 +43,6 @@
 	inherent_traits = list(
 						TRAIT_NOBREATH,
 						TRAIT_ZOMBIE_IMMUNE,
-						TRAIT_BLOODLOSS_IMMUNE,
 						TRAIT_EASYDISMEMBER,
 						TRAIT_REGROW_LIMBS,
 						TRAIT_NASTY_EATER,


### PR DESCRIPTION
Does title.

## Testing Evidence

One line change.
## Why It's Good For The Game

Oozes are immune to chest crits, bleeding out, and as they can wear armor, easydismember functionally does not apply in 90% of cases. They are a powergamer's favorite race accordingly, because even if critted in the chest, they suffer neither fracture nor will they bleed out and die, so the only way to reliably, consistently kill them is to hit the head, which has been made significantly harder lately. This is further made worse by crit resist.

Don't bother leaving feedback on the PR. I will not read it.

## Changelog

:cl:
del: Removed ooze nobleed
/:cl:
