### PR TITLE
Fix necran The Toll ritual not properly checking for DNR & makes TRAIT_DNR transfer with the brain on transplant

### DIFF
--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -994,7 +994,7 @@
 		user.change_stat(STATKEY_WIL, 3)
 		ADD_TRAIT(user, TRAIT_PSYCHOSIS, TRAIT_GENERIC) //Imitates the fact that you are, in fact, going bonkers.
 		ADD_TRAIT(user, TRAIT_NOCSHADES, TRAIT_GENERIC) //Roughly ~30% reduced vision with a sharp red overlay. Provides night vision in the visible tiles.
-		ADD_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC) //If you die while the necklace's on, that's it. Technically saveable if someone knows to remove the necklace, before attempting resurrection.
+		ADD_TRAIT(user, TRAIT_DNR, CLOTHING_TRAIT) //If you die while the necklace's on, that's it. Technically saveable if someone knows to remove the necklace, before attempting resurrection.
 		ADD_TRAIT(user, TRAIT_STRONGKICK, TRAIT_GENERIC)
 		ADD_TRAIT(user, TRAIT_STRENGTH_UNCAPPED, TRAIT_GENERIC)
 	return
@@ -1008,7 +1008,7 @@
 		user.change_stat(STATKEY_WIL, -3)
 		REMOVE_TRAIT(user, TRAIT_PSYCHOSIS, TRAIT_GENERIC)
 		REMOVE_TRAIT(user, TRAIT_NOCSHADES, TRAIT_GENERIC)
-		REMOVE_TRAIT(user, TRAIT_DNR, TRAIT_GENERIC)
+		REMOVE_TRAIT(user, TRAIT_DNR, CLOTHING_TRAIT)
 		REMOVE_TRAIT(user, TRAIT_STRONGKICK, TRAIT_GENERIC)
 		REMOVE_TRAIT(user, TRAIT_STRENGTH_UNCAPPED, TRAIT_GENERIC)
 		active_item = FALSE

--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -33,9 +33,9 @@
 	name = "brain"
 
 	if(brainmob)
-//		if(C.key)
-//			testing("UHM BASED?? [C]")
-//			C.ghostize()
+		if(HAS_TRAIT(brainmob, TRAIT_DNR))
+			for(var/dnr_source in brainmob.status_traits[TRAIT_DNR])
+				ADD_TRAIT(C, TRAIT_DNR, dnr_source)
 
 		if(brainmob.mind)
 			brainmob.mind.transfer_to(C)
@@ -78,6 +78,11 @@
 	brainmob.real_name = L.real_name
 	brainmob.timeofhostdeath = L.timeofdeath
 	brainmob.suiciding = suicided
+	if(HAS_TRAIT(L, TRAIT_DNR))//prevents cheesing DNR, trait transfers with the brain not the body
+		for(var/dnr_source in L.status_traits[TRAIT_DNR])
+			if(dnr_source == CLOTHING_TRAIT)//prevents weird interactions with weeping psycross DNR
+				continue
+			ADD_TRAIT(brainmob, TRAIT_DNR, dnr_source)
 	if(L.has_dna())
 		var/mob/living/carbon/C = L
 		if(!brainmob.stored_dna)

--- a/modular_azurepeak/code/game/objects/items/ritualcircles.dm
+++ b/modular_azurepeak/code/game/objects/items/ritualcircles.dm
@@ -1102,6 +1102,8 @@
 		target.visible_message(span_danger("[target] is unmade by divine magic! The Toll is accepted, and [target] is dragged to ever-death!"), span_userdanger("I'm unmade by divine magic!"))
 		target.gib()
 		return
+	if(!target.check_revive(user))//prevent revives that ignore DNR
+		return
 	target.adjustOxyLoss(-target.getOxyLoss()) //Ye Olde CPR
 	if(!target.revive(full_heal = FALSE))
 		to_chat(user, span_warning("Nothing happens."))


### PR DESCRIPTION
## About The Pull Request

- Add check_revive to necran the toll ritual, meaning the ritual respects TRAIT_DNR
- Add ADD_TRAIT() proc calls in transfer_indentity() and Insert() if(brainmob) to transfer any existing TRAIT_DNR traits on the mob with the brain, preventing players from using head swaps to bypass the DNR trait.

<!-- Describe your pull request. Avoid text walls, use concise bullet points for easier readability. Document every change, or this can delay review and even discourage maintainers from merging your PR. -->

## Testing Evidence
Me transferring a DNR sissean's head to a generic orc corpse I spawned; the trait applies to the donor body:
<img width="712" height="803" alt="test evidence" src="https://github.com/user-attachments/assets/94f05493-4c5a-482c-966f-d67dad9262ae" />

https://github.com/user-attachments/assets/c141d043-be32-432f-8e0b-3ad1941fd9b2



https://github.com/user-attachments/assets/6ad88dc7-b97b-4b2c-8fa7-77c7eb7bb7d3



<!-- It's mandatory to test your PR. Provide images, clips or description of how you tested your changes where possible. -->

## Why It's Good For The Game

DNR should = DNR; cheesy unintended workarounds are bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial. If you can't, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Yuckuza
fix: Players can no longer revive DNR players via head transplants; the DNR trait now follows the brain.
fix: The Toll necran ritual now properly checks and respects TRAIT_DNR
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!-- By contributing to this codebase, you confirm that any code and sprites you provide are legal to share and will be licensed under the terms specified in README.md — AGPLv3 for code and CC-BY-SA 3.0 for assets, unless otherwise stated. You acknowledge that the project maintainers are under no obligation to remove any materials that do not violate these licenses. -->
