### PR TITLE
Magician's brick curved scaling, i.e. 5 int & 15 int both equal +5 brick

### DIFF
--- a/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
+++ b/code/modules/spells/spell_types/wizard/misc/magicians_brick.dm
@@ -29,11 +29,12 @@
 	var/obj/item/rogueweapon/R = new /obj/item/rogueweapon/magicbrick(user.drop_location())
 	R.AddComponent(/datum/component/conjured_item)
 
-	if(user.STAINT > 10)
-		var/int_scaling = user.STAINT - 10
-		R.force = R.force + int_scaling
-		R.throwforce = R.throwforce + int_scaling * 2 // 2x scaling for throwing. Let's go.
-		R.name = "magician's brick +[int_scaling]"
+	var/int_deviation = abs(user.STAINT - 10)//scales linear in a U curve; both the trog and the archmagos understand hitting someone with a brick hurts a lot
+
+	R.force += int_deviation
+	R.throwforce += int_deviation * 2// 2x scaling for throwing. Let's go.
+	R.name = "magician's brick +[int_deviation]"
+
 	user.put_in_hands(R)
 	src.conjured_brick = R
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

- Change magician's brick scaling from int > 10 to a U-shaped curve. Both extremes of int will buff the brick.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence

https://github.com/user-attachments/assets/fd18780a-c9a7-44ef-a72c-c5e73df4af31


<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Funny.
The wisest magos and the dullest thug understand the same fundamental: heavier brick = better concussive force; bonking, if you will.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Magician's Brick spell power scaling is now curved; int deviation both above and below 10 buffs the bricks' force. (i.e. 1 int & 19 int both = +9 brick)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
