### PR TITLE
Puts Portable Hookah in Purity. Removes it from Loadout

### DIFF
--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -262,7 +262,7 @@
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
 	held_items[/obj/item/storage/fancy/shhig] = list("PRICE" = rand(40,60), "NAME" = "Shhig brand premium zigs")
 	held_items[/obj/item/alch/transisdust] = list("PRICE" = rand(80,120), "NAME" = "sui dust")
-	held_items[/obj/item/portable_hookah] = list("PRICE" = rand(90,130) "NAME" = "portable hookah")
+	held_items[/obj/item/portable_hookah] = list("PRICE" = rand(90,130), "NAME" = "portable hookah")
 	// azure peak addition start - lipstick
 	held_items[/obj/item/azure_lipstick] = list("PRICE" = rand(33,50),"NAME" = "red lipstick")
 	held_items[/obj/item/azure_lipstick/jade] = list("PRICE" = rand(33,50),"NAME" = "jade lipstick")

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -262,7 +262,7 @@
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
 	held_items[/obj/item/storage/fancy/shhig] = list("PRICE" = rand(40,60), "NAME" = "Shhig brand premium zigs")
 	held_items[/obj/item/alch/transisdust] = list("PRICE" = rand(80,120), "NAME" = "sui dust")
-	held_items[/obj/item/portable_hookah] = list("PRICE" = 100, "NAME" = "portable hookah")
+	held_items[/obj/item/portable_hookah] = list("PRICE" = rand(90,130) "NAME" = "portable hookah")
 	// azure peak addition start - lipstick
 	held_items[/obj/item/azure_lipstick] = list("PRICE" = rand(33,50),"NAME" = "red lipstick")
 	held_items[/obj/item/azure_lipstick/jade] = list("PRICE" = rand(33,50),"NAME" = "jade lipstick")

--- a/code/modules/roguetown/roguemachine/drugmachine.dm
+++ b/code/modules/roguetown/roguemachine/drugmachine.dm
@@ -262,6 +262,7 @@
 	held_items[/obj/item/clothing/mask/cigarette/rollie/nicotine] = list("PRICE" = rand(5,10),"NAME" = "zig")
 	held_items[/obj/item/storage/fancy/shhig] = list("PRICE" = rand(40,60), "NAME" = "Shhig brand premium zigs")
 	held_items[/obj/item/alch/transisdust] = list("PRICE" = rand(80,120), "NAME" = "sui dust")
+	held_items[/obj/item/portable_hookah] = list("PRICE" = 100, "NAME" = "portable hookah")
 	// azure peak addition start - lipstick
 	held_items[/obj/item/azure_lipstick] = list("PRICE" = rand(33,50),"NAME" = "red lipstick")
 	held_items[/obj/item/azure_lipstick/jade] = list("PRICE" = rand(33,50),"NAME" = "jade lipstick")

--- a/modular_azurepeak/code/datums/loadout.dm
+++ b/modular_azurepeak/code/datums/loadout.dm
@@ -79,11 +79,6 @@ GLOBAL_LIST_INIT(loadout_items, init_subtypes(/datum/loadout_item))
 	name = "Hand Mirror"
 	path = /obj/item/handmirror
 
-/datum/loadout_item/portable_hookah
-	name = "Portable Hookah"
-	path = /obj/item/portable_hookah
-	triumph_cost = 2
-
 //TOOLS
 
 /datum/loadout_item/bauernwehr


### PR DESCRIPTION
## About The Pull Request

I didn't know the portable hookah was insane. I just wanted to larp as a crackie. This should put it in a normal spot.

## Testing Evidence

yeah

## Why It's Good For The Game

This can't be good for me, but I feel great!

## Changelog


:cl:
add: Adds portable Hookah to Purity.
/:cl:
