### PR TITLE
Add cursed_item component to gnoll & werewolf skin so blessed silver does extra integ damage

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -21,6 +21,7 @@
 	// Gnolls don't really get to unequip their skin so they might as well just register it as soon as they get it
 	// loc is shitcode here because the skin is created inside the gnoll so we can juse abuse that logic
 	RegisterSignal(loc, list(COMSIG_SPECIES_ATTACKED_BY, COMSIG_LIVING_ARMOR_CHECKED, COMSIG_MOB_APPLY_DAMGE), PROC_REF(on_attacked_by), override = TRUE)
+	AddComponent(/datum/component/cursed_item, TRAIT_HORDE, "HIDE", "#GNOLLED")/// no one should ever see this unless they spawn in gnoll skin via the game panel
 
 /datum/antagonist/gnoll
 	name = "Gnoll"

--- a/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
+++ b/code/modules/antagonists/roguetown/villain/werewolf/werewolf.dm
@@ -140,6 +140,10 @@
 	max_integrity = 550
 	item_flags = DROPDEL
 
+/obj/item/clothing/suit/roguetown/armor/skin_armor/werewolf_skin/Initialize(mapload)///makes blessed silver do extra damage
+	. = ..()
+	AddComponent(/datum/component/cursed_item, TRAIT_GRABIMMUNE, "HIDE", "#VOLFED")/// no one should ever see this unless they spawn in werewolf skin via the game panel. TRAIT_GRABIMMUNE is only on werewolves and the matyr during their super saiyan, should be fine.
+
 /datum/intent/simple/werewolf
 	name = "claw"
 	icon_state = "inchop"


### PR DESCRIPTION
## About The Pull Request

- Adds cursed_item component to gnoll and werewolf skin armor
- Blessed silvers now affect gnoll hide and werewolf skin, much the same as gilbranze, vicious, gilded, avantyne, etc. armors.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

**Component on gnoll skin**
<img width="594" height="295" alt="test evidence 1" src="https://github.com/user-attachments/assets/695e5856-03ab-4e01-8f81-273cffe439c7" />


> [!NOTE]
>  **Hit with unblessed psydonic flail**
35 base force × 1.2 (12 STR) = 42
42 × 1.4 (40% blunt strike integrity factor) = 58.8
Standard gnoll armor has blunt rating of 70, intdamage reduced by half, 35%
_**58.8 × 0.65 = 38.22, rounded to 38.2 intdamage**_

<img width="341" height="148" alt="test evidence 2" src="https://github.com/user-attachments/assets/ba7570aa-1026-4b0e-95ba-50a417ed25f3" />

> [!NOTE]
>  **Hit with blessed psydonic flail**
Psydonic blessed silver gives us a 1.3x intdamage mult vs cursed armor
**_round(38.22 × 1.3) = round(49.686) = 49 intdamage_**

<img width="339" height="151" alt="test evidence 3" src="https://github.com/user-attachments/assets/1d121678-a18d-4abc-bedc-24afc98a0021" />


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Werewolves sunder on hit so their hide is cursed.
Gnolls are Graggar beasts, their hide should take extra damage just like Graggar heretic armor.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Werewolf skin and gnoll hide are now affected by blessed silver intdamage multiplier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
