### PR TITLE
remove stam drain per tick from frostbite

### DIFF
--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -42,10 +42,6 @@
 	target.add_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, update=TRUE, priority=100, multiplicative_slowdown=4, movetypes=GROUND)
 	target.stamina_add(25)
 
-/datum/status_effect/buff/frostbite/tick()
-	var/mob/living/target = owner
-	target.stamina_add(5)
-
 /datum/status_effect/buff/frostbite/on_remove()
 	var/mob/living/target = owner
 	target.update_vision_cone()

--- a/code/modules/spells/spell_types/wizard/spells_status_effects.dm
+++ b/code/modules/spells/spell_types/wizard/spells_status_effects.dm
@@ -42,6 +42,13 @@
 	target.add_movespeed_modifier(MOVESPEED_ID_ADMIN_VAREDIT, update=TRUE, priority=100, multiplicative_slowdown=4, movetypes=GROUND)
 	target.stamina_add(25)
 
+/datum/status_effect/buff/frostbite/tick()
+	var/mob/living/target = owner
+	target.stamina_add(5)
+	// When stamcrit, removes it to prevent it from chaining too hard
+	if(target.stamina >= target.max_stamina)
+		target.remove_status_effect(/datum/status_effect/buff/frostbite)
+
 /datum/status_effect/buff/frostbite/on_remove()
 	var/mob/living/target = owner
 	target.update_vision_cone()


### PR DESCRIPTION
## About The Pull Request

- Removes stam drain per tick from frostbite status to prevent chain stunning/exhausted pant emote spam from said chain stunning 

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
3-line removal
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
Frostbite spell on sojourner is a single-target hitscan slowdown that, on top of stat debuffs and removing a flat 25 stamina on initial cast, drains 5 stamina per tick. What often happens is the stamina drain gets someone to zero and then repeatedly keeps them at 0 for what is effectively a far longer, and frankly janky-looking, stun that spams the exhausted emote/text span alerts for the duration of the effect. 

Frost by itself is good stamina damage, stat drain, and slowdown; the drain per tick, on top of the other effects, makes it oppressive. 

Sojourner's prime targets are mages, who rely on and drain stamina to a greater extent than melee fighters. Gameplay-wise, timing a frostbite spell on an enemy mage right after they cast to try and push them over the edge of stamina exhaustion with burst stam damage is far more interesting than just mindlessly putting your on tick drain on someone to watch them crumple into chainstun exhaustion.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Frostbite status no longer drains 5 stamina per tick.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
