### PR TITLE
Gnoll claw balance adjustments. No more 60 pen cut intent!

### DIFF
--- a/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
+++ b/code/modules/antagonists/roguetown/villain/gnoll/gnoll.dm
@@ -189,9 +189,10 @@
 /obj/item/rogueweapon/werewolf_claw/gnoll
 	name = "Gnoll Claw"
 	// We are smarter, we can use our solid, steel-like claws to defend ourselves.
-	wdefense = 5
-	force = 30
+	wdefense = 6
+	force = 27
 	possible_item_intents = list(/datum/intent/simple/gnoll_cut, /datum/intent/simple/werewolf/gnoll, /datum/intent/mace/smash/werewolf/gnoll, /datum/intent/mace/strike/gnoll)
+	special = /datum/special_intent/shin_swipe
 
 /obj/item/rogueweapon/werewolf_claw/gnoll/right
 	icon_state = "claw_r"
@@ -208,23 +209,25 @@
 	attack_verb = list("claws", "mauls", "eviscerates")
 	animname = "chop"
 	hitsound = "genslash"
-	penfactor = 20
+	penfactor = 40//same as battleaxe chop
 	miss_text = "slashes the air!"
 	miss_sound = "bluntwooshlarge"
 	item_d_type = "slash"
-	damfactor = 1.2
+	damfactor = 1.4
+	swingdelay = 0.8 SECONDS
+	clickcd = CLICK_CD_CHARGED
 
 /datum/intent/mace/smash/werewolf/gnoll
 	name = "thrash"
 	desc = "A powerful smash of savage muscle that deals normal damage, but can throw a standing opponent back and slow them down, based on your strength. Ineffective below 10 strength. Slowdown & Knockback scales to your Strength up to 15 (1 - 5 tiles). Cannot be used consecutively more than every 5 seconds on the same target. Prone targets halve the knockback distance."
 	icon_state = "insmash"
 	chargetime = 1
-	penfactor = 0
+	penfactor = BLUNT_DEFAULT_PENFACTOR
 
 /datum/intent/simple/gnoll_cut
 	name = "cutting claw"
 	hitsound = "genslash"
-	penfactor = 60
+	penfactor = 20// on azure this is PEN_LIGHT. Crazy this had 60 penfactor for so so long
 	miss_text = "slashes the air!"
 	miss_sound = "bluntwooshlarge"
 	icon_state = "incut"
@@ -238,7 +241,6 @@
 	miss_text = "strikes the air!"
 	miss_sound = "bluntwooshlarge"
 	attack_verb = list("punches", "strikes", "tears")
-
 
 /obj/item/storage/backpack/rogue/satchel/gnoll 
 	name = "stained satchel"


### PR DESCRIPTION
## About The Pull Request

- Gnoll claw adjusted to 6 wdefense, 27 force
- Gnoll claw chop given 50 pen(same as militia chop or spear), 1.5 damfactor, 0 swing delay, a 0.5 charge, and 12 clickcd
- Gnoll claw cut pen adjusted from 60 (literally on par with lesser pick intent) to 30 and changes the BCLASS to BCLASS_CHOP so it wounds better. On azure cut is PEN_LIGHT not PEN_BSTEEL : )
- Gnoll claw given shin swipe special

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
var number changes
<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game
60 pen cut is rots in hell where it belongs. Chop behaves like a chop; cut behaves like a cut.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
balance: Gnoll claw adjusted to 6 wdefense, 27 force. Also given shin swipe special.
balance: Gnoll claw chop given 50 pen(same as militia chop or spear), 1.5 damfactor, 0 swing delay, a 0.5 charge, and 12 clickcd.
balance: Gnoll claw cut penfactor lowered from 60 to 30 and changed the BCLASS to BCLASS_CHOP so it wounds better
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
